### PR TITLE
Update changelog for events endpoint and sensuctl command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ supporting extended attributes.
 - Add silenced command to sensuctl for silencing checks and subscriptions.
 - Add healthz endpoint to agent api for checking agent liveness.
 - Add ability to pass JSON event data to check command STDIN.
+- Add POST /events endpoint to manually create, update, and resolve events.
+- Add "event resolve" command to sensuctl to manually resolve events.
 
 ### Changed
 - Fixed a bug in how silenced entries were deleted. Only one silenced entry will


### PR DESCRIPTION
## What is this change?

Updates the changelog with POST /events endpoint and "sensuctl event resolve" feature.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/675.

## Do you need clarification on anything?

Nah

## Were there any complications while making this change?

Nah