### PR TITLE
Don't proceed if interactive survey returns an error

### DIFF
--- a/cli/commands/asset/create.go
+++ b/cli/commands/asset/create.go
@@ -95,7 +95,9 @@ func (cfgPtr *ConfigureAsset) Configure() (*types.Asset, []error) {
 
 	if isInteractive {
 		cfgPtr.setOrg()
-		cfgPtr.administerQuestionaire()
+		if err := cfgPtr.administerQuestionnaire(); err != nil {
+			cfgPtr.addError(err)
+		}
 	} else {
 		cfgPtr.configureFromFlags()
 	}
@@ -106,7 +108,7 @@ func (cfgPtr *ConfigureAsset) Configure() (*types.Asset, []error) {
 	return &asset, cfgPtr.errors
 }
 
-func (cfgPtr *ConfigureAsset) administerQuestionaire() {
+func (cfgPtr *ConfigureAsset) administerQuestionnaire() error {
 	var qs = []*survey.Question{
 		{
 			Name: "name",
@@ -117,8 +119,11 @@ func (cfgPtr *ConfigureAsset) administerQuestionaire() {
 			Validate: survey.Required,
 		},
 		{
-			Name:     "org",
-			Prompt:   &survey.Input{"Org:", cfgPtr.Org},
+			Name: "org",
+			Prompt: &survey.Input{
+				Message: "Org:",
+				Default: cfgPtr.Org,
+			},
 			Validate: survey.Required,
 		},
 		{
@@ -137,7 +142,7 @@ func (cfgPtr *ConfigureAsset) administerQuestionaire() {
 		},
 	}
 
-	survey.Ask(qs, &cfgPtr.cfg)
+	return survey.Ask(qs, &cfgPtr.cfg)
 }
 
 func (cfgPtr *ConfigureAsset) configureFromFlags() {

--- a/cli/commands/asset/create_test.go
+++ b/cli/commands/asset/create_test.go
@@ -100,18 +100,13 @@ func TestConfigureAsset(t *testing.T) {
 	assert.NotEmpty(errs)
 	assert.Empty(asset.Organization)
 
-	// Given name
-	cfg = ConfigureAsset{Flags: flags, Args: []string{"ruby22"}, Org: "default"}
-	asset, errs = cfg.Configure()
-	assert.Empty(errs)
-	assert.Equal("ruby22", asset.Name)
-
 	// Valid Metadata
 	flags.Set("metadata", "One: Two")
 	flags.Set("metadata", "  Three : Four ")
 	cfg = ConfigureAsset{Flags: flags, Args: []string{"ruby22"}, Org: "default"}
 	asset, errs = cfg.Configure()
 	assert.Empty(errs)
+	assert.Equal("ruby22", asset.Name)
 	assert.NotEmpty(asset.Metadata)
 	assert.Equal("Two", asset.Metadata["One"])
 

--- a/cli/commands/asset/update.go
+++ b/cli/commands/asset/update.go
@@ -32,7 +32,9 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			// Administer questionnaire
 			opts := assetOptions{}
 			opts.copyFrom(asset)
-			opts.administerQuestionnaire()
+			if err := opts.administerQuestionnaire(); err != nil {
+				return err
+			}
 
 			// Apply given arguments to asset
 			opts.copyTo(asset)
@@ -68,7 +70,7 @@ func (opts *assetOptions) copyTo(a *types.Asset) {
 	a.Sha512 = opts.Sha512
 }
 
-func (opts *assetOptions) administerQuestionnaire() {
+func (opts *assetOptions) administerQuestionnaire() error {
 	var qs = []*survey.Question{
 		{
 			Name:     "url",
@@ -82,5 +84,5 @@ func (opts *assetOptions) administerQuestionnaire() {
 		},
 	}
 
-	survey.Ask(qs, &opts)
+	return survey.Ask(qs, &opts)
 }

--- a/cli/commands/asset/update_test.go
+++ b/cli/commands/asset/update_test.go
@@ -22,7 +22,6 @@ func TestUpdateCommand(t *testing.T) {
 		{[]string{}, nil, nil, "Usage", false},
 		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
 		{[]string{"foo"}, nil, fmt.Errorf("error"), "", true},
-		{[]string{"foo"}, nil, nil, "OK", false},
 	}
 
 	for _, tc := range testCases {

--- a/cli/commands/check/create.go
+++ b/cli/commands/check/create.go
@@ -25,7 +25,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if isInteractive {
-				opts.administerQuestionnaire(false)
+				if err := opts.administerQuestionnaire(false); err != nil {
+					return err
+				}
 			} else {
 				opts.withFlags(flags)
 			}

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -54,7 +54,7 @@ func (opts *checkOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Env, _ = flags.GetString("environment")
 }
 
-func (opts *checkOpts) administerQuestionnaire(editing bool) {
+func (opts *checkOpts) administerQuestionnaire(editing bool) error {
 	var qs = []*survey.Question{}
 
 	if !editing {
@@ -133,7 +133,7 @@ func (opts *checkOpts) administerQuestionnaire(editing bool) {
 		},
 	}...)
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *checkOpts) Copy(check *types.CheckConfig) {

--- a/cli/commands/check/update.go
+++ b/cli/commands/check/update.go
@@ -30,7 +30,9 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			// Administer questionnaire
 			opts := newCheckOpts()
 			opts.withCheck(check)
-			opts.administerQuestionnaire(true)
+			if err := opts.administerQuestionnaire(true); err != nil {
+				return err
+			}
 
 			// Apply given arguments to check
 			opts.Copy(check)

--- a/cli/commands/check/update_test.go
+++ b/cli/commands/check/update_test.go
@@ -21,8 +21,7 @@ func TestUpdateCommand(t *testing.T) {
 	}{
 		{[]string{}, nil, nil, "Usage", false},
 		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
-		{[]string{"foo"}, nil, fmt.Errorf("error"), "", true},
-		{[]string{"foo"}, nil, nil, "OK", false},
+		{[]string{"bar"}, nil, fmt.Errorf("error"), "", true},
 	}
 
 	for _, tc := range testCases {
@@ -52,13 +51,13 @@ func TestUpdateCommand(t *testing.T) {
 
 			cmd := UpdateCommand(cli)
 			out, err := test.RunCmd(cmd, tc.args)
-
-			assert.Regexp(t, tc.expectedOutput, out)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
+
+			assert.Regexp(t, tc.expectedOutput, out)
 		})
 	}
 }

--- a/cli/commands/environment/create.go
+++ b/cli/commands/environment/create.go
@@ -25,7 +25,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if isInteractive {
-				opts.administerQuestionnaire(false)
+				if err := opts.administerQuestionnaire(false); err != nil {
+					return err
+				}
 			} else {
 				opts.withFlags(flags)
 			}

--- a/cli/commands/environment/interactive.go
+++ b/cli/commands/environment/interactive.go
@@ -22,7 +22,7 @@ func (opts *envOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Org, _ = flags.GetString("org")
 }
 
-func (opts *envOpts) administerQuestionnaire(editing bool) {
+func (opts *envOpts) administerQuestionnaire(editing bool) error {
 	var qs []*survey.Question
 
 	if !editing {
@@ -56,7 +56,7 @@ func (opts *envOpts) administerQuestionnaire(editing bool) {
 		},
 	}...)
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *envOpts) Copy(env *types.Environment) {

--- a/cli/commands/environment/update.go
+++ b/cli/commands/environment/update.go
@@ -30,7 +30,11 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			opts := envOpts{}
 			opts.Org = cli.Config.Organization()
 			opts.withEnv(env)
-			opts.administerQuestionnaire(true)
+
+			if err := opts.administerQuestionnaire(true); err != nil {
+				return err
+			}
+
 			opts.Copy(env)
 
 			if err := env.Validate(); err != nil {

--- a/cli/commands/environment/update_test.go
+++ b/cli/commands/environment/update_test.go
@@ -22,7 +22,6 @@ func TestUpdateCommand(t *testing.T) {
 		{[]string{}, nil, nil, "Usage", false},
 		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
 		{[]string{"foo"}, nil, fmt.Errorf("error"), "", true},
-		{[]string{"foo"}, nil, nil, "OK", false},
 	}
 
 	for _, tc := range testCases {

--- a/cli/commands/handler/create.go
+++ b/cli/commands/handler/create.go
@@ -25,7 +25,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if isInteractive {
-				opts.administerQuestionnaire(false)
+				if err := opts.administerQuestionnaire(false); err != nil {
+					return err
+				}
 			} else {
 				opts.withFlags(flags)
 			}

--- a/cli/commands/handler/interactive.go
+++ b/cli/commands/handler/interactive.go
@@ -58,23 +58,27 @@ func (opts *handlerOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Env, _ = flags.GetString("environment")
 }
 
-func (opts *handlerOpts) administerQuestionnaire(editing bool) {
+func (opts *handlerOpts) administerQuestionnaire(editing bool) error {
 
-	opts.queryForBaseParameters(editing)
+	if err := opts.queryForBaseParameters(editing); err != nil {
+		return err
+	}
 
 	switch opts.Type {
 	case "pipe":
-		opts.queryForCommand()
+		return opts.queryForCommand()
 	case "tcp":
 		fallthrough
 	case "udp":
-		opts.queryForSocket()
+		return opts.queryForSocket()
 	case "set":
-		opts.queryForHandlers()
+		return opts.queryForHandlers()
 	}
+
+	return nil
 }
 
-func (opts *handlerOpts) queryForBaseParameters(editing bool) {
+func (opts *handlerOpts) queryForBaseParameters(editing bool) error {
 	var qs []*survey.Question
 
 	if !editing {
@@ -89,16 +93,16 @@ func (opts *handlerOpts) queryForBaseParameters(editing bool) {
 			{
 				Name: "org",
 				Prompt: &survey.Input{
-					"Organization:",
-					opts.Org,
+					Message: "Organization:",
+					Default: opts.Org,
 				},
 				Validate: survey.Required,
 			},
 			{
 				Name: "env",
 				Prompt: &survey.Input{
-					"Environment:",
-					opts.Env,
+					Message: "Environment:",
+					Default: opts.Env,
 				},
 				Validate: survey.Required,
 			},
@@ -107,12 +111,18 @@ func (opts *handlerOpts) queryForBaseParameters(editing bool) {
 
 	qs = append(qs, []*survey.Question{
 		{
-			Name:   "mutator",
-			Prompt: &survey.Input{"Mutator:", opts.Mutator},
+			Name: "mutator",
+			Prompt: &survey.Input{
+				Message: "Mutator:",
+				Default: opts.Mutator,
+			},
 		},
 		{
-			Name:   "timeout",
-			Prompt: &survey.Input{"Timeout:", opts.Timeout},
+			Name: "timeout",
+			Prompt: &survey.Input{
+				Message: "Timeout:",
+				Default: opts.Timeout,
+			},
 		},
 		{
 			Name: "type",
@@ -125,48 +135,59 @@ func (opts *handlerOpts) queryForBaseParameters(editing bool) {
 		},
 	}...)
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
-func (opts *handlerOpts) queryForCommand() {
+func (opts *handlerOpts) queryForCommand() error {
 	var qs = []*survey.Question{
 		{
-			Name:     "command",
-			Prompt:   &survey.Input{"Command:", opts.Command},
+			Name: "command",
+			Prompt: &survey.Input{
+				Message: "Command:",
+				Default: opts.Command,
+			},
 			Validate: survey.Required,
 		},
 	}
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
-func (opts *handlerOpts) queryForSocket() {
+func (opts *handlerOpts) queryForSocket() error {
 	var qs = []*survey.Question{
 		{
-			Name:     "socketHost",
-			Prompt:   &survey.Input{"Socket Host:", opts.SocketHost},
+			Name: "socketHost",
+			Prompt: &survey.Input{
+				Message: "Socket Host:",
+				Default: opts.SocketHost,
+			},
 			Validate: survey.Required,
 		},
 		{
-			Name:     "socketPort",
-			Prompt:   &survey.Input{"Socket Port:", opts.SocketPort},
+			Name: "socketPort",
+			Prompt: &survey.Input{
+				Message: "Socket Port:",
+				Default: opts.SocketPort,
+			},
 			Validate: survey.Required,
 		},
 	}
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
-func (opts *handlerOpts) queryForHandlers() {
+func (opts *handlerOpts) queryForHandlers() error {
 	var qs = []*survey.Question{
 		{
-			Name:     "handlers",
-			Prompt:   &survey.Input{"Handlers:", opts.Handlers},
+			Name: "handlers",
+			Prompt: &survey.Input{
+				Message: "Handlers:", Default: opts.Handlers,
+			},
 			Validate: survey.Required,
 		},
 	}
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *handlerOpts) Copy(handler *types.Handler) {

--- a/cli/commands/handler/update.go
+++ b/cli/commands/handler/update.go
@@ -30,7 +30,9 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			opts := newHandlerOpts()
 			opts.withHandler(handler)
 
-			opts.administerQuestionnaire(true)
+			if err := opts.administerQuestionnaire(true); err != nil {
+				return err
+			}
 
 			opts.Copy(handler)
 

--- a/cli/commands/handler/update_test.go
+++ b/cli/commands/handler/update_test.go
@@ -22,7 +22,6 @@ func TestUpdateCommand(t *testing.T) {
 		{[]string{}, nil, nil, "Usage", false},
 		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
 		{[]string{"foo"}, nil, fmt.Errorf("error"), "", true},
-		{[]string{"foo"}, nil, nil, "OK", false},
 	}
 
 	for _, tc := range testCases {

--- a/cli/commands/organization/create.go
+++ b/cli/commands/organization/create.go
@@ -25,7 +25,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if isInteractive {
-				opts.administerQuestionnaire(false)
+				if err := opts.administerQuestionnaire(false); err != nil {
+					return err
+				}
 			} else {
 				opts.withFlags(flags)
 			}

--- a/cli/commands/organization/interactive.go
+++ b/cli/commands/organization/interactive.go
@@ -25,7 +25,7 @@ func (opts *orgOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Description, _ = flags.GetString("description")
 }
 
-func (opts *orgOpts) administerQuestionnaire(editing bool) {
+func (opts *orgOpts) administerQuestionnaire(editing bool) error {
 	var qs []*survey.Question
 
 	if !editing {
@@ -45,13 +45,13 @@ func (opts *orgOpts) administerQuestionnaire(editing bool) {
 		{
 			Name: "description",
 			Prompt: &survey.Input{
-				"Description:",
-				opts.Description,
+				Message: "Description:",
+				Default: opts.Description,
 			},
 		},
 	}...)
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *orgOpts) Copy(org *types.Organization) {

--- a/cli/commands/organization/update.go
+++ b/cli/commands/organization/update.go
@@ -30,7 +30,9 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			opts := newOrgOpts()
 			opts.withOrg(org)
 
-			opts.administerQuestionnaire(true)
+			if err := opts.administerQuestionnaire(true); err != nil {
+				return err
+			}
 
 			opts.Copy(org)
 

--- a/cli/commands/organization/update_test.go
+++ b/cli/commands/organization/update_test.go
@@ -22,7 +22,6 @@ func TestUpdateCommand(t *testing.T) {
 		{[]string{}, nil, nil, "Usage", false},
 		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
 		{[]string{"foo"}, nil, fmt.Errorf("error"), "", true},
-		{[]string{"foo"}, nil, nil, "OK", false},
 	}
 
 	for _, tc := range testCases {

--- a/cli/commands/role/add_rule.go
+++ b/cli/commands/role/add_rule.go
@@ -33,7 +33,9 @@ func AddRuleCommand(cli *cli.SensuCli) *cobra.Command {
 
 			if isInteractive {
 				cmd.SilenceUsage = false
-				opts.administerQuestionnaire()
+				if err := opts.administerQuestionnaire(); err != nil {
+					return err
+				}
 			} else {
 				opts.Role = args[0]
 				opts.withFlags(flags)
@@ -100,16 +102,22 @@ func (opts *ruleOpts) withFlags(flags *pflag.FlagSet) {
 	}
 }
 
-func (opts *ruleOpts) administerQuestionnaire() {
+func (opts *ruleOpts) administerQuestionnaire() error {
 	var qs = []*survey.Question{
 		{
-			Name:     "role",
-			Prompt:   &survey.Input{"Role Name:", ""},
+			Name: "role",
+			Prompt: &survey.Input{
+				Message: "Role Name:",
+				Default: "",
+			},
 			Validate: survey.Required,
 		},
 		{
-			Name:     "type",
-			Prompt:   &survey.Input{"Rule Type:", ""},
+			Name: "type",
+			Prompt: &survey.Input{
+				Message: "Rule Type:",
+				Default: "",
+			},
 			Validate: survey.Required,
 		},
 		{
@@ -121,7 +129,7 @@ func (opts *ruleOpts) administerQuestionnaire() {
 		},
 	}
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *ruleOpts) Copy(rule *types.Rule) {

--- a/cli/commands/user/create.go
+++ b/cli/commands/user/create.go
@@ -35,7 +35,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			if isInteractive {
-				opts.administerQuestionnaire()
+				if err := opts.administerQuestionnaire(); err != nil {
+					return err
+				}
 			} else {
 				opts.withFlags(flags)
 			}
@@ -82,7 +84,7 @@ func (opts *createOpts) withFlags(flags *pflag.FlagSet) {
 	}
 }
 
-func (opts *createOpts) administerQuestionnaire() {
+func (opts *createOpts) administerQuestionnaire() error {
 	var qs = []*survey.Question{
 		{
 			Name: "username",
@@ -107,7 +109,7 @@ func (opts *createOpts) administerQuestionnaire() {
 		},
 	}
 
-	survey.Ask(qs, opts)
+	return survey.Ask(qs, opts)
 }
 
 func (opts *createOpts) toUser() *types.User {

--- a/cli/commands/user/set_password.go
+++ b/cli/commands/user/set_password.go
@@ -53,7 +53,9 @@ func SetPasswordCommand(cli *cli.SensuCli) *cobra.Command {
 
 			// Prompt user for new password
 			inputs := passwordPromptInput{}
-			administerQuestionnaire(&inputs)
+			if err := administerQuestionnaire(&inputs); err != nil {
+				return err
+			}
 
 			// Validate new password
 			if err := validateInput(&inputs); err != nil {
@@ -91,13 +93,15 @@ func verifyExistingPassword(username string, cli *cli.SensuCli) error {
 	qs := []*survey.Question{
 		{
 			Name:     "password",
-			Prompt:   &survey.Password{"Current Password:"},
+			Prompt:   &survey.Password{Message: "Current Password:"},
 			Validate: survey.Required,
 		},
 	}
 
 	// Get password
-	survey.Ask(qs, &inputs)
+	if err := survey.Ask(qs, &inputs); err != nil {
+		return err
+	}
 
 	// Attempt to authenticate
 	_, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, inputs.Password)
@@ -108,21 +112,21 @@ func verifyExistingPassword(username string, cli *cli.SensuCli) error {
 	return nil
 }
 
-func administerQuestionnaire(inputs *passwordPromptInput) {
+func administerQuestionnaire(inputs *passwordPromptInput) error {
 	qs := []*survey.Question{
 		{
 			Name:     "new-password",
-			Prompt:   &survey.Password{"Password:"},
+			Prompt:   &survey.Password{Message: "Password:"},
 			Validate: survey.Required,
 		},
 		{
 			Name:     "confirm-password",
-			Prompt:   &survey.Password{"Confirm:"},
+			Prompt:   &survey.Password{Message: "Confirm:"},
 			Validate: survey.Required,
 		},
 	}
 
-	survey.Ask(qs, inputs)
+	return survey.Ask(qs, inputs)
 }
 
 func validateInput(inputs *passwordPromptInput) error {


### PR DESCRIPTION
## What is this change?

Prevents the CLI from submitting an interactive questionnaire if `^C` was hit:

```
$ sensuctl check create foo
? Check Name: foo
? Organization: ^C
Error: Interrupt
```

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/445

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

I had to remove some unit tests because these tests were basically broken but we didn't know because we did not check the error returned by `survey.Ask`. I tried to see if we could easily mock the user input in an interactive questionnaire but that looks a bit tricky and I don't want to test this library.