### PR TITLE
Add migration tool into sensu-backend binary

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sensu/sensu-go/backend/eventd"
 	"github.com/sensu/sensu-go/backend/keepalived"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/migration"
 	"github.com/sensu/sensu-go/backend/pipelined"
 	"github.com/sensu/sensu-go/backend/schedulerd"
 	"github.com/sensu/sensu-go/backend/store/etcd"
@@ -360,6 +361,18 @@ func (b *Backend) Run() error {
 	// goroutines writing errors to either after shutdown has been initiated.
 	close(b.done)
 
+	return nil
+}
+
+// Migration performs the migration of data inside the store
+func (b *Backend) Migration() error {
+	_, err := b.etcd.NewStore()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("starting migration on the store with URL '%s'", b.etcd.LoopbackURL())
+	migration.Run(b.etcd.LoopbackURL())
 	return nil
 }
 

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -138,6 +138,10 @@ func newStartCommand() *cobra.Command {
 				sensuBackend.Stop()
 			}()
 
+			if len(args) == 1 && args[0] == "migration" {
+				return sensuBackend.Migration()
+			}
+
 			return sensuBackend.Run()
 		},
 	}

--- a/backend/migration/environments.go
+++ b/backend/migration/environments.go
@@ -1,0 +1,59 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/types"
+)
+
+// environments performs a migration on the environments in etcd, required by a
+// breaking change introduced in https://github.com/sensu/sensu-go/pull/574,
+// which effectively prevent users to update their environments because the new
+// organization attribute is required.
+func environments(storeURL string) {
+	logger.Info("running environments migration")
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{storeURL},
+		DialTimeout: 5 * time.Second,
+	})
+
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	envsResponse, err := client.Get(context.Background(), "/sensu.io/environments", clientv3.WithPrefix())
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	for _, kv := range envsResponse.Kvs {
+		envBytes := kv.Value
+		env := &types.Environment{}
+		if err := json.Unmarshal(envBytes, env); err != nil {
+			logger.WithError(err).Info("error unmarshaling environment: ")
+			continue
+		}
+
+		if env.Organization == "" {
+			pathParts := strings.Split(string(kv.Key), "/")
+			if len(pathParts) != 5 {
+				logger.Info("cannot parse environment key for migration: ", kv.Key)
+				continue
+			}
+
+			env.Organization = pathParts[3]
+			envBytes, _ := json.Marshal(env)
+			_, err := client.Put(context.Background(), string(kv.Key), string(envBytes))
+			if err != nil {
+				logger.WithError(err).Info("error updating environment in store: ")
+			}
+		}
+	}
+
+	logger.Info("migration of environment completed")
+}

--- a/backend/migration/migration.go
+++ b/backend/migration/migration.go
@@ -1,0 +1,12 @@
+package migration
+
+import "github.com/Sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "migration",
+})
+
+// Run lauches the migration process
+func Run(storeURL string) {
+	environments(storeURL)
+}

--- a/backend/store/etcd/etcd.go
+++ b/backend/store/etcd/etcd.go
@@ -263,3 +263,8 @@ func (e *Etcd) Healthy() bool {
 	}
 	return true
 }
+
+// LoopbackURL returns the lookback URL used by etcd
+func (e *Etcd) LoopbackURL() string {
+	return e.loopbackURL
+}


### PR DESCRIPTION
## What is this change?

It adds a really basic migration tool into the sensu-backend binary. I included the script Greg wrote previously for migrating environments.

For now, it can be ran with `sensu-backend start migration`.  (We should probably move it to its own subcommand instead of within the `start` one but I had limited time and didn't wanted to duplicate the code required for loading the configuration).

## Why is this change necessary?

So users can edit their environments.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!