### PR TITLE
Listen on localhost when running unit tests

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -28,6 +28,7 @@ type Agentd struct {
 	errChan  chan error
 
 	Store      store.Store
+	Host       string
 	Port       int
 	MessageBus messaging.MessageBus
 }
@@ -47,7 +48,7 @@ func (a *Agentd) Start() error {
 	handler := http.HandlerFunc(a.webSocketHandler)
 
 	server := &http.Server{
-		Addr:         fmt.Sprintf("0.0.0.0:%d", a.Port),
+		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
 		Handler:      handler,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -22,6 +22,7 @@ type APId struct {
 	errChan  chan error
 
 	Store         store.Store
+	Host          string
 	Port          int
 	BackendStatus func() types.StatusMap
 }
@@ -41,7 +42,7 @@ func (a *APId) Start() error {
 	router := httpRouter(a)
 
 	server := &http.Server{
-		Addr:         fmt.Sprintf("0.0.0.0:%d", a.Port),
+		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
 		Handler:      router,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -25,8 +25,10 @@ var (
 
 // Config specifies a Backend configuration.
 type Config struct {
-	APIPort             int
+	AgentHost           string
 	AgentPort           int
+	APIHost             string
+	APIPort             int
 	DashboardDir        string
 	DashboardHost       string
 	DashboardPort       int
@@ -145,6 +147,7 @@ func (b *Backend) Run() error {
 
 	b.apid = &apid.APId{
 		Store:         st,
+		Host:          b.Config.APIHost,
 		Port:          b.Config.APIPort,
 		BackendStatus: b.Status,
 	}
@@ -154,6 +157,7 @@ func (b *Backend) Run() error {
 
 	b.agentd = &agentd.Agentd{
 		Store:      st,
+		Host:       b.Config.AgentHost,
 		Port:       b.Config.AgentPort,
 		MessageBus: b.messageBus,
 	}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -28,8 +28,11 @@ func TestHTTPListener(t *testing.T) {
 		fmt.Println(initCluster)
 
 		b, err := NewBackend(&Config{
+			AgentHost:           "127.0.0.1",
 			AgentPort:           agentPort,
+			APIHost:             "127.0.0.1",
 			APIPort:             apiPort,
+			DashboardHost:       "127.0.0.1",
 			StateDir:            path,
 			EtcdClientListenURL: clURL,
 			EtcdPeerListenURL:   apURL,

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -12,7 +12,9 @@ import (
 )
 
 var (
+	agentHost     string
 	agentPort     int
+	apiHost       string
 	apiPort       int
 	dashboardDir  string
 	dashboardHost string
@@ -34,7 +36,9 @@ func newStartCommand() *cobra.Command {
 		Short: "start the sensu backend",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := &backend.Config{
+				AgentHost:     agentHost,
 				AgentPort:     agentPort,
+				APIHost:       apiHost,
 				APIPort:       apiPort,
 				DashboardDir:  dashboardDir,
 				DashboardHost: dashboardHost,
@@ -86,8 +90,10 @@ func newStartCommand() *cobra.Command {
 		defaultStateDir = "/var/lib/sensu"
 	}
 
-	cmd.Flags().IntVar(&apiPort, "api-port", 8080, "HTTP API port")
+	cmd.Flags().StringVar(&agentHost, "agent-host", "0.0.0.0", "Agent listener host")
 	cmd.Flags().IntVar(&agentPort, "agent-port", 8081, "Agent listener port")
+	cmd.Flags().StringVar(&apiHost, "api-host", "0.0.0.0", "HTTP API listener host")
+	cmd.Flags().IntVar(&apiPort, "api-port", 8080, "HTTP API port")
 	cmd.Flags().StringVar(&dashboardDir, "dashboard-dir", "./bin/dashboard", "path to sensu dashboard static assets")
 	cmd.Flags().StringVar(&dashboardHost, "dashboard-host", "0.0.0.0", "Dashboard listener host")
 	cmd.Flags().IntVar(&dashboardPort, "dashboard-port", 3000, "Dashboard listener port")

--- a/backend/pipelined/handle_test.go
+++ b/backend/pipelined/handle_test.go
@@ -127,7 +127,7 @@ func TestPipelinedTcpHandler(t *testing.T) {
 	eventData, _ := json.Marshal(event)
 
 	go func() {
-		listener, err := net.Listen("tcp", ":5678")
+		listener, err := net.Listen("tcp", "127.0.0.1:5678")
 		assert.NoError(t, err)
 		if err != nil {
 			return

--- a/testing/util/util.go
+++ b/testing/util/util.go
@@ -24,7 +24,7 @@ func WithTempDir(f func(string)) {
 // RandomPorts generates len(p) random ports and assigns them to elements of p.
 func RandomPorts(p []int) error {
 	for i := range p {
-		l, err := net.Listen("tcp", ":0")
+		l, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Adds the flags `--agent-host` & `--api-host`, in addition to `--dashboard-host` which already exists
* Sets the host to `127.0.0.1` when listening on a port in unit tests so it plays nice with MacOS firewall