### PR TITLE
Temporarily disable Visual Studio 2017 image in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 image:
   - Visual Studio 2015
-  - Visual Studio 2017
+  # - Visual Studio 2017
 
 environment:
   GOPATH: c:\gopath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Removed the Visual Studio 2017 image in AppVeyor to prevent random failures
+
 ### Fixed
 - Fixed e2e test for token substitution on Windows
 - Fixed check subdue unit test for token substitution on Windows


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Temporarily disable Visual Studio 2017 image in AppVeyor so AppVeyor builds finally return no error

## Why is this change necessary?

Related to https://github.com/sensu/sensu-go/issues/885

## Does your change need a Changelog entry?

Done

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope