### PR TITLE
Don't update tools each run

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,14 +37,14 @@ function install_deps
     go get gopkg.in/alecthomas/gometalinter.v1
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
-    go get -u github.com/golang/lint/golint
-    go get -u github.com/UnnoTed/fileb0x
+    go get github.com/golang/lint/golint
+    go get github.com/UnnoTed/fileb0x
     install_golang_dep
 }
 
 function install_golang_dep
 {
-    go get -u github.com/golang/dep/cmd/dep
+    go get github.com/golang/dep/cmd/dep
     echo "Running dep ensure..."
     dep ensure -v
 }

--- a/build.sh
+++ b/build.sh
@@ -39,13 +39,13 @@ install_deps () {
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
     go get github.com/kisielk/errcheck
-    go get -u github.com/golang/lint/golint
-    go get -u github.com/UnnoTed/fileb0x
+    go get github.com/golang/lint/golint
+    go get github.com/UnnoTed/fileb0x
     install_golang_dep
 }
 
 install_golang_dep() {
-    go get -u github.com/golang/dep/cmd/dep
+    go get github.com/golang/dep/cmd/dep
     echo "Running dep ensure..."
     dep ensure -v
 }
@@ -243,7 +243,7 @@ install_yarn() {
 }
 
 install_dashboard_deps() {
-    go get -u github.com/UnnoTed/fileb0x
+    go get github.com/UnnoTed/fileb0x
     check_for_presence_of_yarn
     pushd "${DASHBOARD_PATH}"
     yarn install


### PR DESCRIPTION
## What is this change?

Removes the `-u` from our `go get` commands which will prevent our tools from getting updated each build.

## Why is this change necessary?

I suspect we're starting to see some rate limiting from Google's git repositories. This is an attempt to fix the problem.

![screen shot 2017-12-14 at 10 15 55 am](https://user-images.githubusercontent.com/120659/34020632-2823ba40-e0ea-11e7-89f1-601478d237e8.png)


## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!