### PR TITLE
Add embedded field support to dynamic.Marshal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ in `sensuctl` with optional timezone. Stores the field as unix epoch time.
 - Increased the timeout in the store's watchers tests
 - Incremental retry mechanism when waiting for agent and backend in e2e tests.
 
+### Fixed
+- Add support for embedded fields to dynamic.Marshal.
+
 ## [2.0.0-alpha.16] - 2018-02-07
 ### Added
 - Add an e2e test for proxy check requests.

--- a/types/dynamic/encoding.go
+++ b/types/dynamic/encoding.go
@@ -150,6 +150,21 @@ func getJSONFields(v reflect.Value, addressOfAttrs *byte) map[string]structField
 				continue
 			}
 		}
+		// if the field is embedded, flatten it out
+		if sf.Field.Anonymous {
+			var attrAddr *byte
+			if x, ok := sf.Value.Interface().(AttrGetter); ok {
+				attrs := x.GetExtendedAttributes()
+				if len(attrs) > 0 {
+					attrAddr = &attrs[0]
+				}
+			}
+			fields := getJSONFields(sf.Value, attrAddr)
+			for k, v := range fields {
+				result[k] = v
+			}
+			continue
+		}
 		// sf is a valid JSON field.
 		result[sf.JSONName] = sf
 	}


### PR DESCRIPTION
This commit fixes a bug in dynamic.Marshal where embedded fields
were not dealt with correctly.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1000 