### PR TITLE
Ensure atomic fields are 8-byte aligned.

### DIFF
--- a/backend/leader/supervisor.go
+++ b/backend/leader/supervisor.go
@@ -18,6 +18,8 @@ var super *supervisor
 var keyBuilder = store.NewKeyBuilder(sensuLeaderKey)
 
 type supervisor struct {
+	workPerformed int64
+	leaderName    atomic.Value
 	session       *concurrency.Session
 	election      *concurrency.Election
 	isLeader      chan struct{}
@@ -26,8 +28,6 @@ type supervisor struct {
 	cancel        context.CancelFunc
 	nodeName      string
 	logger        *logrus.Entry
-	leaderName    atomic.Value
-	workPerformed int64
 	wg            sync.WaitGroup
 	workInFlight  sync.WaitGroup
 }


### PR DESCRIPTION
This is necessary for 32-bit x86 and ARM when performing atomic
operations.

Signed-off-by: Eric Chlebek <eric@sensu.io>