### PR TITLE
Don't use bytes.Split for parsing item timestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ finished before its allotted execution timeout.
 - Properly log errors whenever a check request can't be published.
 - Fixed some build tags for tests using etcd stores.
 - Keepalive monitors now get updated with changes to a keepalive timeout.
+- Fixed a bug in the queue package where timestamps were not parsed correctly.
 
 ### Changed
 - Queues are now durable.

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -235,8 +235,7 @@ func (q *Queue) Dequeue(ctx context.Context) (*Item, error) {
 }
 
 func (q *Queue) getItemTimestamp(key []byte) (time.Time, error) {
-	splitByte := bytes.Split(key, []byte("/"))
-	binaryTimestamp := splitByte[len(splitByte)-1]
+	binaryTimestamp := key[len(key)-8:]
 
 	var itemTimestamp int64
 	buf := bytes.NewReader(binaryTimestamp)


### PR DESCRIPTION
Because item timestamps are always 8 bytes, we can simply slice off
the last 8 bytes of the key to get the timestamp. This prevents
an issue with Split where '/' was part of the timestamp.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #972 