### PR TITLE
Fix backend.yml.example

### DIFF
--- a/packaging/files/backend.yml.example
+++ b/packaging/files/backend.yml.example
@@ -19,18 +19,18 @@ state-dir: "/var/lib/sensu"
 ##
 # ssl configuration
 ##
-#cert-file "/path/to/ssl/cert.pem"
-#key-file "/path/to/ssl/key.pem"
-#trusted-ca-file "/path/to/trusted-certificate-authorities.pem"
-#insecure-skip-tls-verify false
+#cert-file: "/path/to/ssl/cert.pem"
+#key-file: "/path/to/ssl/key.pem"
+#trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
+#insecure-skip-tls-verify: false
 
 ##
 # store configuration
 ##
-#store-client-url ""
-#store-peer-url ""
-#store-initial-cluster ""
-#store-initial-advertise-peer-url ""
-#store-initial-cluster-state ""
-#store-initial-cluster-token ""
-#store-node-name ""
+#store-client-url: ""
+#store-peer-url: ""
+#store-initial-cluster: ""
+#store-initial-advertise-peer-url: ""
+#store-initial-cluster-state: ""
+#store-initial-cluster-token: ""
+#store-node-name: ""


### PR DESCRIPTION
## What is this change?

This fixes incorrect example configuration files.


## Why is this change necessary?

backend.yml.example had YAML keys without colons.

closes #478 