### PR TITLE
Remove sensu-go from GOPATH/src & GOPATH/pkg on Travis before caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ stages:
 - name: test
 - name: deploy
   if: branch = master OR tag IS present
+before_cache:
+- rm -rf $GOPATH/src/github.com/sensu/sensu-go/*
+- rm -rf $GOPATH/pkg/**/github.com/sensu/sensu-go
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
## What is this change?

Removes sensu-go from GOPATH/src & GOPATH/pkg on Travis before caching

## Why is this change necessary?

Caching appears to be making some builds fail.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Unsure what to do on AppVeyor - will open a separate PR once I've figured it out.
