### PR TITLE
Add command to individually set format

### DIFF
--- a/cli/commands/config/help.go
+++ b/cli/commands/config/help.go
@@ -15,6 +15,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	// Add sub-commands
 	cmd.AddCommand(
 		SetEnvCommand(cli),
+		SetFormatCommand(cli),
 		SetOrgCommand(cli),
 	)
 

--- a/cli/commands/config/set_format.go
+++ b/cli/commands/config/set_format.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/hooks"
+	"github.com/spf13/cobra"
+)
+
+// SetFormatCommand given argument changes format for active profile
+func SetFormatCommand(cli *cli.SensuCli) *cobra.Command {
+	return &cobra.Command{
+		Use:          "set-format [ENVIRONMENT]",
+		Short:        "Set format for active profile",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if argsLen := len(args); argsLen == 0 {
+				return errors.New("please provide the name of the format as an argument")
+			} else if argsLen > 1 {
+				return errors.New("too many arguments provided")
+			}
+
+			newFormat := args[0]
+			if err := cli.Config.SaveFormat(newFormat); err != nil {
+				fmt.Fprintf(
+					cmd.OutOrStderr(),
+					"Unable to write new configuration file with error: %s\n",
+					err,
+				)
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+		Annotations: map[string]string{
+			// We want to be able to run this command regardless of whether the CLI
+			// has been configured.
+			hooks.ConfigurationRequirement: hooks.ConfigurationNotRequired,
+		},
+	}
+}

--- a/cli/commands/config/set_format_test.go
+++ b/cli/commands/config/set_format_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/cli"
+	clienttest "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetFormatCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := &cli.SensuCli{}
+	cmd := SetFormatCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("set-format", cmd.Use)
+	assert.Regexp("Set format", cmd.Short)
+}
+
+func TestSetFormatBadsArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := &cli.SensuCli{}
+	cmd := SetFormatCommand(cli)
+
+	// No args...
+	out, err := test.RunCmd(cmd, []string{})
+	assert.Empty(out, "output should be empty")
+	assert.NotNil(err, "error should be returned")
+
+	// Too many args...
+	out, err = test.RunCmd(cmd, []string{"one", "two"})
+	assert.Empty(out, "output should be empty")
+	assert.NotNil(err, "error should be returned")
+}
+
+func TestSetFormatExec(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := SetFormatCommand(cli)
+
+	config := cli.Config.(*clienttest.MockConfig)
+	config.On("SaveFormat", "json").Return(nil)
+
+	out, err := test.RunCmd(cmd, []string{"json"})
+	assert.Equal(out, "OK\n")
+	assert.Nil(err, "Should not produce any errors")
+}
+
+func TestSetFormatWithWriteErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := SetFormatCommand(cli)
+
+	config := cli.Config.(*clienttest.MockConfig)
+	config.On("SaveFormat", "json").Return(errors.New("blah"))
+
+	out, err := test.RunCmd(cmd, []string{"json"})
+	assert.Contains(out, "Unable to write")
+	assert.Nil(err, "Should not return an error")
+}


### PR DESCRIPTION
## What is this change?

While working on documentation, I realized a convenience method like this would make it easier for users. (Not to mention easier to document.)

Related sensu/sensu-go#293

## Why is this change necessary?

UX

## Do you need clarification on anything?

...

## Were there any complications while making this change?

nope!