### PR TITLE
Add configuration flag to sensu-agent for ephemeral agents

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -36,8 +36,8 @@ type Config struct {
 	// KeepaliveInterval is the interval, in seconds, when agents will send a
 	// keepalive to sensu-backend. Default: 60
 	KeepaliveInterval int
-	// Ephemeral indicates that the entity is ephemeral
-	Ephemeral bool
+	// Deregister indicates whether the entity is ephemeral
+	Deregister bool
 }
 
 var logger *logrus.Entry

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -18,7 +18,7 @@ var (
 	backendURL    string
 	agentID       string
 	subscriptions string
-	ephemeral     bool
+	deregister    bool
 )
 
 func init() {
@@ -41,7 +41,7 @@ func newStartCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := agent.NewConfig()
 			cfg.BackendURL = backendURL
-			cfg.Ephemeral = ephemeral
+			cfg.Deregister = deregister
 
 			if agentID != "" {
 				cfg.AgentID = agentID
@@ -82,8 +82,8 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&subscriptions, "subscriptions", "", "comma-delimited list of agent subscriptions")
 	viper.BindPFlag("subscriptions", cmd.Flags().Lookup("subscriptions"))
 
-	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false, "ephemeral agent")
-	viper.BindPFlag("ephemeral", cmd.Flags().Lookup("ephemeral"))
+	cmd.Flags().BoolVar(&deregister, "deregister", false, "ephemeral agent")
+	viper.BindPFlag("deregister", cmd.Flags().Lookup("deregister"))
 
 	return cmd
 }

--- a/types/entity.go
+++ b/types/entity.go
@@ -10,7 +10,7 @@ type Entity struct {
 	System        System   `json:"system,omitempty"`
 	Subscriptions []string `json:"subscriptions,omitempty"`
 	LastSeen      int64    `json:"last_seen,omitempty"`
-	Ephemeral     bool     `json:"ephemeral"`
+	Deregister    bool     `json:"deregister"`
 }
 
 // System contains information about the system that the Agent process


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/131

Adds a `--deregister` configuration flag to `sensu-agent`.

~Disclaimer: I'm not sure if *ephemeral* is the right name to use, I also thought about *dynamic*. Any thoughts?~

~EDIT: Looks like this might be the equivalent of the `deregister` attribute in Sensu v1? https://sensuapp.org/docs/latest/reference/clients.html#deregistration-attributes. Should we rename it?~