### PR TITLE
Refactoring of the getSilenced in eventd

### DIFF
--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -11,7 +11,7 @@ import (
 // addEntitySubscription appends the entity subscription (using the format
 // "entity:entityID") to the subscriptions of an entity
 func addEntitySubscription(entityID string, subscriptions []string) []string {
-	entityKey := fmt.Sprintf("entity:%s", entityID)
+	entityKey := types.GetEntitySubscription(entityID)
 	return append(subscriptions, entityKey)
 }
 

--- a/backend/eventd/silenced.go
+++ b/backend/eventd/silenced.go
@@ -2,52 +2,104 @@ package eventd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/util/strings"
 )
 
-// Add a list of all silenced subscriptions to the event.
-func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
-	var (
-		silencedSubscriptions []*types.Silenced
-		silencedChecks        []*types.Silenced
-		silencedEntries       map[string]bool
-		err                   error
-	)
-
-	// Get all silenced entries by agent subscription and check name. This takes
-	// any wildcards into account (subscription:* or *checkName).
-	// TODO: implement deletion of silenced entries that have ExpireOnResolve set
-	// to true.
-	silencedEntries = make(map[string]bool)
-
-	// Get the silenced entries for the entity
-	for _, value := range event.Entity.Subscriptions {
-		silencedSubscriptions, err = s.GetSilencedEntriesBySubscription(ctx, value)
-		if err != nil {
-			return err
-		}
+// addToSilencedBy takes a silenced entry ID and adds it to a silence of IDs if
+// it's not already present in order to avoid duplicated elements
+func addToSilencedBy(id string, ids []string) []string {
+	if !strings.InArray(id, ids) {
+		ids = append(ids, id)
 	}
-	appendEntries(event, silencedSubscriptions, silencedEntries)
+	return ids
+}
 
-	// Get the silenced entries for the check
-	silencedChecks, err = s.GetSilencedEntriesByCheckName(ctx, event.Check.Config.Name)
+// getSilenced retrieves all silenced entries for a given event, using the
+// entity subscription, the check subscription and the check name while
+// supporting wildcard silenced entries (e.g. subscription:*)
+func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
+	entries := []*types.Silenced{}
+
+	// Retrieve silenced entries using the entity subscription
+	entitySubscription := types.GetEntitySubscription(event.Entity.ID)
+	results, err := s.GetSilencedEntriesBySubscription(ctx, entitySubscription)
 	if err != nil {
 		return err
 	}
-	appendEntries(event, silencedChecks, silencedEntries)
+	entries = append(entries, results...)
+
+	// Retrieve silenced entries using the check subscriptions
+	for _, value := range event.Check.Config.Subscriptions {
+		results, err = s.GetSilencedEntriesBySubscription(ctx, value)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, results...)
+	}
+
+	// Retrieve silenced entries using the check name
+	results, err = s.GetSilencedEntriesByCheckName(ctx, event.Check.Config.Name)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, results...)
+
+	// Determine which entries silence this event
+	silencedIDs := silencedBy(event, entries)
+
+	// Add to the event all silenced entries ID that actually silence it
+	event.Silenced = silencedIDs
 
 	return nil
 }
 
-// iterate through silencedEntries and create an array of silenced entries in
-// the event minus any duplicates.
-func appendEntries(event *types.Event, silenced []*types.Silenced, silencedEntries map[string]bool) {
-	for _, entry := range silenced {
-		if _, value := silencedEntries[entry.ID]; !value {
-			silencedEntries[entry.ID] = true
-			event.Silenced = append(event.Silenced, entry.ID)
+// silencedBy determines which of the given silenced entries silenced a given
+// event and return a list of silenced entry IDs
+func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string {
+	silencedBy := []string{}
+
+	// Loop through every silenced entries in order to determine if it applies to
+	// the given event
+	for _, entry := range silencedEntries {
+		// Is this event silenced for all subscriptions? (e.g. *:check_cpu)
+		if entry.ID == fmt.Sprintf("*:%s", event.Check.Config.Name) {
+			silencedBy = addToSilencedBy(entry.ID, silencedBy)
+			continue
+		}
+
+		// Is this event silenced by the entity subscription? (e.g. entity:id:*)
+		if entry.ID == fmt.Sprintf("%s:*", types.GetEntitySubscription(event.Entity.ID)) {
+			silencedBy = addToSilencedBy(entry.ID, silencedBy)
+			continue
+		}
+
+		// Is this event silenced for this particular entity? (e.g.
+		// entity:id:check_cpu)
+		if entry.ID == fmt.Sprintf("%s:%s", types.GetEntitySubscription(event.Entity.ID), event.Check.Config.Name) {
+			silencedBy = addToSilencedBy(entry.ID, silencedBy)
+			continue
+		}
+
+		for _, subscription := range event.Check.Config.Subscriptions {
+			// Is this event silenced by one of the check subscription? (e.g.
+			// load-balancer:*)
+			if entry.ID == fmt.Sprintf("%s:*", subscription) {
+				silencedBy = addToSilencedBy(entry.ID, silencedBy)
+				continue
+			}
+
+			// Is this event silenced by one of the check subscription for this
+			// particular check? (e.g. load-balancer:check_cpu)
+			if entry.ID == fmt.Sprintf("%s:%s", subscription, event.Check.Config.Name) {
+				silencedBy = addToSilencedBy(entry.ID, silencedBy)
+				continue
+			}
 		}
 	}
+
+	return silencedBy
 }

--- a/backend/eventd/silenced_test.go
+++ b/backend/eventd/silenced_test.go
@@ -10,145 +10,27 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// test cases:
-// 	silenced check
-func TestIsSilenced(t *testing.T) {
+func TestGetSilenced(t *testing.T) {
 	testCases := []struct {
-		description             string
-		event                   *types.Event
-		silencedSubscriptions   []*types.Silenced
-		silencedChecks          []*types.Silenced
-		expectedSilencedEntries []string
+		name                  string
+		event                 *types.Event
+		silencedSubscriptions []*types.Silenced
+		silencedChecks        []*types.Silenced
+		expectedEntries       []string
 	}{
 		{
-			"silenced with one subscription",
-			&types.Event{
-				Entity: &types.Entity{
-					Subscriptions: []string{"subscription1", "subscription2"},
-				},
-				Check: &types.Check{
-					Config: &types.CheckConfig{},
-					Status: 1,
-				},
+			name:  "Sets the silenced attribute of an event",
+			event: types.FixtureEvent("foo", "check_cpu"),
+			silencedSubscriptions: []*types.Silenced{},
+			silencedChecks: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:check_cpu"),
 			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription1:check1",
-					Subscription: "subscription1",
-					Check:        "check1",
-				},
-			},
-			[]*types.Silenced{},
-			[]string{"subscription1:check1"},
-		},
-		{
-			"silenced with multiple subscriptions",
-			&types.Event{
-				Entity: &types.Entity{
-					Subscriptions: []string{"subscription1", "subscription2", "subscription3"},
-				},
-				Check: &types.Check{
-					Config: &types.CheckConfig{},
-					Status: 1,
-				},
-			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription1:check1",
-					Subscription: "subscription1",
-					Check:        "check1",
-				},
-				&types.Silenced{
-					ID:           "subscription2:check2",
-					Subscription: "subscription2",
-					Check:        "check2",
-				},
-			},
-			[]*types.Silenced{},
-			[]string{"subscription1:check1", "subscription2:check2"},
-		},
-		{
-			"silenced with no silenced events",
-			&types.Event{
-				Entity: &types.Entity{
-					Subscriptions: []string{"subscription1", "subscription2"},
-				},
-				Check: &types.Check{
-					Config: &types.CheckConfig{},
-					Status: 1,
-				},
-			},
-			[]*types.Silenced{},
-			[]*types.Silenced{},
-			nil,
-		},
-		{
-			"silenced with check and subscription",
-			&types.Event{
-				Entity: &types.Entity{
-					Subscriptions: []string{"subscription1"},
-				},
-				Check: &types.Check{
-					Config: &types.CheckConfig{
-						Name: "check2",
-					},
-					Status: 1,
-				},
-			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription1:check1",
-					Subscription: "subscription1",
-					Check:        "check1",
-				},
-			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription2:check2",
-					Subscription: "subscription2",
-					Check:        "check2",
-				},
-			},
-			[]string{"subscription1:check1", "subscription2:check2"},
-		},
-		{
-			"silenced with duplicate check and subscription",
-			&types.Event{
-				Entity: &types.Entity{
-					Subscriptions: []string{"subscription1", "subscription2"},
-				},
-				Check: &types.Check{
-					Config: &types.CheckConfig{
-						Name: "check1",
-					},
-					Status: 1,
-				},
-			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription1:check1",
-					Subscription: "subscription1",
-					Check:        "check1",
-				},
-				&types.Silenced{
-					ID:           "subscription2:check2",
-					Subscription: "subscription2",
-					Check:        "check2",
-				},
-			},
-			[]*types.Silenced{
-				&types.Silenced{
-					ID:           "subscription2:check2",
-					Subscription: "subscription2",
-					Check:        "check2",
-				},
-			},
-			[]string{"subscription1:check1", "subscription2:check2"},
+			expectedEntries: []string{"entity:foo:check_cpu"},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), types.OrganizationKey, "default")
 			ctx = context.WithValue(ctx, types.EnvironmentKey, "default")
 
@@ -165,7 +47,98 @@ func TestIsSilenced(t *testing.T) {
 
 			result := getSilenced(ctx, tc.event, mockStore)
 			assert.Nil(t, result)
-			assert.Equal(t, tc.expectedSilencedEntries, tc.event.Silenced)
+			assert.Equal(t, tc.expectedEntries, tc.event.Silenced)
+		})
+	}
+}
+
+func TestSilencedBy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		event           *types.Event
+		entries         []*types.Silenced
+		expectedEntries []string
+	}{
+		{
+			name:            "no entries",
+			event:           types.FixtureEvent("foo", "check_cpu"),
+			expectedEntries: []string{},
+		},
+		{
+			name:  "not silenced",
+			event: types.FixtureEvent("foo", "check_cpu"),
+			entries: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:check_mem"),
+				types.FixtureSilenced("entity:bar:*"),
+				types.FixtureSilenced("foo:check_cpu"),
+				types.FixtureSilenced("foo:*"),
+				types.FixtureSilenced("*:check_mem"),
+			},
+			expectedEntries: []string{},
+		},
+		{
+			name:  "silenced by check",
+			event: types.FixtureEvent("foo", "check_cpu"),
+			entries: []*types.Silenced{
+				types.FixtureSilenced("*:check_cpu"),
+			},
+			expectedEntries: []string{"*:check_cpu"},
+		},
+		{
+			name:  "silenced by entity subscription",
+			event: types.FixtureEvent("foo", "check_cpu"),
+			entries: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:*"),
+			},
+			expectedEntries: []string{"entity:foo:*"},
+		},
+		{
+			name:  "silenced by entity's check subscription",
+			event: types.FixtureEvent("foo", "check_cpu"),
+			entries: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:check_cpu"),
+			},
+			expectedEntries: []string{"entity:foo:check_cpu"},
+		},
+		{
+			name:  "silenced by check subscription",
+			event: types.FixtureEvent("foo", "check_cpu"), // has a linux subscription
+			entries: []*types.Silenced{
+				types.FixtureSilenced("linux:*"),
+			},
+			expectedEntries: []string{"linux:*"},
+		},
+		{
+			name:  "silenced by subscription with check",
+			event: types.FixtureEvent("foo", "check_cpu"), // has a linux subscription
+			entries: []*types.Silenced{
+				types.FixtureSilenced("linux:check_cpu"),
+			},
+			expectedEntries: []string{"linux:check_cpu"},
+		},
+		{
+			name:  "silenced by multiple entries",
+			event: types.FixtureEvent("foo", "check_cpu"), // has a linux subscription
+			entries: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:*"),
+				types.FixtureSilenced("linux:check_cpu"),
+			},
+			expectedEntries: []string{"entity:foo:*", "linux:check_cpu"},
+		},
+		{
+			name:  "silenced by duplicated entries",
+			event: types.FixtureEvent("foo", "check_cpu"), // has a linux subscription
+			entries: []*types.Silenced{
+				types.FixtureSilenced("entity:foo:*"),
+				types.FixtureSilenced("entity:foo:*"),
+			},
+			expectedEntries: []string{"entity:foo:*"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := silencedBy(tc.event, tc.entries)
+			assert.Equal(t, tc.expectedEntries, result)
 		})
 	}
 }

--- a/types/check.go
+++ b/types/check.go
@@ -134,7 +134,7 @@ func FixtureCheckConfig(id string) *CheckConfig {
 	return &CheckConfig{
 		Name:          id,
 		Interval:      interval,
-		Subscriptions: []string{},
+		Subscriptions: []string{"linux"},
 		Command:       "command",
 		Handlers:      []string{},
 		RuntimeAssets: []string{"ruby-2-4-2"},

--- a/types/entity.go
+++ b/types/entity.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	fmt "fmt"
 
 	"github.com/sensu/sensu-go/types/dynamic"
 )
@@ -53,6 +54,12 @@ func (e *Entity) UnmarshalJSON(b []byte) error {
 // MarshalJSON implements the json.Marshaler interface.
 func (e *Entity) MarshalJSON() ([]byte, error) {
 	return dynamic.Marshal(e)
+}
+
+// GetEntitySubscription returns the entity subscription, using the format
+// "entity:entityID"
+func GetEntitySubscription(entityID string) string {
+	return fmt.Sprintf("entity:%s", entityID)
 }
 
 // FixtureEntity returns a testing fixture for an Entity object.

--- a/types/silenced.go
+++ b/types/silenced.go
@@ -27,14 +27,24 @@ func (s *Silenced) Validate() error {
 
 // FixtureSilenced returns a testing fixutre for a Silenced event struct.
 func FixtureSilenced(id string) *Silenced {
+	var check, subscription string
+
 	parts := strings.Split(id, ":")
-	if len(parts) != 2 {
+
+	if len(parts) == 2 {
+		check = parts[1]
+		subscription = parts[0]
+	} else if len(parts) == 3 {
+		check = parts[2]
+		subscription = strings.Join(parts[0:2], ":")
+	} else {
 		panic("invalid silenced ID")
 	}
+
 	return &Silenced{
 		ID:           id,
-		Check:        parts[1],
-		Subscription: parts[0],
+		Check:        check,
+		Subscription: subscription,
 	}
 }
 

--- a/types/silenced_test.go
+++ b/types/silenced_test.go
@@ -26,6 +26,10 @@ func TestFixtureSilenced(t *testing.T) {
 	assert.NotNil(t, s.Subscription)
 	assert.NotNil(t, s.Organization)
 	assert.NotNil(t, s.Environment)
+
+	s = FixtureSilenced("entity:test_subscription:test_check")
+	assert.Equal(t, "entity:test_subscription", s.Subscription)
+	assert.Equal(t, "test_check", s.Check)
 }
 
 // Validation should fail when we don't provide a CheckName or Subscription


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Refactoring of the getSilenced function in eventd so it properly supports the silenced functionality. 

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/707

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

There might be a confusion regarding how silenced entries work in Sensu v1. We should probably cover that in next week training!

## Is this a new and complete feature?

We already have an entry for fixing entities silencing