### PR TITLE
Set ProxyRequests through sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Added functions for publishing proxy check requests.
 - Added proxy request validation.
+- CLI functionality for proxy check requests (add set-proxy-requests command).
 
 ## [2.0.0-alpha.14] - 2018-01-23
 ### Added

--- a/backend/apid/actions/checks.go
+++ b/backend/apid/actions/checks.go
@@ -25,6 +25,7 @@ var checkConfigUpdateFields = []string{
 	"Cron",
 	"Timeout",
 	"Ttl",
+	"ProxyRequests",
 }
 
 // CheckController exposes actions in which a viewer can perform.

--- a/cli/commands/check/help.go
+++ b/cli/commands/check/help.go
@@ -22,6 +22,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		AddCheckHookCommand(cli),
 		RemoveCheckHookCommand(cli),
 		SubdueCommand(cli),
+		SetProxyRequestsCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/check/proxy_request.go
+++ b/cli/commands/check/proxy_request.go
@@ -1,0 +1,64 @@
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// SetProxyRequestsCommand adds a command that allows a user to set the proxy
+// request for a check
+func SetProxyRequestsCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-proxy-requests NAME",
+		Short:        "set proxy requests for a check from file or stdin",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print usage if we do not receive one argument
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+
+			check, err := cli.Client.FetchCheck(args[0])
+			if err != nil {
+				return err
+			}
+
+			filePath, _ := cmd.Flags().GetString("file")
+			var in *os.File
+
+			if len(filePath) > 0 {
+				in, err = os.Open(filePath)
+				if err != nil {
+					return err
+				}
+
+				defer func() { _ = in.Close() }()
+			} else {
+				in = os.Stdin
+			}
+			var proxyRequest types.ProxyRequests
+			if err := json.NewDecoder(in).Decode(&proxyRequest); err != nil {
+				return err
+			}
+			check.ProxyRequests = &proxyRequest
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Proxy request definition file")
+
+	return cmd
+}

--- a/cli/commands/check/proxy_request_test.go
+++ b/cli/commands/check/proxy_request_test.go
@@ -1,0 +1,69 @@
+package check
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	stest "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetProxyRequestsCommand(t *testing.T) {
+	const proxyJSON = `{"entity_attributes":["foo","bar"], "splay":true, "splay_coverage":90}`
+	const invalidProxyJSON = `{"splay":true, "splay_coverage":0}`
+	tests := []struct {
+		args           []string
+		useflag        bool
+		stdin          string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, false, "", nil, nil, "Usage", false},
+		{[]string{"foo"}, false, "", errors.New("error"), nil, "", true},
+		{[]string{"bar"}, false, "", nil, errors.New("error"), "", true},
+		{[]string{"check1"}, false, "", nil, nil, "", true},
+		{[]string{"check1"}, false, proxyJSON, nil, nil, "OK", false},
+		{[]string{"check1"}, false, "invalidjson", nil, nil, "", true},
+		{[]string{"check1"}, true, proxyJSON, nil, nil, "", false},
+		{[]string{"check1"}, true, invalidProxyJSON, nil, nil, "", true},
+	}
+
+	for i, test := range tests {
+		name := ""
+		if len(test.args) > 0 {
+			name = test.args[0]
+		}
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			check := types.FixtureCheckConfig("check1")
+			cli := stest.NewMockCLI()
+			client := cli.Client.(*client.MockClient)
+			client.On("FetchCheck", name).Return(check, test.fetchResponse)
+			client.On("UpdateCheck", mock.Anything).Return(test.updateResponse)
+			cmd := SetProxyRequestsCommand(cli)
+			name, stdin, cleanup := fileFromString(t, test.stdin)
+			defer cleanup()
+			if test.useflag {
+				require.NoError(t, stdin.Close())
+				require.NoError(t, cmd.Flags().Set("file", name))
+			} else {
+				os.Stdin = stdin
+			}
+			out, err := stest.RunCmd(cmd, test.args)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, test.expectedOutput, out)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the set-proxy-requests command to sensuctl.

## Why is this change necessary?

Closes #903.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.