### PR TITLE
Fix creation of events from asset errors

### DIFF
--- a/agent/assetmanager/asset.go
+++ b/agent/assetmanager/asset.go
@@ -143,7 +143,7 @@ func (d *RuntimeAsset) install() error {
 	}
 
 	// logger.WithFields(logrus.Fields{
-	// 	"asset_name": d.asset.Name,
+	//	"asset_name": d.asset.Name,
 	// }).Info("new dependency encountered; downloading")
 
 	// Download the asset
@@ -177,7 +177,7 @@ func (d *RuntimeAsset) install() error {
 	responseBodySum := hex.EncodeToString(h.Sum(nil))
 	if d.asset.Sha512 != responseBodySum {
 		return fmt.Errorf(
-			"fetched asset did not match '%s' '%s'",
+			"fetched asset checksum did not match '%s' '%s'",
 			d.asset.Sha512,
 			responseBodySum,
 		)

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -58,7 +58,7 @@ func (a *Agent) executeCheck(request *types.CheckRequest) {
 
 	// Ensure that all the dependencies are installed.
 	if err := assets.InstallAll(); err != nil {
-		a.sendFailure(event, fmt.Errorf("error install dependencies: %s", err))
+		a.sendFailure(event, fmt.Errorf("error installing dependencies: %s", err))
 		return
 	}
 
@@ -86,6 +86,7 @@ func (a *Agent) executeCheck(request *types.CheckRequest) {
 func (a *Agent) sendFailure(event *types.Event, err error) {
 	event.Check.Output = err.Error()
 	event.Check.Status = 3
+	event.Entity = a.getAgentEntity()
 	event.Timestamp = time.Now().Unix()
 
 	if msg, err := json.Marshal(event); err != nil {


### PR DESCRIPTION
## What is this change?

Fixes the creation of events when problems arise during the installation of assets. The problem was due to the event not having an entity.

## Why is this change necessary?

Fixes #443 