### PR TITLE
Refactor time.InWindows to not require reflection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Avoid using reflection in time.InWindows function.
+
 ## [2.0.0-alpha.10] - 2017-12-12
 ### Added
 - End-to-end test for the silencing functionality


### PR DESCRIPTION
This commit refactors the InWindows function so that it doesn't
use reflection. Since we have static knowledge about the
TimeWindowWhen type, there is actually no need to use the reflect
package here.

Signed-off-by: Eric Chlebek <eric@sensu.io>