### PR TITLE
Set filters when creating a handler with sensuctl

### DIFF
--- a/cli/commands/handler/create.go
+++ b/cli/commands/handler/create.go
@@ -55,13 +55,14 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("type", "t", typeDefault, "type of handler (pipe, tcp, udp, or set)")
+	cmd.Flags().String("command", "", "command to be executed. The event data is passed to the process via STDIN")
+	cmd.Flags().String("filters", "", "comma separated list of filters to use when filtering events for the handler")
+	cmd.Flags().String("handlers", "", "comma separated list of handlers to call using the handler set")
 	cmd.Flags().StringP("mutator", "m", "", "Sensu event mutator (name) to use to mutate event data for the handler")
-	cmd.Flags().StringP("command", "c", "", "command to be executed. The event data is passed to the process via STDIN")
-	cmd.Flags().StringP("timeout", "i", "", "execution duration timeout in seconds (hard stop)")
 	cmd.Flags().String("socket-host", "", "host of handler socket")
 	cmd.Flags().String("socket-port", "", "port of handler socket")
-	cmd.Flags().StringP("handlers", "", "", "comma separated list of handlers to call")
+	cmd.Flags().StringP("timeout", "i", "", "execution duration timeout in seconds (hard stop)")
+	cmd.Flags().StringP("type", "t", typeDefault, "type of handler (pipe, tcp, udp, or set)")
 
 	return cmd
 }

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -86,6 +86,13 @@ func printHandlersToTable(queryResults []types.Handler, writer io.Writer) {
 			},
 		},
 		{
+			Title: "Filters",
+			CellTransformer: func(data interface{}) string {
+				handler, _ := data.(types.Handler)
+				return strings.Join(handler.Filters, ",")
+			},
+		},
+		{
 			Title: "Mutator",
 			CellTransformer: func(data interface{}) string {
 				handler, _ := data.(types.Handler)


### PR DESCRIPTION
## What is this change?

It allows users to set filters when creating a handler with sensuctl so Sean doesn't have to write some JSON with curl during the happy hour.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/508

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!