### PR TITLE
The API now returns empty arrays instead of 'null'

### DIFF
--- a/backend/apid/controllers/checks.go
+++ b/backend/apid/controllers/checks.go
@@ -32,6 +32,12 @@ func (c *ChecksController) many(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We initialize the variable if no results were returned so we later print
+	// an empty array instead of "null"
+	if checks == nil {
+		checks = []*types.Check{}
+	}
+
 	checksBytes, err := json.Marshal(checks)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/apid/controllers/checks_test.go
+++ b/backend/apid/controllers/checks_test.go
@@ -40,6 +40,24 @@ func TestHttpApiChecksGet(t *testing.T) {
 	assert.EqualValues(t, checks, returnedChecks)
 }
 
+func TestHttpApiChecksGetEmpty(t *testing.T) {
+	store := &mockstore.MockStore{}
+
+	c := &ChecksController{
+		Store: store,
+	}
+
+	var checks []*types.Check
+	store.On("GetChecks").Return(checks, nil)
+	req, _ := http.NewRequest("GET", "/checks", nil)
+	res := processRequest(c, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	body := res.Body.String()
+	assert.Equal(t, "[]", body)
+}
+
 func TestHttpApiChecksGetError(t *testing.T) {
 	store := &mockstore.MockStore{}
 

--- a/backend/apid/controllers/entities.go
+++ b/backend/apid/controllers/entities.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
 )
 
 // EntitiesController defines the fields required by EntitiesController.
@@ -27,6 +28,12 @@ func (c *EntitiesController) many(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	// We initialize the variable if no results were returned so we later print
+	// an empty array instead of "null"
+	if es == nil {
+		es = []*types.Entity{}
 	}
 
 	esb, err := json.Marshal(es)

--- a/backend/apid/controllers/entities_test.go
+++ b/backend/apid/controllers/entities_test.go
@@ -39,6 +39,24 @@ func TestHttpApiEntitiesGet(t *testing.T) {
 	}
 }
 
+func TestHttpApiEntitiesGetEmpty(t *testing.T) {
+	store := &mockstore.MockStore{}
+
+	c := &EntitiesController{
+		Store: store,
+	}
+
+	var entities []*types.Entity
+	store.On("GetEntities").Return(entities, nil)
+	req, _ := http.NewRequest("GET", "/entities", nil)
+	res := processRequest(c, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	body := res.Body.String()
+	assert.Equal(t, "[]", body)
+}
+
 func TestHttpApiEntityGet(t *testing.T) {
 	store := &mockstore.MockStore{}
 

--- a/backend/apid/controllers/events.go
+++ b/backend/apid/controllers/events.go
@@ -83,10 +83,10 @@ func (c *EventsController) events(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the events slice is empty, we want to return an empty array instead
-	// of null for easier consumption
-	if len(events) == 0 {
-		events = make([]*types.Event, 0)
+	// We initialize the variable if no results were returned so we later print
+	// an empty array instead of "null"
+	if events == nil {
+		events = []*types.Event{}
 	}
 
 	jsonStr, err := json.Marshal(events)

--- a/backend/apid/controllers/events_test.go
+++ b/backend/apid/controllers/events_test.go
@@ -1,7 +1,28 @@
 package controllers
 
-import "testing"
+import (
+	"net/http"
+	"testing"
 
-func TestHttpApiEventsGet(t *testing.T) {
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
 
+func TestHttpApiEventsGetEmpty(t *testing.T) {
+	store := &mockstore.MockStore{}
+
+	c := &EventsController{
+		Store: store,
+	}
+
+	var events []*types.Event
+	store.On("GetEvents").Return(events, nil)
+	req, _ := http.NewRequest("GET", "/events", nil)
+	res := processRequest(c, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	body := res.Body.String()
+	assert.Equal(t, "[]", body)
 }

--- a/backend/apid/controllers/handlers.go
+++ b/backend/apid/controllers/handlers.go
@@ -31,6 +31,12 @@ func (c *HandlersController) many(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We initialize the variable if no results were returned so we later print
+	// an empty array instead of "null"
+	if handlers == nil {
+		handlers = []*types.Handler{}
+	}
+
 	handlersBytes, err := json.Marshal(handlers)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/apid/controllers/handlers_test.go
+++ b/backend/apid/controllers/handlers_test.go
@@ -42,6 +42,24 @@ func TestHttpAPIHandlersGet(t *testing.T) {
 	}
 }
 
+func TestHttpAPIHandlersGetEmpty(t *testing.T) {
+	store := &mockstore.MockStore{}
+
+	c := &HandlersController{
+		Store: store,
+	}
+
+	var handlers []*types.Handler
+	store.On("GetHandlers").Return(handlers, nil)
+	req, _ := http.NewRequest("GET", "/handlers", nil)
+	res := processRequest(c, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	body := res.Body.String()
+	assert.Equal(t, "[]", body)
+}
+
 func TestHttpAPIHandlerGet(t *testing.T) {
 	store := &mockstore.MockStore{}
 

--- a/backend/apid/controllers/mutators.go
+++ b/backend/apid/controllers/mutators.go
@@ -31,6 +31,12 @@ func (c *MutatorsController) many(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// We initialize the variable if no results were returned so we later print
+	// an empty array instead of "null"
+	if mutators == nil {
+		mutators = []*types.Mutator{}
+	}
+
 	mutatorsBytes, err := json.Marshal(mutators)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/apid/controllers/mutators_test.go
+++ b/backend/apid/controllers/mutators_test.go
@@ -43,6 +43,24 @@ func TestHttpApiMutatorsGet(t *testing.T) {
 	}
 }
 
+func TestHttpApiMutatorsGetEmpty(t *testing.T) {
+	store := &mockstore.MockStore{}
+
+	c := &MutatorsController{
+		Store: store,
+	}
+
+	var mutators []*types.Mutator
+	store.On("GetMutators").Return(mutators, nil)
+	req, _ := http.NewRequest("GET", "/mutators", nil)
+	res := processRequest(c, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+
+	body := res.Body.String()
+	assert.Equal(t, "[]", body)
+}
+
 func TestHttpApiMutatorGet(t *testing.T) {
 	store := &mockstore.MockStore{}
 


### PR DESCRIPTION
Fixes https://github.com/sensu/sensu-go/issues/151