### PR TITLE
Change Sensu Base URL to Sensu Backend URL

### DIFF
--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -103,8 +103,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			hooks.ConfigurationRequirement: hooks.ConfigurationNotRequired,
 		},
 	}
-	// fmt.Println()
-	cmd.Flags().StringP("url", "", cli.Config.APIUrl(), "the sensu base url")
+	cmd.Flags().StringP("url", "", cli.Config.APIUrl(), "the sensu backend url")
 	cmd.Flags().StringP("username", "", "", "username")
 	cmd.Flags().StringP("password", "", "", "password")
 	cmd.Flags().StringP("environment", "", cli.Config.Environment(), "environment")
@@ -146,7 +145,7 @@ func askForURL(c config.Config) *survey.Question {
 	return &survey.Question{
 		Name: "url",
 		Prompt: &survey.Input{
-			Message: "Sensu Base URL:",
+			Message: "Sensu Backend URL:",
 			Default: url,
 		},
 	}


### PR DESCRIPTION
## What is this change?

A more descriptive naming convention for the api url: Sensu Backend URL vs Sensu Base URL

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/547

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Thankfully, no.