### PR TITLE
Better error message when creating user with missing roles

### DIFF
--- a/backend/apid/controllers/users.go
+++ b/backend/apid/controllers/users.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/authorization"
@@ -324,11 +325,26 @@ func validateRoles(store store.RBACStore, givenRoles []string) error {
 		return err
 	}
 
+	missingRoles := []string{}
+
 	for _, givenRole := range givenRoles {
-		logger.Info(givenRole)
 		if present := hasRole(storedRoles, givenRole); !present {
-			return fmt.Errorf("given role '%s' is not valid", givenRole)
+			missingRoles = append(missingRoles, givenRole)
 		}
+	}
+
+	if len(missingRoles) != 0 {
+		message := "not exist and should be created first"
+		if len(missingRoles) == 1 {
+			message = fmt.Sprintf("given role '%s' does %s", missingRoles[0], message)
+		} else {
+			message = fmt.Sprintf(
+				"given roles '%s' do %s",
+				strings.Join(missingRoles, ", "),
+				message,
+			)
+		}
+		return fmt.Errorf(message)
 	}
 
 	return nil

--- a/backend/apid/controllers/users_test.go
+++ b/backend/apid/controllers/users_test.go
@@ -397,7 +397,15 @@ func TestValidateRolesError(t *testing.T) {
 		{Name: "roleOne"},
 	}
 
+	// Single role missing
 	store.On("GetRoles").Return(storedRoles, nil)
+	err := validateRoles(store, roles)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "given role")
 
-	assert.Error(t, validateRoles(store, roles))
+	// Multiple roles missing
+	roles = append(roles, "roleThree")
+	err = validateRoles(store, roles)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "given roles")
 }


### PR DESCRIPTION
## What is this change?

Improves the quality of produced error message when creating a user with one or multiple missing role(s).

```
 $ sensuctl user create foo
[...]
? Roles: missing1
Error: role 'missing' does not exist, create it first by running: sensuctl role create <rolename>
```

```
$ sensuctl user create foo
[...]
? Roles: admin,missing1,missing2
Error: roles 'missing1, missing2' do not exist, create them first by running: sensuctl role create <rolename>
```

Closes https://github.com/sensu/sensu-go/issues/375

## Why is this change necessary?

Alpha users feedback.

## Do you need clarification on anything?

I just need to make sure the error messages are proper English!