### PR TITLE
Use UTC for InWindow y/m/d calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ change that will cause existing Sensu alpha installations to break if upgraded.
 This change was made before beta release so that further breaking changes could
 be avoided.
 
+### Fixed
+- Fixed a bug in time.InWindow that in some cases would cause subdued checks to
+  be executed.
+
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added
 - Add .gitattributes file with merge strategy for the Changelog.

--- a/util/time/time.go
+++ b/util/time/time.go
@@ -14,7 +14,7 @@ import (
 func InWindow(current time.Time, begin, end string) (bool, error) {
 	// Get the year, month and day of the provided current time (e.g. 2016, 01 &
 	// 02)
-	year, month, day := current.Date()
+	year, month, day := current.UTC().Date()
 
 	// Remove any whitespaces in the begin and end times, for backward
 	// compatibility with Sensu v1 so "3:00 PM" becomes "3:00PM" and satisfies the


### PR DESCRIPTION
## What is this change?

time.InWindow takes a time.Time, and uses it to get the year,
month, and date without first ensuring that it is in UTC. Begin and End
times for the window were calculated based on UTC. In cases where the
time passed in was local time, begin/end would be in advance of the
current time, causing InWindows to return false. time.InWindow has been
updated to get the y/m/d from the current UTC time so the begin and end
time comparison will be more accurate.

## Why is this change necessary?

Closes #960 

## Does your change need a Changelog entry?

Added under Fixed.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!