### PR TITLE
Incremental retry mechanism when waiting for agent and backend in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Silenced `begin` supports human readable time (Format: Jan 02 2006 3:04PM MST)
 in `sensuctl` with optional timezone. Stores the field as unix epoch time.
+- Incremental retry mechanism when waiting for agent and backend in e2e tests.
 
 ## [2.0.0-alpha.16] - 2018-02-07
 ### Added

--- a/testing/e2e/helpers_test.go
+++ b/testing/e2e/helpers_test.go
@@ -28,11 +28,11 @@ func newSensuClient(backendHTTPURL string) *client.RestClient {
 }
 
 func waitForAgent(id string, sensuctl *sensuCtl) bool {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		_, err := sensuctl.run("event", "info", id, "keepalive")
 		if err != nil {
 			log.Println("keepalive not received, sleeping...")
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(i+1) * time.Second)
 			continue
 		}
 
@@ -43,18 +43,18 @@ func waitForAgent(id string, sensuctl *sensuCtl) bool {
 }
 
 func waitForBackend(url string) bool {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		resp, getErr := http.Get(fmt.Sprintf("%s/health", url))
 		if getErr != nil {
 			log.Println("backend not ready, sleeping...")
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(i+1) * time.Second)
 			continue
 		}
 		_ = resp.Body.Close()
 
 		if resp.StatusCode != 200 && resp.StatusCode != 401 {
 			log.Printf("backend returned non-200/401 status code: %d\n", resp.StatusCode)
-			time.Sleep(1 * time.Second)
+			time.Sleep(time.Duration(i+1) * time.Second)
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It improves the retry mechanism in e2e tests when we are waiting for an agent or a backend to show up, with an incremental sleep.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/966.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!