### PR TITLE
Set a standard redirect policy in client.go

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -33,6 +33,9 @@ func New(config config.Config) *RestClient {
 	restyInst := resty.New()
 	client := &RestClient{resty: restyInst, config: config}
 
+	// Standardize redirect policy
+	restyInst.SetRedirectPolicy(resty.FlexibleRedirectPolicy(10))
+
 	// JSON
 	restyInst.SetHeader("Accept", "application/json")
 	restyInst.SetHeader("Content-Type", "application/json")


### PR DESCRIPTION
## What is this change?

Ensuring http and resty clients have the same default redirect policy, allowing 10 consecutive requests.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/539

## Do you need clarification on anything?

Nah

## Were there any complications while making this change?

Nah