### PR TITLE
Fix sensuctl configure (interactive by default)

### DIFF
--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -27,6 +27,15 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 		Use:          "configure",
 		Short:        "Initialize sensuctl configuration",
 		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			flags := cmd.Flags()
+			nonInteractive, _ := flags.GetBool("non-interactive")
+			if nonInteractive {
+				// Mark flags are required for bash-completions
+				_ = cmd.MarkFlagRequired("username")
+				_ = cmd.MarkFlagRequired("password")
+			}
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				_ = cmd.Help()
@@ -121,10 +130,6 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	_ = cmd.Flags().StringP("environment", "", cli.Config.Environment(), "environment")
 	_ = cmd.Flags().StringP("format", "", cli.Config.Format(), "preferred output format")
 	_ = cmd.Flags().StringP("organization", "", cli.Config.Organization(), "organization")
-
-	// Mark flags are required for bash-completions
-	_ = cmd.MarkFlagRequired("username")
-	_ = cmd.MarkFlagRequired("password")
 
 	return cmd
 }


### PR DESCRIPTION
## What is this change?

Fixes `sensuctl configure` interactive mode.

## Why is this change necessary?

`sensuctl configure` interactive mode was broken, requiring username and password flags. Interactive is the default mode for this CLI command (there is no `--interactive`), `--non-interactive` is used to disable it (CLI arguments for secrets is not ideal).

Before:

<img width="1163" alt="screen shot 2018-02-11 at 4 59 51 pm" src="https://user-images.githubusercontent.com/149630/36081104-74e98e98-0f4f-11e8-8bfd-b6060cdd032e.png">

After:

<img width="1295" alt="screen shot 2018-02-11 at 5 15 04 pm" src="https://user-images.githubusercontent.com/149630/36081107-7bb048b6-0f4f-11e8-9dea-25c50a8f5061.png">

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No.


## Were there any complications while making this change?

No.
