### PR TITLE
Fix bugs in Marshal and Unmarshal.

### DIFF
--- a/types/dynamic/dynamic.go
+++ b/types/dynamic/dynamic.go
@@ -108,7 +108,7 @@ type structField struct {
 }
 
 func (s structField) IsEmpty() bool {
-	zeroValue := reflect.Zero(s.Field.Type).Interface()
+	zeroValue := reflect.Zero(reflect.Indirect(s.Value).Type()).Interface()
 	return reflect.DeepEqual(zeroValue, s.Value.Interface())
 }
 
@@ -118,7 +118,9 @@ func (s structField) jsonFieldName() (string, bool) {
 	omitEmpty := false
 	if ok {
 		parts := strings.Split(tag, ",")
-		fieldName = parts[0]
+		if len(parts[0]) > 0 {
+			fieldName = parts[0]
+		}
 		if len(parts) > 1 && parts[1] == "omitempty" {
 			omitEmpty = true
 		}

--- a/types/dynamic/dynamic_test.go
+++ b/types/dynamic/dynamic_test.go
@@ -87,7 +87,7 @@ type MyType struct {
 	Foo string   `json:"foo"`
 	Bar []MyType `json:"bar"`
 
-	Attrs []byte // note that this will not be marshalled directly, despite missing the `json"-"`!
+	Attrs []byte `json:",omitempty"` // note that this will not be marshalled directly, despite missing the `json"-"`!
 }
 
 func (m *MyType) GetExtendedAttributes() []byte {
@@ -153,8 +153,9 @@ func TestMarshal(t *testing.T) {
 
 func TestMarshalEmptyAttrs(t *testing.T) {
 	var m MyType
-	_, err := Marshal(&m)
+	b, err := Marshal(&m)
 	require.NoError(t, err)
+	assert.Equal(t, `{"bar":null,"foo":""}`, string(b))
 }
 
 func TestUnmarshalEmptyAttrs(t *testing.T) {


### PR DESCRIPTION
## What is this change?

* Fixed a bug with early return in Marshal.
* Fixed a bug where empty extended attributes resulted in {}
  instead of nil.

## Why is this change necessary?
Fixes #608

I made these changes while working on #603 but wanted to keep them in a separate branch so that they could be tracked separately.