### PR TITLE
Make the importer package play nice with errcheck

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -165,7 +165,7 @@ function linter_commands
         exit 1
     }
 
-    errcheck $(go list ./... | Select-String -pattern "dashboardd", "cli/commands/importer", "agent/assetmanager", "scripts" -notMatch)
+    errcheck $(go list ./... | Select-String -pattern "dashboardd", "agent/assetmanager", "scripts" -notMatch)
     If ($LASTEXITCODE -ne 0) {
         echo "Linting failed..."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -160,7 +160,7 @@ linter_commands () {
         exit 1
     fi
 
-    errcheck $(go list ./... | grep -v dashboardd | grep -v cli/commands/importer | grep -v agent/assetmanager | grep -v scripts)
+    errcheck $(go list ./... | grep -v dashboardd | grep -v agent/assetmanager | grep -v scripts)
     if [ $? -ne 0 ]; then
         echo "Linting failed..."
         exit 1

--- a/cli/commands/importer/cmd.go
+++ b/cli/commands/importer/cmd.go
@@ -33,7 +33,7 @@ func ImportCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			stat, _ := cli.InFile.Stat()
 			if stat.Mode()&os.ModeNamedPipe == 0 {
-				cmd.Help() // Print out usage
+				_ = cmd.Help() // Print out usage
 				return nil
 			}
 

--- a/cli/commands/importer/cmd_test.go
+++ b/cli/commands/importer/cmd_test.go
@@ -35,7 +35,7 @@ func TestImportCommandRunWithBadJSON(t *testing.T) {
 	assert := assert.New(t)
 
 	reader, writer, _ := os.Pipe()
-	writer.Write([]byte("one two three"))
+	_, _ = writer.Write([]byte("one two three"))
 
 	cli := test.NewMockCLI()
 	cli.InFile = reader
@@ -53,7 +53,7 @@ func TestImportCommandRunWithGoodJSON(t *testing.T) {
 
 	reader, writer, _ := os.Pipe()
 	cli.InFile = reader
-	writer.Write([]byte(`{"ok":"yup"}`))
+	_, _ = writer.Write([]byte(`{"ok":"yup"}`))
 
 	cmd := ImportCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -69,11 +69,11 @@ func TestImportCommandRunWithLegacyImporter(t *testing.T) {
 	reader, writer, _ := os.Pipe()
 	cli.InFile = reader
 
-	writer.Write([]byte(`{"ok":"yup"}`))
+	_, _ = writer.Write([]byte(`{"ok":"yup"}`))
 
 	cmd := ImportCommand(cli)
-	cmd.Flags().Set("legacy", "t")
-	cmd.Flags().Set("verbose", "t")
+	_ = cmd.Flags().Set("legacy", "t")
+	_ = cmd.Flags().Set("verbose", "t")
 
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -89,11 +89,11 @@ func TestImportCommandRunWithLegacyImporterInvalidResources(t *testing.T) {
 	reader, writer, _ := os.Pipe()
 	cli.InFile = reader
 
-	writer.Write([]byte(`{"checks": {"frank%%%": {}}}`))
+	_, _ = writer.Write([]byte(`{"checks": {"frank%%%": {}}}`))
 
 	cmd := ImportCommand(cli)
-	cmd.Flags().Set("legacy", "t")
-	cmd.Flags().Set("verbose", "t")
+	_ = cmd.Flags().Set("legacy", "t")
+	_ = cmd.Flags().Set("verbose", "t")
 
 	out, err := test.RunCmd(cmd, []string{})
 

--- a/cli/commands/importer/legacy_test.go
+++ b/cli/commands/importer/legacy_test.go
@@ -104,7 +104,7 @@ func TestLegacyFilterImporter(t *testing.T) {
 				i := NewImporter(filterImporter)
 
 				// Set the reporter
-				defer i.report.Flush()
+				defer func() { _ = i.report.Flush() }()
 				reporter := report.NewWriter(&i.report)
 				i.importers[0].SetReporter(&reporter)
 
@@ -129,7 +129,7 @@ func TestLegacySettings(t *testing.T) {
 			}
 
 			var data map[string]interface{}
-			json.Unmarshal(file, &data)
+			_ = json.Unmarshal(file, &data)
 
 			client := clientmock.MockClient{}
 			importer := NewSensuV1SettingsImporter("default", "default", &client)


### PR DESCRIPTION
## What is this change?

It explicitly ignores errors in the `cli/commands/importer` package so `errcheck`can be used against that package. 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/703

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!