### PR TITLE
Subdued checks still need to be scheduled for the next interval

### DIFF
--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -64,10 +64,18 @@ func (s *CheckScheduler) Start() error {
 					isSubdued, err := sensutime.InWindows(time.Now(), *subdue)
 					if err == nil && isSubdued {
 						// Check is subdued at this time
-						continue
+						s.logger.Debug("check is not scheduled to be executed")
 					}
 					if err != nil {
-						s.logger.WithError(err).Print("check scheduler: subdued time window")
+						s.logger.WithError(err).Print("unexpected error with time windows")
+					}
+
+					if err != nil || isSubdued {
+						// Reset the timer so the check is scheduled again for the next
+						// interval, since it might no longer be subdued
+						timer.SetInterval(uint(check.Interval))
+						timer.Next()
+						continue
 					}
 				}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes a bug where subdued checks would no longer be scheduled

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/759

## Does your change need a Changelog entry?

I don't think because I would consider that included into the unreleased `Add check subdue mechanism` entry.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!