### PR TITLE
Allow optional static linking of binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,6 +74,7 @@ build_binary () {
 	local goarch=$2
 	local cmd=$3
 	local cmd_name=$4
+	local static=$5
 
 	local outfile="target/${goos}-${goarch}/${cmd_name}"
 
@@ -87,6 +88,9 @@ build_binary () {
 	local ldflags+=" -X $version_pkg.PreReleaseIdentifier=${prerelease}"
 	local ldflags+=" -X $version_pkg.BuildDate=${build_date}"
 	local ldflags+=" -X $version_pkg.BuildSHA=${build_sha}"
+	if [ "$static" == "static" ]; then
+		localldflags+=" -extldflags \"-static\""
+	fi
 
 	GOOS=$goos GOARCH=$goarch go build -ldflags "${ldflags}" -i -o $outfile ${REPO_PATH}/${cmd}/cmd/...
 
@@ -190,7 +194,7 @@ docker_commands () {
 	for cmd in agent backend cli; do
 		echo "Building $cmd for linux-amd64"
 		local cmd_name=$(cmd_name_map $cmd)
-		build_binary linux amd64 $cmd $cmd_name
+		build_binary linux amd64 $cmd $cmd_name static
 	done
 	docker build --label build.sha=${build_sha} -t sensuapp/sensu-go .
 }


### PR DESCRIPTION
## What is this change?

For Docker builds, we want to statically link binaries to avoid linking
issues in Alpine Linux. Statically linked binaries aren't necessary on
Linux (most systems will have libc), and they aren't possible on Darwin.
Allowing us to optionally compile statically means we can easily support
Docker and possibly other platforms where statically linked binaries are
required--potentially rolling it out to all Linux builds in the future.

## Why is this change necessary?

Without it, our Docker images do not work.

## Were there any complications while making this change?

I didn't realize that you couldn't statically link binaries in OS X. So it took me a while to figure that out.