### PR TITLE
Remove time.sleep to avoid context switching

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/backend/messaging"
@@ -195,11 +194,6 @@ func (s *Session) subPump() {
 			s.sendq <- msg
 		case <-s.stopping:
 			return
-		default:
-			if s.conn.Closed() {
-				return
-			}
-			time.Sleep(1 * time.Millisecond)
 		}
 	}
 }
@@ -225,11 +219,6 @@ func (s *Session) sendPump() {
 			}
 		case <-s.stopping:
 			return
-		default:
-			if s.conn.Closed() {
-				return
-			}
-			time.Sleep(1 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
## What is this change?

Removes sleeps from IO goroutines.

## Why is this change necessary?

We were context switching once a millisecond instead of blocking
on IO and channel selects. Remove the defaults in the case
statements where this was happening and allow goroutines to be
parked indefinitely (allowing sensu agent and backend to have
their threads likewise parked by the kernel). This is like a
100x decrease (with linear multiplier) in context switching
per agent on the backend and a 100x decrease in context switching
in the agent.
