### PR TITLE
The agent stops if the connection to the backend is closed

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -25,10 +25,11 @@ func TestSendLoop(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := server.Serve(w, r)
 		assert.NoError(t, err)
-		msg, err := conn.Receive()
 
+		msg, err := conn.Receive()
 		assert.NoError(t, err)
 		assert.Equal(t, "keepalive", msg.Type)
+
 		event := &types.Event{}
 		assert.NoError(t, json.Unmarshal(msg.Payload, event))
 		assert.NotNil(t, event.Entity)
@@ -65,6 +66,7 @@ func TestReceiveLoop(t *testing.T) {
 
 		msgBytes, err := json.Marshal(testMessage)
 		assert.NoError(t, err)
+
 		tm := &transport.Message{
 			Type:    "testMessageType",
 			Payload: msgBytes,

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -134,7 +134,7 @@ func (t *WebSocketTransport) Send(m *Message) error {
 	t.mutex.RLock()
 	if t.closed {
 		t.mutex.RUnlock()
-		return ClosedError{"connection closed"}
+		return ClosedError{"the websocket connection is no longer open"}
 	}
 	t.mutex.RUnlock()
 
@@ -164,7 +164,7 @@ func (t *WebSocketTransport) Receive() (*Message, error) {
 	t.mutex.RLock()
 	if t.closed {
 		t.mutex.RUnlock()
-		return nil, ClosedError{"connection closed"}
+		return nil, ClosedError{"the websocket connection is no longer open"}
 	}
 	t.mutex.RUnlock()
 


### PR DESCRIPTION
## What is this change?

It stops the agent if the connection to the backend is closed, instead of sending keepalives messages in the void.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/506.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

I tried to do the same with the message receiving part: https://github.com/sensu/sensu-go/blob/b1c8c45dfe82eecb9a45bd34847cc5d03a03a651/agent/agent.go#L342-L352 

But it broke everything and it took me some time to figure out that even if the server sends `CloseGoingAway`, the client still see it as an error. I finally decided to only go with the proposed change here in order to avoid going down the rabbit hole since it prevents the described behavior in the  related issue.