### PR TITLE
Remove an unused ticker in the agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -564,8 +564,6 @@ func (a *Agent) Run() error {
 
 	go func(wg *sync.WaitGroup) {
 		retries := 0
-		ticker := time.NewTicker(100 * time.Millisecond)
-		defer ticker.Stop()
 		for {
 			select {
 			case <-a.stopping:


### PR DESCRIPTION
## What is this change?

This removes a ticker from the agent's main Run() loop that isn't used.

## Why is this change necessary?

This ticker just ticks and ticks and ticks, and nobody listens. Let's put it out of its misery.
