### PR TITLE
Set default org and env when creating objects through sensuctl

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -38,11 +39,15 @@ func New(config config.Config) *RestClient {
 
 	// Check that Access-Token has not expired
 	restyInst.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
-		// Pass the organization and environment as query parameters
-		r.SetQueryParams(map[string]string{
-			"env": config.Environment(),
-			"org": config.Organization(),
-		})
+		// Pass the organization and environment as query parameters, except when
+		// we are creating or updating an object, since we will use the object
+		// attributes to determine the org & env
+		if r.Method != http.MethodPost && r.Method != http.MethodPut {
+			r.SetQueryParams(map[string]string{
+				"env": config.Environment(),
+				"org": config.Organization(),
+			})
+		}
 
 		// Guard against requests that are not sending auth details
 		if c.Token == "" || r.UserInfo != nil {

--- a/cli/commands/check/create.go
+++ b/cli/commands/check/create.go
@@ -24,20 +24,15 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				opts.Name = args[0]
 			}
 
+			opts.Org = cli.Config.Organization()
+			opts.Env = cli.Config.Environment()
+
 			if isInteractive {
 				if err := opts.administerQuestionnaire(false); err != nil {
 					return err
 				}
 			} else {
 				opts.withFlags(flags)
-			}
-
-			if opts.Org == "" {
-				opts.Org = cli.Config.Organization()
-			}
-
-			if opts.Env == "" {
-				opts.Env = cli.Config.Environment()
 			}
 
 			// Apply given arguments to check
@@ -50,11 +45,6 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				}
 				return err
 			}
-
-			// Ensure that the client is configured to create the check within the
-			// corrent context.
-			cli.Config.SetOrganization(check.Organization)
-			cli.Config.SetEnvironment(check.Environment)
 
 			//
 			// TODO:

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -50,10 +50,15 @@ func (opts *checkOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Subscriptions, _ = flags.GetString("subscriptions")
 	opts.Handlers, _ = flags.GetString("handlers")
 	opts.RuntimeAssets, _ = flags.GetString("runtime-assets")
-	opts.Org, _ = flags.GetString("organization")
-	opts.Env, _ = flags.GetString("environment")
 	publishBool, _ := flags.GetBool("publish")
 	opts.Publish = strconv.FormatBool(publishBool)
+
+	if org, _ := flags.GetString("organization"); org != "" {
+		opts.Org = org
+	}
+	if env, _ := flags.GetString("environment"); env != "" {
+		opts.Env = env
+	}
 }
 
 func (opts *checkOpts) administerQuestionnaire(editing bool) error {

--- a/cli/commands/environment/create.go
+++ b/cli/commands/environment/create.go
@@ -24,6 +24,8 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				opts.Name = args[0]
 			}
 
+			opts.Org = cli.Config.Organization()
+
 			if isInteractive {
 				if err := opts.administerQuestionnaire(false); err != nil {
 					return err
@@ -34,10 +36,6 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 
 			env := types.Environment{}
 			opts.Copy(&env)
-
-			if opts.Org == "" {
-				opts.Org = cli.Config.Organization()
-			}
 
 			if err := env.Validate(); err != nil {
 				if !isInteractive {

--- a/cli/commands/environment/interactive.go
+++ b/cli/commands/environment/interactive.go
@@ -19,7 +19,10 @@ func (opts *envOpts) withEnv(env *types.Environment) {
 
 func (opts *envOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Description, _ = flags.GetString("description")
-	opts.Org, _ = flags.GetString("org")
+
+	if org, _ := flags.GetString("organization"); org != "" {
+		opts.Org = org
+	}
 }
 
 func (opts *envOpts) administerQuestionnaire(editing bool) error {

--- a/cli/commands/handler/create.go
+++ b/cli/commands/handler/create.go
@@ -24,20 +24,15 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				opts.Name = args[0]
 			}
 
+			opts.Org = cli.Config.Organization()
+			opts.Env = cli.Config.Environment()
+
 			if isInteractive {
 				if err := opts.administerQuestionnaire(false); err != nil {
 					return err
 				}
 			} else {
 				opts.withFlags(flags)
-			}
-
-			if opts.Org == "" {
-				opts.Org = cli.Config.Organization()
-			}
-
-			if opts.Env == "" {
-				opts.Env = cli.Config.Environment()
 			}
 
 			handler := types.Handler{}

--- a/cli/commands/handler/interactive.go
+++ b/cli/commands/handler/interactive.go
@@ -54,8 +54,13 @@ func (opts *handlerOpts) withFlags(flags *pflag.FlagSet) {
 	opts.SocketHost, _ = flags.GetString("socket-host")
 	opts.SocketPort, _ = flags.GetString("socket-port")
 	opts.Handlers, _ = flags.GetString("handlers")
-	opts.Org, _ = flags.GetString("organization")
-	opts.Env, _ = flags.GetString("environment")
+
+	if org, _ := flags.GetString("organization"); org != "" {
+		opts.Org = org
+	}
+	if env, _ := flags.GetString("environment"); env != "" {
+		opts.Env = env
+	}
 }
 
 func (opts *handlerOpts) administerQuestionnaire(editing bool) error {

--- a/cli/commands/role/add_rule.go
+++ b/cli/commands/role/add_rule.go
@@ -31,6 +31,9 @@ func AddRuleCommand(cli *cli.SensuCli) *cobra.Command {
 
 			opts := &ruleOpts{}
 
+			opts.Org = cli.Config.Organization()
+			opts.Env = cli.Config.Environment()
+
 			if isInteractive {
 				cmd.SilenceUsage = false
 				if err := opts.administerQuestionnaire(); err != nil {
@@ -39,14 +42,6 @@ func AddRuleCommand(cli *cli.SensuCli) *cobra.Command {
 			} else {
 				opts.Role = args[0]
 				opts.withFlags(flags)
-			}
-
-			if opts.Org == "" {
-				opts.Org = cli.Config.Organization()
-			}
-
-			if opts.Env == "" {
-				opts.Env = cli.Config.Environment()
 			}
 
 			if opts.Role == "" {
@@ -85,8 +80,6 @@ func AddRuleCommand(cli *cli.SensuCli) *cobra.Command {
 
 func (opts *ruleOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Type, _ = flags.GetString("type")
-	opts.Org, _ = flags.GetString("organization")
-	opts.Env, _ = flags.GetString("environment")
 
 	if create, _ := flags.GetBool("create"); create {
 		opts.Permissions = append(opts.Permissions, "create")
@@ -99,6 +92,13 @@ func (opts *ruleOpts) withFlags(flags *pflag.FlagSet) {
 	}
 	if delete, _ := flags.GetBool("delete"); delete {
 		opts.Permissions = append(opts.Permissions, "delete")
+	}
+
+	if org, _ := flags.GetString("organization"); org != "" {
+		opts.Org = org
+	}
+	if env, _ := flags.GetString("environment"); env != "" {
+		opts.Env = env
 	}
 }
 

--- a/testing/e2e/rbac_test.go
+++ b/testing/e2e/rbac_test.go
@@ -58,13 +58,18 @@ func TestRBAC(t *testing.T) {
 	)
 	assert.NoError(t, err, string(output))
 
+	output, err = adminctl.run("environment", "create", "default",
+		"--organization", "acme",
+	)
+	assert.NoError(t, err, string(output))
+
 	output, err = adminctl.run("environment", "create", "dev",
-		"--org", "acme",
+		"--organization", "acme",
 	)
 	assert.NoError(t, err, string(output))
 
 	output, err = adminctl.run("environment", "create", "prod",
-		"--org", "acme",
+		"--organization", "acme",
 	)
 	assert.NoError(t, err, string(output))
 


### PR DESCRIPTION
## What is this change?

It sets the default organization and environment when creating objects with the flags and interactive mode in `sensuctl`.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/444

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

I had to prevent the `cli/client` package from sending the object's org & env as query parameters during creation or update (see https://github.com/sensu/sensu-go/compare/bugfix/default-org-env?expand=1#diff-956571bc126deb997197601bf096aa96R45), otherwise it was rejected by the `environment` middleware, which makes sure both env and org exist.