### PR TITLE
Add Peek method to Ring.

### DIFF
--- a/backend/ring/ring_test.go
+++ b/backend/ring/ring_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package ring
 
 import (
@@ -68,4 +70,25 @@ func TestNext(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, newItems[i%2], item)
 	}
+}
+
+func TestPeek(t *testing.T) {
+	t.Parallel()
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	ring := EtcdGetter{client}.GetRing("testpeek")
+
+	items := []string{"foo", "bar", "baz"}
+	for _, item := range items {
+		require.NoError(t, ring.Add(context.Background(), item))
+	}
+
+	item, err := ring.Peek(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "foo", item)
 }


### PR DESCRIPTION
Peek can be used by clients that wish to know what's next in the
ring, but don't wish to advance the iteration.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

I realized I need this for the schedulerd round robin stuff stuff.