### PR TITLE
Ensure that GraphQL queries are compiled before building dashboard

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@ set -o pipefail
 set -e
 
 REPO_PATH="github.com/sensu/sensu-go"
+DASHBOARD_PATH="dashboard"
 
 eval $(go env)
 
@@ -232,23 +233,25 @@ check_for_presence_of_yarn() {
 install_dashboard_deps() {
   go get -u github.com/UnnoTed/fileb0x
   check_for_presence_of_yarn
-  cd dashboard
+  pushd "${DASHBOARD_PATH}"
   yarn install
-  cd $OLDPWD
+  yarn precompile
+  popd
 }
 
 test_dashboard() {
-  cd dashboard
+  pushd "${DASHBOARD_PATH}"
   yarn lint
   yarn test --coverage
-  cd $OLDPWD
+  popd
 }
 
 build_dashboard() {
-  cd dashboard
+  pushd "${DASHBOARD_PATH}"
   yarn install
+  yarn precompile
   yarn build
-  cd $OLDPWD
+  popd
 }
 
 bundle_static_assets() {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -74,8 +74,9 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "postinstall": "yarn update-schema",
-    "prestart": "yarn update-schema && yarn compile-queries",
+    "postinstall": "yarn run precompile",
+    "prestart": "yarn precompile",
+    "pretest": "yarn precompile",
     "prettier": "./node_module/.bin/prettier --write src/**/*.js",
     "lint": "./node_modules/.bin/eslint src",
     "start": "node scripts/start.js",
@@ -83,7 +84,8 @@
     "test": "node scripts/test.js --env=jsdom",
     "quality": "yarn lint && yarn test",
     "compile-queries": "./node_modules/.bin/relay-compiler --src ./src --schema ./data/schema.json",
-    "update-schema": "go run scripts/updateSchema.go"
+    "update-schema": "go run scripts/updateSchema.go",
+    "precompile": "npm run update-schema && npm run compile-queries"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
## What is this change?

Ensure that GraphQL queries are compiled before building dashboard

## Why is this change necessary?

`yarn build` errs out if queries are not built.
