### PR TITLE
Resolve ptr when unable to update asset in cli

### DIFF
--- a/cli/commands/asset/update.go
+++ b/cli/commands/asset/update.go
@@ -89,5 +89,5 @@ func (opts *assetOptions) administerQuestionnaire() error {
 		},
 	}
 
-	return survey.Ask(qs, &opts)
+	return survey.Ask(qs, opts)
 }


### PR DESCRIPTION
## What is this change?

Resolves the ptr error that was blocking cli updates to asset.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/562

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.