### PR TITLE
The API now returns empty arrays instead of 'null'

### DIFF
--- a/backend/apid/controllers/events.go
+++ b/backend/apid/controllers/events.go
@@ -83,12 +83,6 @@ func (c *EventsController) events(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the events slice is empty, we want to return an empty array instead
-	// of null for easier consumption
-	if len(events) == 0 {
-		events = make([]*types.Event, 0)
-	}
-
 	jsonStr, err := json.Marshal(events)
 	if err != nil {
 		http.Error(w, "error marshalling response", http.StatusInternalServerError)

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -49,7 +49,7 @@ func (s *etcdStore) GetEntities() ([]*types.Entity, error) {
 		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Entity{}, nil
 	}
 
 	earr := make([]*types.Entity, len(resp.Kvs))

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -10,21 +10,31 @@ import (
 
 func TestEntityStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
-		entity := types.FixtureEntity("entity")
-		err := store.UpdateEntity(entity)
+		// We should receive an empty slice if no results were found
+		entities, err := store.GetEntities()
 		assert.NoError(t, err)
+		assert.NotNil(t, entities)
+
+		entity := types.FixtureEntity("entity")
+		err = store.UpdateEntity(entity)
+		assert.NoError(t, err)
+
 		retrieved, err := store.GetEntityByID(entity.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, entity.ID, retrieved.ID)
-		entities, err := store.GetEntities()
+
+		entities, err = store.GetEntities()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(entities))
 		assert.Equal(t, entity.ID, entities[0].ID)
+
 		err = store.DeleteEntity(entity)
 		assert.NoError(t, err)
+
 		retrieved, err = store.GetEntityByID(entity.ID)
 		assert.Nil(t, retrieved)
 		assert.NoError(t, err)
+
 		// Nonexistent entity deletion should return no error.
 		err = store.DeleteEntity(entity)
 		assert.NoError(t, err)

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -46,7 +46,7 @@ func (s *etcdStore) GetHandlers() ([]*types.Handler, error) {
 		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Handler{}, nil
 	}
 
 	handlersArray := make([]*types.Handler, len(resp.Kvs))
@@ -110,7 +110,7 @@ func (s *etcdStore) GetMutators() ([]*types.Mutator, error) {
 		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Mutator{}, nil
 	}
 
 	mutatorsArray := make([]*types.Mutator, len(resp.Kvs))
@@ -174,7 +174,7 @@ func (s *etcdStore) GetChecks() ([]*types.Check, error) {
 		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Check{}, nil
 	}
 
 	checksArray := make([]*types.Check, len(resp.Kvs))
@@ -240,7 +240,7 @@ func (s *etcdStore) GetEvents() ([]*types.Event, error) {
 	}
 
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Event{}, nil
 	}
 
 	eventsArray := make([]*types.Event, len(resp.Kvs))

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -47,6 +47,11 @@ func testWithEtcd(t *testing.T, f func(store.Store)) {
 
 func TestHandlerStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
+		// We should receive an empty slice if no results were found
+		handlers, err := store.GetHandlers()
+		assert.NoError(t, err)
+		assert.NotNil(t, handlers)
+
 		handler := &types.Handler{
 			Name:    "handler1",
 			Type:    "pipe",
@@ -54,8 +59,9 @@ func TestHandlerStorage(t *testing.T) {
 			Timeout: 10,
 		}
 
-		err := store.UpdateHandler(handler)
+		err = store.UpdateHandler(handler)
 		assert.NoError(t, err)
+
 		retrieved, err := store.GetHandlerByName("handler1")
 		assert.NoError(t, err)
 		assert.NotNil(t, retrieved)
@@ -65,7 +71,7 @@ func TestHandlerStorage(t *testing.T) {
 		assert.Equal(t, handler.Command, retrieved.Command)
 		assert.Equal(t, handler.Timeout, retrieved.Timeout)
 
-		handlers, err := store.GetHandlers()
+		handlers, err = store.GetHandlers()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, handlers)
 		assert.Equal(t, 1, len(handlers))
@@ -74,13 +80,18 @@ func TestHandlerStorage(t *testing.T) {
 
 func TestMutatorStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
+		// We should receive an empty slice if no results were found
+		mutators, err := store.GetMutators()
+		assert.NoError(t, err)
+		assert.NotNil(t, mutators)
+
 		mutator := &types.Mutator{
 			Name:    "mutator1",
 			Command: "command1",
 			Timeout: 10,
 		}
 
-		err := store.UpdateMutator(mutator)
+		err = store.UpdateMutator(mutator)
 		assert.NoError(t, err)
 		retrieved, err := store.GetMutatorByName("mutator1")
 		assert.NoError(t, err)
@@ -90,7 +101,7 @@ func TestMutatorStorage(t *testing.T) {
 		assert.Equal(t, mutator.Command, retrieved.Command)
 		assert.Equal(t, mutator.Timeout, retrieved.Timeout)
 
-		mutators, err := store.GetMutators()
+		mutators, err = store.GetMutators()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, mutators)
 		assert.Equal(t, 1, len(mutators))
@@ -99,6 +110,11 @@ func TestMutatorStorage(t *testing.T) {
 
 func TestCheckStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
+		// We should receive an empty slice if no results were found
+		checks, err := store.GetChecks()
+		assert.NoError(t, err)
+		assert.NotNil(t, checks)
+
 		check := &types.Check{
 			Name:          "check1",
 			Interval:      60,
@@ -106,7 +122,7 @@ func TestCheckStorage(t *testing.T) {
 			Command:       "command1",
 		}
 
-		err := store.UpdateCheck(check)
+		err = store.UpdateCheck(check)
 		assert.NoError(t, err)
 		retrieved, err := store.GetCheckByName("check1")
 		assert.NoError(t, err)
@@ -117,7 +133,7 @@ func TestCheckStorage(t *testing.T) {
 		assert.Equal(t, check.Subscriptions, retrieved.Subscriptions)
 		assert.Equal(t, check.Command, retrieved.Command)
 
-		checks, err := store.GetChecks()
+		checks, err = store.GetChecks()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, checks)
 		assert.Equal(t, 1, len(checks))
@@ -127,6 +143,11 @@ func TestCheckStorage(t *testing.T) {
 func TestEventStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
 		sysinfo, _ := system.Info()
+
+		// We should receive an empty slice if no results were found
+		events, err := store.GetEvents()
+		assert.NoError(t, err)
+		assert.NotNil(t, events)
 
 		event := &types.Event{
 			Entity: &types.Entity{
@@ -148,7 +169,7 @@ func TestEventStorage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, event, newEv)
 
-		events, err := store.GetEvents()
+		events, err = store.GetEvents()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(events))
 		assert.EqualValues(t, event, events[0])


### PR DESCRIPTION
Fixes https://github.com/sensu/sensu-go/issues/151