### PR TITLE
ab0x.go needs to be committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ change that will cause existing Sensu alpha installations to break if upgraded.
 This change was made before beta release so that further breaking changes could
 be avoided.
 - Make indentation in protocol buffers files consistent.
-- Update the dashboard static assets.
 - Refactor Hook data structure. This is similar to what was done to Check,
 except that HookConfig is now embedded in Hook.
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Ensures the `ab0x.go` file is not committed. 

## Why is this change necessary?

Bugfix for https://github.com/sensu/sensu-go/commit/b7458685bd5b0bb45177e59c2e68ac7e7a2edf17

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!