### PR TITLE
Additional agent subscriptions fixed by HeaderKeySubscriptions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -466,10 +467,7 @@ func (a *Agent) buildTransportHeaderMap() http.Header {
 	header.Set(transport.HeaderKeyEnvironment, a.config.Environment)
 	header.Set(transport.HeaderKeyOrganization, a.config.Organization)
 	header.Set(transport.HeaderKeyUser, a.config.User)
-
-	for _, sub := range a.config.Subscriptions {
-		header.Add(transport.HeaderKeySubscriptions, sub)
-	}
+	header.Set(transport.HeaderKeySubscriptions, strings.Join(a.config.Subscriptions, ","))
 
 	return header
 }


### PR DESCRIPTION
## What is this change?

Additional agent subscriptions were not working due to the way we were setting the HeaderKeySubscriptions header. By passing the subscriptions as a single header in agent, agentd already has the logic to split the headers parameters into multiple subscriptions. 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/514

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.