### PR TITLE
Refactor util.WithTempDir to testutil.TempDir

### DIFF
--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +25,7 @@ func TestExecuteCheck(t *testing.T) {
 	ch := make(chan *transport.Message, 1)
 	agent.sendq = ch
 
-	truePath := util.CommandPath(filepath.Join(toolsDir, "true"))
+	truePath := testutil.CommandPath(filepath.Join(toolsDir, "true"))
 	checkConfig.Command = truePath
 
 	agent.executeCheck(request)
@@ -37,7 +37,7 @@ func TestExecuteCheck(t *testing.T) {
 	assert.NotZero(event.Timestamp)
 	assert.Equal(0, event.Check.Status)
 
-	falsePath := util.CommandPath(filepath.Join(toolsDir, "false"))
+	falsePath := testutil.CommandPath(filepath.Join(toolsDir, "false"))
 	checkConfig.Command = falsePath
 
 	agent.executeCheck(request)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -8,75 +8,76 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/backend/store/etcd"
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHTTPListener(t *testing.T) {
-	util.WithTempDir(func(path string) {
-		ports := make([]int, 4)
-		err := util.RandomPorts(ports)
-		if err != nil {
-			log.Panic(err)
-		}
-		clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
-		apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
-		agentPort := ports[2]
-		apiPort := ports[3]
-		initCluster := fmt.Sprintf("default=%s", apURL)
-		fmt.Println(initCluster)
+	path, remove := testutil.TempDir(t)
+	defer remove()
 
-		b, err := NewBackend(&Config{
-			AgentHost:                   "127.0.0.1",
-			AgentPort:                   agentPort,
-			APIHost:                     "127.0.0.1",
-			APIPort:                     apiPort,
-			DashboardHost:               "127.0.0.1",
-			StateDir:                    path,
-			EtcdListenClientURL:         clURL,
-			EtcdListenPeerURL:           apURL,
-			EtcdInitialCluster:          initCluster,
-			EtcdInitialClusterState:     etcd.ClusterStateNew,
-			EtcdInitialAdvertisePeerURL: apURL,
-		})
-		assert.NoError(t, err)
-		if err != nil {
-			assert.FailNow(t, "failed to start backend")
-		}
+	ports := make([]int, 4)
+	err := testutil.RandomPorts(ports)
+	if err != nil {
+		log.Panic(err)
+	}
+	clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
+	apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
+	agentPort := ports[2]
+	apiPort := ports[3]
+	initCluster := fmt.Sprintf("default=%s", apURL)
+	fmt.Println(initCluster)
 
-		go func() {
-			err = b.Run()
-			assert.NoError(t, err)
-		}()
-
-		for i := 0; i < 5; i++ {
-			conn, derr := net.Dial("tcp", fmt.Sprintf("localhost:%d", agentPort))
-			if derr != nil {
-				fmt.Println("Waiting for backend to start")
-				time.Sleep(time.Duration(i) * time.Second)
-			} else {
-				conn.Close()
-				continue
-			}
-		}
-
-		client, err := transport.Connect(fmt.Sprintf("ws://localhost:%d/", agentPort))
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-
-		msg := &transport.Message{
-			Type:    types.AgentHandshakeType,
-			Payload: []byte("{}"),
-		}
-		err = client.Send(msg)
-		assert.NoError(t, err)
-		resp, err := client.Receive()
-		assert.NoError(t, err)
-		assert.Equal(t, types.BackendHandshakeType, resp.Type)
-
-		assert.NoError(t, client.Close())
-		b.Stop()
+	b, err := NewBackend(&Config{
+		AgentHost:                   "127.0.0.1",
+		AgentPort:                   agentPort,
+		APIHost:                     "127.0.0.1",
+		APIPort:                     apiPort,
+		DashboardHost:               "127.0.0.1",
+		StateDir:                    path,
+		EtcdListenClientURL:         clURL,
+		EtcdListenPeerURL:           apURL,
+		EtcdInitialCluster:          initCluster,
+		EtcdInitialClusterState:     etcd.ClusterStateNew,
+		EtcdInitialAdvertisePeerURL: apURL,
 	})
+	assert.NoError(t, err)
+	if err != nil {
+		assert.FailNow(t, "failed to start backend")
+	}
+
+	go func() {
+		err = b.Run()
+		assert.NoError(t, err)
+	}()
+
+	for i := 0; i < 5; i++ {
+		conn, derr := net.Dial("tcp", fmt.Sprintf("localhost:%d", agentPort))
+		if derr != nil {
+			fmt.Println("Waiting for backend to start")
+			time.Sleep(time.Duration(i) * time.Second)
+		} else {
+			conn.Close()
+			continue
+		}
+	}
+
+	client, err := transport.Connect(fmt.Sprintf("ws://localhost:%d/", agentPort))
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	msg := &transport.Message{
+		Type:    types.AgentHandshakeType,
+		Payload: []byte("{}"),
+	}
+	err = client.Send(msg)
+	assert.NoError(t, err)
+	resp, err := client.Receive()
+	assert.NoError(t, err)
+	assert.Equal(t, types.BackendHandshakeType, resp.Type)
+
+	assert.NoError(t, client.Close())
+	b.Stop()
 }

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -8,73 +8,74 @@ import (
 
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store/etcd"
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSchedulerd(t *testing.T) {
-	util.WithTempDir(func(tmpDir string) {
-		p := make([]int, 2)
-		err := util.RandomPorts(p)
-		if err != nil {
-			assert.FailNow(t, "failed to get ports for testing: ", err.Error())
-		}
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 
-		cfg := etcd.NewConfig()
-		cfg.DataDir = tmpDir
+	p := make([]int, 2)
+	err := testutil.RandomPorts(p)
+	if err != nil {
+		assert.FailNow(t, "failed to get ports for testing: ", err.Error())
+	}
 
-		peerURL := fmt.Sprintf("http://127.0.0.1:%d", p[1])
+	cfg := etcd.NewConfig()
+	cfg.DataDir = tmpDir
 
-		cfg.ListenClientURL = fmt.Sprintf("http://127.0.0.1:%d", p[0])
-		cfg.ListenPeerURL = peerURL
-		cfg.InitialCluster = fmt.Sprintf("default=http://127.0.0.1:%d", p[1])
-		cfg.InitialAdvertisePeerURL = peerURL
-		e, err := etcd.NewEtcd(cfg)
-		assert.NoError(t, err)
-		defer e.Shutdown()
+	peerURL := fmt.Sprintf("http://127.0.0.1:%d", p[1])
 
-		st, err := e.NewStore()
-		bus := &messaging.WizardBus{}
-		assert.NoError(t, bus.Start())
+	cfg.ListenClientURL = fmt.Sprintf("http://127.0.0.1:%d", p[0])
+	cfg.ListenPeerURL = peerURL
+	cfg.InitialCluster = fmt.Sprintf("default=http://127.0.0.1:%d", p[1])
+	cfg.InitialAdvertisePeerURL = peerURL
+	e, err := etcd.NewEtcd(cfg)
+	assert.NoError(t, err)
+	defer e.Shutdown()
 
-		// Mock a default organization
-		st.UpdateOrganization(
-			context.Background(),
-			&types.Organization{
-				Name: "default",
-			})
+	st, err := e.NewStore()
+	bus := &messaging.WizardBus{}
+	assert.NoError(t, bus.Start())
 
-		checker := &Schedulerd{
-			Store:      st,
-			MessageBus: bus,
-		}
-		checker.Start()
+	// Mock a default organization
+	st.UpdateOrganization(
+		context.Background(),
+		&types.Organization{
+			Name: "default",
+		})
 
-		ch := make(chan interface{}, 10)
-		assert.NoError(t, bus.Subscribe("subscription", "channel", ch))
+	checker := &Schedulerd{
+		Store:      st,
+		MessageBus: bus,
+	}
+	checker.Start()
 
-		check := types.FixtureCheckConfig("check_name")
-		ctx := context.WithValue(context.Background(), types.OrganizationKey, check.Organization)
+	ch := make(chan interface{}, 10)
+	assert.NoError(t, bus.Subscribe("subscription", "channel", ch))
 
-		assert.NoError(t, check.Validate())
-		assert.NoError(t, st.UpdateCheckConfig(ctx, check))
+	check := types.FixtureCheckConfig("check_name")
+	ctx := context.WithValue(context.Background(), types.OrganizationKey, check.Organization)
 
-		time.Sleep(1 * time.Second)
+	assert.NoError(t, check.Validate())
+	assert.NoError(t, st.UpdateCheckConfig(ctx, check))
 
-		err = st.DeleteCheckConfigByName(ctx, check.Name)
-		assert.NoError(t, err)
+	time.Sleep(1 * time.Second)
 
-		time.Sleep(1 * time.Second)
+	err = st.DeleteCheckConfigByName(ctx, check.Name)
+	assert.NoError(t, err)
 
-		assert.NoError(t, checker.Stop())
-		assert.NoError(t, bus.Stop())
-		close(ch)
+	time.Sleep(1 * time.Second)
 
-		for msg := range ch {
-			result, ok := msg.(*types.CheckConfig)
-			assert.True(t, ok)
-			assert.EqualValues(t, check, result)
-		}
-	})
+	assert.NoError(t, checker.Stop())
+	assert.NoError(t, bus.Stop())
+	close(ch)
+
+	for msg := range ch {
+		result, ok := msg.(*types.CheckConfig)
+		assert.True(t, ok)
+		assert.EqualValues(t, check, result)
+	}
 }

--- a/backend/store/etcd/etcd_test.go
+++ b/backend/store/etcd/etcd_test.go
@@ -9,67 +9,68 @@ import (
 	"testing"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewEtcd(t *testing.T) {
-	util.WithTempDir(func(tmpDir string) {
-		ports := make([]int, 2)
-		err := util.RandomPorts(ports)
-		if err != nil {
-			log.Panic(err)
-		}
-		clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
-		apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
-		initCluster := fmt.Sprintf("default=%s", apURL)
-		fmt.Println(initCluster)
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 
-		cfg := NewConfig()
-		cfg.DataDir = tmpDir
-		cfg.ListenClientURL = clURL
-		cfg.ListenPeerURL = apURL
-		cfg.InitialCluster = initCluster
-		cfg.InitialClusterState = ClusterStateNew
-		cfg.InitialAdvertisePeerURL = apURL
-		cfg.Name = "default"
+	ports := make([]int, 2)
+	err := testutil.RandomPorts(ports)
+	if err != nil {
+		log.Panic(err)
+	}
+	clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
+	apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
+	initCluster := fmt.Sprintf("default=%s", apURL)
+	fmt.Println(initCluster)
 
-		e, err := NewEtcd(cfg)
-		if e != nil {
-			defer e.Shutdown()
-		}
-		assert.NoError(t, err)
-		if err != nil {
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
-			pprof.Lookup("threadcreate").WriteTo(os.Stdout, 1)
-			pprof.Lookup("heap").WriteTo(os.Stdout, 1)
-			assert.FailNow(t, "unable to start new etcd")
-		}
+	cfg := NewConfig()
+	cfg.DataDir = tmpDir
+	cfg.ListenClientURL = clURL
+	cfg.ListenPeerURL = apURL
+	cfg.InitialCluster = initCluster
+	cfg.InitialClusterState = ClusterStateNew
+	cfg.InitialAdvertisePeerURL = apURL
+	cfg.Name = "default"
 
-		client, err := e.NewClient()
-		assert.NoError(t, err)
-		kv := clientv3.NewKV(client)
-		assert.NotNil(t, kv)
+	e, err := NewEtcd(cfg)
+	if e != nil {
+		defer e.Shutdown()
+	}
+	assert.NoError(t, err)
+	if err != nil {
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		pprof.Lookup("threadcreate").WriteTo(os.Stdout, 1)
+		pprof.Lookup("heap").WriteTo(os.Stdout, 1)
+		assert.FailNow(t, "unable to start new etcd")
+	}
 
-		putsResp, err := kv.Put(context.Background(), "key", "value")
-		assert.NoError(t, err)
-		assert.NotNil(t, putsResp)
+	client, err := e.NewClient()
+	assert.NoError(t, err)
+	kv := clientv3.NewKV(client)
+	assert.NotNil(t, kv)
 
-		if putsResp == nil {
-			assert.FailNow(t, "got nil put response from etcd")
-		}
+	putsResp, err := kv.Put(context.Background(), "key", "value")
+	assert.NoError(t, err)
+	assert.NotNil(t, putsResp)
 
-		getResp, err := kv.Get(context.Background(), "key")
-		assert.NoError(t, err)
-		assert.NotNil(t, getResp)
+	if putsResp == nil {
+		assert.FailNow(t, "got nil put response from etcd")
+	}
 
-		if getResp == nil {
-			assert.FailNow(t, "got nil get response from etcd")
-		}
-		assert.Equal(t, 1, len(getResp.Kvs))
-		assert.Equal(t, "key", string(getResp.Kvs[0].Key))
-		assert.Equal(t, "value", string(getResp.Kvs[0].Value))
+	getResp, err := kv.Get(context.Background(), "key")
+	assert.NoError(t, err)
+	assert.NotNil(t, getResp)
 
-		e.Shutdown()
-	})
+	if getResp == nil {
+		assert.FailNow(t, "got nil get response from etcd")
+	}
+	assert.Equal(t, 1, len(getResp.Kvs))
+	assert.Equal(t, "key", string(getResp.Kvs[0].Key))
+	assert.Equal(t, "value", string(getResp.Kvs[0].Value))
+
+	e.Shutdown()
 }

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -7,48 +7,49 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func testWithEtcd(t *testing.T, f func(store.Store)) {
-	util.WithTempDir(func(tmpDir string) {
-		ports := make([]int, 2)
-		err := util.RandomPorts(ports)
-		if err != nil {
-			log.Panic(err)
-		}
-		clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
-		apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
-		initCluster := fmt.Sprintf("default=%s", apURL)
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 
-		cfg := NewConfig()
-		cfg.DataDir = tmpDir
-		cfg.ListenClientURL = clURL
-		cfg.ListenPeerURL = apURL
-		cfg.InitialCluster = initCluster
-		cfg.InitialClusterState = ClusterStateNew
-		cfg.InitialAdvertisePeerURL = apURL
-		cfg.Name = "default"
+	ports := make([]int, 2)
+	err := testutil.RandomPorts(ports)
+	if err != nil {
+		log.Panic(err)
+	}
+	clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
+	apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
+	initCluster := fmt.Sprintf("default=%s", apURL)
 
-		e, err := NewEtcd(cfg)
-		assert.NoError(t, err)
-		if e != nil {
-			defer e.Shutdown()
-		}
+	cfg := NewConfig()
+	cfg.DataDir = tmpDir
+	cfg.ListenClientURL = clURL
+	cfg.ListenPeerURL = apURL
+	cfg.InitialCluster = initCluster
+	cfg.InitialClusterState = ClusterStateNew
+	cfg.InitialAdvertisePeerURL = apURL
+	cfg.Name = "default"
 
-		s, err := e.NewStore()
-		assert.NoError(t, err)
-		if err != nil {
-			assert.FailNow(t, "failed to get store from etcd")
-		}
+	e, err := NewEtcd(cfg)
+	assert.NoError(t, err)
+	if e != nil {
+		defer e.Shutdown()
+	}
 
-		// Mock a default organization
-		s.UpdateOrganization(context.Background(), &types.Organization{
-			Name: "default",
-		})
+	s, err := e.NewStore()
+	assert.NoError(t, err)
+	if err != nil {
+		assert.FailNow(t, "failed to get store from etcd")
+	}
 
-		f(s)
+	// Mock a default organization
+	s.UpdateOrganization(context.Background(), &types.Organization{
+		Name: "default",
 	})
+
+	f(s)
 }

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +60,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	catExec, catErr := ExecuteCommand(context.Background(), cat)
 	assert.Equal(t, nil, catErr)
-	assert.Equal(t, "bar", util.CleanOutput(catExec.Output))
+	assert.Equal(t, "bar", testutil.CleanOutput(catExec.Output))
 	assert.Equal(t, 0, catExec.Status)
 	assert.NotEqual(t, 0, catExec.Duration)
 
@@ -69,7 +69,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	falseExec, falseErr := ExecuteCommand(context.Background(), falseCmd)
 	assert.Equal(t, nil, falseErr)
-	assert.Equal(t, "", util.CleanOutput(falseExec.Output))
+	assert.Equal(t, "", testutil.CleanOutput(falseExec.Output))
 	assert.Equal(t, 1, falseExec.Status)
 	assert.NotEqual(t, 0, falseExec.Duration)
 
@@ -78,7 +78,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	outputsExec, outputsErr := ExecuteCommand(context.Background(), outputs)
 	assert.Equal(t, nil, outputsErr)
-	assert.Equal(t, "bar\n", util.CleanOutput(outputsExec.Output))
+	assert.Equal(t, "bar\n", testutil.CleanOutput(outputsExec.Output))
 	assert.Equal(t, 0, outputsExec.Status)
 	assert.NotEqual(t, 0, outputsExec.Duration)
 
@@ -88,7 +88,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	sleepExec, sleepErr := ExecuteCommand(context.Background(), sleep)
 	assert.Equal(t, nil, sleepErr)
-	assert.Equal(t, "Execution timed out\n", util.CleanOutput(sleepExec.Output))
+	assert.Equal(t, "Execution timed out\n", testutil.CleanOutput(sleepExec.Output))
 	assert.Equal(t, 2, sleepExec.Status)
 	assert.NotEqual(t, 0, sleepExec.Duration)
 }

--- a/testing/e2e/keepalive_test.go
+++ b/testing/e2e/keepalive_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,7 +21,7 @@ import (
 // I'd love to see this organized better.
 func TestAgentKeepalives(t *testing.T) {
 	ports := make([]int, 5)
-	err := util.RandomPorts(ports)
+	err := testutil.RandomPorts(ports)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestAgentKeepalives(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	falsePath := util.CommandPath(filepath.Join(binDir, "false"))
+	falsePath := testutil.CommandPath(filepath.Join(binDir, "false"))
 	falseAbsPath, err := filepath.Abs(falsePath)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, falseAbsPath)

--- a/testing/e2e/main_test.go
+++ b/testing/e2e/main_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/coreos/etcd/pkg/fileutil"
-	"github.com/sensu/sensu-go/testing/util"
+	"github.com/sensu/sensu-go/testing/testutil"
 )
 
 var binDir string
@@ -17,8 +17,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&binDir, "bin-dir", "../../bin", "directory containing sensu binaries")
 	flag.Parse()
 
-	agentBin := util.CommandPath("sensu-agent")
-	backendBin := util.CommandPath("sensu-backend")
+	agentBin := testutil.CommandPath("sensu-agent")
+	backendBin := testutil.CommandPath("sensu-backend")
 
 	agentPath := filepath.Join(binDir, agentBin)
 	backendPath := filepath.Join(binDir, backendBin)

--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -1,24 +1,26 @@
-package util
+package testutil
 
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"runtime"
 	"strings"
+	"testing"
 )
 
-// WithTempDir runs function f within a temporary directory whose contents
-// will be removed when execution of the function is finished.
-func WithTempDir(f func(string)) {
+// TempDir provides a test with a temporary directory (under os.TempDir())
+// returning the absolute path to the directory and a remove() function
+// that should be deferred immediately after calling TempDir(t) to recursively
+// delete the contents of the directory.
+func TempDir(t *testing.T) (tmpDir string, remove func()) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "sensu")
-	defer os.RemoveAll(tmpDir)
 	if err != nil {
-		log.Panic(err)
+		t.FailNow()
 	}
-	f(tmpDir)
+
+	return tmpDir, func() { os.RemoveAll(tmpDir) }
 }
 
 // RandomPorts generates len(p) random ports and assigns them to elements of p.


### PR DESCRIPTION
This changes the interface to the temp directory helper to accept the *testing.T from the calling test and return the path to the temporary directory as well as a function to remove the directory. This feels less magical than passing in the closure including the test. It should also make stack traces easier. We also now call t.FailNow() from within the helper instead of just panicking which led to slightly more annoying stack traces.