### PR TITLE
Fix TravisCI build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 stages:
   - name: test
   - name: deploy
-    if: branch = bugfix/travis-build-stages OR tag IS present
+    if: branch = master OR tag IS present
 cache:
   yarn: true
   directories:
@@ -16,9 +16,8 @@ install:
   - "npm install --global yarn"
   - "./build.sh deps"
   - "./build.sh build_tools"
-# script: "./build.sh ci $TEST_SUITE"
-# after_script: "./build.sh coverage $TEST_SUITE"
-script: "echo 0"
+script: "./build.sh ci $TEST_SUITE"
+after_script: "./build.sh coverage $TEST_SUITE"
 jobs:
   include:
     - stage: deploy
@@ -29,7 +28,7 @@ jobs:
           skip_cleanup: true
           script: "./build.sh docker push"
           on:
-            all_branches: true
+            branch: master
         - provider: script
           script: "./build-gcs-release.sh"
           on:

--- a/build.sh
+++ b/build.sh
@@ -198,13 +198,12 @@ docker_commands () {
 		build_binary linux amd64 $cmd $cmd_name static
   done
 
-	docker build --label build.sha=${build_sha} -t sensuapp/sensu-go:testing .
+	docker build --label build.sha=${build_sha} -t sensuapp/sensu-go .
 
 	if [ "$push" == "push" ]; then
-		echo $DOCKER_USERNAME
 		docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-		# docker tag sensuapp/sensu-go:latest sensuapp/sensu-go:master
-		docker push sensuapp/sensu-go:testing
+		docker tag sensuapp/sensu-go:latest sensuapp/sensu-go:master
+		docker push sensuapp/sensu-go:master
 	fi
 }
 


### PR DESCRIPTION
## What is this change?

It fixes the TravisCI build stage so we can automatically build and push Docker images from the master branch.

## Why is this change necessary?

Because it's broken.

## Were there any complications while making this change?

TIL the deployment script line in TravisCI can only contain a single command.

> If you need to run multiple commands, write a executable wrapper script that runs them all.

https://docs.travis-ci.com/user/deployment/script