### PR TITLE
Move transport message types out of types package into transport

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -243,7 +243,7 @@ func (a *Agent) handleTCPMessages(c net.Conn) {
 			return
 		}
 
-		a.sendMessage(types.EventType, payload)
+		a.sendMessage(transport.EventMessageType, payload)
 		c.Write([]byte("ok"))
 		return
 	}
@@ -304,7 +304,7 @@ func (a *Agent) handleUDPMessages(c net.PacketConn) {
 			if err != nil {
 				return
 			}
-			a.sendMessage(types.EventType, payload)
+			a.sendMessage(transport.EventMessageType, payload)
 		}
 
 	}
@@ -405,7 +405,7 @@ func (a *Agent) sendPump(wg *sync.WaitGroup, conn transport.Transport) {
 func (a *Agent) sendKeepalive() error {
 	logger.Info("sending keepalive")
 	msg := &transport.Message{
-		Type: types.KeepaliveType,
+		Type: transport.KeepaliveMessageType,
 	}
 	keepalive := &types.Event{}
 	keepalive.Entity = a.getAgentEntity()

--- a/agent/api.go
+++ b/agent/api.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -67,7 +68,7 @@ func addEvent(a *Agent) http.HandlerFunc {
 			return
 		}
 
-		a.sendMessage(types.EventType, msg)
+		a.sendMessage(transport.EventMessageType, msg)
 
 		w.WriteHeader(http.StatusCreated)
 		return

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/command"
+	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -79,7 +80,7 @@ func (a *Agent) executeCheck(request *types.CheckRequest) {
 		return
 	}
 
-	a.sendMessage(types.EventType, msg)
+	a.sendMessage(transport.EventMessageType, msg)
 }
 
 func (a *Agent) sendFailure(event *types.Event, err error) {
@@ -90,6 +91,6 @@ func (a *Agent) sendFailure(event *types.Event, err error) {
 	if msg, err := json.Marshal(event); err != nil {
 		logger.Error("error marshaling check failure: ", err.Error())
 	} else {
-		a.sendMessage(types.EventType, msg)
+		a.sendMessage(transport.EventMessageType, msg)
 	}
 }

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -36,8 +36,8 @@ type Session struct {
 
 func newSessionHandler(s *Session) *handler.MessageHandler {
 	handler := handler.NewMessageHandler()
-	handler.AddHandler(types.KeepaliveType, s.handleKeepalive)
-	handler.AddHandler(types.EventType, s.handleEvent)
+	handler.AddHandler(transport.KeepaliveMessageType, s.handleKeepalive)
+	handler.AddHandler(transport.EventMessageType, s.handleEvent)
 
 	return handler
 }

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -158,7 +158,7 @@ func TestNoHandshake(t *testing.T) {
 	assert.NotNil(t, session)
 
 	conn.Send(&transport.Message{
-		Type:    types.EventType,
+		Type:    transport.EventMessageType,
 		Payload: []byte("..."),
 	})
 	assert.Error(t, session.Start())

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -13,6 +13,13 @@ var (
 	sep = []byte("\n")
 )
 
+// KeepaliveMessageType is the message type sent for keepalives--which are just an
+// event without a Check or Metrics section.
+const KeepaliveMessageType = "keepalive"
+
+// EventMessageType is the message type string for events.
+const EventMessageType = "event"
+
 // A ClosedError is returned when Receive or Send is called on a closed
 // Transport.
 type ClosedError struct {

--- a/types/event.go
+++ b/types/event.go
@@ -2,10 +2,6 @@ package types
 
 import "time"
 
-// KeepaliveType is the message type sent for keepalives--which are just an
-// event without a Check or Metrics section.
-const KeepaliveType = "keepalive"
-
 // EventFailingState indicates failing check result status
 const EventFailingState = "failing"
 
@@ -14,9 +10,6 @@ const EventFlappingState = "flapping"
 
 // EventPassingState indicates successful check result status
 const EventPassingState = "passing"
-
-// EventType is the message type string for events.
-const EventType = "event"
 
 // An Event is the encapsulating type sent across the Sensu websocket transport.
 type Event struct {


### PR DESCRIPTION
## What is this change?

I've moved the transport even types out of the types package into the transport package.

## Why is this change necessary?

Living in the types package really doesn't make any sense, and I want to confine the transport code to that package as much a possible (so that, some day, we can more easily kill it with fire). It also just makes more logical sense for it to be there.