### PR TITLE
Add ownership concept to the Ring.

### DIFF
--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -10,15 +10,23 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
-var ringPathPrefix = "rings"
+var (
+	// ErrEmptyRing is returned when the ring has no items to retrieve.
+	ErrEmptyRing = errors.New("ring: empty ring")
 
-var ringKeyBuilder = store.NewKeyBuilder(ringPathPrefix)
+	// ErrNotOwner is returned when a client tries to operate on a ring item
+	// that it does not have ownership of.
+	ErrNotOwner = errors.New("ring: not owner")
 
-// ErrEmptyRing is returned when the ring has no items to retrieve.
-var ErrEmptyRing = errors.New("empty ring")
+	backendID      = uuid.New().String()
+	ringPathPrefix = "rings"
+	ringKeyBuilder = store.NewKeyBuilder(ringPathPrefix)
+)
 
 // Interface is the interface of a Ring. Ring's methods are atomic and
 // goroutine-safe.
@@ -66,16 +74,20 @@ type Ring struct {
 	// The name of the ring.
 	Name string
 
-	client *clientv3.Client
-	kv     clientv3.KV
+	client       *clientv3.Client
+	kv           clientv3.KV
+	backendID    string
+	leaseTimeout int64
 }
 
 // New returns a new Ring.
 func New(name string, client *clientv3.Client) *Ring {
 	return &Ring{
-		Name:   name,
-		client: client,
-		kv:     clientv3.NewKV(client),
+		Name:         name,
+		client:       client,
+		kv:           clientv3.NewKV(client),
+		backendID:    backendID,
+		leaseTimeout: 15, // 15 seconds
 	}
 }
 
@@ -89,36 +101,63 @@ func newKey(prefix string) string {
 	return path.Join(prefix, buf.String())
 }
 
-// Add adds a new value to the ring, if it is not already present.
+// Add adds a new owned value to the ring, which is associated with the client
+// that added it. Only the client that added it will be able to retrieve it with
+// Next. If the value already exists, ownership will be transferred.
 func (r *Ring) Add(ctx context.Context, value string) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		lease, err := r.client.Grant(ctx, r.leaseTimeout)
+		if err != nil {
+			return err
+		}
 		key := newKey(r.Name)
 		putCmp := clientv3.Compare(clientv3.Version(key), "=", 0)
-		putOp := clientv3.OpPut(key, value)
+		putOp := clientv3.OpPut(key, value, clientv3.WithLease(lease.ID))
 		cmps, ops, err := r.getRemovalOps(ctx, value)
 		if err != nil {
 			return err
 		}
+		ownershipAssertion := clientv3.OpPut(
+			path.Join(r.Name, value), r.backendID, clientv3.WithLease(lease.ID))
 		cmps = append(cmps, putCmp)
-		ops = append(ops, putOp)
+		ops = append(ops, putOp, ownershipAssertion)
 		response, err := r.kv.Txn(ctx).If(cmps...).Then(ops...).Commit()
 		if err != nil {
 			return err
 		}
 		if response.Succeeded {
+			ch, err := r.client.KeepAlive(ctx, lease.ID)
+			if err != nil {
+				return err
+			}
+			<-ch
 			return nil
+		}
+		if _, err := r.client.Revoke(ctx, lease.ID); err != nil {
+			return err
 		}
 	}
 }
 
-// Remove removes a value from the ring.
+// Remove removes a value from the ring. It must be owned by the client that
+// placed it there, or ErrNotOwner will be returned.
 func (r *Ring) Remove(ctx context.Context, value string) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+		resp, err := r.client.Get(ctx, path.Join(r.Name, value))
+		if err != nil {
+			return err
+		}
+		if len(resp.Kvs) == 0 {
+			return nil
+		}
+		if string(resp.Kvs[0].Value) != r.backendID {
+			return ErrNotOwner
 		}
 		cmps, ops, err := r.getRemovalOps(ctx, value)
 		if err != nil {
@@ -127,6 +166,12 @@ func (r *Ring) Remove(ctx context.Context, value string) error {
 		if len(ops) == 0 {
 			return nil
 		}
+		// Ensure the owner has not changed
+		eqCmp := clientv3.Compare(clientv3.Value(path.Join(r.Name, value)), "=", r.backendID)
+		// Delete the ownership assertion
+		delOp := clientv3.OpDelete(path.Join(r.Name, value))
+		ops = append(ops, delOp)
+		cmps = append(cmps, eqCmp)
 		response, err := r.kv.Txn(ctx).If(cmps...).Then(ops...).Commit()
 		if err != nil {
 			return err
@@ -158,10 +203,42 @@ func (r *Ring) getRemovalOps(ctx context.Context, value string) ([]clientv3.Cmp,
 	return cmps, ops, nil
 }
 
-// Next returns the next item in the Ring and advances the iteration. If the
-// Ring is empty, then Next will return an empty value, and ErrEmptyRing.
+// Next returns the next owned item in the Ring and advances the iteration. If
+// the Ring does not contain any items owned by this client, then Next will
+// block until the context is cancelled. If the Ring contains no items
+// whatsoever, then ErrEmptyRing will be returned.
 func (r *Ring) Next(ctx context.Context) (string, error) {
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	delChan := make(chan struct{})
+	wc := r.client.Watch(watchCtx, r.Name, clientv3.WithPrefix())
+	if wc == nil {
+		return "", ctx.Err()
+	}
+	go func() {
+		// This goroutine watches the ring for delete events
+		defer func() {
+			close(delChan)
+		}()
+		for {
+			select {
+			case resp := <-wc:
+				for _, evt := range resp.Events {
+					if evt.Type == mvccpb.DELETE {
+						delChan <- struct{}{}
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
 		response, err := r.client.Get(ctx, r.Name, clientv3.WithFirstKey()...)
 		if err != nil {
 			return "", err
@@ -169,17 +246,31 @@ func (r *Ring) Next(ctx context.Context) (string, error) {
 		if len(response.Kvs) == 0 {
 			return "", ErrEmptyRing
 		}
+		ownedKvs, err := r.getOwnedKvs(ctx, response.Kvs)
+		if err != nil {
+			return "", err
+		}
+		if len(ownedKvs) == 0 || ownedKvs[0] != response.Kvs[0] {
+			<-delChan
+			continue
+		}
 		kvs := response.Kvs[0]
 		key := string(kvs.Key)
 		value := string(kvs.Value)
+
+		// Ensure ownership has not changed in the meantime
+		eqCmp := clientv3.Compare(clientv3.Value(path.Join(r.Name, value)), "=", r.backendID)
+
+		// Delete the head of the ring
 		delCmp := clientv3.Compare(clientv3.ModRevision(key), "=", kvs.ModRevision)
 		delOp := clientv3.OpDelete(key)
 
+		// Place the value at the tail of the ring
 		nextKey := newKey(r.Name)
 		putCmp := clientv3.Compare(clientv3.ModRevision(nextKey), "=", 0)
 		putOp := clientv3.OpPut(nextKey, value)
 
-		resp, err := r.kv.Txn(ctx).If(delCmp, putCmp).Then(delOp, putOp).Commit()
+		resp, err := r.kv.Txn(ctx).If(delCmp, putCmp, eqCmp).Then(delOp, putOp).Commit()
 		if err != nil {
 			return "", err
 		}
@@ -187,6 +278,23 @@ func (r *Ring) Next(ctx context.Context) (string, error) {
 			return value, nil
 		}
 	}
+}
+
+func (r *Ring) getOwnedKvs(ctx context.Context, kvs []*mvccpb.KeyValue) ([]*mvccpb.KeyValue, error) {
+	result := make([]*mvccpb.KeyValue, 0, len(kvs))
+	for _, kv := range kvs {
+		resp, err := r.client.Get(ctx, path.Join(r.Name, string(kv.Value)))
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Kvs) == 0 {
+			continue
+		}
+		if string(resp.Kvs[0].Value) == r.backendID {
+			result = append(result, kv)
+		}
+	}
+	return result, nil
 }
 
 // Peek returns the next item in the Ring without advancing the iteration. If

--- a/backend/ring/ring_test.go
+++ b/backend/ring/ring_test.go
@@ -4,7 +4,9 @@ package ring
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/stretchr/testify/assert"
@@ -91,4 +93,121 @@ func TestPeek(t *testing.T) {
 	item, err := ring.Peek(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "foo", item)
+
+	ring = EtcdGetter{client}.GetRing("testempty")
+	_, err = ring.Peek(context.Background())
+	assert.Equal(t, ErrEmptyRing, err)
+}
+
+func TestBlockOnNext(t *testing.T) {
+	t.Parallel()
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	getter := EtcdGetter{client}
+
+	r1 := getter.GetRing("blocknext")
+	r2 := getter.GetRing("blocknext")
+	r2.(*Ring).backendID = "something-else-entirely"
+
+	require.NoError(t, r1.Add(context.Background(), "foo"))
+	require.NoError(t, r2.Add(context.Background(), "bar"))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		value, err := r2.Next(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "bar", value)
+	}()
+
+	value, err := r1.Next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "foo", value)
+
+	wg.Wait()
+
+	value, err = r1.Next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "foo", value)
+}
+
+func TestTransferOwnership(t *testing.T) {
+	t.Parallel()
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	getter := EtcdGetter{client}
+
+	r1 := getter.GetRing("testtransfer")
+	r2 := getter.GetRing("testtransfer")
+	r2.(*Ring).backendID = "something-else-entirely"
+
+	require.NoError(t, r1.Add(context.Background(), "foo"))
+	require.NoError(t, r2.Add(context.Background(), "foo"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-time.After(time.Second)
+		cancel()
+	}()
+	_, err = r1.Next(ctx)
+	assert.Equal(t, ctx.Err(), err) // it timed out
+
+	value, err := r2.Next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "foo", value)
+}
+
+func TestErrNotOwner(t *testing.T) {
+	t.Parallel()
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	getter := EtcdGetter{client}
+
+	r1 := getter.GetRing("testerrnotowner")
+	r2 := getter.GetRing("testerrnotowner")
+	r2.(*Ring).backendID = "something-else-entirely"
+
+	require.NoError(t, r1.Add(context.Background(), "foo"))
+	assert.Equal(t, ErrNotOwner, r2.Remove(context.Background(), "foo"))
+}
+
+func TestExpire(t *testing.T) {
+	t.Parallel()
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	ring := EtcdGetter{client}.GetRing("testexpire").(*Ring)
+	ring.leaseTimeout = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, ring.Add(ctx, "foo"))
+
+	cancel()
+	// Give the cluster some time to expire the lease. Unfortunately there
+	// doesn't seem to be any way to be informed of when the lease expires.
+	time.Sleep(time.Second * 5)
+
+	_, err = ring.Next(context.Background())
+	assert.Equal(t, ErrEmptyRing, err)
 }


### PR DESCRIPTION
* Adding ring items implicitly tracks ownership by backends.
* Only the backend that added an item can retrieve it via Next().
* A backend can transfer ownership of an item to itself with Add().

This commit provides a way to disambiguate relationships between
backends and agents, when the ring is used by schedulerd. When a
client receives a value via Next(), the client knows for a fact
that the value is one placed there by them.

The order of the Ring is maintained throughout, by making Next
block until it has an item that it is allowed to consume.

Signed-off-by: Eric Chlebek <eric@sensu.io>