### PR TITLE
Push all docker tags on git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 branches:
   only:
   - master
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 stages:
 - name: test
 - name: deploy


### PR DESCRIPTION
## What is this change?

It automatically push the `latest` & other Docker tags (e.g. `2.0-pre`) to the Docker hub when we have a git tag.

## Why is this change necessary?

So it doesn't have to be manually ran.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!