### PR TITLE
Fix Travis deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ stages:
 - name: deploy
   if: branch = master OR tag IS present
 before_cache:
-- rm -rf $GOPATH/src/github.com/sensu/sensu-go/*
+- mkdir /tmp/sensu-go
+- mv $GOPATH/src/github.com/sensu/sensu-go/* /tmp/sensu-go
 - rm -rf $GOPATH/pkg/**/github.com/sensu/sensu-go
 cache:
   yarn: true
@@ -22,6 +23,8 @@ cache:
   - vendor
   - $GOPATH/src
   - $GOPATH/pkg
+after_cache:
+  - mv /tmp/sensu-go/* $GOPATH/src/github.com/sensu/sensu-go
 install:
 - "./build.sh deps"
 - "./build.sh build_tools"


### PR DESCRIPTION
## What is this change?

Move sensu-go src directory to `/tmp` during `before_cache`, move it back `after_cache`.

## Why is this change necessary?

We're currently removing the src directory during `before_cache`. Travis deploys (which run after the cache is updated) are currently failing due to the src directory not existing.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!
  