### PR TITLE
Remove extraneous GetEnv & GetOrg getter methods

### DIFF
--- a/backend/apid/actions/util.go
+++ b/backend/apid/actions/util.go
@@ -7,10 +7,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-func addOrgEnvToContext(ctx context.Context, record types.MultitenantResource) context.Context {
-	ctx = context.WithValue(ctx, types.OrganizationKey, record.GetOrg())
-	ctx = context.WithValue(ctx, types.EnvironmentKey, record.GetEnv())
-	return ctx
+func addOrgEnvToContext(
+	ctx context.Context,
+	record types.MultitenantResource,
+) context.Context {
+	return types.SetContextFromResource(ctx, record)
 }
 
 func copyFields(target interface{}, source interface{}, fields ...string) {

--- a/backend/apid/graphql/globalid/util.go
+++ b/backend/apid/graphql/globalid/util.go
@@ -61,8 +61,8 @@ func (r commonTranslator) Decode(components StandardComponents) Components {
 //
 
 func addMultitenantFields(c *StandardComponents, r types.MultitenantResource) {
-	c.organization = r.GetOrg()
-	c.environment = r.GetEnv()
+	c.organization = r.GetOrganization()
+	c.environment = r.GetEnvironment()
 }
 
 // newComponentsWith returns new instance of StandardComponents w/ name and ids

--- a/backend/pipelined/filter.go
+++ b/backend/pipelined/filter.go
@@ -70,7 +70,7 @@ func evaluateEventFilter(store store.Store, event *types.Event, filterName strin
 	// Something weird happened, let's not filter the event and log a warning message
 	logger.WithFields(logrus.Fields{
 		"filter":       filter.GetName(),
-		"organization": filter.GetOrg(),
+		"organization": filter.GetOrganization(),
 		"environment":  filter.GetEnvironment(),
 	}).Warn("pipelined not filtering event due to unhandled case")
 

--- a/backend/store/etcd/key_builder.go
+++ b/backend/store/etcd/key_builder.go
@@ -25,8 +25,8 @@ func (b keyBuilder) withOrg(org string) keyBuilder {
 }
 
 func (b keyBuilder) withResource(r types.MultitenantResource) keyBuilder {
-	b.org = r.GetOrg()
-	b.env = r.GetEnv()
+	b.org = r.GetOrganization()
+	b.env = r.GetEnvironment()
 	return b
 }
 

--- a/types/asset.go
+++ b/types/asset.go
@@ -45,13 +45,8 @@ func (a *Asset) Validate() error {
 	return validateStatements(a.Filters)
 }
 
-// GetOrg refers to the organization the check belongs to
-func (a *Asset) GetOrg() string {
-	return a.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (a *Asset) GetEnv() string {
+// GetEnvironment refers to the organization the check belongs to
+func (a *Asset) GetEnvironment() string {
 	return ""
 }
 

--- a/types/check.go
+++ b/types/check.go
@@ -52,16 +52,6 @@ func (c *CheckConfig) Validate() error {
 	return nil
 }
 
-// GetOrg refers to the organization the check belongs to
-func (c *CheckConfig) GetOrg() string {
-	return c.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (c *CheckConfig) GetEnv() string {
-	return c.Environment
-}
-
 // ByExecuted implements the sort.Interface for []CheckHistory based on the
 // Executed field.
 //

--- a/types/entity.go
+++ b/types/entity.go
@@ -30,16 +30,6 @@ func (e *Entity) Validate() error {
 	return nil
 }
 
-// GetOrg refers to the organization the check belongs to
-func (e *Entity) GetOrg() string {
-	return e.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (e *Entity) GetEnv() string {
-	return e.Environment
-}
-
 // FixtureEntity returns a testing fixture for an Entity object.
 func FixtureEntity(id string) *Entity {
 	return &Entity{

--- a/types/environment.go
+++ b/types/environment.go
@@ -26,13 +26,8 @@ func FixtureEnvironment(name string) *Environment {
 	}
 }
 
-// GetOrg gets the Organization that e belongs to.
-func (e *Environment) GetOrg() string {
-	return e.Organization
-}
-
-// GetEnv gets the Evironment that e belongs to (itself).
-func (e *Environment) GetEnv() string {
+// GetEnvironment gets the Evironment that e belongs to (itself).
+func (e *Environment) GetEnvironment() string {
 	return e.Name
 }
 

--- a/types/error.go
+++ b/types/error.go
@@ -1,15 +1,5 @@
 package types
 
-// GetOrg refers to the organization the check belongs to
-func (e *Error) GetOrg() string {
-	return e.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (e *Error) GetEnv() string {
-	return e.Environment
-}
-
 // FixtureError returns a testing fixture for an Error object.
 func FixtureError(name string, message string) *Error {
 	event := FixtureEvent("agent", "check")

--- a/types/filter.go
+++ b/types/filter.go
@@ -92,16 +92,6 @@ func validateStatements(statements []string) error {
 	return nil
 }
 
-// GetOrg refers to the organization the filter belongs to
-func (f *EventFilter) GetOrg() string {
-	return f.Organization
-}
-
-// GetEnv refers to the organization the filter belongs to
-func (f *EventFilter) GetEnv() string {
-	return f.Environment
-}
-
 // FixtureEventFilter returns a Filter fixture for testing.
 func FixtureEventFilter(name string) *EventFilter {
 	return &EventFilter{

--- a/types/handler.go
+++ b/types/handler.go
@@ -42,16 +42,6 @@ func (h *Handler) Validate() error {
 	return nil
 }
 
-// GetOrg refers to the organization the handler belongs to
-func (h *Handler) GetOrg() string {
-	return h.Organization
-}
-
-// GetEnv refers to the organization the handler belongs to
-func (h *Handler) GetEnv() string {
-	return h.Environment
-}
-
 // FixtureHandler returns a Handler fixture for testing.
 func FixtureHandler(name string) *Handler {
 	return &Handler{

--- a/types/multitenant.go
+++ b/types/multitenant.go
@@ -4,14 +4,14 @@ import "context"
 
 // MultitenantResource is a object that belongs to an organization
 type MultitenantResource interface {
-	GetOrg() string
-	GetEnv() string
+	GetOrganization() string
+	GetEnvironment() string
 }
 
 // SetContextFromResource takes a context and a multi-tenant resource, adds the environment and
 // organization to the context, and returns the udpated context
 func SetContextFromResource(ctx context.Context, r MultitenantResource) context.Context {
-	ctx = context.WithValue(ctx, EnvironmentKey, r.GetEnv())
-	ctx = context.WithValue(ctx, OrganizationKey, r.GetOrg())
+	ctx = context.WithValue(ctx, EnvironmentKey, r.GetEnvironment())
+	ctx = context.WithValue(ctx, OrganizationKey, r.GetOrganization())
 	return ctx
 }

--- a/types/mutator.go
+++ b/types/mutator.go
@@ -44,16 +44,6 @@ func (m *Mutator) Update(from *Mutator, fields ...string) error {
 	return nil
 }
 
-// GetOrg refers to the organization the check belongs to
-func (m *Mutator) GetOrg() string {
-	return m.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (m *Mutator) GetEnv() string {
-	return m.Environment
-}
-
 // FixtureMutator returns a Mutator fixture for testing.
 func FixtureMutator(name string) *Mutator {
 	return &Mutator{

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -69,19 +69,6 @@ var (
 )
 
 //
-// Getters
-
-// GetOrg refers to the organization the check belongs to
-func (r *Rule) GetOrg() string {
-	return r.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (r *Rule) GetEnv() string {
-	return r.Environment
-}
-
-//
 // Validators
 
 // Validate returns an error if the rule is invalid.

--- a/types/silenced.go
+++ b/types/silenced.go
@@ -13,16 +13,6 @@ func (s *Silenced) Validate() error {
 	return nil
 }
 
-// GetOrg refers to the organization the check belongs to
-func (s *Silenced) GetOrg() string {
-	return s.Organization
-}
-
-// GetEnv refers to the organization the check belongs to
-func (s *Silenced) GetEnv() string {
-	return s.Environment
-}
-
 // FixtureSilenced returns a testing fixutre for a Silenced event struct.
 func FixtureSilenced(checkName string) *Silenced {
 	return &Silenced{


### PR DESCRIPTION
## What is this change?

As protobuf now defines getters for us, I have removed the now extraneous `GetEnv` & `GetOrg` getter methods.

## Why is this change necessary?

Closes #606 