### PR TITLE
Avoid panic when ExtendedAttributes are empty

### DIFF
--- a/types/dynamic/dynamic.go
+++ b/types/dynamic/dynamic.go
@@ -176,7 +176,10 @@ func GetField(v AttrGetter, name string) (interface{}, error) {
 		return nil, errors.New("dynamic: empty path specified")
 	}
 	extendedAttributes := v.GetExtendedAttributes()
-	extAttrPtr := &extendedAttributes[0]
+	var extAttrPtr *byte
+	if len(extendedAttributes) > 0 {
+		extAttrPtr = &extendedAttributes[0]
+	}
 	if s := string([]rune(name)[0]); strings.Title(s) == s {
 		// Exported fields are always upper-cased for the first rune
 		strukt := reflect.Indirect(reflect.ValueOf(v))

--- a/types/dynamic/dynamic_test.go
+++ b/types/dynamic/dynamic_test.go
@@ -227,6 +227,40 @@ func TestGetField(t *testing.T) {
 	}
 }
 
+func TestGetFieldEmptyBytes(t *testing.T) {
+	m := MyType{
+		Foo:   "hello",
+		Attrs: []byte(``),
+	}
+
+	testCases := []struct {
+		field     string
+		expected  interface{}
+		expectErr bool
+	}{
+		{
+			field:     "Foo",
+			expected:  "hello",
+			expectErr: false,
+		},
+		{
+			field:     "bar",
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.field, func(t *testing.T) {
+			field, err := GetField(&m, tc.field)
+			assert.Equal(t, tc.expected, field)
+			if tc.expectErr {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestQueryGovaluateSimple(t *testing.T) {
 	m := &MyType{
 		Attrs: []byte(`{"hello":5}`),


### PR DESCRIPTION
## What is this change?

I suspect this is the safest approach considering that, at very least,
all of our existing types will not have have ExtendedAttributes field
set.

## Why is this change necessary?

Was discovered while writing a test for #604.