### PR TITLE
Append :8081 to Agent backend URLs if no port set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ except that HookConfig is now embedded in Hook.
 - Removed 3DES from the list of allowed ciphers in the backend and agent.
 - Password input fields are now aligned in  `sensuctl user change-password`
 subcommand.
+- Agent backend URLs without a port specified will now default to port 8081.
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,7 +91,7 @@ func NewConfig() *Config {
 			Host: "127.0.0.1",
 			Port: 3031,
 		},
-		BackendURLs:       []string{"ws://127.0.0.1:8081"},
+		BackendURLs:       []string{},
 		CacheDir:          "/var/cache/sensu",
 		Environment:       "default",
 		KeepaliveInterval: 20,

--- a/util/url/LICENSE
+++ b/util/url/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/util/url/url.go
+++ b/util/url/url.go
@@ -1,0 +1,16 @@
+package url
+
+import "net/url"
+
+// AppendPortIfMissing takes a URL and port as strings and appends the provided
+// port to the URL if it is missing
+func AppendPortIfMissing(u string, p string) (string, error) {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return "", err
+	}
+	if parsedURL.Port() == "" {
+		return parsedURL.String() + ":" + p, nil
+	}
+	return parsedURL.String(), nil
+}

--- a/util/url/url.go
+++ b/util/url/url.go
@@ -1,6 +1,10 @@
 package url
 
-import "net/url"
+import (
+	"net"
+	"net/url"
+	"strings"
+)
 
 // AppendPortIfMissing takes a URL and port as strings and appends the provided
 // port to the URL if it is missing
@@ -9,8 +13,24 @@ func AppendPortIfMissing(u string, p string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if parsedURL.Port() == "" {
-		return parsedURL.String() + ":" + p, nil
+
+	port := parsedURL.Port()
+	if port == "" {
+		port = p
 	}
+
+	host := parsedURL.Hostname()
+	if IsIPv6(host) {
+		host = "[" + host + "]"
+	}
+
+	parsedURL.Host = host + ":" + port
 	return parsedURL.String(), nil
+}
+
+// IsIPv6 takes a string containing an IP address and will a boolean value
+// based on whether or not the IP is IPv6
+func IsIPv6(str string) bool {
+	ip := net.ParseIP(str)
+	return ip != nil && strings.Contains(str, ":")
 }

--- a/util/url/url_test.go
+++ b/util/url/url_test.go
@@ -1,0 +1,39 @@
+package url
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test(t *testing.T) {
+	testCases := []struct {
+		name        string
+		backendURL  string
+		port        string
+		expectedURL string
+	}{
+		{
+			name:        "URL without port",
+			backendURL:  "ws://127.0.0.1",
+			port:        "8081",
+			expectedURL: "ws://127.0.0.1:8081",
+		},
+		{
+			name:        "URL with port",
+			backendURL:  "ws://127.0.0.1:8081",
+			port:        "8081",
+			expectedURL: "ws://127.0.0.1:8081",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			newURL, err := AppendPortIfMissing(tc.backendURL, tc.port)
+			if err != nil {
+				assert.FailNow(t, err.Error())
+			}
+			assert.Equal(t, tc.expectedURL, newURL)
+		})
+	}
+}

--- a/util/url/url_test.go
+++ b/util/url/url_test.go
@@ -20,10 +20,40 @@ func Test(t *testing.T) {
 			expectedURL: "ws://127.0.0.1:8081",
 		},
 		{
-			name:        "URL with port",
+			name:        "URL with default port",
 			backendURL:  "ws://127.0.0.1:8081",
 			port:        "8081",
 			expectedURL: "ws://127.0.0.1:8081",
+		},
+		{
+			name:        "URL with non-default port",
+			backendURL:  "ws://127.0.0.1:8082",
+			port:        "8081",
+			expectedURL: "ws://127.0.0.1:8082",
+		},
+		{
+			name:        "URL without port with forward-slash",
+			backendURL:  "ws://127.0.0.1/",
+			port:        "8081",
+			expectedURL: "ws://127.0.0.1:8081/",
+		},
+		{
+			name:        "URL with non-default port with forward-slash",
+			backendURL:  "ws://127.0.0.1:8082/",
+			port:        "8081",
+			expectedURL: "ws://127.0.0.1:8082/",
+		},
+		{
+			name:        "URL without port with forward-slash",
+			backendURL:  "ws://[::1]/",
+			port:        "8081",
+			expectedURL: "ws://[::1]:8081/",
+		},
+		{
+			name:        "URL with non-default port with forward-slash",
+			backendURL:  "ws://[::1]:8082/",
+			port:        "8081",
+			expectedURL: "ws://[::1]:8082/",
 		},
 	}
 


### PR DESCRIPTION
## What is this change?

Append `:8081` any of an agent's backend urls that do not have a port specified.

## Why is this change necessary?

Fixes #985.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!
