### PR TITLE
Duplicate CheckConfig fields in Check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 of a check. This allows updating single fields and completely clearing out
 non-required fields.
 
+### Changed
+- Refactor Check data structure to not depend on CheckConfig. This is a breaking
+change that will cause existing Sensu alpha installations to break if upgraded.
+This change was made before beta release so that further breaking changes could
+be avoided.
+
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added
 - Add .gitattributes file with merge strategy for the Changelog.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -145,7 +145,7 @@ func TestHandleTCPMessages(t *testing.T) {
 	}
 
 	assert.NotNil(event.Entity)
-	assert.Equal("app_01", event.Check.Config.Name)
+	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(int32(0), event.Check.Status)
 	ta.Stop()
 }
@@ -191,7 +191,7 @@ func TestHandleUDPMessages(t *testing.T) {
 	}
 
 	assert.NotNil(event.Entity)
-	assert.Equal("app_01", event.Check.Config.Name)
+	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(int32(0), event.Check.Status)
 	ta.Stop()
 }
@@ -269,7 +269,7 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 	event := &types.Event{}
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotNil(event.Entity)
-	assert.Equal("app_01", event.Check.Config.Name)
+	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(int32(0), event.Check.Status)
 
 	ta.Stop()

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -61,7 +61,7 @@ func (a *Agent) getEntities(event *types.Event) {
 	if event.Entity != nil && event.Entity.ID != a.config.AgentID {
 		// Identify the event's source as the provided entity so it can be properly
 		// handled by the backend
-		event.Check.Config.ProxyEntityID = event.Entity.ID
+		event.Check.ProxyEntityID = event.Entity.ID
 	}
 
 	// From this point we make sure that the agent's entity is used in the event

--- a/agent/entity_test.go
+++ b/agent/entity_test.go
@@ -93,7 +93,7 @@ func TestGetEntities(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.agent.getEntities(tc.event)
 			assert.Equal(tc.expectedAgentID, tc.event.Entity.ID)
-			assert.Equal(tc.expectedSource, tc.event.Check.Config.ProxyEntityID)
+			assert.Equal(tc.expectedSource, tc.event.Check.ProxyEntityID)
 		})
 	}
 }

--- a/agent/event.go
+++ b/agent/event.go
@@ -21,16 +21,16 @@ func prepareEvent(a *Agent, event *types.Event) error {
 	}
 
 	// Make sure the check has all required attributes
-	if event.Check.Config.Interval == 0 {
-		event.Check.Config.Interval = 1
+	if event.Check.Interval == 0 {
+		event.Check.Interval = 1
 	}
 
-	if event.Check.Config.Organization == "" {
-		event.Check.Config.Organization = a.config.Organization
+	if event.Check.Organization == "" {
+		event.Check.Organization = a.config.Organization
 	}
 
-	if event.Check.Config.Environment == "" {
-		event.Check.Config.Environment = a.config.Environment
+	if event.Check.Environment == "" {
+		event.Check.Environment = a.config.Environment
 	}
 
 	if event.Check.Executed == 0 {
@@ -55,9 +55,6 @@ func prepareEvent(a *Agent, event *types.Event) error {
 // translateToEvent accepts a 1.x compatible check result
 // and attempts to translate it to a 2.x event
 func translateToEvent(a *Agent, result v1.CheckResult, event *types.Event) error {
-	var checkConfig types.CheckConfig
-	var check types.Check
-
 	if result.Name == "" {
 		return fmt.Errorf("a check name must be provided")
 	}
@@ -76,20 +73,21 @@ func translateToEvent(a *Agent, result v1.CheckResult, event *types.Event) error
 		}
 	}
 
-	check.Status = result.Status
-	checkConfig.Command = result.Command
-	checkConfig.Subscriptions = result.Subscribers
-	checkConfig.Interval = result.Interval
-	checkConfig.Name = result.Name
-	check.Issued = result.Issued
-	check.Executed = result.Executed
-	check.Duration = result.Duration
-	check.Output = result.Output
-	checkConfig.SetExtendedAttributes(result.GetExtendedAttributes())
+	check := &types.Check{
+		Status:        result.Status,
+		Command:       result.Command,
+		Subscriptions: result.Subscribers,
+		Interval:      result.Interval,
+		Name:          result.Name,
+		Issued:        result.Issued,
+		Executed:      result.Executed,
+		Duration:      result.Duration,
+		Output:        result.Output,
+	}
+	check.SetExtendedAttributes(result.GetExtendedAttributes())
 
 	// add config and check values to the 2.x event
-	check.Config = &checkConfig
-	event.Check = &check
+	event.Check = check
 
 	return nil
 }

--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -23,9 +23,9 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 	ctx = context.WithValue(ctx, types.EnvironmentKey, event.Entity.Environment)
 
 	// Verify if a proxy entity id, representing a proxy entity, is defined in the check
-	if event.Check.Config.ProxyEntityID != "" {
+	if event.Check.ProxyEntityID != "" {
 		// Query the store for an entity using the given proxy entity ID
-		entity, err := s.GetEntityByID(ctx, event.Check.Config.ProxyEntityID)
+		entity, err := s.GetEntityByID(ctx, event.Check.ProxyEntityID)
 		if err != nil {
 			return fmt.Errorf("could not query the store for a proxy entity: %s", err.Error())
 		}
@@ -33,11 +33,11 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 		// Check if an entity was found for this proxy entity. If not, we need to create it
 		if entity == nil {
 			entity = &types.Entity{
-				ID:            event.Check.Config.ProxyEntityID,
+				ID:            event.Check.ProxyEntityID,
 				Class:         types.EntityProxyClass,
 				Environment:   event.Entity.Environment,
 				Organization:  event.Entity.Organization,
-				Subscriptions: addEntitySubscription(event.Check.Config.ProxyEntityID, []string{}),
+				Subscriptions: addEntitySubscription(event.Check.ProxyEntityID, []string{}),
 			}
 
 			if err := s.UpdateEntity(ctx, entity); err != nil {

--- a/backend/agentd/entity_test.go
+++ b/backend/agentd/entity_test.go
@@ -42,9 +42,7 @@ func TestGetProxyEntity(t *testing.T) {
 			name: "The event has a proxy entity with a corresponding entity",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						ProxyEntityID: "bar",
-					},
+					ProxyEntityID: "bar",
 				},
 				Entity: types.FixtureEntity("foo"),
 			},
@@ -55,9 +53,7 @@ func TestGetProxyEntity(t *testing.T) {
 			name: "The event has a proxy entity with no corresponding entity",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						ProxyEntityID: "baz",
-					},
+					ProxyEntityID: "baz",
 				},
 				Entity: types.FixtureEntity("foo"),
 			},
@@ -68,9 +64,7 @@ func TestGetProxyEntity(t *testing.T) {
 			name: "The proxy entity can't be queried",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						ProxyEntityID: "quux",
-					},
+					ProxyEntityID: "quux",
 				},
 				Entity: types.FixtureEntity("foo"),
 			},
@@ -80,9 +74,7 @@ func TestGetProxyEntity(t *testing.T) {
 			name: "The proxy entity can't be created",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						ProxyEntityID: "qux",
-					},
+					ProxyEntityID: "qux",
 				},
 				Entity: types.FixtureEntity("foo"),
 			},

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -118,7 +118,7 @@ func (a EventController) Destroy(ctx context.Context, params QueryParams) error 
 
 // Update updates the event indicated by the supplied entity and check.
 func (a EventController) Update(ctx context.Context, event types.Event) error {
-	check := event.Check.Config
+	check := event.Check
 	entity := event.Entity
 
 	// Adjust context
@@ -156,7 +156,7 @@ func (a EventController) Update(ctx context.Context, event types.Event) error {
 // Create creates the event indicated by the supplied entity and check.
 // If an event already exists for the entity and check, it updates that event.
 func (a EventController) Create(ctx context.Context, event types.Event) error {
-	check := event.Check.Config
+	check := event.Check
 	entity := event.Entity
 
 	// Adjust context

--- a/backend/apid/actions/events_test.go
+++ b/backend/apid/actions/events_test.go
@@ -336,7 +336,7 @@ func TestEventUpdate(t *testing.T) {
 	)
 
 	badEvent := types.FixtureEvent("entity1", "check1")
-	badEvent.Check.Config.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
+	badEvent.Check.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
 	testCases := []struct {
 		name            string
@@ -445,7 +445,7 @@ func TestEventCreate(t *testing.T) {
 	)
 
 	badEvent := types.FixtureEvent("entity1", "check1")
-	badEvent.Check.Config.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
+	badEvent.Check.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
 	testCases := []struct {
 		name            string

--- a/backend/apid/graphql/globalid/events.go
+++ b/backend/apid/graphql/globalid/events.go
@@ -99,7 +99,7 @@ func encodeEvent(event *types.Event) StandardComponents {
 		components.resourceType = eventCheckType
 		components.uniqueComponent = encodeUniqueComponents(
 			event.Entity.ID,
-			event.Check.Config.Name,
+			event.Check.Name,
 			timestamp,
 		)
 	} else if event.Metrics != nil {

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -145,7 +145,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 	ctx = context.WithValue(ctx, types.EnvironmentKey, event.Entity.Environment)
 
 	prevEvent, err := e.Store.GetEventByEntityCheck(
-		ctx, event.Entity.ID, event.Check.Config.Name,
+		ctx, event.Entity.ID, event.Check.Name,
 	)
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 
 	entity := event.Entity
 
-	if event.Check.Config.Ttl > 0 && !event.Check.Config.RoundRobin {
+	if event.Check.Ttl > 0 && !event.Check.RoundRobin {
 		// create a monitor for the event's entity if it doesn't exist in the
 		// monitor map
 		// only monitor if there is a check TTL and the check is not a
@@ -193,7 +193,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 		e.mu.Lock()
 		mon, ok = e.monitors[entity.ID]
 		if !ok || mon.IsStopped() {
-			timeout := time.Duration(event.Check.Config.Ttl) * time.Second
+			timeout := time.Duration(event.Check.Ttl) * time.Second
 			mon = e.MonitorFactory(entity, event, timeout, e, e)
 			e.monitors[entity.ID] = mon
 		}
@@ -242,7 +242,7 @@ func (e *Eventd) HandleFailure(entity *types.Entity, event *types.Event) error {
 
 func (e *Eventd) createFailedCheckEvent(ctx context.Context, event *types.Event) (*types.Event, error) {
 	lastCheckResult, err := e.Store.GetEventByEntityCheck(
-		ctx, event.Entity.ID, event.Check.Config.Name,
+		ctx, event.Entity.ID, event.Check.Name,
 	)
 	if err != nil {
 		return nil, err

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -94,7 +94,7 @@ func TestEventMonitor(t *testing.T) {
 	require.NoError(t, bus.Publish(messaging.TopicEventRaw, nil))
 
 	event := types.FixtureEvent("entity", "check")
-	event.Check.Config.Ttl = 90
+	event.Check.Ttl = 90
 
 	var nilEvent *types.Event
 	// no previous event.

--- a/backend/eventd/flapping.go
+++ b/backend/eventd/flapping.go
@@ -5,17 +5,17 @@ import "github.com/sensu/sensu-go/types"
 // isFlapping determines if the check is flapping, based on the TotalStateChange
 // and configured thresholds
 func isFlapping(event *types.Event) bool {
-	if event.Check.Config.LowFlapThreshold == 0 || event.Check.Config.HighFlapThreshold == 0 {
+	if event.Check.LowFlapThreshold == 0 || event.Check.HighFlapThreshold == 0 {
 		return false
 	}
 
 	// Is the check already flapping?
 	if event.Check.State == types.EventFlappingState {
-		return event.Check.TotalStateChange > event.Check.Config.LowFlapThreshold
+		return event.Check.TotalStateChange > event.Check.LowFlapThreshold
 	}
 
 	// The check was not flapping, now determine if it does now
-	return event.Check.TotalStateChange >= event.Check.Config.HighFlapThreshold
+	return event.Check.TotalStateChange >= event.Check.HighFlapThreshold
 }
 
 // state determines the check state based on whether the check is flapping and

--- a/backend/eventd/flapping_test.go
+++ b/backend/eventd/flapping_test.go
@@ -43,9 +43,7 @@ func TestIsFlapping(t *testing.T) {
 		{
 			"low_flap_threshold not configured",
 			&types.Event{
-				Check: &types.Check{
-					Config: &types.CheckConfig{},
-				},
+				Check: &types.Check{},
 			},
 			false,
 		},
@@ -53,9 +51,7 @@ func TestIsFlapping(t *testing.T) {
 			"high_flap_threshold not configured",
 			&types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						LowFlapThreshold: 10,
-					},
+					LowFlapThreshold: 10,
 				},
 			},
 			false,
@@ -64,12 +60,10 @@ func TestIsFlapping(t *testing.T) {
 			"check is still flapping",
 			&types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						LowFlapThreshold:  10,
-						HighFlapThreshold: 30,
-					},
-					State:            types.EventFlappingState,
-					TotalStateChange: 15,
+					LowFlapThreshold:  10,
+					HighFlapThreshold: 30,
+					State:             types.EventFlappingState,
+					TotalStateChange:  15,
 				},
 			},
 			true,
@@ -78,12 +72,10 @@ func TestIsFlapping(t *testing.T) {
 			"check is no longer flapping",
 			&types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						LowFlapThreshold:  10,
-						HighFlapThreshold: 30,
-					},
-					State:            types.EventFlappingState,
-					TotalStateChange: 5,
+					LowFlapThreshold:  10,
+					HighFlapThreshold: 30,
+					State:             types.EventFlappingState,
+					TotalStateChange:  5,
 				},
 			},
 			false,
@@ -92,12 +84,10 @@ func TestIsFlapping(t *testing.T) {
 			"check is now flapping",
 			&types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						LowFlapThreshold:  10,
-						HighFlapThreshold: 30,
-					},
-					State:            types.EventFailingState,
-					TotalStateChange: 35,
+					LowFlapThreshold:  10,
+					HighFlapThreshold: 30,
+					State:             types.EventFailingState,
+					TotalStateChange:  35,
 				},
 			},
 			true,
@@ -106,12 +96,10 @@ func TestIsFlapping(t *testing.T) {
 			"check is not flapping",
 			&types.Event{
 				Check: &types.Check{
-					State: types.EventPassingState,
-					Config: &types.CheckConfig{
-						LowFlapThreshold:  10,
-						HighFlapThreshold: 30,
-					},
-					TotalStateChange: 5,
+					State:             types.EventPassingState,
+					LowFlapThreshold:  10,
+					HighFlapThreshold: 30,
+					TotalStateChange:  5,
 				},
 			},
 			false,

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -44,8 +44,8 @@ func TestEventdMonitor(t *testing.T) {
 	}
 
 	event := types.FixtureEvent("entity1", "check1")
-	event.Check.Config.Interval = 1
-	event.Check.Config.Ttl = 2
+	event.Check.Interval = 1
+	event.Check.Ttl = 2
 
 	if err := bus.Publish(messaging.TopicEventRaw, event); err != nil {
 		assert.FailNow(t, "failed to publish event to TopicEventRaw")

--- a/backend/eventd/silenced.go
+++ b/backend/eventd/silenced.go
@@ -34,7 +34,7 @@ func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
 	entries = append(entries, results...)
 
 	// Retrieve silenced entries using the check subscriptions
-	for _, value := range event.Check.Config.Subscriptions {
+	for _, value := range event.Check.Subscriptions {
 		results, err = s.GetSilencedEntriesBySubscription(ctx, value)
 		if err != nil {
 			return err
@@ -43,7 +43,7 @@ func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
 	}
 
 	// Retrieve silenced entries using the check name
-	results, err = s.GetSilencedEntriesByCheckName(ctx, event.Check.Config.Name)
+	results, err = s.GetSilencedEntriesByCheckName(ctx, event.Check.Name)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string 
 	for _, entry := range silencedEntries {
 
 		// Is this event silenced for all subscriptions? (e.g. *:check_cpu)
-		if entry.ID == fmt.Sprintf("*:%s", event.Check.Config.Name) && entry.StartSilence(time.Now().Unix()) {
+		if entry.ID == fmt.Sprintf("*:%s", event.Check.Name) && entry.StartSilence(time.Now().Unix()) {
 			silencedBy = addToSilencedBy(entry.ID, silencedBy)
 			continue
 		}
@@ -81,12 +81,12 @@ func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string 
 
 		// Is this event silenced for this particular entity? (e.g.
 		// entity:id:check_cpu)
-		if entry.ID == fmt.Sprintf("%s:%s", types.GetEntitySubscription(event.Entity.ID), event.Check.Config.Name) && entry.StartSilence(time.Now().Unix()) {
+		if entry.ID == fmt.Sprintf("%s:%s", types.GetEntitySubscription(event.Entity.ID), event.Check.Name) && entry.StartSilence(time.Now().Unix()) {
 			silencedBy = addToSilencedBy(entry.ID, silencedBy)
 			continue
 		}
 
-		for _, subscription := range event.Check.Config.Subscriptions {
+		for _, subscription := range event.Check.Subscriptions {
 			// Make sure the entity is subscribed to this specific subscription
 			if !stringsutil.InArray(subscription, event.Entity.Subscriptions) {
 				continue
@@ -101,7 +101,7 @@ func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string 
 
 			// Is this event silenced by one of the check subscription for this
 			// particular check? (e.g. load-balancer:check_cpu)
-			if entry.ID == fmt.Sprintf("%s:%s", subscription, event.Check.Config.Name) && entry.StartSilence(time.Now().Unix()) {
+			if entry.ID == fmt.Sprintf("%s:%s", subscription, event.Check.Name) && entry.StartSilence(time.Now().Unix()) {
 				silencedBy = addToSilencedBy(entry.ID, silencedBy)
 				continue
 			}

--- a/backend/eventd/silenced_test.go
+++ b/backend/eventd/silenced_test.go
@@ -138,10 +138,8 @@ func TestSilencedBy(t *testing.T) {
 			name: "not silenced, silenced & client don't have a common subscription",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						Name:          "check_cpu",
-						Subscriptions: []string{"linux", "windows"},
-					},
+					Name:          "check_cpu",
+					Subscriptions: []string{"linux", "windows"},
 				},
 				Entity: &types.Entity{
 					ID:            "foo",
@@ -157,10 +155,8 @@ func TestSilencedBy(t *testing.T) {
 			name: "silenced, silenced & client do have a common subscription",
 			event: &types.Event{
 				Check: &types.Check{
-					Config: &types.CheckConfig{
-						Name:          "check_cpu",
-						Subscriptions: []string{"linux", "windows"},
-					},
+					Name:          "check_cpu",
+					Subscriptions: []string{"linux", "windows"},
 				},
 				Entity: &types.Entity{
 					ID:            "foo",

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -40,7 +40,7 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 
 	for _, event := range events {
 		if err := adapterPtr.Store.DeleteEventByEntityCheck(
-			ctx, entity.ID, event.Check.Config.Name,
+			ctx, entity.ID, event.Check.Name,
 		); err != nil {
 			return fmt.Errorf("error deleting event for entity: %s", err.Error())
 		}
@@ -56,16 +56,14 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 
 	if entity.Deregistration.Handler != "" {
 		deregistrationCheck := &types.Check{
-			Config: &types.CheckConfig{
-				Name:          "deregistration",
-				Interval:      entity.KeepaliveTimeout,
-				Subscriptions: []string{""},
-				Command:       "",
-				Handlers:      []string{entity.Deregistration.Handler},
-				Environment:   entity.Environment,
-				Organization:  entity.Organization,
-			},
-			Status: 1,
+			Name:          "deregistration",
+			Interval:      entity.KeepaliveTimeout,
+			Subscriptions: []string{""},
+			Command:       "",
+			Handlers:      []string{entity.Deregistration.Handler},
+			Environment:   entity.Environment,
+			Organization:  entity.Organization,
+			Status:        1,
 		}
 
 		deregistrationEvent := &types.Event{

--- a/backend/keepalived/deregisterer_test.go
+++ b/backend/keepalived/deregisterer_test.go
@@ -25,10 +25,10 @@ func TestDeregister(t *testing.T) {
 	entity := types.FixtureEntity("entity")
 	entity.Deregister = true
 	check := types.FixtureCheck("check")
-	event := types.FixtureEvent(entity.ID, check.Config.Name)
+	event := types.FixtureEvent(entity.ID, check.Name)
 
 	mockStore.On("GetEventsByEntity", mock.Anything, entity.ID).Return([]*types.Event{event}, nil)
-	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.ID, check.Config.Name).Return(nil)
+	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.ID, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 
 	mockBus.On("Publish", mock.AnythingOfType("string"), mock.Anything).Return(nil)
@@ -55,7 +55,7 @@ func TestDeregistrationHandler(t *testing.T) {
 	check := types.FixtureCheck("check")
 
 	mockStore.On("GetEventsByEntity", mock.Anything, entity.ID).Return([]*types.Event{}, nil)
-	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.ID, check.Config.Name).Return(nil)
+	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.ID, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 
 	mockBus.On("Publish", messaging.TopicEvent, mock.Anything).Return(nil).Run(func(args mock.Arguments) {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -260,14 +260,12 @@ func (k *Keepalived) startMonitorSweeper() {
 
 func createKeepaliveEvent(entity *types.Entity) *types.Event {
 	keepaliveCheck := &types.Check{
-		Config: &types.CheckConfig{
-			Name:         KeepaliveCheckName,
-			Interval:     entity.KeepaliveTimeout,
-			Handlers:     []string{KeepaliveHandlerName},
-			Environment:  entity.Environment,
-			Organization: entity.Organization,
-		},
-		Status: 1,
+		Name:         KeepaliveCheckName,
+		Interval:     entity.KeepaliveTimeout,
+		Handlers:     []string{KeepaliveHandlerName},
+		Environment:  entity.Environment,
+		Organization: entity.Organization,
+		Status:       1,
 	}
 	keepaliveEvent := &types.Event{
 		Timestamp: time.Now().Unix(),
@@ -280,14 +278,12 @@ func createKeepaliveEvent(entity *types.Entity) *types.Event {
 
 func createRegistrationEvent(entity *types.Entity) *types.Event {
 	registrationCheck := &types.Check{
-		Config: &types.CheckConfig{
-			Name:         RegistrationCheckName,
-			Interval:     entity.KeepaliveTimeout,
-			Handlers:     []string{RegistrationHandlerName},
-			Environment:  entity.Environment,
-			Organization: entity.Organization,
-		},
-		Status: 1,
+		Name:         RegistrationCheckName,
+		Interval:     entity.KeepaliveTimeout,
+		Handlers:     []string{RegistrationHandlerName},
+		Environment:  entity.Environment,
+		Organization: entity.Organization,
+		Status:       1,
 	}
 	registrationEvent := &types.Event{
 		Timestamp: time.Now().Unix(),

--- a/backend/pipelined/handle.go
+++ b/backend/pipelined/handle.go
@@ -27,7 +27,7 @@ func (p *Pipelined) handleEvent(event *types.Event) error {
 	ctx := context.WithValue(context.Background(), types.OrganizationKey, event.Entity.Organization)
 	ctx = context.WithValue(ctx, types.EnvironmentKey, event.Entity.Environment)
 
-	handlers, err := p.expandHandlers(ctx, event.Check.Config.Handlers, 1)
+	handlers, err := p.expandHandlers(ctx, event.Check.Handlers, 1)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (p *Pipelined) handleEvent(event *types.Event) error {
 
 		if filtered {
 			logger.WithFields(logrus.Fields{
-				"check":        event.Check.Config.GetName(),
+				"check":        event.Check.Name,
 				"entity":       event.Entity.ID,
 				"organization": event.Entity.Organization,
 				"environment":  event.Entity.Environment,

--- a/backend/pipelined/handle_test.go
+++ b/backend/pipelined/handle_test.go
@@ -57,7 +57,7 @@ func TestPipelinedHandleEvent(t *testing.T) {
 	// how useful this would be.
 	assert.NoError(t, p.handleEvent(event))
 
-	event.Check.Config.Handlers = []string{"handler1"}
+	event.Check.Handlers = []string{"handler1"}
 	store.On("GetHandlerByName", mock.Anything, "handler1").Return(handler, nil)
 	assert.NoError(t, p.handleEvent(event))
 }

--- a/backend/store/etcd/error_store.go
+++ b/backend/store/etcd/error_store.go
@@ -197,7 +197,7 @@ func (s *Store) CreateError(ctx context.Context, perr *types.Error) error {
 	key := errorsKeyBuilder.WithContext(ctx).Build(
 		perr.Event.Entity.ID,
 		"check", // Eventually will need a conditional when metrics are implemented
-		perr.Event.Check.Config.Name,
+		perr.Event.Check.Name,
 		string(perr.Timestamp),
 	)
 
@@ -215,7 +215,7 @@ func (s *Store) CreateError(ctx context.Context, perr *types.Error) error {
 		return fmt.Errorf(
 			"could not create the error %s/%s in environment %s/%s",
 			perr.Event.Entity.ID,
-			perr.Event.Check.Config.Name,
+			perr.Event.Check.Name,
 			perr.GetOrganization(),
 			perr.GetEnvironment(),
 		)
@@ -266,7 +266,7 @@ func shouldRejectError(ns store.Namespace, entity string, check string) rejectEr
 	if check != "" {
 		rejectWhereCheckDoesNotMatch = func(perr *types.Error) bool {
 			errCheck := perr.Event.Check
-			return errCheck != nil && errCheck.Config.Name != check
+			return errCheck != nil && errCheck.Name != check
 		}
 	}
 

--- a/backend/store/etcd/error_store_test.go
+++ b/backend/store/etcd/error_store_test.go
@@ -36,20 +36,20 @@ func TestErrorStorage(t *testing.T) {
 		assert.EqualValues(t, []*types.Error{perr}, entityErrors)
 
 		// GetErrorsByCheck
-		checkErrors, err := store.GetErrorsByEntityCheck(ctx, perr.Event.Entity.ID, perr.Event.Check.Config.Name)
+		checkErrors, err := store.GetErrorsByEntityCheck(ctx, perr.Event.Entity.ID, perr.Event.Check.Name)
 		require.NoError(t, err)
 		assert.Len(t, checkErrors, 1)
 		assert.EqualValues(t, []*types.Error{perr}, checkErrors)
 
 		// GetError
-		perrRes, err := store.GetError(ctx, perr.Event.Entity.ID, perr.Event.Check.Config.Name, string(perr.Timestamp))
+		perrRes, err := store.GetError(ctx, perr.Event.Entity.ID, perr.Event.Check.Name, string(perr.Timestamp))
 		require.NoError(t, err)
 		assert.EqualValues(t, perr, perrRes)
 
 		// Delete error
 		cerr = store.CreateError(ctx, perr) // Ensure error is present
 		require.NoError(t, cerr)
-		err = store.DeleteError(ctx, perr.Event.Entity.ID, perr.Event.Check.Config.Name, string(perr.Timestamp))
+		err = store.DeleteError(ctx, perr.Event.Entity.ID, perr.Event.Check.Name, string(perr.Timestamp))
 		require.NoError(t, err)
 		allErrors, err = store.GetErrors(ctx) // Check that error is gone
 		require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestErrorStorage(t *testing.T) {
 		// Delete errors by check
 		cerr = store.CreateError(ctx, perr) // Ensure error is present
 		require.NoError(t, cerr)
-		err = store.DeleteErrorsByEntityCheck(ctx, perr.Event.Entity.ID, perr.Event.Check.Config.Name)
+		err = store.DeleteErrorsByEntityCheck(ctx, perr.Event.Entity.ID, perr.Event.Check.Name)
 		require.NoError(t, err)
 		allErrors, err = store.GetErrors(ctx) // Check that error is gone
 		require.NoError(t, err)

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -27,7 +27,7 @@ func getEventPath(event *types.Event) string {
 		event.Entity.Organization,
 		event.Entity.Environment,
 		event.Entity.ID,
-		event.Check.Config.Name,
+		event.Check.Name,
 	)
 }
 
@@ -172,7 +172,7 @@ func (s *Store) UpdateEvent(ctx context.Context, event *types.Event) error {
 		return fmt.Errorf(
 			"could not create the event %s/%s in environment %s/%s",
 			event.Entity.ID,
-			event.Check.Config.Name,
+			event.Check.Name,
 			event.Entity.Organization,
 			event.Entity.Environment,
 		)

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -62,7 +62,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title: "Check",
 			CellTransformer: func(data interface{}) string {
 				event, _ := data.(types.Event)
-				return event.Check.Config.Name
+				return event.Check.Name
 			},
 		},
 		{

--- a/cli/commands/event/show.go
+++ b/cli/commands/event/show.go
@@ -65,7 +65,7 @@ func printEntityToList(event *types.Event, writer io.Writer) {
 	}
 
 	cfg := &list.Config{
-		Title: fmt.Sprintf("%s - %s", event.Entity.ID, event.Check.Config.Name),
+		Title: fmt.Sprintf("%s - %s", event.Entity.ID, event.Check.Name),
 		Rows: []*list.Row{
 			{
 				Label: "Entity",
@@ -73,7 +73,7 @@ func printEntityToList(event *types.Event, writer io.Writer) {
 			},
 			{
 				Label: "Check",
-				Value: event.Check.Config.Name,
+				Value: event.Check.Name,
 			},
 			{
 				Label: "Output",

--- a/handlers/slack/main.go
+++ b/handlers/slack/main.go
@@ -115,7 +115,7 @@ func chomp(s string) string {
 }
 
 func eventKey(event *types.Event) string {
-	return fmt.Sprintf("%s/%s", event.Entity.ID, event.Check.Config.Name)
+	return fmt.Sprintf("%s/%s", event.Entity.ID, event.Check.Name)
 }
 
 func eventSummary(event *types.Event, maxLength int) string {
@@ -171,7 +171,7 @@ func messageAttachment(event *types.Event) *slack.Attachment {
 			},
 			&slack.AttachmentField{
 				Title: "Check",
-				Value: event.Check.Config.Name,
+				Value: event.Check.Name,
 				Short: true,
 			},
 		},

--- a/testing/e2e/asset_store_test.go
+++ b/testing/e2e/asset_store_test.go
@@ -81,6 +81,6 @@ func TestAssetStore(t *testing.T) {
 	assert.NotNil(t, event.Check)
 	assert.NotNil(t, event.Entity)
 	assert.Equal(t, "TestAssetStore", event.Entity.ID)
-	assert.Equal(t, "test", event.Check.Config.Name)
-	assert.Equal(t, "asset", strings.Join(event.Check.Config.RuntimeAssets, ","))
+	assert.Equal(t, "test", event.Check.Name)
+	assert.Equal(t, "asset", strings.Join(event.Check.RuntimeAssets, ","))
 }

--- a/testing/e2e/event_handler_test.go
+++ b/testing/e2e/event_handler_test.go
@@ -85,7 +85,7 @@ func TestEventHandler(t *testing.T) {
 	assert.NotNil(t, event.Check)
 	assert.NotNil(t, event.Entity)
 	assert.Equal(t, "TestEventHandler", event.Entity.ID)
-	assert.Equal(t, "test", event.Check.Config.Name)
+	assert.Equal(t, "test", event.Check.Name)
 
 	// There should be a JSON event file in the OS temp directory
 	_, err = os.Stat(handlerJSONFile)

--- a/testing/e2e/keepalive_test.go
+++ b/testing/e2e/keepalive_test.go
@@ -68,7 +68,7 @@ func (suite *EventTestSuite) TestKeepaliveEvent() {
 
 	seen := false
 	for _, ev := range events {
-		if ev.Check.Config.Name == "keepalive" {
+		if ev.Check.Name == "keepalive" {
 			seen = true
 			assert.Equal("TestKeepalives", ev.Entity.ID)
 			assert.NotZero(ev.Timestamp)
@@ -132,7 +132,7 @@ func (suite *EventTestSuite) TestCheck() {
 	assert.NotNil(event.Check)
 	assert.NotNil(event.Entity)
 	assert.Equal("TestKeepalives", event.Entity.ID)
-	assert.Equal(checkName, event.Check.Config.Name)
+	assert.Equal(checkName, event.Check.Name)
 }
 
 func (suite *EventTestSuite) TestHTTPAPI() {

--- a/types/adhoc.proto
+++ b/types/adhoc.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
-import "check.proto";
 
 package sensu.types;
 

--- a/types/check.pb.go
+++ b/types/check.pb.go
@@ -297,25 +297,67 @@ func (m *CheckConfig) GetRoundRobin() bool {
 // A Check is a check specification and optionally the results of the check's
 // execution.
 type Check struct {
-	// Config is the specification of a check
-	Config *CheckConfig `protobuf:"bytes,1,opt,name=config" json:"config,omitempty"`
+	// Command is the command to be executed.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Environment indicates to which env a check belongs to
+	Environment string `protobuf:"bytes,2,opt,name=environment,proto3" json:"environment,omitempty"`
+	// Handlers are the event handler for the check (incidents and/or metrics).
+	Handlers []string `protobuf:"bytes,3,rep,name=handlers" json:"handlers"`
+	// HighFlapThreshold is the flap detection high threshold (% state change) for
+	// the check. Sensu uses the same flap detection algorithm as Nagios.
+	HighFlapThreshold uint32 `protobuf:"varint,4,opt,name=high_flap_threshold,json=highFlapThreshold,proto3" json:"high_flap_threshold,omitempty"`
+	// Interval is the interval, in seconds, at which the check should be run.
+	Interval uint32 `protobuf:"varint,5,opt,name=interval,proto3" json:"interval,omitempty"`
+	// LowFlapThreshold is the flap detection low threshold (% state change) for
+	// the check. Sensu uses the same flap detection algorithm as Nagios.
+	LowFlapThreshold uint32 `protobuf:"varint,6,opt,name=low_flap_threshold,json=lowFlapThreshold,proto3" json:"low_flap_threshold,omitempty"`
+	// Name is the unique identifier for a check.
+	Name string `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
+	// Organization indicates to which org a check belongs to
+	Organization string `protobuf:"bytes,8,opt,name=organization,proto3" json:"organization,omitempty"`
+	// Publish indicates if check requests are published for the check
+	Publish bool `protobuf:"varint,9,opt,name=publish,proto3" json:"publish,omitempty"`
+	// RuntimeAssets are a list of assets required to execute check.
+	RuntimeAssets []string `protobuf:"bytes,10,rep,name=runtime_assets,json=runtimeAssets" json:"runtime_assets"`
+	// Subscriptions is the list of subscribers for the check.
+	Subscriptions []string `protobuf:"bytes,11,rep,name=subscriptions" json:"subscriptions"`
+	// Sources indicates the name of the entity representing an external resource
+	ProxyEntityID string `protobuf:"bytes,13,opt,name=proxy_entity_id,json=proxyEntityId,proto3" json:"proxy_entity_id"`
+	// CheckHooks is the list of check hooks for the check
+	CheckHooks []HookList `protobuf:"bytes,14,rep,name=check_hooks,json=checkHooks" json:"check_hooks"`
+	// STDIN indicates if the check command accepts JSON via stdin from the agent
+	Stdin bool `protobuf:"varint,15,opt,name=stdin,proto3" json:"stdin,omitempty"`
+	// Subdue represents one or more time windows when the check should be subdued.
+	Subdue *TimeWindowWhen `protobuf:"bytes,16,opt,name=subdue" json:"subdue"`
+	// Cron is the cron string at which the check should be run.
+	Cron string `protobuf:"bytes,17,opt,name=cron,proto3" json:"cron,omitempty"`
+	// TTL represents the length of time in seconds for which a check result is valid.
+	Ttl int64 `protobuf:"varint,18,opt,name=ttl,proto3" json:"ttl,omitempty"`
+	// Timeout is the timeout, in seconds, at which the check has to run
+	Timeout uint32 `protobuf:"varint,19,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	// ProxyRequests represents a request to execute a proxy check
+	ProxyRequests *ProxyRequests `protobuf:"bytes,20,opt,name=proxy_requests,json=proxyRequests" json:"proxy_requests,omitempty"`
+	// RoundRobin enables round-robin scheduling if set true.
+	RoundRobin bool `protobuf:"varint,21,opt,name=round_robin,json=roundRobin,proto3" json:"round_robin,omitempty"`
 	// Duration of execution
-	Duration float64 `protobuf:"fixed64,2,opt,name=duration,proto3" json:"duration,omitempty"`
+	Duration float64 `protobuf:"fixed64,22,opt,name=duration,proto3" json:"duration,omitempty"`
 	// Executed describes the time in which the check request was executed
-	Executed int64 `protobuf:"varint,3,opt,name=executed,proto3" json:"executed,omitempty"`
+	Executed int64 `protobuf:"varint,23,opt,name=executed,proto3" json:"executed,omitempty"`
 	// History is the check state history.
-	History []CheckHistory `protobuf:"bytes,4,rep,name=history" json:"history"`
+	History []CheckHistory `protobuf:"bytes,24,rep,name=history" json:"history"`
 	// Issued describes the time in which the check request was issued
-	Issued int64 `protobuf:"varint,5,opt,name=issued,proto3" json:"issued,omitempty"`
+	Issued int64 `protobuf:"varint,25,opt,name=issued,proto3" json:"issued,omitempty"`
 	// Output from the execution of Command
-	Output string `protobuf:"bytes,6,opt,name=output,proto3" json:"output,omitempty"`
+	Output string `protobuf:"bytes,26,opt,name=output,proto3" json:"output,omitempty"`
 	// State provides handlers with more information about the state change
-	State string `protobuf:"bytes,7,opt,name=state,proto3" json:"state,omitempty"`
+	State string `protobuf:"bytes,27,opt,name=state,proto3" json:"state,omitempty"`
 	// Status is the exit status code produced by the check
-	Status int32 `protobuf:"varint,8,opt,name=status,proto3" json:"status,omitempty"`
+	Status int32 `protobuf:"varint,28,opt,name=status,proto3" json:"status,omitempty"`
 	// TotalStateChange indicates the total state change percentage for the
 	// check's history
-	TotalStateChange uint32 `protobuf:"varint,9,opt,name=total_state_change,json=totalStateChange,proto3" json:"total_state_change,omitempty"`
+	TotalStateChange uint32 `protobuf:"varint,29,opt,name=total_state_change,json=totalStateChange,proto3" json:"total_state_change,omitempty"`
+	// ExtendedAttributes store serialized arbitrary JSON-encoded data
+	ExtendedAttributes []byte `protobuf:"bytes,99,opt,name=ExtendedAttributes,proto3" json:"-"`
 }
 
 func (m *Check) Reset()                    { *m = Check{} }
@@ -323,11 +365,144 @@ func (m *Check) String() string            { return proto.CompactTextString(m) }
 func (*Check) ProtoMessage()               {}
 func (*Check) Descriptor() ([]byte, []int) { return fileDescriptorCheck, []int{3} }
 
-func (m *Check) GetConfig() *CheckConfig {
+func (m *Check) GetCommand() string {
 	if m != nil {
-		return m.Config
+		return m.Command
+	}
+	return ""
+}
+
+func (m *Check) GetEnvironment() string {
+	if m != nil {
+		return m.Environment
+	}
+	return ""
+}
+
+func (m *Check) GetHandlers() []string {
+	if m != nil {
+		return m.Handlers
 	}
 	return nil
+}
+
+func (m *Check) GetHighFlapThreshold() uint32 {
+	if m != nil {
+		return m.HighFlapThreshold
+	}
+	return 0
+}
+
+func (m *Check) GetInterval() uint32 {
+	if m != nil {
+		return m.Interval
+	}
+	return 0
+}
+
+func (m *Check) GetLowFlapThreshold() uint32 {
+	if m != nil {
+		return m.LowFlapThreshold
+	}
+	return 0
+}
+
+func (m *Check) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Check) GetOrganization() string {
+	if m != nil {
+		return m.Organization
+	}
+	return ""
+}
+
+func (m *Check) GetPublish() bool {
+	if m != nil {
+		return m.Publish
+	}
+	return false
+}
+
+func (m *Check) GetRuntimeAssets() []string {
+	if m != nil {
+		return m.RuntimeAssets
+	}
+	return nil
+}
+
+func (m *Check) GetSubscriptions() []string {
+	if m != nil {
+		return m.Subscriptions
+	}
+	return nil
+}
+
+func (m *Check) GetProxyEntityID() string {
+	if m != nil {
+		return m.ProxyEntityID
+	}
+	return ""
+}
+
+func (m *Check) GetCheckHooks() []HookList {
+	if m != nil {
+		return m.CheckHooks
+	}
+	return nil
+}
+
+func (m *Check) GetStdin() bool {
+	if m != nil {
+		return m.Stdin
+	}
+	return false
+}
+
+func (m *Check) GetSubdue() *TimeWindowWhen {
+	if m != nil {
+		return m.Subdue
+	}
+	return nil
+}
+
+func (m *Check) GetCron() string {
+	if m != nil {
+		return m.Cron
+	}
+	return ""
+}
+
+func (m *Check) GetTtl() int64 {
+	if m != nil {
+		return m.Ttl
+	}
+	return 0
+}
+
+func (m *Check) GetTimeout() uint32 {
+	if m != nil {
+		return m.Timeout
+	}
+	return 0
+}
+
+func (m *Check) GetProxyRequests() *ProxyRequests {
+	if m != nil {
+		return m.ProxyRequests
+	}
+	return nil
+}
+
+func (m *Check) GetRoundRobin() bool {
+	if m != nil {
+		return m.RoundRobin
+	}
+	return false
 }
 
 func (m *Check) GetDuration() float64 {
@@ -384,6 +559,13 @@ func (m *Check) GetTotalStateChange() uint32 {
 		return m.TotalStateChange
 	}
 	return 0
+}
+
+func (m *Check) GetExtendedAttributes() []byte {
+	if m != nil {
+		return m.ExtendedAttributes
+	}
+	return nil
 }
 
 // CheckHistory is a record of a check execution and its status
@@ -642,7 +824,84 @@ func (this *Check) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
-	if !this.Config.Equal(that1.Config) {
+	if this.Command != that1.Command {
+		return false
+	}
+	if this.Environment != that1.Environment {
+		return false
+	}
+	if len(this.Handlers) != len(that1.Handlers) {
+		return false
+	}
+	for i := range this.Handlers {
+		if this.Handlers[i] != that1.Handlers[i] {
+			return false
+		}
+	}
+	if this.HighFlapThreshold != that1.HighFlapThreshold {
+		return false
+	}
+	if this.Interval != that1.Interval {
+		return false
+	}
+	if this.LowFlapThreshold != that1.LowFlapThreshold {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if this.Organization != that1.Organization {
+		return false
+	}
+	if this.Publish != that1.Publish {
+		return false
+	}
+	if len(this.RuntimeAssets) != len(that1.RuntimeAssets) {
+		return false
+	}
+	for i := range this.RuntimeAssets {
+		if this.RuntimeAssets[i] != that1.RuntimeAssets[i] {
+			return false
+		}
+	}
+	if len(this.Subscriptions) != len(that1.Subscriptions) {
+		return false
+	}
+	for i := range this.Subscriptions {
+		if this.Subscriptions[i] != that1.Subscriptions[i] {
+			return false
+		}
+	}
+	if this.ProxyEntityID != that1.ProxyEntityID {
+		return false
+	}
+	if len(this.CheckHooks) != len(that1.CheckHooks) {
+		return false
+	}
+	for i := range this.CheckHooks {
+		if !this.CheckHooks[i].Equal(&that1.CheckHooks[i]) {
+			return false
+		}
+	}
+	if this.Stdin != that1.Stdin {
+		return false
+	}
+	if !this.Subdue.Equal(that1.Subdue) {
+		return false
+	}
+	if this.Cron != that1.Cron {
+		return false
+	}
+	if this.Ttl != that1.Ttl {
+		return false
+	}
+	if this.Timeout != that1.Timeout {
+		return false
+	}
+	if !this.ProxyRequests.Equal(that1.ProxyRequests) {
+		return false
+	}
+	if this.RoundRobin != that1.RoundRobin {
 		return false
 	}
 	if this.Duration != that1.Duration {
@@ -672,6 +931,9 @@ func (this *Check) Equal(that interface{}) bool {
 		return false
 	}
 	if this.TotalStateChange != that1.TotalStateChange {
+		return false
+	}
+	if !bytes.Equal(this.ExtendedAttributes, that1.ExtendedAttributes) {
 		return false
 	}
 	return true
@@ -1028,30 +1290,206 @@ func (m *Check) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
-	if m.Config != nil {
+	if len(m.Command) > 0 {
 		dAtA[i] = 0xa
 		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Config.Size()))
-		n4, err := m.Config.MarshalTo(dAtA[i:])
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Command)))
+		i += copy(dAtA[i:], m.Command)
+	}
+	if len(m.Environment) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Environment)))
+		i += copy(dAtA[i:], m.Environment)
+	}
+	if len(m.Handlers) > 0 {
+		for _, s := range m.Handlers {
+			dAtA[i] = 0x1a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if m.HighFlapThreshold != 0 {
+		dAtA[i] = 0x20
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.HighFlapThreshold))
+	}
+	if m.Interval != 0 {
+		dAtA[i] = 0x28
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.Interval))
+	}
+	if m.LowFlapThreshold != 0 {
+		dAtA[i] = 0x30
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.LowFlapThreshold))
+	}
+	if len(m.Name) > 0 {
+		dAtA[i] = 0x3a
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Name)))
+		i += copy(dAtA[i:], m.Name)
+	}
+	if len(m.Organization) > 0 {
+		dAtA[i] = 0x42
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Organization)))
+		i += copy(dAtA[i:], m.Organization)
+	}
+	if m.Publish {
+		dAtA[i] = 0x48
+		i++
+		if m.Publish {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i++
+	}
+	if len(m.RuntimeAssets) > 0 {
+		for _, s := range m.RuntimeAssets {
+			dAtA[i] = 0x52
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if len(m.Subscriptions) > 0 {
+		for _, s := range m.Subscriptions {
+			dAtA[i] = 0x5a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
+	if len(m.ProxyEntityID) > 0 {
+		dAtA[i] = 0x6a
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ProxyEntityID)))
+		i += copy(dAtA[i:], m.ProxyEntityID)
+	}
+	if len(m.CheckHooks) > 0 {
+		for _, msg := range m.CheckHooks {
+			dAtA[i] = 0x72
+			i++
+			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	if m.Stdin {
+		dAtA[i] = 0x78
+		i++
+		if m.Stdin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i++
+	}
+	if m.Subdue != nil {
+		dAtA[i] = 0x82
+		i++
+		dAtA[i] = 0x1
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.Subdue.Size()))
+		n4, err := m.Subdue.MarshalTo(dAtA[i:])
 		if err != nil {
 			return 0, err
 		}
 		i += n4
 	}
+	if len(m.Cron) > 0 {
+		dAtA[i] = 0x8a
+		i++
+		dAtA[i] = 0x1
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Cron)))
+		i += copy(dAtA[i:], m.Cron)
+	}
+	if m.Ttl != 0 {
+		dAtA[i] = 0x90
+		i++
+		dAtA[i] = 0x1
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.Ttl))
+	}
+	if m.Timeout != 0 {
+		dAtA[i] = 0x98
+		i++
+		dAtA[i] = 0x1
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.Timeout))
+	}
+	if m.ProxyRequests != nil {
+		dAtA[i] = 0xa2
+		i++
+		dAtA[i] = 0x1
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(m.ProxyRequests.Size()))
+		n5, err := m.ProxyRequests.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
+	}
+	if m.RoundRobin {
+		dAtA[i] = 0xa8
+		i++
+		dAtA[i] = 0x1
+		i++
+		if m.RoundRobin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i++
+	}
 	if m.Duration != 0 {
-		dAtA[i] = 0x11
+		dAtA[i] = 0xb1
+		i++
+		dAtA[i] = 0x1
 		i++
 		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Duration))))
 		i += 8
 	}
 	if m.Executed != 0 {
-		dAtA[i] = 0x18
+		dAtA[i] = 0xb8
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.Executed))
 	}
 	if len(m.History) > 0 {
 		for _, msg := range m.History {
-			dAtA[i] = 0x22
+			dAtA[i] = 0xc2
+			i++
+			dAtA[i] = 0x1
 			i++
 			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
 			n, err := msg.MarshalTo(dAtA[i:])
@@ -1062,31 +1500,49 @@ func (m *Check) MarshalTo(dAtA []byte) (int, error) {
 		}
 	}
 	if m.Issued != 0 {
-		dAtA[i] = 0x28
+		dAtA[i] = 0xc8
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.Issued))
 	}
 	if len(m.Output) > 0 {
-		dAtA[i] = 0x32
+		dAtA[i] = 0xd2
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(len(m.Output)))
 		i += copy(dAtA[i:], m.Output)
 	}
 	if len(m.State) > 0 {
-		dAtA[i] = 0x3a
+		dAtA[i] = 0xda
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(len(m.State)))
 		i += copy(dAtA[i:], m.State)
 	}
 	if m.Status != 0 {
-		dAtA[i] = 0x40
+		dAtA[i] = 0xe0
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.Status))
 	}
 	if m.TotalStateChange != 0 {
-		dAtA[i] = 0x48
+		dAtA[i] = 0xe8
+		i++
+		dAtA[i] = 0x1
 		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.TotalStateChange))
+	}
+	if len(m.ExtendedAttributes) > 0 {
+		dAtA[i] = 0x9a
+		i++
+		dAtA[i] = 0x6
+		i++
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ExtendedAttributes)))
+		i += copy(dAtA[i:], m.ExtendedAttributes)
 	}
 	return i, nil
 }
@@ -1228,9 +1684,52 @@ func NewPopulatedCheckConfig(r randyCheck, easy bool) *CheckConfig {
 
 func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 	this := &Check{}
-	if r.Intn(10) != 0 {
-		this.Config = NewPopulatedCheckConfig(r, easy)
+	this.Command = string(randStringCheck(r))
+	this.Environment = string(randStringCheck(r))
+	v12 := r.Intn(10)
+	this.Handlers = make([]string, v12)
+	for i := 0; i < v12; i++ {
+		this.Handlers[i] = string(randStringCheck(r))
 	}
+	this.HighFlapThreshold = uint32(r.Uint32())
+	this.Interval = uint32(r.Uint32())
+	this.LowFlapThreshold = uint32(r.Uint32())
+	this.Name = string(randStringCheck(r))
+	this.Organization = string(randStringCheck(r))
+	this.Publish = bool(bool(r.Intn(2) == 0))
+	v13 := r.Intn(10)
+	this.RuntimeAssets = make([]string, v13)
+	for i := 0; i < v13; i++ {
+		this.RuntimeAssets[i] = string(randStringCheck(r))
+	}
+	v14 := r.Intn(10)
+	this.Subscriptions = make([]string, v14)
+	for i := 0; i < v14; i++ {
+		this.Subscriptions[i] = string(randStringCheck(r))
+	}
+	this.ProxyEntityID = string(randStringCheck(r))
+	if r.Intn(10) != 0 {
+		v15 := r.Intn(5)
+		this.CheckHooks = make([]HookList, v15)
+		for i := 0; i < v15; i++ {
+			v16 := NewPopulatedHookList(r, easy)
+			this.CheckHooks[i] = *v16
+		}
+	}
+	this.Stdin = bool(bool(r.Intn(2) == 0))
+	if r.Intn(10) != 0 {
+		this.Subdue = NewPopulatedTimeWindowWhen(r, easy)
+	}
+	this.Cron = string(randStringCheck(r))
+	this.Ttl = int64(r.Int63())
+	if r.Intn(2) == 0 {
+		this.Ttl *= -1
+	}
+	this.Timeout = uint32(r.Uint32())
+	if r.Intn(10) != 0 {
+		this.ProxyRequests = NewPopulatedProxyRequests(r, easy)
+	}
+	this.RoundRobin = bool(bool(r.Intn(2) == 0))
 	this.Duration = float64(r.Float64())
 	if r.Intn(2) == 0 {
 		this.Duration *= -1
@@ -1240,11 +1739,11 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		this.Executed *= -1
 	}
 	if r.Intn(10) != 0 {
-		v12 := r.Intn(5)
-		this.History = make([]CheckHistory, v12)
-		for i := 0; i < v12; i++ {
-			v13 := NewPopulatedCheckHistory(r, easy)
-			this.History[i] = *v13
+		v17 := r.Intn(5)
+		this.History = make([]CheckHistory, v17)
+		for i := 0; i < v17; i++ {
+			v18 := NewPopulatedCheckHistory(r, easy)
+			this.History[i] = *v18
 		}
 	}
 	this.Issued = int64(r.Int63())
@@ -1258,6 +1757,11 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		this.Status *= -1
 	}
 	this.TotalStateChange = uint32(r.Uint32())
+	v19 := r.Intn(100)
+	this.ExtendedAttributes = make([]byte, v19)
+	for i := 0; i < v19; i++ {
+		this.ExtendedAttributes[i] = byte(r.Intn(256))
+	}
 	if !easy && r.Intn(10) != 0 {
 	}
 	return this
@@ -1297,9 +1801,9 @@ func randUTF8RuneCheck(r randyCheck) rune {
 	return rune(ru + 61)
 }
 func randStringCheck(r randyCheck) string {
-	v14 := r.Intn(100)
-	tmps := make([]rune, v14)
-	for i := 0; i < v14; i++ {
+	v20 := r.Intn(100)
+	tmps := make([]rune, v20)
+	for i := 0; i < v20; i++ {
 		tmps[i] = randUTF8RuneCheck(r)
 	}
 	return string(tmps)
@@ -1321,11 +1825,11 @@ func randFieldCheck(dAtA []byte, r randyCheck, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCheck(dAtA, uint64(key))
-		v15 := r.Int63()
+		v21 := r.Int63()
 		if r.Intn(2) == 0 {
-			v15 *= -1
+			v21 *= -1
 		}
-		dAtA = encodeVarintPopulateCheck(dAtA, uint64(v15))
+		dAtA = encodeVarintPopulateCheck(dAtA, uint64(v21))
 	case 1:
 		dAtA = encodeVarintPopulateCheck(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))
@@ -1483,38 +1987,118 @@ func (m *CheckConfig) Size() (n int) {
 func (m *Check) Size() (n int) {
 	var l int
 	_ = l
-	if m.Config != nil {
-		l = m.Config.Size()
+	l = len(m.Command)
+	if l > 0 {
 		n += 1 + l + sovCheck(uint64(l))
 	}
-	if m.Duration != 0 {
-		n += 9
+	l = len(m.Environment)
+	if l > 0 {
+		n += 1 + l + sovCheck(uint64(l))
 	}
-	if m.Executed != 0 {
-		n += 1 + sovCheck(uint64(m.Executed))
+	if len(m.Handlers) > 0 {
+		for _, s := range m.Handlers {
+			l = len(s)
+			n += 1 + l + sovCheck(uint64(l))
+		}
 	}
-	if len(m.History) > 0 {
-		for _, e := range m.History {
+	if m.HighFlapThreshold != 0 {
+		n += 1 + sovCheck(uint64(m.HighFlapThreshold))
+	}
+	if m.Interval != 0 {
+		n += 1 + sovCheck(uint64(m.Interval))
+	}
+	if m.LowFlapThreshold != 0 {
+		n += 1 + sovCheck(uint64(m.LowFlapThreshold))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovCheck(uint64(l))
+	}
+	l = len(m.Organization)
+	if l > 0 {
+		n += 1 + l + sovCheck(uint64(l))
+	}
+	if m.Publish {
+		n += 2
+	}
+	if len(m.RuntimeAssets) > 0 {
+		for _, s := range m.RuntimeAssets {
+			l = len(s)
+			n += 1 + l + sovCheck(uint64(l))
+		}
+	}
+	if len(m.Subscriptions) > 0 {
+		for _, s := range m.Subscriptions {
+			l = len(s)
+			n += 1 + l + sovCheck(uint64(l))
+		}
+	}
+	l = len(m.ProxyEntityID)
+	if l > 0 {
+		n += 1 + l + sovCheck(uint64(l))
+	}
+	if len(m.CheckHooks) > 0 {
+		for _, e := range m.CheckHooks {
 			l = e.Size()
 			n += 1 + l + sovCheck(uint64(l))
 		}
 	}
+	if m.Stdin {
+		n += 2
+	}
+	if m.Subdue != nil {
+		l = m.Subdue.Size()
+		n += 2 + l + sovCheck(uint64(l))
+	}
+	l = len(m.Cron)
+	if l > 0 {
+		n += 2 + l + sovCheck(uint64(l))
+	}
+	if m.Ttl != 0 {
+		n += 2 + sovCheck(uint64(m.Ttl))
+	}
+	if m.Timeout != 0 {
+		n += 2 + sovCheck(uint64(m.Timeout))
+	}
+	if m.ProxyRequests != nil {
+		l = m.ProxyRequests.Size()
+		n += 2 + l + sovCheck(uint64(l))
+	}
+	if m.RoundRobin {
+		n += 3
+	}
+	if m.Duration != 0 {
+		n += 10
+	}
+	if m.Executed != 0 {
+		n += 2 + sovCheck(uint64(m.Executed))
+	}
+	if len(m.History) > 0 {
+		for _, e := range m.History {
+			l = e.Size()
+			n += 2 + l + sovCheck(uint64(l))
+		}
+	}
 	if m.Issued != 0 {
-		n += 1 + sovCheck(uint64(m.Issued))
+		n += 2 + sovCheck(uint64(m.Issued))
 	}
 	l = len(m.Output)
 	if l > 0 {
-		n += 1 + l + sovCheck(uint64(l))
+		n += 2 + l + sovCheck(uint64(l))
 	}
 	l = len(m.State)
 	if l > 0 {
-		n += 1 + l + sovCheck(uint64(l))
+		n += 2 + l + sovCheck(uint64(l))
 	}
 	if m.Status != 0 {
-		n += 1 + sovCheck(uint64(m.Status))
+		n += 2 + sovCheck(uint64(m.Status))
 	}
 	if m.TotalStateChange != 0 {
-		n += 1 + sovCheck(uint64(m.TotalStateChange))
+		n += 2 + sovCheck(uint64(m.TotalStateChange))
+	}
+	l = len(m.ExtendedAttributes)
+	if l > 0 {
+		n += 2 + l + sovCheck(uint64(l))
 	}
 	return n
 }
@@ -2432,7 +3016,316 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 		switch fieldNum {
 		case 1:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Command", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Command = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Environment", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Environment = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Handlers", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Handlers = append(m.Handlers, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HighFlapThreshold", wireType)
+			}
+			m.HighFlapThreshold = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.HighFlapThreshold |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Interval", wireType)
+			}
+			m.Interval = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Interval |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LowFlapThreshold", wireType)
+			}
+			m.LowFlapThreshold = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.LowFlapThreshold |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Organization", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Organization = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Publish", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Publish = bool(v != 0)
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeAssets", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RuntimeAssets = append(m.RuntimeAssets, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Subscriptions", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Subscriptions = append(m.Subscriptions, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProxyEntityID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ProxyEntityID = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CheckHooks", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2456,14 +3349,185 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.Config == nil {
-				m.Config = &CheckConfig{}
-			}
-			if err := m.Config.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			m.CheckHooks = append(m.CheckHooks, HookList{})
+			if err := m.CheckHooks[len(m.CheckHooks)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
-		case 2:
+		case 15:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Stdin", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Stdin = bool(v != 0)
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Subdue", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Subdue == nil {
+				m.Subdue = &TimeWindowWhen{}
+			}
+			if err := m.Subdue.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Cron", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Cron = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 18:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ttl", wireType)
+			}
+			m.Ttl = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Ttl |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 19:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Timeout", wireType)
+			}
+			m.Timeout = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Timeout |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 20:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProxyRequests", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ProxyRequests == nil {
+				m.ProxyRequests = &ProxyRequests{}
+			}
+			if err := m.ProxyRequests.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RoundRobin", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RoundRobin = bool(v != 0)
+		case 22:
 			if wireType != 1 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Duration", wireType)
 			}
@@ -2474,7 +3538,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 			v = uint64(encoding_binary.LittleEndian.Uint64(dAtA[iNdEx:]))
 			iNdEx += 8
 			m.Duration = float64(math.Float64frombits(v))
-		case 3:
+		case 23:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Executed", wireType)
 			}
@@ -2493,7 +3557,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 4:
+		case 24:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field History", wireType)
 			}
@@ -2524,7 +3588,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 25:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Issued", wireType)
 			}
@@ -2543,7 +3607,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 6:
+		case 26:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Output", wireType)
 			}
@@ -2572,7 +3636,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 			}
 			m.Output = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 7:
+		case 27:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field State", wireType)
 			}
@@ -2601,7 +3665,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 			}
 			m.State = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 8:
+		case 28:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
 			}
@@ -2620,7 +3684,7 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		case 9:
+		case 29:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TotalStateChange", wireType)
 			}
@@ -2639,6 +3703,37 @@ func (m *Check) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 99:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExtendedAttributes", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCheck
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthCheck
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExtendedAttributes = append(m.ExtendedAttributes[:0], dAtA[iNdEx:postIndex]...)
+			if m.ExtendedAttributes == nil {
+				m.ExtendedAttributes = []byte{}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipCheck(dAtA[iNdEx:])
@@ -2856,63 +3951,64 @@ var (
 func init() { proto.RegisterFile("check.proto", fileDescriptorCheck) }
 
 var fileDescriptorCheck = []byte{
-	// 913 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x55, 0xc1, 0x6e, 0x23, 0x45,
-	0x10, 0xdd, 0x8e, 0x63, 0x27, 0x6e, 0xc7, 0x89, 0xdd, 0xd9, 0x40, 0x63, 0x24, 0x8f, 0x65, 0x40,
-	0xf2, 0x81, 0xf5, 0xa2, 0x5d, 0x01, 0xe2, 0x84, 0x32, 0xd9, 0x45, 0x41, 0xec, 0x01, 0x35, 0x2b,
-	0xad, 0xc4, 0x65, 0x34, 0x9e, 0xe9, 0x78, 0x5a, 0x8c, 0xbb, 0x87, 0xe9, 0x9e, 0x24, 0xe6, 0xc4,
-	0x27, 0x70, 0xe4, 0x13, 0xb8, 0x70, 0xe7, 0x13, 0x96, 0x1b, 0x5f, 0x30, 0x02, 0x73, 0xf3, 0x17,
-	0x70, 0x44, 0x5d, 0xd3, 0xf6, 0x7a, 0x12, 0x4e, 0x9c, 0x5c, 0xaf, 0xea, 0x55, 0x77, 0x4d, 0x55,
-	0xbd, 0x36, 0xee, 0x44, 0x09, 0x8f, 0xbe, 0x9b, 0x66, 0xb9, 0x32, 0x8a, 0x74, 0x34, 0x97, 0xba,
-	0x98, 0x9a, 0x65, 0xc6, 0xf5, 0xe0, 0xd1, 0x5c, 0x98, 0xa4, 0x98, 0x4d, 0x23, 0xb5, 0x78, 0x3c,
-	0x57, 0x73, 0xf5, 0x18, 0x38, 0xb3, 0xe2, 0x0a, 0x10, 0x00, 0xb0, 0xaa, 0xdc, 0x41, 0x27, 0xd4,
-	0x9a, 0x1b, 0x07, 0x70, 0xa2, 0x94, 0x3b, 0x74, 0xd0, 0x37, 0x62, 0xc1, 0x83, 0x1b, 0x21, 0x63,
-	0x75, 0x53, 0xb9, 0xc6, 0xbf, 0x22, 0x7c, 0x74, 0x61, 0xef, 0x65, 0xfc, 0xfb, 0x82, 0x6b, 0x43,
-	0x3e, 0xc1, 0xad, 0x48, 0xc9, 0x2b, 0x31, 0xa7, 0x68, 0x84, 0x26, 0x9d, 0x27, 0x74, 0xba, 0x53,
-	0xc9, 0x14, 0xa8, 0x17, 0x10, 0xf7, 0xf7, 0x5f, 0x97, 0x1e, 0x62, 0x8e, 0x4d, 0x3e, 0xc2, 0x2d,
-	0xb8, 0x56, 0xd3, 0xbd, 0x51, 0x63, 0xd2, 0x79, 0x42, 0x6a, 0x79, 0xe7, 0x36, 0x04, 0x19, 0x0f,
-	0x98, 0xe3, 0x91, 0xa7, 0xb8, 0x69, 0x6b, 0xd3, 0xb4, 0x01, 0x09, 0x6f, 0xd7, 0x12, 0x2e, 0x95,
-	0xda, 0xbd, 0xe7, 0x01, 0xab, 0xb8, 0xe3, 0x9f, 0x10, 0xee, 0x7e, 0x9d, 0xab, 0xdb, 0xa5, 0xab,
-	0x57, 0x13, 0x1f, 0xf7, 0xb9, 0x34, 0xc2, 0x2c, 0x83, 0xd0, 0x98, 0x5c, 0xcc, 0x0a, 0xc3, 0x35,
-	0x45, 0xa3, 0xc6, 0xa4, 0xed, 0x9f, 0xad, 0x4b, 0xef, 0x7e, 0x90, 0xf5, 0x2a, 0xd7, 0xf9, 0xd6,
-	0x43, 0x1e, 0xe2, 0xa6, 0xce, 0xd2, 0x70, 0x49, 0xf7, 0x46, 0x68, 0x72, 0xc8, 0x2a, 0x40, 0x3e,
-	0xc0, 0xc7, 0x60, 0x04, 0x91, 0xba, 0xe6, 0x79, 0x38, 0xe7, 0xb4, 0x31, 0x42, 0x93, 0x2e, 0xeb,
-	0x82, 0xf7, 0xc2, 0x39, 0xc7, 0x3f, 0x1e, 0xe0, 0xce, 0x4e, 0x5f, 0x08, 0xc5, 0x07, 0x91, 0x5a,
-	0x2c, 0x42, 0x19, 0x43, 0x0b, 0xdb, 0x6c, 0x03, 0xc9, 0x08, 0x77, 0xb8, 0xbc, 0x16, 0xb9, 0x92,
-	0x0b, 0x2e, 0x0d, 0x5c, 0xd6, 0x66, 0xbb, 0x2e, 0x32, 0xc1, 0x87, 0x49, 0x28, 0xe3, 0x94, 0xe7,
-	0x55, 0x5b, 0xda, 0xfe, 0xd1, 0xba, 0xf4, 0xb6, 0x3e, 0xb6, 0xb5, 0xc8, 0x14, 0x9f, 0x26, 0x62,
-	0x9e, 0x04, 0x57, 0x69, 0x98, 0x05, 0x26, 0xc9, 0xb9, 0x4e, 0x54, 0x1a, 0xd3, 0x7d, 0xa8, 0xb0,
-	0x6f, 0x43, 0x5f, 0xa4, 0x61, 0xf6, 0x72, 0x13, 0x20, 0x03, 0x7c, 0x28, 0xa4, 0xe1, 0xf9, 0x75,
-	0x98, 0xd2, 0x26, 0x90, 0xb6, 0x98, 0x7c, 0x88, 0x49, 0xaa, 0x6e, 0xee, 0x1e, 0xd5, 0x02, 0x56,
-	0x2f, 0x55, 0x37, 0xf5, 0x93, 0x08, 0xde, 0x97, 0xe1, 0x82, 0xd3, 0x03, 0x28, 0x1f, 0x6c, 0x32,
-	0xc6, 0x47, 0x2a, 0x9f, 0x87, 0x52, 0xfc, 0x10, 0x1a, 0xa1, 0x24, 0x3d, 0x84, 0x58, 0xcd, 0x67,
-	0xfb, 0x92, 0x15, 0xb3, 0x54, 0xe8, 0x84, 0xb6, 0xa1, 0xcd, 0x1b, 0x48, 0x3e, 0xc3, 0xc7, 0x79,
-	0x21, 0x61, 0x39, 0xdd, 0x0e, 0x61, 0xf8, 0x76, 0xb2, 0x2e, 0xbd, 0x3b, 0x11, 0xd6, 0x75, 0xf8,
-	0xbc, 0x5a, 0xa2, 0x4f, 0x71, 0x57, 0x17, 0x33, 0x1d, 0xe5, 0x22, 0xb3, 0x97, 0x68, 0xda, 0x81,
-	0xcc, 0xfe, 0xba, 0xf4, 0xea, 0x01, 0x56, 0x87, 0xe4, 0x63, 0x4c, 0x9e, 0xdf, 0x1a, 0x2e, 0x63,
-	0x1e, 0xbf, 0x59, 0x04, 0x7a, 0x34, 0x42, 0x93, 0x23, 0xbf, 0xb9, 0x2e, 0x3d, 0xf4, 0x88, 0xfd,
-	0x07, 0x81, 0xbc, 0xc0, 0x27, 0x99, 0x5d, 0xbf, 0xc0, 0xad, 0x95, 0x88, 0x69, 0xd7, 0x7e, 0xab,
-	0xff, 0xfe, 0xaa, 0xf4, 0xaa, 0xcd, 0x7c, 0x0e, 0x91, 0x2f, 0x9f, 0xad, 0x4b, 0xef, 0x2e, 0x97,
-	0x75, 0xb3, 0x1d, 0x46, 0x4c, 0xbe, 0x72, 0xa2, 0x0f, 0x2a, 0x21, 0x1c, 0x83, 0x10, 0xce, 0xee,
-	0x09, 0xe1, 0x85, 0xd0, 0xc6, 0x3f, 0xb5, 0x32, 0x58, 0x97, 0xde, 0x6e, 0x06, 0xc3, 0x00, 0x2c,
-	0xa7, 0x5a, 0x62, 0x13, 0x0b, 0x49, 0x4f, 0xdc, 0x12, 0x5b, 0x40, 0x3e, 0xc7, 0x2d, 0x5d, 0xcc,
-	0xe2, 0x82, 0xd3, 0x1e, 0xe8, 0xf9, 0xdd, 0xda, 0xe9, 0x2f, 0xc5, 0x82, 0xbf, 0x82, 0xf7, 0xe0,
-	0x55, 0xc2, 0xa5, 0x8f, 0xd7, 0xa5, 0xe7, 0xe8, 0xcc, 0xfd, 0xda, 0x71, 0x47, 0xb9, 0x92, 0xb4,
-	0x5f, 0x8d, 0xdb, 0xda, 0xa4, 0x87, 0x1b, 0xc6, 0xa4, 0x94, 0x8c, 0xd0, 0xa4, 0xc1, 0xac, 0x69,
-	0x87, 0x6b, 0xa7, 0xa2, 0x0a, 0x43, 0x4f, 0x61, 0x6f, 0x36, 0x90, 0x9c, 0xe3, 0xe3, 0xaa, 0x0b,
-	0xb9, 0x53, 0x2c, 0x7d, 0x08, 0x85, 0x0c, 0x6a, 0x85, 0xd4, 0x34, 0xed, 0xda, 0xb4, 0x95, 0xb8,
-	0x87, 0x3b, 0xb9, 0x2a, 0x64, 0x1c, 0xe4, 0x6a, 0x26, 0x24, 0x3d, 0x83, 0xef, 0xc3, 0xe0, 0x62,
-	0xd6, 0x33, 0xfe, 0x7d, 0x0f, 0x37, 0x41, 0x82, 0xff, 0xfb, 0xf9, 0x1a, 0xe0, 0xc3, 0xb8, 0xc8,
-	0xab, 0xe5, 0xb5, 0xba, 0x44, 0x6c, 0x8b, 0x6d, 0x8c, 0xdf, 0xf2, 0xa8, 0x30, 0x3c, 0x86, 0x17,
-	0xa0, 0xc1, 0xb6, 0x98, 0x3c, 0xc3, 0x07, 0x89, 0xd0, 0x46, 0xe5, 0x4b, 0xba, 0x0f, 0xd3, 0x7b,
-	0xe7, 0xfe, 0x85, 0x97, 0x15, 0xc1, 0x3f, 0x71, 0x13, 0xdc, 0x64, 0xb0, 0x8d, 0x41, 0xde, 0xc2,
-	0x2d, 0xa1, 0x75, 0xc1, 0x63, 0x90, 0x66, 0x83, 0x39, 0x64, 0xfd, 0xaa, 0x30, 0x59, 0x61, 0x40,
-	0x8c, 0x6d, 0xe6, 0x50, 0x35, 0xea, 0xd0, 0x6c, 0x34, 0x58, 0x01, 0xcb, 0xb6, 0x46, 0xa1, 0x41,
-	0x7e, 0x4d, 0xe6, 0x90, 0x95, 0xb7, 0x51, 0x26, 0x4c, 0x03, 0xa0, 0x05, 0x51, 0x12, 0xca, 0x39,
-	0x07, 0x0d, 0x76, 0x59, 0x0f, 0x22, 0xdf, 0xd8, 0xc0, 0x05, 0xf8, 0xc7, 0xbe, 0xfb, 0x43, 0xb8,
-	0x7c, 0x53, 0x9b, 0x3b, 0x15, 0xd5, 0x4e, 0xdd, 0xed, 0xca, 0x5e, 0xbd, 0x2b, 0xfe, 0x7b, 0xff,
-	0xfc, 0x35, 0x44, 0xbf, 0xac, 0x86, 0xe8, 0xb7, 0xd5, 0x10, 0xbd, 0x5e, 0x0d, 0xd1, 0x1f, 0xab,
-	0x21, 0xfa, 0x73, 0x35, 0x44, 0x3f, 0xff, 0x3d, 0x7c, 0xf0, 0x6d, 0x13, 0x7a, 0x33, 0x6b, 0xc1,
-	0x3f, 0xd0, 0xd3, 0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x8d, 0x72, 0xb7, 0x0d, 0xf8, 0x06, 0x00,
-	0x00,
+	// 941 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xec, 0x56, 0xcf, 0x8e, 0x23, 0xb5,
+	0x13, 0x1e, 0x4f, 0x26, 0x99, 0x89, 0x33, 0x99, 0x3f, 0x9e, 0x9d, 0x5d, 0x6f, 0xf6, 0xf7, 0x4b,
+	0x47, 0x01, 0xa4, 0x1c, 0xd8, 0x2c, 0xda, 0x15, 0x20, 0x4e, 0x68, 0x7a, 0x76, 0xd1, 0x20, 0xf6,
+	0x80, 0xcc, 0x4a, 0x2b, 0x71, 0x69, 0x75, 0xba, 0x3d, 0x69, 0x8b, 0x8e, 0xdd, 0xb4, 0xdd, 0xf3,
+	0x87, 0x13, 0x07, 0x1e, 0x80, 0x23, 0x8f, 0xc0, 0x85, 0x3b, 0x8f, 0xb0, 0x47, 0x9e, 0xa0, 0x05,
+	0xe1, 0x96, 0x27, 0xe0, 0x88, 0x5c, 0xed, 0x64, 0xd3, 0x33, 0x20, 0xae, 0x20, 0xed, 0x29, 0xf5,
+	0x55, 0x7d, 0x65, 0x97, 0xcb, 0xf5, 0xa5, 0x8d, 0x3b, 0x51, 0xc2, 0xa3, 0xaf, 0xc6, 0x59, 0xae,
+	0x8c, 0x22, 0x1d, 0xcd, 0xa5, 0x2e, 0xc6, 0xe6, 0x3a, 0xe3, 0xba, 0xf7, 0x70, 0x2a, 0x4c, 0x52,
+	0x4c, 0xc6, 0x91, 0x9a, 0x3d, 0x9a, 0xaa, 0xa9, 0x7a, 0x04, 0x9c, 0x49, 0x71, 0x0e, 0x08, 0x00,
+	0x58, 0x55, 0x6e, 0xaf, 0x13, 0x6a, 0xcd, 0x8d, 0x03, 0x38, 0x51, 0xca, 0x2d, 0xda, 0x3b, 0x34,
+	0x62, 0xc6, 0x83, 0x4b, 0x21, 0x63, 0x75, 0x59, 0xb9, 0x86, 0x3f, 0x21, 0xbc, 0x7b, 0x6a, 0xf7,
+	0x65, 0xfc, 0xeb, 0x82, 0x6b, 0x43, 0x3e, 0xc0, 0xad, 0x48, 0xc9, 0x73, 0x31, 0xa5, 0x68, 0x80,
+	0x46, 0x9d, 0xc7, 0x74, 0xbc, 0x56, 0xc9, 0x18, 0xa8, 0xa7, 0x10, 0xf7, 0xb7, 0x5e, 0x95, 0x1e,
+	0x62, 0x8e, 0x4d, 0xde, 0xc3, 0x2d, 0xd8, 0x56, 0xd3, 0xcd, 0x41, 0x63, 0xd4, 0x79, 0x4c, 0x6a,
+	0x79, 0x27, 0x36, 0x04, 0x19, 0x1b, 0xcc, 0xf1, 0xc8, 0x13, 0xdc, 0xb4, 0xb5, 0x69, 0xda, 0x80,
+	0x84, 0x7b, 0xb5, 0x84, 0x33, 0xa5, 0xd6, 0xf7, 0xd9, 0x60, 0x15, 0x77, 0xf8, 0x3d, 0xc2, 0xdd,
+	0xcf, 0x73, 0x75, 0x75, 0xed, 0xea, 0xd5, 0xc4, 0xc7, 0x87, 0x5c, 0x1a, 0x61, 0xae, 0x83, 0xd0,
+	0x98, 0x5c, 0x4c, 0x0a, 0xc3, 0x35, 0x45, 0x83, 0xc6, 0xa8, 0xed, 0x1f, 0x2f, 0x4a, 0xef, 0x76,
+	0x90, 0x1d, 0x54, 0xae, 0x93, 0x95, 0x87, 0xdc, 0xc1, 0x4d, 0x9d, 0xa5, 0xe1, 0x35, 0xdd, 0x1c,
+	0xa0, 0xd1, 0x0e, 0xab, 0x00, 0x79, 0x07, 0xef, 0x81, 0x11, 0x44, 0xea, 0x82, 0xe7, 0xe1, 0x94,
+	0xd3, 0xc6, 0x00, 0x8d, 0xba, 0xac, 0x0b, 0xde, 0x53, 0xe7, 0x1c, 0x7e, 0xbb, 0x8d, 0x3b, 0x6b,
+	0x7d, 0x21, 0x14, 0x6f, 0x47, 0x6a, 0x36, 0x0b, 0x65, 0x0c, 0x2d, 0x6c, 0xb3, 0x25, 0x24, 0x03,
+	0xdc, 0xe1, 0xf2, 0x42, 0xe4, 0x4a, 0xce, 0xb8, 0x34, 0xb0, 0x59, 0x9b, 0xad, 0xbb, 0xc8, 0x08,
+	0xef, 0x24, 0xa1, 0x8c, 0x53, 0x9e, 0x57, 0x6d, 0x69, 0xfb, 0xbb, 0x8b, 0xd2, 0x5b, 0xf9, 0xd8,
+	0xca, 0x22, 0x63, 0x7c, 0x94, 0x88, 0x69, 0x12, 0x9c, 0xa7, 0x61, 0x16, 0x98, 0x24, 0xe7, 0x3a,
+	0x51, 0x69, 0x4c, 0xb7, 0xa0, 0xc2, 0x43, 0x1b, 0xfa, 0x24, 0x0d, 0xb3, 0x17, 0xcb, 0x00, 0xe9,
+	0xe1, 0x1d, 0x21, 0x0d, 0xcf, 0x2f, 0xc2, 0x94, 0x36, 0x81, 0xb4, 0xc2, 0xe4, 0x5d, 0x4c, 0x52,
+	0x75, 0x79, 0x73, 0xa9, 0x16, 0xb0, 0x0e, 0x52, 0x75, 0x59, 0x5f, 0x89, 0xe0, 0x2d, 0x19, 0xce,
+	0x38, 0xdd, 0x86, 0xf2, 0xc1, 0x26, 0x43, 0xbc, 0xab, 0xf2, 0x69, 0x28, 0xc5, 0x37, 0xa1, 0x11,
+	0x4a, 0xd2, 0x1d, 0x88, 0xd5, 0x7c, 0xb6, 0x2f, 0x59, 0x31, 0x49, 0x85, 0x4e, 0x68, 0x1b, 0xda,
+	0xbc, 0x84, 0xe4, 0x23, 0xbc, 0x97, 0x17, 0x12, 0x86, 0xd3, 0xcd, 0x10, 0x86, 0xb3, 0x93, 0x45,
+	0xe9, 0xdd, 0x88, 0xb0, 0xae, 0xc3, 0x27, 0xd5, 0x10, 0x7d, 0x88, 0xbb, 0xba, 0x98, 0xe8, 0x28,
+	0x17, 0x99, 0xdd, 0x44, 0xd3, 0x0e, 0x64, 0x1e, 0x2e, 0x4a, 0xaf, 0x1e, 0x60, 0x75, 0x48, 0xde,
+	0xc7, 0xe4, 0xd9, 0x95, 0xe1, 0x32, 0xe6, 0xf1, 0xeb, 0x41, 0xa0, 0xbb, 0x03, 0x34, 0xda, 0xf5,
+	0x9b, 0x8b, 0xd2, 0x43, 0x0f, 0xd9, 0x5f, 0x10, 0xc8, 0x73, 0xbc, 0x9f, 0xd9, 0xf1, 0x0b, 0xdc,
+	0x58, 0x89, 0x98, 0x76, 0xed, 0x59, 0xfd, 0xb7, 0xe7, 0xa5, 0x57, 0x4d, 0xe6, 0x33, 0x88, 0x7c,
+	0xfa, 0x74, 0x51, 0x7a, 0x37, 0xb9, 0xac, 0x9b, 0xad, 0x31, 0x62, 0xf2, 0x99, 0x13, 0x7d, 0x50,
+	0x09, 0x61, 0x0f, 0x84, 0x70, 0x7c, 0x4b, 0x08, 0xcf, 0x85, 0x36, 0xfe, 0x91, 0x95, 0xc1, 0xa2,
+	0xf4, 0xd6, 0x33, 0x18, 0x06, 0x60, 0x39, 0xd5, 0x10, 0x9b, 0x58, 0x48, 0xba, 0xef, 0x86, 0xd8,
+	0x02, 0xf2, 0x31, 0x6e, 0xe9, 0x62, 0x12, 0x17, 0x9c, 0x1e, 0x80, 0x9e, 0x1f, 0xd4, 0x56, 0x7f,
+	0x21, 0x66, 0xfc, 0x25, 0xfc, 0x1f, 0xbc, 0x4c, 0xb8, 0xf4, 0xf1, 0xa2, 0xf4, 0x1c, 0x9d, 0xb9,
+	0x5f, 0x7b, 0xdd, 0x51, 0xae, 0x24, 0x3d, 0xac, 0xae, 0xdb, 0xda, 0xe4, 0x00, 0x37, 0x8c, 0x49,
+	0x29, 0x19, 0xa0, 0x51, 0x83, 0x59, 0xd3, 0x5e, 0xae, 0xbd, 0x15, 0x55, 0x18, 0x7a, 0x04, 0x73,
+	0xb3, 0x84, 0xe4, 0x04, 0xef, 0x55, 0x5d, 0xc8, 0x9d, 0x62, 0xe9, 0x1d, 0x28, 0xa4, 0x57, 0x2b,
+	0xa4, 0xa6, 0x69, 0xd7, 0xa6, 0x95, 0xc4, 0x3d, 0xdc, 0xc9, 0x55, 0x21, 0xe3, 0x20, 0x57, 0x13,
+	0x21, 0xe9, 0x31, 0x9c, 0x0f, 0x83, 0x8b, 0x59, 0xcf, 0xf0, 0xbb, 0x36, 0x6e, 0x82, 0x04, 0xdf,
+	0x88, 0xef, 0x3f, 0x21, 0xbe, 0x37, 0x2a, 0xfa, 0x17, 0xaa, 0xc8, 0x4e, 0x69, 0x5c, 0xe4, 0xd5,
+	0x0c, 0xdd, 0x1d, 0xa0, 0x11, 0x62, 0x2b, 0x6c, 0x63, 0xfc, 0x8a, 0x47, 0x85, 0xe1, 0x31, 0xbd,
+	0x07, 0x05, 0xaf, 0x30, 0x79, 0x8a, 0xb7, 0x13, 0xa1, 0x8d, 0xca, 0xaf, 0x29, 0x85, 0xde, 0xdf,
+	0xbf, 0xfd, 0x66, 0x38, 0xab, 0x08, 0xfe, 0xbe, 0xeb, 0xff, 0x32, 0x83, 0x2d, 0x0d, 0x72, 0x17,
+	0xb7, 0x84, 0xd6, 0x05, 0x8f, 0xe9, 0x7d, 0x58, 0xdf, 0x21, 0xeb, 0x57, 0x85, 0xc9, 0x0a, 0x43,
+	0x7b, 0xd0, 0x3b, 0x87, 0xaa, 0x8b, 0x0a, 0x0d, 0xa7, 0x0f, 0xc0, 0x5d, 0x01, 0xcb, 0xb6, 0x46,
+	0xa1, 0xe9, 0xff, 0x06, 0x68, 0xd4, 0x64, 0x0e, 0x59, 0x95, 0x19, 0x65, 0xc2, 0x34, 0x00, 0x5a,
+	0x10, 0x25, 0xa1, 0x9c, 0x72, 0xfa, 0xff, 0x4a, 0x65, 0x10, 0xf9, 0xc2, 0x06, 0x4e, 0xc1, 0xff,
+	0x37, 0x1f, 0x87, 0xe8, 0x1f, 0x3e, 0x0e, 0x43, 0xdf, 0xbd, 0xa5, 0xce, 0x5e, 0x1f, 0xc9, 0x15,
+	0x83, 0x6a, 0xc5, 0xac, 0x37, 0x73, 0xb3, 0xde, 0x4c, 0xff, 0xad, 0x3f, 0x7e, 0xeb, 0xa3, 0x1f,
+	0xe7, 0x7d, 0xf4, 0xf3, 0xbc, 0x8f, 0x5e, 0xcd, 0xfb, 0xe8, 0x97, 0x79, 0x1f, 0xfd, 0x3a, 0xef,
+	0xa3, 0x1f, 0x7e, 0xef, 0x6f, 0x7c, 0xd9, 0x84, 0x96, 0x4e, 0x5a, 0xf0, 0x78, 0x7b, 0xf2, 0x67,
+	0x00, 0x00, 0x00, 0xff, 0xff, 0xc7, 0xcc, 0xad, 0x9b, 0x33, 0x0a, 0x00, 0x00,
 }

--- a/types/check.proto
+++ b/types/check.proto
@@ -113,33 +113,95 @@ message CheckConfig {
 // A Check is a check specification and optionally the results of the check's
 // execution.
 message Check {
-  // Config is the specification of a check
-  CheckConfig config = 1 [(gogoproto.nullable) = true];
+  // Command is the command to be executed.
+  string command = 1;
+
+  // Environment indicates to which env a check belongs to
+  string environment = 2;
+
+  // Handlers are the event handler for the check (incidents and/or metrics).
+  repeated string handlers = 3 [(gogoproto.jsontag) = "handlers"];
+
+  // HighFlapThreshold is the flap detection high threshold (% state change) for
+  // the check. Sensu uses the same flap detection algorithm as Nagios.
+  uint32 high_flap_threshold = 4;
+
+  // Interval is the interval, in seconds, at which the check should be run.
+  uint32 interval = 5;
+
+  // LowFlapThreshold is the flap detection low threshold (% state change) for
+  // the check. Sensu uses the same flap detection algorithm as Nagios.
+  uint32 low_flap_threshold = 6;
+
+  // Name is the unique identifier for a check.
+  string name = 7;
+
+  // Organization indicates to which org a check belongs to
+  string organization = 8;
+
+  // Publish indicates if check requests are published for the check
+  bool publish = 9;
+
+  // RuntimeAssets are a list of assets required to execute check.
+  repeated string runtime_assets = 10 [(gogoproto.jsontag) = "runtime_assets"];
+
+  // Subscriptions is the list of subscribers for the check.
+  repeated string subscriptions = 11 [(gogoproto.jsontag) = "subscriptions"];
+
+  // Sources indicates the name of the entity representing an external resource
+  string proxy_entity_id = 13 [(gogoproto.jsontag) = "proxy_entity_id", (gogoproto.customname) = "ProxyEntityID"];
+
+  // CheckHooks is the list of check hooks for the check
+  repeated HookList check_hooks = 14 [(gogoproto.jsontag) = "check_hooks", (gogoproto.nullable) = false];
+
+  // STDIN indicates if the check command accepts JSON via stdin from the agent
+  bool stdin = 15;
+
+  // Subdue represents one or more time windows when the check should be subdued.
+  TimeWindowWhen subdue = 16 [(gogoproto.jsontag) = "subdue"];
+
+  // Cron is the cron string at which the check should be run.
+  string cron = 17;
+
+  // TTL represents the length of time in seconds for which a check result is valid.
+  int64 ttl = 18;
+
+  // Timeout is the timeout, in seconds, at which the check has to run
+  uint32 timeout = 19;
+
+  // ProxyRequests represents a request to execute a proxy check
+  ProxyRequests proxy_requests = 20;
+
+  // RoundRobin enables round-robin scheduling if set true.
+  bool round_robin = 21;
 
   // Duration of execution
-  double duration = 2;
+  double duration = 22;
 
   // Executed describes the time in which the check request was executed
-  int64 executed = 3;
+  int64 executed = 23;
 
   // History is the check state history.
-  repeated CheckHistory history = 4 [(gogoproto.jsontag) = "history", (gogoproto.nullable) = false];
+  repeated CheckHistory history = 24 [(gogoproto.jsontag) = "history", (gogoproto.nullable) = false];
 
   // Issued describes the time in which the check request was issued
-  int64 issued = 5;
+  int64 issued = 25;
 
   // Output from the execution of Command
-  string output = 6;
+  string output = 26;
 
   // State provides handlers with more information about the state change
-  string state = 7;
+  string state = 27;
 
   // Status is the exit status code produced by the check
-  int32 status = 8;
+  int32 status = 28;
 
   // TotalStateChange indicates the total state change percentage for the
   // check's history
-  uint32 total_state_change = 9;
+  uint32 total_state_change = 29;
+
+  // ExtendedAttributes store serialized arbitrary JSON-encoded data
+  bytes ExtendedAttributes = 99 [(gogoproto.jsontag) = "-"];
 }
 
 // CheckHistory is a record of a check execution and its status

--- a/types/check_test.go
+++ b/types/check_test.go
@@ -15,26 +15,8 @@ func TestCheckValidate(t *testing.T) {
 	assert.Error(t, c.Validate())
 	c.Status = 0
 
-	// Valid w/o config
-	assert.NoError(t, c.Validate())
+	c.Name = "test"
 
-	c.Config = &CheckConfig{
-		Name: "test",
-	}
-
-	// Invalid w/ bad config
-	assert.Error(t, c.Validate())
-
-	c.Config = &CheckConfig{
-		Name:         "test",
-		Interval:     10,
-		Command:      "yes",
-		Environment:  "default",
-		Organization: "default",
-		Ttl:          30,
-	}
-
-	// Valid check
 	assert.NoError(t, c.Validate())
 }
 
@@ -72,33 +54,31 @@ func TestCheckConfig(t *testing.T) {
 
 func TestScheduleValidation(t *testing.T) {
 	c := FixtureCheck("check")
-	config := c.Config
 
 	// Fixture comes with valid interval-based schedule
-	assert.NoError(t, config.Validate())
+	assert.NoError(t, c.Validate())
 
-	config.Cron = "* * * * *"
-	assert.Error(t, config.Validate())
+	c.Cron = "* * * * *"
+	assert.Error(t, c.Validate())
 
-	config.Interval = 0
-	assert.NoError(t, config.Validate())
+	c.Interval = 0
+	assert.NoError(t, c.Validate())
 
-	config.Cron = "this is an invalid cron"
-	assert.Error(t, config.Validate())
+	c.Cron = "this is an invalid cron"
+	assert.Error(t, c.Validate())
 }
 
 func TestFixtureCheckIsValid(t *testing.T) {
 	c := FixtureCheck("check")
-	config := c.Config
 
-	assert.Equal(t, "check", config.Name)
-	assert.NoError(t, config.Validate())
+	assert.Equal(t, "check", c.Name)
+	assert.NoError(t, c.Validate())
 
-	config.RuntimeAssets = []string{"good"}
-	assert.NoError(t, config.Validate())
+	c.RuntimeAssets = []string{"good"}
+	assert.NoError(t, c.Validate())
 
-	config.RuntimeAssets = []string{"BAD--a!!!---ASDFASDF$$$$"}
-	assert.Error(t, config.Validate())
+	c.RuntimeAssets = []string{"BAD--a!!!---ASDFASDF$$$$"}
+	assert.Error(t, c.Validate())
 }
 
 func TestMergeWith(t *testing.T) {
@@ -120,8 +100,8 @@ func TestExtendedAttributes(t *testing.T) {
 		Get(string) (interface{}, error)
 	}
 	check := FixtureCheck("chekov")
-	check.Config.SetExtendedAttributes([]byte(`{"foo":{"bar":42,"baz":9001}}`))
-	g, err := check.Config.Get("foo")
+	check.SetExtendedAttributes([]byte(`{"foo":{"bar":42,"baz":9001}}`))
+	g, err := check.Get("foo")
 	require.NoError(t, err)
 	v, err := g.(getter).Get("bar")
 	require.NoError(t, err)

--- a/types/event_test.go
+++ b/types/event_test.go
@@ -18,9 +18,9 @@ func TestFixtureEventIsValid(t *testing.T) {
 func TestEventValidate(t *testing.T) {
 	event := FixtureEvent("entity", "check")
 
-	event.Check.Config.Name = ""
+	event.Check.Name = ""
 	assert.Error(t, event.Validate())
-	event.Check.Config.Name = "check"
+	event.Check.Name = "check"
 
 	event.Entity.ID = ""
 	assert.Error(t, event.Validate())


### PR DESCRIPTION
In order to make the data model a little simpler before releasing
the beta, we've decided to simply duplicate all the CheckConfig
fields in Check. Embedding was attempted, but abandoned due to
complexities surrounding json encoding and package dynamic, since
CheckConfig has methods that once promoted, lead to undesirable
behaviour for Check.

Also removed a line of cruft in adhoc.proto after noticing a
warning from protoc.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #996 