### PR TITLE
Check flap detection

### DIFF
--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -151,12 +151,8 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 	// Calculate percent state change for this check's history
 	event.Check.TotalStateChange = totalStateChange(event)
 
-	// Determine if the check is flapping
-	if flapping := isFlapping(event); flapping {
-		event.Check.Action = types.EventFlappingAction
-	} else {
-		event.Check.Action = types.EventCreateAction
-	}
+	// Determine the check's state
+	state(event)
 
 	err = e.Store.UpdateEvent(ctx, event)
 	if err != nil {

--- a/backend/eventd/flapping_test.go
+++ b/backend/eventd/flapping_test.go
@@ -64,11 +64,11 @@ func TestIsFlapping(t *testing.T) {
 			"check is still flapping",
 			&types.Event{
 				Check: &types.Check{
-					Action: types.EventFlappingAction,
 					Config: &types.CheckConfig{
 						LowFlapThreshold:  10,
 						HighFlapThreshold: 30,
 					},
+					State:            types.EventFlappingState,
 					TotalStateChange: 15,
 				},
 			},
@@ -78,11 +78,11 @@ func TestIsFlapping(t *testing.T) {
 			"check is no longer flapping",
 			&types.Event{
 				Check: &types.Check{
-					Action: types.EventFlappingAction,
 					Config: &types.CheckConfig{
 						LowFlapThreshold:  10,
 						HighFlapThreshold: 30,
 					},
+					State:            types.EventFlappingState,
 					TotalStateChange: 5,
 				},
 			},
@@ -92,11 +92,11 @@ func TestIsFlapping(t *testing.T) {
 			"check is now flapping",
 			&types.Event{
 				Check: &types.Check{
-					Action: types.EventCreateAction,
 					Config: &types.CheckConfig{
 						LowFlapThreshold:  10,
 						HighFlapThreshold: 30,
 					},
+					State:            types.EventFailingState,
 					TotalStateChange: 35,
 				},
 			},
@@ -106,7 +106,7 @@ func TestIsFlapping(t *testing.T) {
 			"check is not flapping",
 			&types.Event{
 				Check: &types.Check{
-					Action: types.EventCreateAction,
+					State: types.EventPassingState,
 					Config: &types.CheckConfig{
 						LowFlapThreshold:  10,
 						HighFlapThreshold: 30,

--- a/types/check.go
+++ b/types/check.go
@@ -22,9 +22,6 @@ type CheckRequest struct {
 // A Check is a check specification and optionally the results of the check's
 // execution.
 type Check struct {
-	// Action provides handlers with more information about the state change
-	Action string `json:"action,omitempty"`
-
 	// Config is the specification of a check.
 	Config *CheckConfig `json:"config,omitempty"`
 
@@ -42,6 +39,9 @@ type Check struct {
 
 	// Output from the execution of Command.
 	Output string `json:"output,omitempty"`
+
+	// State provides handlers with more information about the state change
+	State string `json:"state,omitempty"`
 
 	// Status is the exit status code produced by the check.
 	Status int `json:"status,omitempty"`

--- a/types/event.go
+++ b/types/event.go
@@ -6,16 +6,14 @@ import "time"
 // event without a Check or Metrics section.
 const KeepaliveType = "keepalive"
 
-// EventCreateAction indicates a check result status change from zero to
-// non-zero
-const EventCreateAction = "create"
+// EventFailingState indicates failing check result status
+const EventFailingState = "failing"
 
-// EventFlappingAction indicates a rapid change in check result status
-const EventFlappingAction = "flapping"
+// EventFlappingState indicates a rapid change in check result status
+const EventFlappingState = "flapping"
 
-// EventResolveAction indicates a check result status change from a non-zero to
-// zero
-const EventResolveAction = "resolve"
+// EventPassingState indicates successful check result status
+const EventPassingState = "passing"
 
 // EventType is the message type string for events.
 const EventType = "event"


### PR DESCRIPTION
## What is this change?

It adds check flap detection to sensu-go

Closes https://github.com/sensu/sensu-go/issues/382

## Why is this change necessary?

Sensu 1.x feature parity.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

I got confused by the example given at https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/flapping.html. Basically, the non-weighted state change percentage is 35%, and then, for the purpose of their example, they assume the weighted state change would be 31%. However, the real weighted percentage is 34%, which I confirmed by running the Sensu 1.x code and the Nagios C++ code...

![](http://68.media.tumblr.com/283f674ce42a0498521d8b9b505e2067/tumblr_inline_o3a9e7ooZE1raprkq_400.gif)