### PR TITLE
Prevent race condition in agent's HTTP API server

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -404,10 +404,11 @@ func (a *Agent) Run() error {
 
 	// Prepare the HTTP API server
 	a.api = newServer(a)
-	logger.Info("starting api on address: ", a.api.Addr)
 
 	// Start the HTTP API server
 	go func() {
+		logger.Info("starting api on address: ", a.api.Addr)
+
 		if err := a.api.ListenAndServe(); err != http.ErrServerClosed {
 			logger.Fatal(err)
 		}


### PR DESCRIPTION
## What is this change?
Prevent a race condition detected by the Go race detector

## Why is this change necessary?

See https://travis-ci.com/sensu/sensu-go/builds/55910752#L508


## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!