### PR TITLE
Add slack notifications on build failures and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,53 @@
 sudo: required
 services:
-  - docker
+- docker
 language: go
 go:
-  - 1.9.x
+- 1.9.x
 branches:
   only:
   - master
 stages:
-  - name: test
-  - name: deploy
-    if: branch = master OR tag IS present
+- name: test
+- name: deploy
+  if: branch = master OR tag IS present
 cache:
   yarn: true
   directories:
-    - backend/dashboardd/node_modules
+  - backend/dashboardd/node_modules
 install:
-  - "npm install --global yarn"
-  - "./build.sh deps"
-  - "./build.sh build_tools"
+- npm install --global yarn
+- "./build.sh deps"
+- "./build.sh build_tools"
 script: "./build.sh ci $TEST_SUITE"
 after_script: "./build.sh coverage $TEST_SUITE"
 jobs:
   include:
-    - stage: deploy
-      env: GOARCH=amd64 TEST_SUITE=none
-      script: skip
-      deploy:
-        - provider: script
-          skip_cleanup: true
-          script: "./build.sh docker push master"
-          on:
-            branch: master
-        - provider: script
-          script: "./build-gcs-release.sh"
-          on:
-            tags: true
+  - stage: deploy
+    env: GOARCH=amd64 TEST_SUITE=none
+    script: skip
+    deploy:
+    - provider: script
+      skip_cleanup: true
+      script: "./build.sh docker push master"
+      on:
+        branch: master
+    - provider: script
+      script: "./build-gcs-release.sh"
+      on:
+        tags: true
 env:
   matrix:
-    - GOARCH=386
-    - GOARCH=amd64
-    - TEST_SUITE=dashboard
+  - GOARCH=386
+  - GOARCH=amd64
+  - TEST_SUITE=dashboard
   global:
-    - secure: hkfmIw8kqHSb1xwJOq9kjtJL5J8VZfVNOjDeQTq6tzUzovqQQzKylENSOs0kmbgRTADOUHRNDt2iVp5/cGtGpFchaIyErJNQVh1l1A1iq1jDgma1UMEoKujn0FYJOurBkZyF3APYJ15n08GoHZdVdUmgWvgeErLyvGJkWhPXOYume2RS0gX5eItB6jdtlj1xiNlCvDc8KpZ6OluMczoe2tNykdX7MwOzhx4uI6uHO5Y4kclBOyJClMWK4aDQfm6SJFyRzEn9nOlGLgCrbJBmc+vF6ge59pWeIaChlp0ukT9M3f074XfiICnRiY9VMofQ7hiWZYfbPApIVX2QthNTuCTJOc4QiI58fZ89+++1lp2GHUG7A2d0M4Uiexc0Io4Or5U+hnb+xIScUzJTWiAIezqCeGjFhTqK/tpUUI0frsBgtpjBTcDTP70vIETardcZD/m/7U+JCLRaF/qhoQgelXyZ2nqsOqqJJayv4WaWHavYTYZhdGkNUdHVV3IrSnkAx2ZClHBV+2nyv1frIv4tGLo0qheQQZ7hrmFkGRO6/zzGB0pKLxF8cJmrM+svt18pW3w56C5c09UAXu5IT0SfYEsPJqXw1aQjxhLplHKJrrstZjVnXU3S+/h20TZS+8mNxxYU0/Ox9MrmETzI4cZ2BiiylMle2gLtqIisQB/qNKY=
-    - secure: f+DtaaLy5X0+tbllNOLbWhtVRxkxtm9SUu2DXzmJc4tVV5SKzdD8ewINoPuHmH6XmjhcevFDSTuQEct7gG7d5Pp1HNrtgYmZnrdDFhFXmRUMRwbzUIM4znEl6ej6DsXDvvQ/VZ85b8lH2eSHUk57DRnnrn5Ig96ZNCVy1MZcUZlXS4wx+sgMgsPcPlufkJYZD8pI/jTjLYrurWc96Pb7FsgEsJGbFq5cSQWXoLWgvSs8ZcqaKhR13ikdBhAuXPvASeRTlby+AY7YsDslTb5vgppw5Xt5cfSA0OPlzXA0FgLz60T15CQjq9zQJTndRFHB6cpcMDywF5dmPsec8TnWfr2DziOtQCF8e1+V+gAhL5gaZLj1qvK4Fd/WWBcOlXcdBfTQqRWYXpy81uDwERXzDqkw1wlRqZOmHqR9JdvQgERzrk36AkAWGGOk0Ib3wCobHC2xE4oYW2CNNk/TinwZov5e+rEZEcM4qzlxloHvIjNYTEBbZrhf7nOymTrZCxUtatcZqb76Vd7CJOnoovRAhq1n79GmFKf5vovJWR0RrsW5s2akdB39Rh/uXi2aqfFQ7HCiLGd1dZCvFzWjYjnSVrfmNNZtxBcyBv1sNc/G9hoWqCZPR/7LqL1fQi/xk1CpK92uPl5Z6lNqLoHIAUi8EurcUd3aDuy1SzCZq2w8F5U=
-    - GS_ACCESS_KEY_ID=GOOGX24DX63IJ6WNE2DH
-    - secure: Uuo+tdIghOu3lspdkzJKxlMVbaKqiWfCuh+Pl2Mp/mooK+cKOEk2wdBoEH1iqbdwC4NH3ttO1vdX84U9RSbuH/7iGLCVd14gxaPRj7anqHUoFKxb2rf9I6sA5DzkGPS+Oia9As4lr6jk29gh5NRjQWQAKfvr6ER7NcIwJIuU+UjVZsmIR50VmV7xS2G6TjyXeDYUzXubVhIWKu1u9JpPz+U/dvkbkEd5pW7nc/0Z0QDtwLQASCS4sVlGAzMFFRVYANtGMqY/j0qeEK8zp3PftLPAm5UV4/Hx68T+H3TAeaKtHFXl08J4wZMG1BM+mR3/rmLwgkC20otmy4o2ijIfrPtm1nB3nU7SSKK0il6M5eqEYeEYhI2cBXBWdSoBtHez2UFoUNqutN5OHvqR++mcK97oWO6INHH0NYi7sb+OM4Yz90s7E1gsd2gN4h6iuaVhOpnGRKaIHhVCiTEK+9qQfIpnwSB9HeJrb2bbAHcITRxMULpd+f9h88WW6gJzPfNwoZLtFdCOMH3AlKXtmU8t2yg8tTJ+NaFwPi/+WuSuUrzuVoRdOA4jTEukpmULnFfkm1enBq7fzITJhhD5Jsf85ytOZwZwYHcsYdDXVZel6RowKiJuvLT3dEAXtVKFKdqqGIEX7oxuKu1lshhSZimN4Vxj7PE46SUzN9EAXMjHkfM=
+  - secure: hkfmIw8kqHSb1xwJOq9kjtJL5J8VZfVNOjDeQTq6tzUzovqQQzKylENSOs0kmbgRTADOUHRNDt2iVp5/cGtGpFchaIyErJNQVh1l1A1iq1jDgma1UMEoKujn0FYJOurBkZyF3APYJ15n08GoHZdVdUmgWvgeErLyvGJkWhPXOYume2RS0gX5eItB6jdtlj1xiNlCvDc8KpZ6OluMczoe2tNykdX7MwOzhx4uI6uHO5Y4kclBOyJClMWK4aDQfm6SJFyRzEn9nOlGLgCrbJBmc+vF6ge59pWeIaChlp0ukT9M3f074XfiICnRiY9VMofQ7hiWZYfbPApIVX2QthNTuCTJOc4QiI58fZ89+++1lp2GHUG7A2d0M4Uiexc0Io4Or5U+hnb+xIScUzJTWiAIezqCeGjFhTqK/tpUUI0frsBgtpjBTcDTP70vIETardcZD/m/7U+JCLRaF/qhoQgelXyZ2nqsOqqJJayv4WaWHavYTYZhdGkNUdHVV3IrSnkAx2ZClHBV+2nyv1frIv4tGLo0qheQQZ7hrmFkGRO6/zzGB0pKLxF8cJmrM+svt18pW3w56C5c09UAXu5IT0SfYEsPJqXw1aQjxhLplHKJrrstZjVnXU3S+/h20TZS+8mNxxYU0/Ox9MrmETzI4cZ2BiiylMle2gLtqIisQB/qNKY=
+  - secure: f+DtaaLy5X0+tbllNOLbWhtVRxkxtm9SUu2DXzmJc4tVV5SKzdD8ewINoPuHmH6XmjhcevFDSTuQEct7gG7d5Pp1HNrtgYmZnrdDFhFXmRUMRwbzUIM4znEl6ej6DsXDvvQ/VZ85b8lH2eSHUk57DRnnrn5Ig96ZNCVy1MZcUZlXS4wx+sgMgsPcPlufkJYZD8pI/jTjLYrurWc96Pb7FsgEsJGbFq5cSQWXoLWgvSs8ZcqaKhR13ikdBhAuXPvASeRTlby+AY7YsDslTb5vgppw5Xt5cfSA0OPlzXA0FgLz60T15CQjq9zQJTndRFHB6cpcMDywF5dmPsec8TnWfr2DziOtQCF8e1+V+gAhL5gaZLj1qvK4Fd/WWBcOlXcdBfTQqRWYXpy81uDwERXzDqkw1wlRqZOmHqR9JdvQgERzrk36AkAWGGOk0Ib3wCobHC2xE4oYW2CNNk/TinwZov5e+rEZEcM4qzlxloHvIjNYTEBbZrhf7nOymTrZCxUtatcZqb76Vd7CJOnoovRAhq1n79GmFKf5vovJWR0RrsW5s2akdB39Rh/uXi2aqfFQ7HCiLGd1dZCvFzWjYjnSVrfmNNZtxBcyBv1sNc/G9hoWqCZPR/7LqL1fQi/xk1CpK92uPl5Z6lNqLoHIAUi8EurcUd3aDuy1SzCZq2w8F5U=
+  - GS_ACCESS_KEY_ID=GOOGX24DX63IJ6WNE2DH
+  - secure: Uuo+tdIghOu3lspdkzJKxlMVbaKqiWfCuh+Pl2Mp/mooK+cKOEk2wdBoEH1iqbdwC4NH3ttO1vdX84U9RSbuH/7iGLCVd14gxaPRj7anqHUoFKxb2rf9I6sA5DzkGPS+Oia9As4lr6jk29gh5NRjQWQAKfvr6ER7NcIwJIuU+UjVZsmIR50VmV7xS2G6TjyXeDYUzXubVhIWKu1u9JpPz+U/dvkbkEd5pW7nc/0Z0QDtwLQASCS4sVlGAzMFFRVYANtGMqY/j0qeEK8zp3PftLPAm5UV4/Hx68T+H3TAeaKtHFXl08J4wZMG1BM+mR3/rmLwgkC20otmy4o2ijIfrPtm1nB3nU7SSKK0il6M5eqEYeEYhI2cBXBWdSoBtHez2UFoUNqutN5OHvqR++mcK97oWO6INHH0NYi7sb+OM4Yz90s7E1gsd2gN4h6iuaVhOpnGRKaIHhVCiTEK+9qQfIpnwSB9HeJrb2bbAHcITRxMULpd+f9h88WW6gJzPfNwoZLtFdCOMH3AlKXtmU8t2yg8tTJ+NaFwPi/+WuSuUrzuVoRdOA4jTEukpmULnFfkm1enBq7fzITJhhD5Jsf85ytOZwZwYHcsYdDXVZel6RowKiJuvLT3dEAXtVKFKdqqGIEX7oxuKu1lshhSZimN4Vxj7PE46SUzN9EAXMjHkfM=
+notifications:
+  slack:
+    on_success: change
+    on_failure: always
+    secure: iXhhz0drjrH6Z2weDkyhCN0vEYiKNjA9J46U6HL8V3kp4Eo//Fk55DnBiL/uW896lTYynZNML5wa0IZ3yMuEP67p8LXIzFQI7li7R007uBiqdYGK1+cyid7KTMX6kNSG8H4DchCK56XjL4V8nPhlplXBB2MklBKrRUpXWtXQAulq6wj+rL7/fvx7rsky8yEqb+/GkkrKXDMgmSnR8qvyrI5n1PrYzx1Or2hv5efFIvzf8n7uWViC+V+DctvVkVsmRWsoWuTqHD91stifHTFbH7M3hEiOVzYsn7rHkpX3DLIlW2yEwyk1uRM51tAT/+JwELPeJqyCsABelW8/U6RLebjiUdPDjJ2ausizHpbeyPXohSij2/hFhQqIltLaqGF1B7tJ5Uth3OEhhaQHM8IaUywg5oN8si9K38W61rQcitcf6WCMENj6mDsZPttw/qMqg6pEl62VXhwslddyUomoo+tvFxpfNVG/Ttbdc432l4zDE/Xl7s/txpCirwHI82sVZRrcyc8kNYYaRX/sZP7gOBf93s45byy3wbeFUKK6yREPgKf0o1NZ51/AplWxaUnjjFON8G6t9cOwYvZeF21Nqry4fYAG1u8ugAG2ltpKJw3ViEzRElbcD7p5la14Ukvj4o/Sux4048hbXEZGLZr7kVIWQE95XcPfo+k3NDwmKeM=


### PR DESCRIPTION
## What is this change?

This adds Slack notifications builds on Travis CI. If a build fails, we will receive a notification. When the build starts passing again, we'll receive a notification indicating the status change. We won't get notifications on every successful build.

## Why is this change necessary?

I have a theory that this will be useful and will speed up PRs. It's particularly important to know if master is failing (which we've seen happen before and go unnoticed in spite of e-mail notifications).

## Do you need clarification on anything?

I'm curious to find out if the first build of a PR notifies us upon success (I would think "no build" to "passing" is considered a "change" in state, but we'll see).

## Were there any complications while making this change?

Yes, sorry, but the travis CLI tool reformatted the travis YAML file. Sorry bout it.