### PR TITLE
Do not retrieve roles based on prefix

### DIFF
--- a/backend/store/etcd/rbac_store.go
+++ b/backend/store/etcd/rbac_store.go
@@ -39,7 +39,7 @@ func (s *etcdStore) GetRoleByName(name string) (*types.Role, error) {
 	resp, err := s.kvc.Get(
 		context.TODO(),
 		getRolePath(name),
-		clientv3.WithPrefix(),
+		clientv3.WithLimit(1),
 	)
 
 	if err != nil {


### PR DESCRIPTION
## What is this change?

Example:

```sh
sensuctl role list-rules admin # produced the same results as
sensuctl role list-rules admi  # this,
sensuctl role list-rules a     # and this.
```

## Why is this change necessary?

Could lead to subtle bugs, frustration, confusion,...

## Do you need clarification on anything?

n/a

## Were there any complications while making this change?

n/a