### PR TITLE
Bugfix: resolve a panic in dynamic.Marshal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ to clean up existing errcheck lint.
 - Fixed a bug in the agent where it was ignoring keepalive interval and timeout
   settings on start
 - Keepalives now alert when entities go away!
+- Fixed a bug in package dynamic that could lead to an error in json.Marshal
+in certain cases.
 
 ## [2.0.0-alpha.9] - 2017-12-5
 ### Added

--- a/types/dynamic/dynamic_test.go
+++ b/types/dynamic/dynamic_test.go
@@ -418,3 +418,46 @@ func TestSetFieldOnExtendedAttributes(t *testing.T) {
 		})
 	}
 }
+
+type Problematic struct {
+	Foo   string
+	Bar   *string
+	Attrs []byte `json:"-"`
+}
+
+func (p *Problematic) GetExtendedAttributes() []byte {
+	return p.Attrs
+}
+
+func (p *Problematic) SetExtendedAttributes(b []byte) {
+	p.Attrs = b
+}
+
+func TestMarshalNilField(t *testing.T) {
+	p := &Problematic{
+		Foo: "yes",
+		Bar: nil,
+	}
+	b, err := Marshal(p)
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"Bar":null,"Foo":"yes"}`), b)
+}
+
+func TestUnmarshalNilField(t *testing.T) {
+	p := &Problematic{}
+	err := Unmarshal([]byte(`{"Bar":null,"Foo":"yes"}`), p)
+	require.NoError(t, err)
+}
+
+func TestMarshalNilProblematic(t *testing.T) {
+	var p *Problematic = nil //nolint
+	b, err := Marshal(p)
+	require.NoError(t, err)
+	require.Equal(t, []byte("null"), b)
+}
+
+func TestUnmarshalNilProblematic(t *testing.T) {
+	var p *Problematic = nil //nolint
+	err := Unmarshal([]byte("{}"), p)
+	require.Error(t, err)
+}

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -1,9 +1,11 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFixtureEventIsValid(t *testing.T) {
@@ -25,4 +27,10 @@ func TestEventValidate(t *testing.T) {
 	event.Entity.ID = "entity"
 
 	assert.NoError(t, event.Validate())
+}
+
+func TestMarshalJSON(t *testing.T) {
+	event := FixtureEvent("entity", "check")
+	_, err := json.Marshal(event)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
In certain cases, dynamic.Marshal would attempt to call Interface()
on nil reflect values. Add checks and tests for various edge cases
so that the functions in this package don't have so many sharp
edges.

Fixes #720

Signed-off-by: Eric Chlebek <eric@sensu.io>