### PR TITLE
Fix NPE in transport client Connect()

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -30,9 +30,11 @@ func Connect(wsServerURL string, tlsOpts *types.TLSOptions, requestHeader http.H
 
 	conn, resp, err := dialer.Dial(u.String(), requestHeader)
 	if err != nil {
-		fmt.Printf("Error is %s %s", err, resp.StatusCode)
-		if err == websocket.ErrBadHandshake {
-			return nil, fmt.Errorf("handshake failed with status %d", resp.StatusCode)
+		if resp != nil {
+			if err == websocket.ErrBadHandshake {
+				return nil, fmt.Errorf("handshake failed with status %d", resp.StatusCode)
+			}
+			return nil, fmt.Errorf("connection failed with status %d", resp.StatusCode)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
## What is this change?

When the agent cannot connect to the backend, if it doesn't receive a response it would cause a panic.

## Why is this change necessary?

This let's the agent continue to run if the backend crashes/goes away.
