### PR TITLE
List hooks in check list/info

### DIFF
--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -92,6 +92,13 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
+			Title: "Hooks",
+			CellTransformer: func(data interface{}) string {
+				check, _ := data.(types.CheckConfig)
+				return globals.FormatCheckHooks(check.CheckHooks)
+			},
+		},
+		{
 			Title: "Publish?",
 			CellTransformer: func(data interface{}) string {
 				check, _ := data.(types.CheckConfig)

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -83,6 +83,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert.Contains(out, "name-one")  // check name
 	assert.Contains(out, "asset-one") // asset name
 	assert.Contains(out, "60")        // interval
+	assert.Contains(out, "Hooks")     // heading
 	assert.Nil(err)
 }
 

--- a/cli/commands/check/show.go
+++ b/cli/commands/check/show.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/globals"
 	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
@@ -81,6 +82,10 @@ func printCheckToList(r *types.CheckConfig, writer io.Writer) {
 			{
 				Label: "Runtime Assets",
 				Value: strings.Join(r.RuntimeAssets, ", "),
+			},
+			{
+				Label: "Hooks",
+				Value: globals.FormatCheckHooks(r.CheckHooks),
 			},
 			{
 				Label: "Publish?",

--- a/cli/commands/check/show_test.go
+++ b/cli/commands/check/show_test.go
@@ -65,6 +65,7 @@ func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert.Contains(out, "Name")
 	assert.Contains(out, "Interval")
 	assert.Contains(out, "Command")
+	assert.Contains(out, "Hooks")
 	assert.Nil(err)
 }
 

--- a/cli/elements/globals/maps.go
+++ b/cli/elements/globals/maps.go
@@ -1,0 +1,19 @@
+package globals
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// FormatCheckHooks formats the Check Hook struct into a string mapping
+func FormatCheckHooks(checkHooks []types.CheckHook) string {
+	hooksString := []string{}
+	for _, checkHook := range checkHooks {
+		hookString := fmt.Sprintf("%s: [", checkHook.Type)
+		hookString += fmt.Sprintf("%s]", strings.Join(checkHook.Hooks, ", "))
+		hooksString = append(hooksString, hookString)
+	}
+	return strings.Join(hooksString, ", ")
+}


### PR DESCRIPTION
## What is this change?

List all hooks associated with a check in `sensuctl check list` and `sensuctl check info`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/682.

## Do you need clarification on anything?

Nah. But I'm super open to stylistic changes in how the hook strings are formatted here. 
ex:
```
=== check1
Name:           check1
Hooks:          critical: [burn-everything], non-zero: [ps-aux, do-something]
```

## Were there any complications while making this change?

Nah

## Is this a new and complete feature?

N/A