### PR TITLE
Add package leader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added proxy request validation.
 - CLI functionality for proxy check requests (add set-proxy-requests command).
 - Entities have been added to the state manager and synchronizer.
+- Added package leader, for facilitating execution by a single backend.
 
 ### Changed
 - Govaluate logic is now wrapped in the `util/eval` package.

--- a/backend/leader/do.go
+++ b/backend/leader/do.go
@@ -1,0 +1,37 @@
+package leader
+
+import (
+	"context"
+)
+
+// Do executes f if and only if this node is the leader. It returns the error
+// that f returns, or any error it encountered while trying to establish
+// leadership.
+//
+// Typically, functions executed by Do are long-lived and run until they are
+// terminated by loss of leadership.
+//
+// f MUST exit early if its context is cancelled before f is finished. If f
+// does not terminate when its context is cancelled, then its actions may be
+// concurrent with the next elected leader's.
+//
+// If this node is not the leader, Do will block until it is elected. This can
+// be terminated by calling Resign.
+//
+// Do can lead to etcd leader elections, which may also fail. These failures
+// will be returned as errors.
+//
+// Do will run f in its own goroutine after coordinating the work, but blocks
+// as if the function was being executed synchronously.
+func Do(f func(context.Context) error) error {
+	if override {
+		return f(context.Background())
+	}
+	if super == nil {
+		// Init not called.
+		return ErrNotInitialized
+	}
+	work := newWork(f)
+	super.Exec(work)
+	return work.Err()
+}

--- a/backend/leader/doc.go
+++ b/backend/leader/doc.go
@@ -1,0 +1,15 @@
+// Package leader provides functions that will only be executed if the Go
+// runtime process is the sensu leader.
+//
+// Since leadership is global, the package relies on package-level state that
+// is initialized through the Initialize function. The package is therefore a
+// singleton.
+//
+// If Override is called, then the other functions in this package will proceed
+// assuming that this node is the leader.
+//
+// If neither Override or Initialize are called, then the functions in this
+// package will return ErrNotInitialized.
+//
+// The exported functions in this package are goroutine-safe.
+package leader

--- a/backend/leader/init.go
+++ b/backend/leader/init.go
@@ -1,0 +1,68 @@
+package leader
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/clientv3/concurrency"
+)
+
+var (
+	// sensuLeaderKey is to be used in concert with KeyBuilder
+	sensuLeaderKey = "/leader/"
+)
+
+var (
+	// ErrNotInitialized is returned when Init has not been called.
+	ErrNotInitialized = errors.New("package not initialized")
+)
+
+var (
+	pkgMu    sync.Mutex
+	session  *concurrency.Session
+	override = false
+)
+
+// Override overrides the package. Calls to Do will always result in Do's
+// argument being executed. Meant for testing purposes.
+func Override() {
+	pkgMu.Lock()
+	defer pkgMu.Unlock()
+	override = true
+}
+
+// Initialize intializes the package, triggering an initial election.
+func Initialize(c *clientv3.Client) error {
+	pkgMu.Lock()
+	defer pkgMu.Unlock()
+	override = false
+	var err error
+	session, err = concurrency.NewSession(c)
+	if err != nil {
+		return err
+	}
+	initSupervisor(session)
+	return nil
+}
+
+func initSupervisor(session *concurrency.Session) {
+	super = newSupervisor(session)
+	super.Start()
+}
+
+// Resign resigns from leadership if the node holds it. To be used on shutdown.
+// Once Resign is called, all further calls to Do will result in an error.
+func Resign() error {
+	pkgMu.Lock()
+	defer pkgMu.Unlock()
+	var err error
+	if super != nil {
+		err = super.Stop()
+	}
+	super = nil
+	if err != nil {
+		return err
+	}
+	return session.Close()
+}

--- a/backend/leader/integration_test.go
+++ b/backend/leader/integration_test.go
@@ -1,0 +1,126 @@
+// +build integration
+
+package leader
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDo(t *testing.T) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	require.NoError(t, Initialize(client))
+
+	workPerformed := false
+	f := func(context.Context) error {
+		workPerformed = true
+		return nil
+	}
+
+	require.NoError(t, Do(f))
+	require.True(t, workPerformed)
+
+	// Test that work is cancelled after resigning
+	var funcWg, workWg sync.WaitGroup
+	funcWg.Add(1)
+	workWg.Add(1)
+
+	f = func(ctx context.Context) error {
+		workWg.Done()
+		<-ctx.Done()
+		funcWg.Done()
+		return nil
+	}
+
+	go func() {
+		Do(f)
+	}()
+
+	workWg.Wait()
+	require.NoError(t, Resign())
+
+	funcWg.Wait()
+}
+
+func TestLeaderContention(t *testing.T) {
+	logrus.SetLevel(logrus.ErrorLevel)
+	sensuLeaderKey = "/somethingelse/"
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	ssn1, err := concurrency.NewSession(client)
+	require.NoError(t, err)
+
+	ssn2, err := concurrency.NewSession(client)
+	require.NoError(t, err)
+
+	s1 := newSupervisor(ssn1)
+	s1.Start()
+	s1.WaitLeader()
+	s2 := newSupervisor(ssn2)
+	s2.Start()
+
+	assert.True(t, s1.IsLeader())
+	assert.False(t, s2.IsLeader())
+
+	workPerformed := false
+	f := func(context.Context) error {
+		workPerformed = true
+		return nil
+	}
+	g := func(context.Context) error {
+		return nil
+	}
+	w1 := newWork(f)
+	w2 := newWork(g)
+
+	s1.Exec(w1)
+	go s2.Exec(w2)
+
+	require.NoError(t, w1.Err())
+	require.True(t, workPerformed)
+
+	require.NoError(t, s1.Stop())
+
+	// Wait for the other session to become leader.
+	s2.WaitLeader()
+	assert.True(t, s2.IsLeader())
+
+	require.NoError(t, w2.Err())
+
+	s1.Start()
+	require.NoError(t, s2.Stop())
+
+	s1.WaitLeader()
+	assert.True(t, s1.IsLeader())
+
+	h := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	w3 := newWork(h)
+
+	s1.Exec(w3)
+
+	// simulate a loss of leadership during ongoing work
+	s1.isFollower <- struct{}{}
+
+	assert.Error(t, w3.Err())
+	require.NoError(t, s1.Stop())
+}

--- a/backend/leader/logging.go
+++ b/backend/leader/logging.go
@@ -1,0 +1,35 @@
+package leader
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+var (
+	logger      = logrus.WithFields(logrus.Fields{"package": "leader"})
+	logInterval = int64(time.Minute)
+)
+
+// SetLogInterval sets the interval for logging from this package. Values <= 0
+// are ignored. SetLogInterval has no effect after Init is run.
+func SetLogInterval(t time.Duration) {
+	if t > 0 {
+		atomic.StoreInt64(&logInterval, int64(t))
+	}
+}
+
+func getLogInterval() time.Duration {
+	return time.Duration(atomic.LoadInt64(&logInterval))
+}
+
+func logPeriodic(nodeName, leaderName string, totalWork int64) {
+	isLeader := nodeName == leaderName
+	logger.WithFields(logrus.Fields{
+		"leading":        isLeader,
+		"node_name":      nodeName,
+		"leader_name":    leaderName,
+		"work_completed": totalWork,
+	}).Info("leader")
+}

--- a/backend/leader/supervisor.go
+++ b/backend/leader/supervisor.go
@@ -1,0 +1,188 @@
+package leader
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd/clientv3/concurrency"
+	"github.com/google/uuid"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+var super *supervisor
+
+var keyBuilder = store.NewKeyBuilder(sensuLeaderKey)
+
+type supervisor struct {
+	session       *concurrency.Session
+	election      *concurrency.Election
+	isLeader      chan struct{}
+	isFollower    chan struct{}
+	work          chan *work
+	cancel        context.CancelFunc
+	nodeName      string
+	logger        *logrus.Entry
+	leaderName    atomic.Value
+	workPerformed int64
+	wg            sync.WaitGroup
+	workInFlight  sync.WaitGroup
+}
+
+func newSupervisor(session *concurrency.Session) *supervisor {
+	nodeName := fmt.Sprintf("sensu-backend-%s", uuid.New().String())
+	s := &supervisor{
+		session:    session,
+		election:   concurrency.NewElection(session, keyBuilder.Build()),
+		isLeader:   make(chan struct{}),
+		isFollower: make(chan struct{}),
+		work:       make(chan *work),
+		nodeName:   nodeName,
+		logger: logger.WithFields(logrus.Fields{
+			"node_name": nodeName,
+		}),
+	}
+	return s
+}
+
+// Start starts the supervisor.
+func (s *supervisor) Start() {
+	s.logger.Debug("campaigning for leadership")
+	s.wg.Add(1)
+	s.leaderName.Store("")
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+
+	go s.campaign(ctx)
+	go s.observer(ctx)
+	go s.worker(ctx)
+	go s.periodicLogger(ctx)
+}
+
+func (s *supervisor) periodicLogger(ctx context.Context) {
+	s.logger.Debug("starting up logger")
+	defer s.logger.Debug("shutting down logger")
+	ticker := time.NewTicker(getLogInterval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			logPeriodic(
+				s.nodeName,
+				s.leaderName.Load().(string),
+				atomic.LoadInt64(&s.workPerformed))
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *supervisor) worker(ctx context.Context) {
+	s.logger.Debug("starting up worker")
+	defer s.logger.Debug("shutting down worker")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.isLeader:
+			s.processWork(ctx)
+		}
+	}
+}
+
+func (s *supervisor) processWork(ctx context.Context) {
+	s.logger.Debug("starting up work processor")
+	defer s.logger.Debug("shutting down work processor")
+	workCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for {
+		select {
+		case <-s.isFollower:
+			s.logger.Warn("lost cluster leadership")
+			// Cancel any work that's in-flight. The work is responsible for
+			// terminating itself by waiting for its context to cancel.
+			return
+		case <-ctx.Done():
+			return
+		case work := <-s.work:
+			s.workInFlight.Add(1)
+			s.logger.Debugf("starting work (ID %d)", work.id)
+			go func() {
+				defer s.logger.Debugf("finished work (ID %d)", work.id)
+				defer atomic.AddInt64(&s.workPerformed, 1)
+				defer s.workInFlight.Done()
+				work.result <- work.f(workCtx)
+			}()
+		}
+	}
+}
+
+func (s *supervisor) campaign(ctx context.Context) {
+	s.logger.Debug("starting up campaign")
+	defer s.logger.Debug("finished campaign")
+	if err := s.election.Campaign(ctx, s.nodeName); err != nil {
+		if err != ctx.Err() {
+			s.logger.WithError(err).Error("error running campaign")
+		}
+		return
+	}
+	// The Campaign method blocks until the node is elected
+	s.logger.Info("gained cluster leadership")
+	s.leaderName.Store(s.nodeName)
+	s.wg.Done()
+	// Ensure that all work from previous leadership round has completed first.
+	s.workInFlight.Wait()
+	s.isLeader <- struct{}{}
+}
+
+func (s *supervisor) observer(ctx context.Context) {
+	s.logger.Debug("starting up election observer")
+	defer s.logger.Debug("shutting down election observer")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		observer := s.election.Observe(ctx)
+		for response := range observer {
+			wasLeading := s.IsLeader()
+			leaderName := string(response.Kvs[0].Value)
+			s.leaderName.Store(leaderName)
+			if leaderName != s.nodeName && wasLeading {
+				s.isFollower <- struct{}{}
+				s.wg.Add(1)
+				s.campaign(ctx)
+			}
+		}
+	}
+}
+
+// Stop stops the supervisor. It blocks until the election has been resigned,
+// and all work has been completed or cancelled.
+func (s *supervisor) Stop() error {
+	s.logger.Info("resigning from leadership or election")
+	s.cancel()
+	s.workInFlight.Wait()
+	return s.election.Resign(context.Background())
+}
+
+// Exec sends the work its given to the work channel.
+func (s *supervisor) Exec(w *work) {
+	s.work <- w
+}
+
+// WaitLeader blocks until the supervisor has attained leadership.
+// This method is meant for testing purposes.
+func (s *supervisor) WaitLeader() {
+	s.wg.Wait()
+}
+
+// IsLeader returns true if the supervisor is the leader. This method is meant
+// for testing purposes.
+func (s *supervisor) IsLeader() bool {
+	return s.leaderName.Load().(string) == s.nodeName
+}

--- a/backend/leader/work.go
+++ b/backend/leader/work.go
@@ -1,0 +1,39 @@
+package leader
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+var (
+	workItemSerial int64
+)
+
+// work is a single unit of work, performed by f.
+type work struct {
+	id     int64
+	f      func(context.Context) error
+	result chan error
+	err    error
+}
+
+func newWork(f func(context.Context) error) *work {
+	return &work{
+		id:     newWorkID(),
+		f:      f,
+		result: make(chan error, 1),
+	}
+}
+
+func newWorkID() int64 {
+	return atomic.AddInt64(&workItemSerial, 1)
+}
+
+func (w *work) Err() error {
+	err, ok := <-w.result
+	if ok {
+		w.err = err
+		close(w.result)
+	}
+	return w.err
+}

--- a/backend/leader/work_test.go
+++ b/backend/leader/work_test.go
@@ -1,0 +1,25 @@
+package leader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewWork(t *testing.T) {
+	f := func(context.Context) error {
+		return nil
+	}
+	w := newWork(f)
+	assert.NotNil(t, w.f)
+	assert.NotNil(t, w.result)
+	w2 := newWork(f)
+	assert.True(t, w.id < w2.id)
+	err := errors.New("foo")
+	w2.result <- err
+	assert.Equal(t, err, w2.Err())
+	// returns the same result after multiple invocations
+	assert.Equal(t, err, w2.Err())
+}


### PR DESCRIPTION
Package leader provides the Do function, which allows package
users to execute functions exclusively from the leader node.
The leader package uses etcd elections to achieve this.

Closes https://github.com/sensu/sensu-go/issues/890

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?
Necessary for round robin scheduling and other things that require exclusive execution.

## Does your change need a Changelog entry?
CL entry included.

## Do you need clarification on anything?
I am uncertain if this approach is safe in all circumstances. I'm not completely sure what happens at the boundary of leader demise and re-election.