### PR TITLE
Export etcd.Store.

### DIFF
--- a/backend/store/etcd/asset_store.go
+++ b/backend/store/etcd/asset_store.go
@@ -29,8 +29,8 @@ func getAssetsPath(ctx context.Context, name string) string {
 	return assetKeyBuilder.WithOrg(org).Build(name)
 }
 
-// TODO Cleanup associated checks?
-func (s *etcdStore) DeleteAssetByName(ctx context.Context, name string) error {
+// DeleteAssetByName deletes an asset by name.
+func (s *Store) DeleteAssetByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name")
 	}
@@ -40,7 +40,7 @@ func (s *etcdStore) DeleteAssetByName(ctx context.Context, name string) error {
 }
 
 // GetAssets fetches all assets from the store
-func (s *etcdStore) GetAssets(ctx context.Context) ([]*types.Asset, error) {
+func (s *Store) GetAssets(ctx context.Context) ([]*types.Asset, error) {
 	resp, err := query(ctx, s, getAssetsPath)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,8 @@ func (s *etcdStore) GetAssets(ctx context.Context) ([]*types.Asset, error) {
 	return assetArray, nil
 }
 
-func (s *etcdStore) GetAssetByName(ctx context.Context, name string) (*types.Asset, error) {
+// GetAssetByName gets an Asset by name.
+func (s *Store) GetAssetByName(ctx context.Context, name string) (*types.Asset, error) {
 	if name == "" {
 		return nil, errors.New("must specify organization and name")
 	}
@@ -84,7 +85,8 @@ func (s *etcdStore) GetAssetByName(ctx context.Context, name string) (*types.Ass
 	return asset, nil
 }
 
-func (s *etcdStore) UpdateAsset(ctx context.Context, asset *types.Asset) error {
+// UpdateAsset updates an asset.
+func (s *Store) UpdateAsset(ctx context.Context, asset *types.Asset) error {
 	if err := asset.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/authentication.go
+++ b/backend/store/etcd/authentication.go
@@ -12,7 +12,7 @@ func getAuthenticationPath(id string) string {
 }
 
 // CreateJWTSecret creates a new JWT secret
-func (s *etcdStore) CreateJWTSecret(secret []byte) error {
+func (s *Store) CreateJWTSecret(secret []byte) error {
 	// We need to prepare a transaction to verify the version of the key
 	// corresponding to the user in etcd in order to ensure we only put the key
 	// if it does not exist
@@ -30,7 +30,7 @@ func (s *etcdStore) CreateJWTSecret(secret []byte) error {
 }
 
 // GetJWTSecret retrieves the JWT signing secret
-func (s *etcdStore) GetJWTSecret() ([]byte, error) {
+func (s *Store) GetJWTSecret() ([]byte, error) {
 	resp, err := s.kvc.Get(context.TODO(), getAuthenticationPath("secret"), clientv3.WithLimit(1))
 	if err != nil {
 		return nil, err
@@ -42,7 +42,8 @@ func (s *etcdStore) GetJWTSecret() ([]byte, error) {
 	return resp.Kvs[0].Value, nil
 }
 
-func (s *etcdStore) UpdateJWTSecret(secret []byte) error {
+// UpdateJWTSecret replaces the jwt secret with a new one.
+func (s *Store) UpdateJWTSecret(secret []byte) error {
 	_, err := s.kvc.Put(context.TODO(), getAuthenticationPath("secret"), string(secret))
 	return err
 }

--- a/backend/store/etcd/check_store.go
+++ b/backend/store/etcd/check_store.go
@@ -27,7 +27,8 @@ func getCheckConfigsPath(ctx context.Context, name string) string {
 	return checkKeyBuilder.WithContext(ctx).Build(name)
 }
 
-func (s *etcdStore) DeleteCheckConfigByName(ctx context.Context, name string) error {
+// DeleteCheckConfigByName deletes a CheckConfig by name.
+func (s *Store) DeleteCheckConfigByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name")
 	}
@@ -38,7 +39,7 @@ func (s *etcdStore) DeleteCheckConfigByName(ctx context.Context, name string) er
 
 // GetCheckConfigs returns check configurations for an (optional) organization.
 // If org is the empty string, it returns all check configs.
-func (s *etcdStore) GetCheckConfigs(ctx context.Context) ([]*types.CheckConfig, error) {
+func (s *Store) GetCheckConfigs(ctx context.Context) ([]*types.CheckConfig, error) {
 	resp, err := query(ctx, s, getCheckConfigsPath)
 	if err != nil {
 		return nil, err
@@ -60,7 +61,8 @@ func (s *etcdStore) GetCheckConfigs(ctx context.Context) ([]*types.CheckConfig, 
 	return checksArray, nil
 }
 
-func (s *etcdStore) GetCheckConfigByName(ctx context.Context, name string) (*types.CheckConfig, error) {
+// GetCheckConfigByName gets a CheckConfig by name.
+func (s *Store) GetCheckConfigByName(ctx context.Context, name string) (*types.CheckConfig, error) {
 	if name == "" {
 		return nil, errors.New("must specify name")
 	}
@@ -82,7 +84,8 @@ func (s *etcdStore) GetCheckConfigByName(ctx context.Context, name string) (*typ
 	return check, nil
 }
 
-func (s *etcdStore) UpdateCheckConfig(ctx context.Context, check *types.CheckConfig) error {
+// UpdateCheckConfig updates a CheckConfig.
+func (s *Store) UpdateCheckConfig(ctx context.Context, check *types.CheckConfig) error {
 	if err := check.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -27,7 +27,8 @@ func getEntitiesPath(ctx context.Context, id string) string {
 	return entityKeyBuilder.WithContext(ctx).Build(id)
 }
 
-func (s *etcdStore) DeleteEntity(ctx context.Context, e *types.Entity) error {
+// DeleteEntity deletes an Entity.
+func (s *Store) DeleteEntity(ctx context.Context, e *types.Entity) error {
 	if err := e.Validate(); err != nil {
 		return err
 	}
@@ -35,7 +36,8 @@ func (s *etcdStore) DeleteEntity(ctx context.Context, e *types.Entity) error {
 	return err
 }
 
-func (s *etcdStore) DeleteEntityByID(ctx context.Context, id string) error {
+// DeleteEntityByID deletes an Entity by its ID.
+func (s *Store) DeleteEntityByID(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("must specify id")
 	}
@@ -44,7 +46,8 @@ func (s *etcdStore) DeleteEntityByID(ctx context.Context, id string) error {
 	return err
 }
 
-func (s *etcdStore) GetEntityByID(ctx context.Context, id string) (*types.Entity, error) {
+// GetEntityByID gets an Entity by ID.
+func (s *Store) GetEntityByID(ctx context.Context, id string) (*types.Entity, error) {
 	if id == "" {
 		return nil, errors.New("must specify id")
 	}
@@ -66,7 +69,7 @@ func (s *etcdStore) GetEntityByID(ctx context.Context, id string) (*types.Entity
 
 // GetEntities takes an optional org argument, an empty string will return
 // all entities.
-func (s *etcdStore) GetEntities(ctx context.Context) ([]*types.Entity, error) {
+func (s *Store) GetEntities(ctx context.Context) ([]*types.Entity, error) {
 	resp, err := query(ctx, s, getEntitiesPath)
 	if err != nil {
 		return nil, err
@@ -88,7 +91,8 @@ func (s *etcdStore) GetEntities(ctx context.Context) ([]*types.Entity, error) {
 	return earr, nil
 }
 
-func (s *etcdStore) UpdateEntity(ctx context.Context, e *types.Entity) error {
+// UpdateEntity updates an Entity.
+func (s *Store) UpdateEntity(ctx context.Context, e *types.Entity) error {
 	if err := e.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/environment_store.go
+++ b/backend/store/etcd/environment_store.go
@@ -22,7 +22,7 @@ func getEnvironmentsPath(org, env string) string {
 }
 
 // DeleteEnvironment deletes an environment
-func (s *etcdStore) DeleteEnvironment(ctx context.Context, env *types.Environment) error {
+func (s *Store) DeleteEnvironment(ctx context.Context, env *types.Environment) error {
 	if err := env.Validate(); err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (s *etcdStore) DeleteEnvironment(ctx context.Context, env *types.Environmen
 }
 
 // GetEnvironment returns a single environment
-func (s *etcdStore) GetEnvironment(ctx context.Context, org, env string) (*types.Environment, error) {
+func (s *Store) GetEnvironment(ctx context.Context, org, env string) (*types.Environment, error) {
 	resp, err := s.kvc.Get(
 		ctx,
 		getEnvironmentsPath(org, env),
@@ -98,8 +98,8 @@ func (s *etcdStore) GetEnvironment(ctx context.Context, org, env string) (*types
 	return envs[0], nil
 }
 
-// GetOrganizations returns all organizations
-func (s *etcdStore) GetEnvironments(ctx context.Context, org string) ([]*types.Environment, error) {
+// GetEnvironments returns all Environments.
+func (s *Store) GetEnvironments(ctx context.Context, org string) ([]*types.Environment, error) {
 	// Support "*" as a wildcard
 	if org == "*" {
 		org = ""
@@ -115,7 +115,7 @@ func (s *etcdStore) GetEnvironments(ctx context.Context, org string) ([]*types.E
 }
 
 // UpdateEnvironment updates an environment
-func (s *etcdStore) UpdateEnvironment(ctx context.Context, env *types.Environment) error {
+func (s *Store) UpdateEnvironment(ctx context.Context, env *types.Environment) error {
 	if err := env.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/error_store.go
+++ b/backend/store/etcd/error_store.go
@@ -37,7 +37,7 @@ func errPathFromEntity(ns store.Namespace, entity string) string {
 
 // DeleteError deletes an error using the given entity, check and timestamp,
 // within the organization and environment stored in ctx.
-func (s *etcdStore) DeleteError(
+func (s *Store) DeleteError(
 	ctx context.Context,
 	entity string,
 	check string,
@@ -58,7 +58,7 @@ func (s *etcdStore) DeleteError(
 
 // DeleteErrorsByEntity deletes all errors associated with the given entity,
 // within the organization and environment stored in ctx.
-func (s *etcdStore) DeleteErrorsByEntity(
+func (s *Store) DeleteErrorsByEntity(
 	ctx context.Context,
 	entity string,
 ) error {
@@ -77,7 +77,7 @@ func (s *etcdStore) DeleteErrorsByEntity(
 
 // DeleteErrorsByEntityCheck deletes all errors associated with the given
 // entity and check within the organization and environment stored in ctx.
-func (s *etcdStore) DeleteErrorsByEntityCheck(
+func (s *Store) DeleteErrorsByEntityCheck(
 	ctx context.Context,
 	entity string,
 	check string,
@@ -97,7 +97,7 @@ func (s *etcdStore) DeleteErrorsByEntityCheck(
 
 // GetError returns error associated with given entity, check and timestamp,
 // in the given ctx's organization and environment.
-func (s *etcdStore) GetError(
+func (s *Store) GetError(
 	ctx context.Context,
 	entity string,
 	check string,
@@ -131,7 +131,7 @@ func (s *etcdStore) GetError(
 
 // GetErrors returns all errors in the given ctx's organization and
 // environment.
-func (s *etcdStore) GetErrors(ctx context.Context) ([]*types.Error, error) {
+func (s *Store) GetErrors(ctx context.Context) ([]*types.Error, error) {
 
 	// Build key
 	ns := store.NewNamespaceFromContext(ctx)
@@ -152,14 +152,14 @@ func (s *etcdStore) GetErrors(ctx context.Context) ([]*types.Error, error) {
 // GetErrorsByEntity returns all errors for the given entity within the ctx's
 // organization and environment. A nil slice with no error is returned if none
 // were found.
-func (s *etcdStore) GetErrorsByEntity(ctx context.Context, entity string) ([]*types.Error, error) {
+func (s *Store) GetErrorsByEntity(ctx context.Context, entity string) ([]*types.Error, error) {
 	return s.GetErrorsByEntityCheck(ctx, entity, "")
 }
 
-// GetErrorByEntityCheck returns an error using the given entity and check,
+// GetErrorsByEntityCheck returns an error using the given entity and check,
 // within the organization and environment stored in ctx. The resulting error
 // is nil if none was found.
-func (s *etcdStore) GetErrorsByEntityCheck(ctx context.Context, entity, check string) ([]*types.Error, error) {
+func (s *Store) GetErrorsByEntityCheck(ctx context.Context, entity, check string) ([]*types.Error, error) {
 	if entity == "" {
 		return nil, errors.New("must specify entity id")
 	}
@@ -180,7 +180,7 @@ func (s *etcdStore) GetErrorsByEntityCheck(ctx context.Context, entity, check st
 }
 
 // CreateError creates or updates a given error.
-func (s *etcdStore) CreateError(ctx context.Context, perr *types.Error) error {
+func (s *Store) CreateError(ctx context.Context, perr *types.Error) error {
 	// Obtain new lease
 	lease, err := s.client.Grant(ctx, errorsKeyTTL)
 	if err != nil {

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -42,7 +42,8 @@ func getEventsPath(ctx context.Context, entity string) string {
 	return eventKeyBuilder.WithContext(ctx).Build(entity)
 }
 
-func (s *etcdStore) DeleteEventByEntityCheck(ctx context.Context, entityID, checkID string) error {
+// DeleteEventByEntityCheck deletes an event by entity ID and check ID.
+func (s *Store) DeleteEventByEntityCheck(ctx context.Context, entityID, checkID string) error {
 	if entityID == "" || checkID == "" {
 		return errors.New("must specify entity and check id")
 	}
@@ -53,7 +54,7 @@ func (s *etcdStore) DeleteEventByEntityCheck(ctx context.Context, entityID, chec
 
 // GetEvents returns the events for an (optional) organization. If org is the
 // empty string, GetEvents returns all events for all orgs.
-func (s *etcdStore) GetEvents(ctx context.Context) ([]*types.Event, error) {
+func (s *Store) GetEvents(ctx context.Context) ([]*types.Event, error) {
 	resp, err := query(ctx, s, getEventsPath)
 	if err != nil {
 		return nil, err
@@ -89,7 +90,8 @@ func (s *etcdStore) GetEvents(ctx context.Context) ([]*types.Event, error) {
 	return eventsArray, nil
 }
 
-func (s *etcdStore) GetEventsByEntity(ctx context.Context, entityID string) ([]*types.Event, error) {
+// GetEventsByEntity gets all events matching a given entity ID.
+func (s *Store) GetEventsByEntity(ctx context.Context, entityID string) ([]*types.Event, error) {
 	if entityID == "" {
 		return nil, errors.New("must specify entity id")
 	}
@@ -116,7 +118,8 @@ func (s *etcdStore) GetEventsByEntity(ctx context.Context, entityID string) ([]*
 	return eventsArray, nil
 }
 
-func (s *etcdStore) GetEventByEntityCheck(ctx context.Context, entityID, checkID string) (*types.Event, error) {
+// GetEventByEntityCheck gets an event by entity and check ID.
+func (s *Store) GetEventByEntityCheck(ctx context.Context, entityID, checkID string) (*types.Event, error) {
 	if entityID == "" || checkID == "" {
 		return nil, errors.New("must specify entity and check id")
 	}
@@ -138,7 +141,8 @@ func (s *etcdStore) GetEventByEntityCheck(ctx context.Context, entityID, checkID
 	return event, nil
 }
 
-func (s *etcdStore) UpdateEvent(ctx context.Context, event *types.Event) error {
+// UpdateEvent updates an event.
+func (s *Store) UpdateEvent(ctx context.Context, event *types.Event) error {
 	if event.Check == nil {
 		return errors.New("event has no check")
 	}

--- a/backend/store/etcd/filter_store.go
+++ b/backend/store/etcd/filter_store.go
@@ -24,7 +24,8 @@ func getEventFiltersPath(ctx context.Context, name string) string {
 	return eventFilterKeyBuilder.WithContext(ctx).Build(name)
 }
 
-func (s *etcdStore) DeleteEventFilterByName(ctx context.Context, name string) error {
+// DeleteEventFilterByName deletes an EventFilter by name.
+func (s *Store) DeleteEventFilterByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name of filter")
 	}
@@ -43,7 +44,7 @@ func (s *etcdStore) DeleteEventFilterByName(ctx context.Context, name string) er
 
 // GetEventFilters gets the list of filters for an (optional) organization. Passing
 // the empty string as the org will return all filters.
-func (s *etcdStore) GetEventFilters(ctx context.Context) ([]*types.EventFilter, error) {
+func (s *Store) GetEventFilters(ctx context.Context) ([]*types.EventFilter, error) {
 	resp, err := query(ctx, s, getEventFiltersPath)
 	if err != nil {
 		return nil, err
@@ -65,7 +66,8 @@ func (s *etcdStore) GetEventFilters(ctx context.Context) ([]*types.EventFilter, 
 	return filtersArray, nil
 }
 
-func (s *etcdStore) GetEventFilterByName(ctx context.Context, name string) (*types.EventFilter, error) {
+// GetEventFilterByName gets an EventFilter by name.
+func (s *Store) GetEventFilterByName(ctx context.Context, name string) (*types.EventFilter, error) {
 	if name == "" {
 		return nil, errors.New("must specify name of filter")
 	}
@@ -87,7 +89,8 @@ func (s *etcdStore) GetEventFilterByName(ctx context.Context, name string) (*typ
 	return filter, nil
 }
 
-func (s *etcdStore) UpdateEventFilter(ctx context.Context, filter *types.EventFilter) error {
+// UpdateEventFilter updates an EventFilter.
+func (s *Store) UpdateEventFilter(ctx context.Context, filter *types.EventFilter) error {
 	if err := filter.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/handler_store.go
+++ b/backend/store/etcd/handler_store.go
@@ -24,7 +24,8 @@ func getHandlersPath(ctx context.Context, name string) string {
 	return handlerKeyBuilder.WithContext(ctx).Build(name)
 }
 
-func (s *etcdStore) DeleteHandlerByName(ctx context.Context, name string) error {
+// DeleteHandlerByName deletes a Handler by name.
+func (s *Store) DeleteHandlerByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name of handler")
 	}
@@ -35,7 +36,7 @@ func (s *etcdStore) DeleteHandlerByName(ctx context.Context, name string) error 
 
 // GetHandlers gets the list of handlers for an (optional) organization. Passing
 // the empty string as the org will return all handlers.
-func (s *etcdStore) GetHandlers(ctx context.Context) ([]*types.Handler, error) {
+func (s *Store) GetHandlers(ctx context.Context) ([]*types.Handler, error) {
 	resp, err := query(ctx, s, getHandlersPath)
 	if err != nil {
 		return nil, err
@@ -57,7 +58,8 @@ func (s *etcdStore) GetHandlers(ctx context.Context) ([]*types.Handler, error) {
 	return handlersArray, nil
 }
 
-func (s *etcdStore) GetHandlerByName(ctx context.Context, name string) (*types.Handler, error) {
+// GetHandlerByName gets a Handler by name.
+func (s *Store) GetHandlerByName(ctx context.Context, name string) (*types.Handler, error) {
 	if name == "" {
 		return nil, errors.New("must specify name of handler")
 	}
@@ -79,7 +81,8 @@ func (s *etcdStore) GetHandlerByName(ctx context.Context, name string) (*types.H
 	return handler, nil
 }
 
-func (s *etcdStore) UpdateHandler(ctx context.Context, handler *types.Handler) error {
+// UpdateHandler updates a Handler.
+func (s *Store) UpdateHandler(ctx context.Context, handler *types.Handler) error {
 	if err := handler.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/helpers.go
+++ b/backend/store/etcd/helpers.go
@@ -17,7 +17,7 @@ type getObjectsPath func(context.Context, string) string
 // N.B. Even if we only query across organizations, we still need to filter the
 // values returned based on their environment afterwards if the objects type
 // doesn't contain the environment at the top level of the object
-func query(ctx context.Context, store *etcdStore, fn getObjectsPath) (*clientv3.GetResponse, error) {
+func query(ctx context.Context, store *Store, fn getObjectsPath) (*clientv3.GetResponse, error) {
 	// Support "*" as a wildcard
 	var org, env string
 	if org = organization(ctx); org == "*" {

--- a/backend/store/etcd/helpers_test.go
+++ b/backend/store/etcd/helpers_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestQuery(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
-		etcd := store.(*etcdStore)
+		etcd := store.(*Store)
 
 		// Create a new org "acme" and its environments "default" & "dev"
 		require.NoError(t, store.UpdateOrganization(context.Background(), types.FixtureOrganization("acme")))

--- a/backend/store/etcd/hook_store.go
+++ b/backend/store/etcd/hook_store.go
@@ -27,7 +27,8 @@ func getHookConfigsPath(ctx context.Context, name string) string {
 	return hookKeyBuilder.WithContext(ctx).Build(name)
 }
 
-func (s *etcdStore) DeleteHookConfigByName(ctx context.Context, name string) error {
+// DeleteHookConfigByName deletes a HookConfig by name.
+func (s *Store) DeleteHookConfigByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name")
 	}
@@ -38,7 +39,7 @@ func (s *etcdStore) DeleteHookConfigByName(ctx context.Context, name string) err
 
 // GetHookConfigs returns hook configurations for an (optional) organization.
 // If org is the empty string, it returns all hook configs.
-func (s *etcdStore) GetHookConfigs(ctx context.Context) ([]*types.HookConfig, error) {
+func (s *Store) GetHookConfigs(ctx context.Context) ([]*types.HookConfig, error) {
 	resp, err := query(ctx, s, getHookConfigsPath)
 	if err != nil {
 		return nil, err
@@ -60,7 +61,8 @@ func (s *etcdStore) GetHookConfigs(ctx context.Context) ([]*types.HookConfig, er
 	return hooksArray, nil
 }
 
-func (s *etcdStore) GetHookConfigByName(ctx context.Context, name string) (*types.HookConfig, error) {
+// GetHookConfigByName gets a HookConfig by name.
+func (s *Store) GetHookConfigByName(ctx context.Context, name string) (*types.HookConfig, error) {
 	if name == "" {
 		return nil, errors.New("must specify name")
 	}
@@ -82,7 +84,8 @@ func (s *etcdStore) GetHookConfigByName(ctx context.Context, name string) (*type
 	return hook, nil
 }
 
-func (s *etcdStore) UpdateHookConfig(ctx context.Context, hook *types.HookConfig) error {
+// UpdateHookConfig updates a HookConfig.
+func (s *Store) UpdateHookConfig(ctx context.Context, hook *types.HookConfig) error {
 	if err := hook.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -23,7 +23,7 @@ type StoreInitializer struct {
 }
 
 // NewInitializer returns a new store initializer
-func (store *etcdStore) NewInitializer() (store.Initializer, error) {
+func (store *Store) NewInitializer() (store.Initializer, error) {
 	client := store.client
 	session, err := concurrency.NewSession(client) // TODO: move session into etcdStore?
 	if err != nil {

--- a/backend/store/etcd/keepalive_store.go
+++ b/backend/store/etcd/keepalive_store.go
@@ -18,12 +18,14 @@ func getKeepalivePath(keepalivesPath string, entity *types.Entity) string {
 	return path.Join(keepalivesPath, entity.Organization, entity.Environment, entity.ID)
 }
 
-func (s *etcdStore) DeleteFailingKeepalive(ctx context.Context, entity *types.Entity) error {
+// DeleteFailingKeepalive deletes a failing KeepaliveRecord.
+func (s *Store) DeleteFailingKeepalive(ctx context.Context, entity *types.Entity) error {
 	_, err := s.client.Delete(ctx, getKeepalivePath(s.keepalivesPath, entity))
 	return err
 }
 
-func (s *etcdStore) GetFailingKeepalives(ctx context.Context) ([]*types.KeepaliveRecord, error) {
+// GetFailingKeepalives gets all of the failing KeepaliveRecords.
+func (s *Store) GetFailingKeepalives(ctx context.Context) ([]*types.KeepaliveRecord, error) {
 	resp, err := s.client.Get(ctx, s.keepalivesPath, clientv3.WithPrefix())
 	if err != nil {
 		return nil, err
@@ -46,7 +48,8 @@ func (s *etcdStore) GetFailingKeepalives(ctx context.Context) ([]*types.Keepaliv
 	return keepalives, nil
 }
 
-func (s *etcdStore) UpdateFailingKeepalive(ctx context.Context, entity *types.Entity, expiration int64) error {
+// UpdateFailingKeepalive updates a failing KeepaliveRecord.
+func (s *Store) UpdateFailingKeepalive(ctx context.Context, entity *types.Entity, expiration int64) error {
 	kr := types.NewKeepaliveRecord(entity, expiration)
 	krBytes, err := json.Marshal(kr)
 	if err != nil {

--- a/backend/store/etcd/mutator_store.go
+++ b/backend/store/etcd/mutator_store.go
@@ -24,7 +24,8 @@ func getMutatorsPath(ctx context.Context, name string) string {
 	return mutatorKeyBuilder.WithContext(ctx).Build(name)
 }
 
-func (s *etcdStore) DeleteMutatorByName(ctx context.Context, name string) error {
+// DeleteMutatorByName deletes a Mutator by name.
+func (s *Store) DeleteMutatorByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name of mutator")
 	}
@@ -33,9 +34,9 @@ func (s *etcdStore) DeleteMutatorByName(ctx context.Context, name string) error 
 	return err
 }
 
-// Mutators gets the list of mutators for an (optional) organization. If org is
+// GetMutators gets the list of mutators for an (optional) organization. If org is
 // the empty string, GetMutators returns all mutators for all orgs.
-func (s *etcdStore) GetMutators(ctx context.Context) ([]*types.Mutator, error) {
+func (s *Store) GetMutators(ctx context.Context) ([]*types.Mutator, error) {
 	resp, err := query(ctx, s, getMutatorsPath)
 	if err != nil {
 		return nil, err
@@ -57,7 +58,8 @@ func (s *etcdStore) GetMutators(ctx context.Context) ([]*types.Mutator, error) {
 	return mutatorsArray, nil
 }
 
-func (s *etcdStore) GetMutatorByName(ctx context.Context, name string) (*types.Mutator, error) {
+// GetMutatorByName gets a Mutator by name.
+func (s *Store) GetMutatorByName(ctx context.Context, name string) (*types.Mutator, error) {
 	if name == "" {
 		return nil, errors.New("must specify name of mutator")
 	}
@@ -79,7 +81,8 @@ func (s *etcdStore) GetMutatorByName(ctx context.Context, name string) (*types.M
 	return mutator, nil
 }
 
-func (s *etcdStore) UpdateMutator(ctx context.Context, mutator *types.Mutator) error {
+// UpdateMutator updates a Mutator.
+func (s *Store) UpdateMutator(ctx context.Context, mutator *types.Mutator) error {
 	if err := mutator.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/organization_store.go
+++ b/backend/store/etcd/organization_store.go
@@ -21,7 +21,7 @@ func getOrganizationsPath(name string) string {
 }
 
 // DeleteOrganizationByName deletes the organization named *name*
-func (s *etcdStore) DeleteOrganizationByName(ctx context.Context, name string) error {
+func (s *Store) DeleteOrganizationByName(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("must specify name")
 	}
@@ -71,7 +71,7 @@ func (s *etcdStore) DeleteOrganizationByName(ctx context.Context, name string) e
 }
 
 // GetOrganizationByName returns a single organization named *name*
-func (s *etcdStore) GetOrganizationByName(ctx context.Context, name string) (*types.Organization, error) {
+func (s *Store) GetOrganizationByName(ctx context.Context, name string) (*types.Organization, error) {
 	resp, err := s.kvc.Get(
 		ctx,
 		getOrganizationsPath(name),
@@ -94,7 +94,7 @@ func (s *etcdStore) GetOrganizationByName(ctx context.Context, name string) (*ty
 }
 
 // GetOrganizations returns all organizations
-func (s *etcdStore) GetOrganizations(ctx context.Context) ([]*types.Organization, error) {
+func (s *Store) GetOrganizations(ctx context.Context) ([]*types.Organization, error) {
 	resp, err := s.kvc.Get(
 		ctx,
 		getOrganizationsPath(""),
@@ -109,7 +109,7 @@ func (s *etcdStore) GetOrganizations(ctx context.Context) ([]*types.Organization
 }
 
 // UpdateOrganization updates an organization with the provided org
-func (s *etcdStore) UpdateOrganization(ctx context.Context, org *types.Organization) error {
+func (s *Store) UpdateOrganization(ctx context.Context, org *types.Organization) error {
 	if err := org.Validate(); err != nil {
 		return err
 	}

--- a/backend/store/etcd/rbac_store.go
+++ b/backend/store/etcd/rbac_store.go
@@ -19,7 +19,7 @@ func getRolePath(name string) string {
 }
 
 // GetRoles ...
-func (s *etcdStore) GetRoles(ctx context.Context) ([]*types.Role, error) {
+func (s *Store) GetRoles(ctx context.Context) ([]*types.Role, error) {
 	resp, err := s.kvc.Get(ctx, getRolePath(""), clientv3.WithPrefix())
 	if err != nil {
 		return []*types.Role{}, err
@@ -29,7 +29,7 @@ func (s *etcdStore) GetRoles(ctx context.Context) ([]*types.Role, error) {
 }
 
 // GetRoleByName ...
-func (s *etcdStore) GetRoleByName(ctx context.Context, name string) (*types.Role, error) {
+func (s *Store) GetRoleByName(ctx context.Context, name string) (*types.Role, error) {
 	resp, err := s.kvc.Get(ctx, getRolePath(name), clientv3.WithLimit(1))
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (s *etcdStore) GetRoleByName(ctx context.Context, name string) (*types.Role
 }
 
 // UpdateRole ...
-func (s *etcdStore) UpdateRole(ctx context.Context, role *types.Role) error {
+func (s *Store) UpdateRole(ctx context.Context, role *types.Role) error {
 	if err := role.Validate(); err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (s *etcdStore) UpdateRole(ctx context.Context, role *types.Role) error {
 }
 
 // DeleteRoleByName ...
-func (s *etcdStore) DeleteRoleByName(ctx context.Context, name string) error {
+func (s *Store) DeleteRoleByName(ctx context.Context, name string) error {
 	_, err := s.kvc.Delete(ctx, getRolePath(name))
 	return err
 }

--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -29,8 +29,8 @@ func getSilencedPath(ctx context.Context, name string) string {
 	return silencedKeyBuilder.WithContext(ctx).Build(name)
 }
 
-// Delete a silenced entry by its id (subscription + checkname)
-func (s *etcdStore) DeleteSilencedEntryByID(ctx context.Context, silencedID string) error {
+// DeleteSilencedEntryByID a silenced entry by its id (subscription + checkname)
+func (s *Store) DeleteSilencedEntryByID(ctx context.Context, silencedID string) error {
 	if silencedID == "" {
 		return errors.New("must specify id")
 	}
@@ -39,8 +39,8 @@ func (s *etcdStore) DeleteSilencedEntryByID(ctx context.Context, silencedID stri
 	return err
 }
 
-// Get all silenced entries
-func (s *etcdStore) GetSilencedEntries(ctx context.Context) ([]*types.Silenced, error) {
+// GetSilencedEntries gets all silenced entries.
+func (s *Store) GetSilencedEntries(ctx context.Context) ([]*types.Silenced, error) {
 	resp, err := query(ctx, s, getSilencedPath)
 	if err != nil {
 		return nil, err
@@ -52,8 +52,8 @@ func (s *etcdStore) GetSilencedEntries(ctx context.Context) ([]*types.Silenced, 
 	return silencedArray, nil
 }
 
-// Get silenced entries by subscription
-func (s *etcdStore) GetSilencedEntriesBySubscription(ctx context.Context, subscription string) ([]*types.Silenced, error) {
+// GetSilencedEntriesBySubscription gets all silenced entries that match a subscription.
+func (s *Store) GetSilencedEntriesBySubscription(ctx context.Context, subscription string) ([]*types.Silenced, error) {
 	if subscription == "" {
 		return nil, errors.New("must specify subscription")
 	}
@@ -69,8 +69,8 @@ func (s *etcdStore) GetSilencedEntriesBySubscription(ctx context.Context, subscr
 	return silencedArray, nil
 }
 
-// Get silenced entries by checkname
-func (s *etcdStore) GetSilencedEntriesByCheckName(ctx context.Context, checkName string) ([]*types.Silenced, error) {
+// GetSilencedEntriesByCheckName gets all silenced entries that match a check name.
+func (s *Store) GetSilencedEntriesByCheckName(ctx context.Context, checkName string) ([]*types.Silenced, error) {
 	if checkName == "" {
 		return nil, errors.New("must specify check name")
 	}
@@ -96,8 +96,8 @@ func (s *etcdStore) GetSilencedEntriesByCheckName(ctx context.Context, checkName
 	return silencedArray, nil
 }
 
-// Get silenced entry by id
-func (s *etcdStore) GetSilencedEntryByID(ctx context.Context, id string) (*types.Silenced, error) {
+// GetSilencedEntryByID gets a silenced entry by id.
+func (s *Store) GetSilencedEntryByID(ctx context.Context, id string) (*types.Silenced, error) {
 	if id == "" {
 		return nil, errors.New("must specify id")
 	}
@@ -117,8 +117,8 @@ func (s *etcdStore) GetSilencedEntryByID(ctx context.Context, id string) (*types
 	return silencedArray[0], nil
 }
 
-// Create new silenced entry
-func (s *etcdStore) UpdateSilencedEntry(ctx context.Context, silenced *types.Silenced) error {
+// UpdateSilencedEntry updates a Silenced.
+func (s *Store) UpdateSilencedEntry(ctx context.Context, silenced *types.Silenced) error {
 	if err := silenced.Validate(); err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (s *etcdStore) UpdateSilencedEntry(ctx context.Context, silenced *types.Sil
 
 // arraySilencedEntries is a helper function to unmarshal entries from json and return
 // them as an array
-func (s *etcdStore) arraySilencedEntries(resp *clientv3.GetResponse) ([]*types.Silenced, error) {
+func (s *Store) arraySilencedEntries(resp *clientv3.GetResponse) ([]*types.Silenced, error) {
 	if len(resp.Kvs) == 0 {
 		return []*types.Silenced{}, nil
 	}

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -4,7 +4,6 @@ import (
 	"path"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/sensu/sensu-go/backend/store"
 )
 
 const (
@@ -13,7 +12,7 @@ const (
 )
 
 // Store is an implementation of the sensu-go/backend/store.Store iface.
-type etcdStore struct {
+type Store struct {
 	client *clientv3.Client
 	kvc    clientv3.KV
 	etcd   *Etcd
@@ -21,14 +20,14 @@ type etcdStore struct {
 	keepalivesPath string
 }
 
-// NewStore ...
-func (e *Etcd) NewStore() (store.Store, error) {
+// NewStore creates a new Store.
+func (e *Etcd) NewStore() (*Store, error) {
 	c, err := e.NewClient()
 	if err != nil {
 		return nil, err
 	}
 
-	store := &etcdStore{
+	store := &Store{
 		etcd:   e,
 		client: c,
 		kvc:    clientv3.NewKV(c),

--- a/backend/store/etcd/token_store.go
+++ b/backend/store/etcd/token_store.go
@@ -14,7 +14,8 @@ func getTokenPath(subject, id string) string {
 	return fmt.Sprintf("%s/tokens/%s/%s", EtcdRoot, subject, id)
 }
 
-func (s *etcdStore) CreateToken(claims *types.Claims) error {
+// CreateToken creates a Claims.
+func (s *Store) CreateToken(claims *types.Claims) error {
 	bytes, err := json.Marshal(claims)
 	if err != nil {
 		return err
@@ -26,7 +27,7 @@ func (s *etcdStore) CreateToken(claims *types.Claims) error {
 
 // DeleteTokens deletes multiples tokens, belonging to the same subject, with
 // a transaction
-func (s *etcdStore) DeleteTokens(subject string, ids []string) error {
+func (s *Store) DeleteTokens(subject string, ids []string) error {
 	if subject == "" || len(ids) == 0 {
 		return errors.New("must specify token subject and at least one ID")
 	}
@@ -48,7 +49,8 @@ func (s *etcdStore) DeleteTokens(subject string, ids []string) error {
 	return nil
 }
 
-func (s *etcdStore) GetToken(subject, id string) (*types.Claims, error) {
+// GetToken gets a Claims.
+func (s *Store) GetToken(subject, id string) (*types.Claims, error) {
 	resp, err := s.kvc.Get(context.TODO(), getTokenPath(subject, id), clientv3.WithLimit(1))
 	if err != nil {
 		return nil, err

--- a/backend/store/etcd/user_store.go
+++ b/backend/store/etcd/user_store.go
@@ -15,7 +15,8 @@ func getUserPath(id string) string {
 	return fmt.Sprintf("%s/users/%s", EtcdRoot, id)
 }
 
-func (s *etcdStore) AuthenticateUser(ctx context.Context, username, password string) (*types.User, error) {
+// AuthenticateUser authenticates a User by username and password.
+func (s *Store) AuthenticateUser(ctx context.Context, username, password string) (*types.User, error) {
 	user, err := s.GetUser(ctx, username)
 	if user == nil {
 		return nil, fmt.Errorf("User %s does not exist", username)
@@ -36,7 +37,7 @@ func (s *etcdStore) AuthenticateUser(ctx context.Context, username, password str
 }
 
 // CreateUser creates a new user
-func (s *etcdStore) CreateUser(u *types.User) error {
+func (s *Store) CreateUser(u *types.User) error {
 	// Hash the password
 	hash, err := hashPassword(u.Password)
 	if err != nil {
@@ -65,10 +66,11 @@ func (s *etcdStore) CreateUser(u *types.User) error {
 	return nil
 }
 
+// DeleteUser deletes a User.
 // NOTE:
 // Store probably shouldn't be responsible for deleting the token;
 // business logic.
-func (s *etcdStore) DeleteUser(ctx context.Context, user *types.User) error {
+func (s *Store) DeleteUser(ctx context.Context, user *types.User) error {
 	// Mark it as disabled
 	user.Disabled = true
 
@@ -106,7 +108,8 @@ func (s *etcdStore) DeleteUser(ctx context.Context, user *types.User) error {
 	return nil
 }
 
-func (s *etcdStore) GetUser(ctx context.Context, username string) (*types.User, error) {
+// GetUser gets a User.
+func (s *Store) GetUser(ctx context.Context, username string) (*types.User, error) {
 	resp, err := s.kvc.Get(ctx, getUserPath(username), clientv3.WithLimit(1))
 	if err != nil {
 		return nil, err
@@ -125,7 +128,7 @@ func (s *etcdStore) GetUser(ctx context.Context, username string) (*types.User, 
 }
 
 // GetUsers retrieves all enabled users
-func (s *etcdStore) GetUsers() ([]*types.User, error) {
+func (s *Store) GetUsers() ([]*types.User, error) {
 	allUsers, err := s.GetAllUsers()
 	if err != nil {
 		return allUsers, err
@@ -143,7 +146,7 @@ func (s *etcdStore) GetUsers() ([]*types.User, error) {
 }
 
 // GetAllUsers retrieves all users
-func (s *etcdStore) GetAllUsers() ([]*types.User, error) {
+func (s *Store) GetAllUsers() ([]*types.User, error) {
 	resp, err := s.kvc.Get(context.TODO(), getUserPath(""), clientv3.WithPrefix())
 	if err != nil {
 		return nil, err
@@ -166,7 +169,8 @@ func (s *etcdStore) GetAllUsers() ([]*types.User, error) {
 	return usersArray, nil
 }
 
-func (s *etcdStore) UpdateUser(u *types.User) error {
+// UpdateUser updates a User.
+func (s *Store) UpdateUser(u *types.User) error {
 	// Hash the password
 	hash, err := hashPassword(u.Password)
 	if err != nil {

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -28,7 +28,7 @@ func getWatcherAction(event *clientv3.Event) store.WatchActionType {
 // the caller that a CheckConfig was updated. If the watcher runs into a terminal error
 // or the context passed is cancelled, then the channel will be closed. The caller must
 // restart the watcher, if needed.
-func (s *etcdStore) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEventCheckConfig {
+func (s *Store) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEventCheckConfig {
 	ch := make(chan store.WatchEventCheckConfig)
 
 	go func() {
@@ -71,7 +71,7 @@ func (s *etcdStore) GetCheckConfigWatcher(ctx context.Context) <-chan store.Watc
 // the caller that an Asset was updated. If the watcher runs into a terminal error
 // or the context passed is cancelled, then the channel will be closed. The caller must
 // restart the watcher, if needed.
-func (s *etcdStore) GetAssetWatcher(ctx context.Context) <-chan store.WatchEventAsset {
+func (s *Store) GetAssetWatcher(ctx context.Context) <-chan store.WatchEventAsset {
 	ch := make(chan store.WatchEventAsset)
 
 	go func() {
@@ -114,7 +114,7 @@ func (s *etcdStore) GetAssetWatcher(ctx context.Context) <-chan store.WatchEvent
 // the caller that a HookConfig was updated. If the watcher runs into a terminal error
 // or the context passed is cancelled, then the channel will be closed. The caller must
 // restart the watcher, if needed.
-func (s *etcdStore) GetHookConfigWatcher(ctx context.Context) <-chan store.WatchEventHookConfig {
+func (s *Store) GetHookConfigWatcher(ctx context.Context) <-chan store.WatchEventHookConfig {
 	ch := make(chan store.WatchEventHookConfig)
 
 	go func() {


### PR DESCRIPTION
* Export etcd.etcdStore as etcd.Store.
* Return *etcd.Store from etcd.NewStore.
* Document methods that were missing documentation.

Closes #917

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

In addition to bringing the codebase more in line with Google's code review standards, this change will help facilitate the work that I need to do for round robin scheduling.