### PR TITLE
Use user preferred format when listing with CLI

### DIFF
--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -20,12 +20,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list assets",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch assets from API
 			r, err := cli.Client.ListAssets()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			if format == "json" {

--- a/cli/commands/asset/list_test.go
+++ b/cli/commands/asset/list_test.go
@@ -28,7 +28,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	cli := newCLI()
 
 	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("tabular")
+	config.On("Format").Return("none")
 
 	client := cli.Client.(*client.MockClient)
 	client.On("ListAssets").Return([]types.Asset{

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -19,12 +19,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list checks",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch checks from the API
 			r, err := cli.Client.ListChecks()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			// Print out events in requested format

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -54,7 +54,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	client.On("ListChecks").Return([]types.CheckConfig{*check}, nil)
 
 	cmd := ListCommand(cli)
-	cmd.Flags().Set("format", "tabular")
+	cmd.Flags().Set("format", "none")
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -144,7 +144,7 @@ func askForDefaultFormat(c config.Config) *survey.Question {
 		Name: "format",
 		Prompt: &survey.Select{
 			Message: "Preferred output format:",
-			Options: []string{"none", "json", "yaml"},
+			Options: []string{"none", "json"},
 			Default: format,
 		},
 	}

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -19,12 +19,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list entities",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch handlers from API
 			r, err := cli.Client.ListEntities()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			if format == "json" {

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -53,7 +53,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	}, nil)
 
 	cmd := ListCommand(cli)
-	cmd.Flags().Set("format", "tabular")
+	cmd.Flags().Set("format", "none")
 
 	out, err := test.RunCmd(cmd, []string{})
 

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -18,12 +18,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list events",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch events from API
 			r, err := cli.Client.ListEvents()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			if format == "json" {

--- a/cli/commands/event/list_test.go
+++ b/cli/commands/event/list_test.go
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	}, nil)
 
 	cmd := ListCommand(cli)
-	cmd.Flags().Set("format", "tabular")
+	cmd.Flags().Set("format", "none")
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -20,12 +20,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list handlers",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch handlers from API
 			r, err := cli.Client.ListHandlers()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			if format == "json" {

--- a/cli/commands/handler/list_test.go
+++ b/cli/commands/handler/list_test.go
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	}, nil)
 
 	cmd := ListCommand(cli)
-	cmd.Flags().Set("format", "tabular")
+	cmd.Flags().Set("format", "none")
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -17,12 +17,16 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list users",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			format, _ := cmd.Flags().GetString("format")
-
 			// Fetch users from API
 			r, err := cli.Client.ListUsers()
 			if err != nil {
 				return err
+			}
+
+			// Determine the format to use to output the data
+			var format string
+			if format, _ = cmd.Flags().GetString("format"); format == "" {
+				format = cli.Config.Format()
 			}
 
 			if format == "json" {


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/234
Closes https://github.com/sensu/sensu-go/issues/209

- The user preferred format is already saved now when running `sensu-cli configure`
- We use the user preferred format by default
- If the user uses the `--format` flag, it has precedence over the configured format
