### PR TITLE
Initialize a changelog and add 2.0.0-alpha.8 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## [2.0.0-alpha.8] - 2017-11-28
 ### Added
 - New "event delete" subcommand in sensuctl


### PR DESCRIPTION
## What is this change?

Adds a changelog for sensu-go and includes the 2.0.0-alpha.8 changes

## Why is this change necessary?

> To make it easier for users and contributors to see precisely what notable changes have been made between each release (or version) of the project.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!