### PR TITLE
Suggest you need a changelog entry in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@ A brief one-sentence-ish description of the change.
 
 A brief description of why the change of behavior is necessary.
 
+## Does your change need a Changelog entry?
+
+Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
 
 ## Do you need clarification on anything?
 
@@ -22,8 +25,3 @@ If anything went awry while working on this change or if you ran into systemic i
 - it was difficult to get the information you needed to complete the issue
 
 Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-
-
-## Is this a new and complete feature?
-
-Did you update CHANGELOG.md, if applicable?


### PR DESCRIPTION
## What is this change?

Update the changelog PR template section to be a lit more encouraging for people to add a changelog entry.

## Why is this change necessary?

I've moved the changelog reminder closer to the top, so it's less likely people will highlight everything after the second section and hit delete. Also, this links to the contributing changelog guidelines.


