### PR TITLE
CLI: Add, remove & list rules

### DIFF
--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -84,7 +84,9 @@ type UserAPIClient interface {
 type RoleAPIClient interface {
 	CreateRole(*types.Role) error
 	DeleteRole(string) error
+	FetchRole(string) (*types.Role, error)
 	ListRoles() ([]types.Role, error)
+
 	AddRule(role string, rule *types.Rule) error
 	RemoveRule(role string, ruleType string) error
 }

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -44,6 +44,23 @@ func (client *RestClient) DeleteRole(name string) error {
 	return nil
 }
 
+// FetchRole fetches role from configured Sensu instance
+func (client *RestClient) FetchRole(name string) (*types.Role, error) {
+	var role *types.Role
+
+	res, err := client.R().Get("/rbac/roles/" + name)
+	if err != nil {
+		return role, err
+	}
+
+	if res.StatusCode() >= 400 {
+		return role, fmt.Errorf("%v", res.String())
+	}
+
+	err = json.Unmarshal(res.Body(), &role)
+	return role, err
+}
+
 // ListRoles fetches all roles from configured Sensu instance
 func (client *RestClient) ListRoles() ([]types.Role, error) {
 	var roles []types.Role
@@ -68,7 +85,7 @@ func (client *RestClient) AddRule(roleName string, rule *types.Rule) error {
 		return err
 	}
 
-	key := "/rbac/roles/" + roleName + "/type/" + rule.Type
+	key := "/rbac/roles/" + roleName + "/rules/" + rule.Type
 	res, err := client.R().SetBody(bytes).Put(key)
 
 	if err != nil {
@@ -84,8 +101,8 @@ func (client *RestClient) AddRule(roleName string, rule *types.Rule) error {
 
 // RemoveRule removes rule from existing role for configured Sensu instance
 func (client *RestClient) RemoveRule(name string, t string) error {
-	key := "/rbac/roles/" + name + "/types/" + t
-	res, err := client.R().Delete(key)
+	path := "/rbac/roles/" + name + "/rules/" + t
+	res, err := client.R().Delete(path)
 
 	if err != nil {
 		return err

--- a/cli/client/testing/mock_role_client.go
+++ b/cli/client/testing/mock_role_client.go
@@ -8,6 +8,12 @@ func (c *MockClient) CreateRole(check *types.Role) error {
 	return args.Error(0)
 }
 
+// FetchRole for use with mock lib
+func (c *MockClient) FetchRole(name string) (*types.Role, error) {
+	args := c.Called(name)
+	return args.Get(0).(*types.Role), args.Error(1)
+}
+
 // DeleteRole for use with mock lib
 func (c *MockClient) DeleteRole(name string) error {
 	args := c.Called(name)

--- a/cli/commands/role/add_rule.go
+++ b/cli/commands/role/add_rule.go
@@ -80,11 +80,14 @@ func (opts *ruleOpts) withFlags(flags *pflag.FlagSet) {
 
 	if create, _ := flags.GetBool("create"); create {
 		opts.Permissions = append(opts.Permissions, "create")
-	} else if read, _ := flags.GetBool("read"); read {
+	}
+	if read, _ := flags.GetBool("read"); read {
 		opts.Permissions = append(opts.Permissions, "read")
-	} else if update, _ := flags.GetBool("update"); update {
+	}
+	if update, _ := flags.GetBool("update"); update {
 		opts.Permissions = append(opts.Permissions, "update")
-	} else if delete, _ := flags.GetBool("delete"); delete {
+	}
+	if delete, _ := flags.GetBool("delete"); delete {
 		opts.Permissions = append(opts.Permissions, "delete")
 	}
 }

--- a/cli/commands/role/help.go
+++ b/cli/commands/role/help.go
@@ -17,6 +17,9 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		CreateCommand(cli),
 		DeleteCommand(cli),
 		ListCommand(cli),
+		AddRuleCommand(cli),
+		ListRulesCommand(cli),
+		RemoveRuleCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/role/list_rules_test.go
+++ b/cli/commands/role/list_rules_test.go
@@ -1,0 +1,87 @@
+package role
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListRulesCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("json")
+
+	cmd := ListRulesCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list-rules", cmd.Use)
+	assert.Regexp("list rules", cmd.Short)
+}
+
+func TestListRulesCommandRunEWithError(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchRole", "abc").Return(
+		types.FixtureRole("abc", "default", "default"),
+		errors.New("sadfa"),
+	)
+
+	cmd := ListRulesCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"abc"})
+
+	assert.Empty(out)
+	assert.Error(err)
+}
+
+func TestListRulesCommandRunEClosure(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchRole", "abc").Return(
+		types.FixtureRole("abc", "default", "default"),
+		nil,
+	)
+
+	cmd := ListRulesCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"abc"})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "Type")
+	assert.Contains(out, "Org")
+	assert.Contains(out, "Env")
+	assert.Contains(out, "Permissions")
+	assert.Nil(err)
+}
+
+func TestListRulesCommandRunEJSON(t *testing.T) {
+	assert := assert.New(t)
+	cli := newCLI()
+
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchRole", "abc").Return(
+		types.FixtureRole("abc", "default", "default"),
+		nil,
+	)
+
+	cmd := ListRulesCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"abc"})
+
+	assert.NotEmpty(out)
+	assert.NoError(err)
+}


### PR DESCRIPTION
## What is this change?

Allow users to add, remove and list rules associated w/ a role. Add & remove commands had been written previously, however, had not been hooked up or manually tested. 🤦‍♂️ 

## Why is this change necessary?

Without this you can't really do anything with RBAC.

## Do you need clarification on anything?

n/a

## Were there any complications while making this change?

n/a