### PR TITLE
Updated store to return TTLs from etcd for silenced entries

### DIFF
--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -170,9 +170,7 @@ func (s *etcdStore) arraySilencedEntries(resp *clientv3.GetResponse) ([]*types.S
 		if err != nil {
 			return nil, err
 		}
-		if ttl.TTL > 0 {
-			silencedEntry.Expire = ttl.TTL
-		}
+		silencedEntry.Expire = ttl.TTL
 		silencedArray[i] = silencedEntry
 	}
 	return silencedArray, nil

--- a/backend/store/etcd/silenced_store_test.go
+++ b/backend/store/etcd/silenced_store_test.go
@@ -65,8 +65,8 @@ func TestSilencedStorage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, entry)
 		assert.Equal(t, "subscription:*", entry.ID)
-		// Entries without expirations should return zero
-		assert.Zero(t, entry.Expire)
+		// Entries without expirations should return -1
+		assert.Equal(t, int64(-1), entry.Expire)
 
 		// Delete silenced entry by id
 		err = store.DeleteSilencedEntryByID(ctx, silenced.ID)


### PR DESCRIPTION
## What is this change?

Silenced entries now return actual TTLs from etcd if they have an expiry set.

## Why is this change necessary?

Closes #667.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!