### PR TITLE
Add request org to updated environments if org is missing

### DIFF
--- a/backend/apid/routers/environments.go
+++ b/backend/apid/routers/environments.go
@@ -59,6 +59,15 @@ func (r *EnvironmentsRouter) update(req *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	// https://github.com/sensu/sensu-go/pull/574
+	// Introduced a breaking change to environments that caused them to fail
+	// updates because organization is required, but it wasn't previously.
+	// This allows users to update environments that were created before this
+	// requirement.
+	if env.Organization == "" {
+		env.Organization = mux.Vars(req)["organization"]
+	}
+
 	err := r.controller.Update(req.Context(), env)
 	return env, err
 }


### PR DESCRIPTION
## What is this change?

When updating an environment, we will now insert the organization specified in the request if the org is missing from the updated environment.

## Why is this change necessary?

The CLI does not allow users to modify the organization of an environment, and so it would fail upon updating environments.