### PR TITLE
Address feedback re: entity CLI command

### DIFF
--- a/cli/commands/entity/help.go
+++ b/cli/commands/entity/help.go
@@ -15,7 +15,8 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	// Add sub-commands
 	cmd.AddCommand(
 		ListCommand(cli),
-		InfoCommand(cli),
+		ShowCommand(cli),
+		DeleteCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -50,7 +50,7 @@ func printEntitiesToTable(queryResults []types.Entity, writer io.Writer) {
 
 	table := table.New([]*table.Column{
 		{
-			Title:       "Host",
+			Title:       "ID",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
 				entity, _ := data.(types.Entity)

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -58,8 +58,10 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)
-	assert.Contains(out, "Host")
+	assert.Contains(out, "ID")
 	assert.Contains(out, "OS")
+	assert.Contains(out, "Subscriptions")
+	assert.Contains(out, "Last Seen")
 	assert.Nil(err)
 }
 

--- a/cli/commands/entity/show.go
+++ b/cli/commands/entity/show.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// InfoCommand defines new entity info command
-func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+// ShowCommand defines new entity info command
+func ShowCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "info [ID]",
 		Short:        "show detailed entity information",

--- a/cli/commands/entity/show_test.go
+++ b/cli/commands/entity/show_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInfoCommand(t *testing.T) {
+func TestShowCommand(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := newCLI()
-	cmd := InfoCommand(cli)
+	cmd := ShowCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
@@ -22,14 +22,14 @@ func TestInfoCommand(t *testing.T) {
 	assert.Regexp("entity", cmd.Short)
 }
 
-func TestInfoCommandRunEClosure(t *testing.T) {
+func TestShowCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := newCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(*types.FixtureEntity("name-one"), nil)
 
-	cmd := InfoCommand(cli)
+	cmd := ShowCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"in"})
 
 	assert.NotEmpty(out)
@@ -37,11 +37,11 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestInfoCommandRunMissingArgs(t *testing.T) {
+func TestShowCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := newCLI()
-	cmd := InfoCommand(cli)
+	cmd := ShowCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)
@@ -49,14 +49,14 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestInfoCommandRunEClosureWithTable(t *testing.T) {
+func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := newCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(*types.FixtureEntity("name-one"), nil)
 
-	cmd := InfoCommand(cli)
+	cmd := ShowCommand(cli)
 	cmd.Flags().Set("format", "tabular")
 
 	out, err := test.RunCmd(cmd, []string{"in"})
@@ -67,14 +67,14 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestInfoCommandRunEClosureWithErr(t *testing.T) {
+func TestShowCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := newCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(types.Entity{}, errors.New("my-err"))
 
-	cmd := InfoCommand(cli)
+	cmd := ShowCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"in"})
 
 	assert.NotNil(err)


### PR DESCRIPTION
- changes name of info subcommand to show
- add delete subcommand to parent so that it is accessible
- correctly lists the ID as 'ID' instead of 'Host'

Closes #178 #179 #180