### PR TITLE
Cache builds; only use -race on supported platforms

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -13,6 +13,23 @@ ForEach ($env_cmd in $env_commands) {
   Invoke-Expression $ps_cmd
 }
 
+$RACE = ""
+
+function set_race_flag
+{
+  If ($env:GOARCH -eq "amd64") {
+    $RACE = "-race"
+  }
+}
+
+switch ($env:GOOS)
+{
+        "darwin" {set_race_flag}
+        "freebsd" {set_race_flag}
+        "linux" {set_race_flag}
+        "windows" {set_race_flag}
+}
+
 function install_deps
 {
   go get github.com/axw/gocov/gocov
@@ -27,7 +44,7 @@ function build_tool_binary([string]$goos, [string]$goarch, [string]$bin)
   $outfile = "target/$goos-$goarch/$bin.exe"
   $env:GOOS = $goos
   $env:GOARCH = $goarch
-  go build -o $outfile "$REPO_PATH/tools/$bin/..."
+  go build -i -o $outfile "$REPO_PATH/tools/$bin/..."
   If ($LASTEXITCODE -ne 0) {
     echo "Failed to build $outfile..."
     exit 1
@@ -41,7 +58,7 @@ function build_binary([string]$goos, [string]$goarch, [string]$bin)
   $outfile = "target/$goos-$goarch/sensu-$bin.exe"
   $env:GOOS = $goos
   $env:GOARCH = $goarch
-  go build -o $outfile "$REPO_PATH/$bin/cmd/..."
+  go build -i -o $outfile "$REPO_PATH/$bin/cmd/..."
   If ($LASTEXITCODE -ne 0) {
     echo "Failed to build $outfile..."
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -8,9 +8,28 @@ eval $(go env)
 
 cmd=${1:-"all"}
 
-if [ "$GOARCH" == "amd64" ]; then
-	RACE="-race"
-fi
+RACE=""
+
+set_race_flag() {
+	if [ "$GOARCH" == "amd64" ]; then
+		RACE="-race"
+	fi
+}
+
+case "$GOOS" in
+	darwin)
+		set_race_flag
+		;;
+	freebsd)
+		set_race_flag
+		;;
+	linux)
+		set_race_flag
+		;;
+	windows)
+		set_race_flag
+		;;
+esac
 
 install_deps () {
 	go get github.com/axw/gocov/gocov
@@ -27,7 +46,7 @@ build_tool_binary () {
 
 	local outfile="target/${goos}-${goarch}/${cmd}"
 
-	GOOS=$goos GOARCH=$goarch go build -o $outfile ${REPO_PATH}/tools/${cmd}/...
+	GOOS=$goos GOARCH=$goarch go build -i -o $outfile ${REPO_PATH}/tools/${cmd}/...
 
 	echo $outfile
 }
@@ -39,7 +58,7 @@ build_binary () {
 
 	local outfile="target/${goos}-${goarch}/sensu-${cmd}"
 
-	GOOS=$goos GOARCH=$goarch go build -o $outfile ${REPO_PATH}/${cmd}/cmd/...
+	GOOS=$goos GOARCH=$goarch go build -i -o $outfile ${REPO_PATH}/${cmd}/cmd/...
 
 	echo $outfile
 }


### PR DESCRIPTION
Greatly speeds up builds via caching.

Also ensures the `-race` flag is only added on supported platforms which are currently:

* `linux/amd64`
* `freebsd/amd64`
* `darwin/amd64`
* `windows/amd64`