### PR TITLE
after_cache doesn't exist, use before_deploy in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
   - vendor
   - $GOPATH/src
   - $GOPATH/pkg
-after_cache:
+before_deploy:
   - mv /tmp/sensu-go/* $GOPATH/src/github.com/sensu/sensu-go
 install:
 - "./build.sh deps"


### PR DESCRIPTION
## What is this change?

Use `before_deploy` instead of `after_cache`

## Why is this change necessary?

The `after_cache` hook doesn't exist

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!