### PR TITLE
Fix GET /assets

### DIFF
--- a/backend/store/etcd/asset_store.go
+++ b/backend/store/etcd/asset_store.go
@@ -23,7 +23,9 @@ func getAssetPath(asset *types.Asset) string {
 }
 
 func getAssetsPath(ctx context.Context, name string) string {
-	return assetKeyBuilder.withContext(ctx).build(name)
+	org := organization(ctx)
+
+	return assetKeyBuilder.withOrg(org).build(name)
 }
 
 // TODO Cleanup associated checks?


### PR DESCRIPTION
## What is this change?

Fixed `getAssetsPath()`, allowing API GET /assets to retrieve and provide created assets. Context Environment was being included in assets path, which is incorrect.


## Why is this change necessary?

GET /assets and in turn `sensuctl asset list` are broken.


## Do you need clarification on anything?

Don't think so.


## Were there any complications while making this change?

Nope.