### PR TITLE
Remove iteration from go code

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -58,7 +58,7 @@ func newVersionCommand() *cobra.Command {
 		Short: "Show the sensu-agent version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("sensu-agent version %s, build %s, built %s\n",
-				version.WithIteration(),
+				version.Version,
 				version.BuildSHA,
 				version.BuildDate,
 			)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -55,7 +55,7 @@ func newVersionCommand() *cobra.Command {
 		Short: "Show the sensu-backend version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("sensu-backend version %s, build %s, built %s\n",
-				version.WithIteration(),
+				version.Version,
 				version.BuildSHA,
 				version.BuildDate,
 			)

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -63,7 +63,7 @@ func newVersionCommand() *cobra.Command {
 		Short: "Show the sensu-ctl version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("sensu-ctl version %s, build %s, built %s\n",
-				version.WithIteration(),
+				version.Version,
 				version.BuildSHA,
 				version.BuildDate,
 			)

--- a/version/version.go
+++ b/version/version.go
@@ -1,13 +1,8 @@
 package version
 
-import "fmt"
-
 var (
 	// Version stores the version of the current build (e.g. 2.0.0)
 	Version string
-
-	// Iteration stores the iteration of the current iteration (e.g. 1)
-	Iteration string
 
 	// BuildDate stores the timestamp of the build (e.g. 2017-07-31T13:11:15-0700)
 	BuildDate string
@@ -15,11 +10,3 @@ var (
 	// BuildSHA stores the git sha of the build (e.g. 8673bed0a9705083987b9ecbbc1cc0758df13dd2)
 	BuildSHA string
 )
-
-// WithIteration returns the version with iteration as a string
-func WithIteration() string {
-	return fmt.Sprintf("%s-%s",
-		Version,
-		Iteration,
-	)
-}


### PR DESCRIPTION
## What is this change?

Removes the concept of build iterations from Sensu's scope.


## Why is this change necessary?

Build iterations are meant for package-specific changes. (e.g. deb packaging hooks changed, bump iteration for deb packages but _not_ for rpm packages).