### PR TITLE
Return and handle error in PrintJSON

### DIFF
--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -39,7 +39,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printAssetsToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/asset/show.go
+++ b/cli/commands/asset/show.go
@@ -33,7 +33,9 @@ func ShowCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printAssetToList(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -39,7 +39,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 
 			// Print out events in requested format
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printCheckConfigsToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/check/show.go
+++ b/cli/commands/check/show.go
@@ -34,7 +34,9 @@ func ShowCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printCheckToList(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -38,7 +38,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printEntitiesToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/entity/show.go
+++ b/cli/commands/entity/show.go
@@ -35,7 +35,9 @@ func ShowCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printEntityToList(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/environment/list.go
+++ b/cli/commands/environment/list.go
@@ -32,7 +32,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printEnvironmentsToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -37,7 +37,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printEventsToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -39,7 +39,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printHandlersToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -9,7 +9,11 @@ import (
 // PrintJSON takes a record(s) and an io.Writer, converts the record to human-
 // readable JSON (prrtty-prints), and then prints the result to the given
 // writer.
-func PrintJSON(r interface{}, io io.Writer) {
-	result, _ := json.MarshalIndent(r, "", "  ")
+func PrintJSON(r interface{}, io io.Writer) error {
+	result, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
 	fmt.Fprintf(io, "%s\n", result)
+	return nil
 }

--- a/cli/commands/organization/list.go
+++ b/cli/commands/organization/list.go
@@ -30,7 +30,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printOrganizationsToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -30,7 +30,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printRolesToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/role/list_rules.go
+++ b/cli/commands/role/list_rules.go
@@ -36,7 +36,9 @@ func ListRulesCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printRulesToTable(r, cmd.OutOrStdout())
 			}

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -32,7 +32,9 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if format == "json" {
-				helpers.PrintJSON(r, cmd.OutOrStdout())
+				if err := helpers.PrintJSON(r, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			} else {
 				printUsersToTable(r, cmd.OutOrStdout())
 			}


### PR DESCRIPTION
## What is this change?

PrintJSON was ignoring marshaling errors. While it's not likely we end up with them, this would yield blank output from sensuctl commands if, for example, reflect barfed for some reason. So, let's just avoid that.