### PR TITLE
Separate prerelease versions with ~

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ URL="https://sensuapp.org"
 BIN_SOURCE_DIR=target/$(GOOS)-$(GOARCH)
 
 FPM_FLAGS = \
-	--version $(VERSION)-$(PRERELEASE) \
+	--version $(VERSION)~$(subst .,,$(PRERELEASE)) \
 	--iteration $(ITERATION) \
 	--url $(URL) \
 	--license $(LICENSE) \


### PR DESCRIPTION
Fixes #393.

Tested upgrade paths from alpha -> beta -> rc -> stable on:

* [x] CentOS 7
* [x] RHEL 7
* [x] Fedora 26
* [x] OpenSUSE 42.3
* [x] Ubuntu 16.04