### PR TITLE
Support special characters in resource names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ except that HookConfig is now embedded in Hook.
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to
   be executed.
+- Fixed a bug in the HTTP API where resource names could not contain special characters.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -47,10 +47,10 @@
   revision = "48ea1b39c25fc1bab3506fbc712ecbaa842c4d2d"
 
 [[projects]]
+  branch = "master"
   name = "github.com/coreos/etcd"
   packages = ["alarm","auth","auth/authpb","client","clientv3","clientv3/concurrency","compactor","discovery","embed","error","etcdserver","etcdserver/api","etcdserver/api/etcdhttp","etcdserver/api/v2http","etcdserver/api/v2http/httptypes","etcdserver/api/v2v3","etcdserver/api/v3client","etcdserver/api/v3election","etcdserver/api/v3election/v3electionpb","etcdserver/api/v3election/v3electionpb/gw","etcdserver/api/v3lock","etcdserver/api/v3lock/v3lockpb","etcdserver/api/v3lock/v3lockpb/gw","etcdserver/api/v3rpc","etcdserver/api/v3rpc/rpctypes","etcdserver/auth","etcdserver/etcdserverpb","etcdserver/etcdserverpb/gw","etcdserver/membership","etcdserver/stats","lease","lease/leasehttp","lease/leasepb","mvcc","mvcc/backend","mvcc/mvccpb","pkg/adt","pkg/contention","pkg/cors","pkg/cpuutil","pkg/crc","pkg/debugutil","pkg/fileutil","pkg/httputil","pkg/idutil","pkg/ioutil","pkg/logutil","pkg/netutil","pkg/pathutil","pkg/pbutil","pkg/runtime","pkg/schedule","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","pkg/wait","proxy/grpcproxy/adapter","raft","raft/raftpb","rafthttp","snap","snap/snappb","store","version","wal","wal/walpb"]
-  revision = "28f3f26c0e303392556035b694f75768d449d33d"
-  version = "v3.3.1"
+  revision = "a7f1fbe00ec216fcb3a1919397a103b41dca8413"
 
 [[projects]]
   name = "github.com/coreos/go-semver"
@@ -98,12 +98,6 @@
   name = "github.com/dsnet/compress"
   packages = [".","bzip2","bzip2/internal/sais","internal","internal/errors","internal/prefix"]
   revision = "f41072d47fff1112fa37146dfc812a476cce2d7f"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/dustin/go-humanize"
-  packages = ["."]
-  revision = "bb3d318650d48840a39aa21a027c6630e198e626"
 
 [[projects]]
   name = "github.com/emicklei/proto"
@@ -167,7 +161,7 @@
   name = "github.com/gorilla/mux"
   packages = ["."]
   revision = "24fca303ac6da784b9e8269f724ddeb0b2eea5e7"
-  version = "v1.5.0"
+  version = "v1.6.1"
 
 [[projects]]
   name = "github.com/gorilla/websocket"
@@ -484,8 +478,8 @@
 [[projects]]
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = ["core","terminal"]
-  revision = "344ec26ea976135df7508f1f513e5490a4686e11"
-  version = "v1.4.0"
+  revision = "0aa8b6a162b391fe2d95648b7677d1d6ac2090a6"
+  version = "v1.4.1"
 
 [[projects]]
   name = "gopkg.in/h2non/filetype.v1"
@@ -502,6 +496,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "57ac0e0b4e0b48ae1a89ea41559069114de64a91197af07f1cb57f5a48b698a6"
+  inputs-digest = "fdf70818de1519fadbc690581098ba6e37526dc2cb9f5df069b45f89d9f5c09b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -32,11 +32,8 @@ func NewEventController(store store.EventStore, bus messaging.MessageBus) EventC
 }
 
 // Query returns resources available to the viewer filter by given params.
-func (a EventController) Query(ctx context.Context, params QueryParams) ([]*types.Event, error) {
+func (a EventController) Query(ctx context.Context, entityID, checkName string) ([]*types.Event, error) {
 	var results []*types.Event
-
-	entityID := params["entity"]
-	checkName := params["check"]
 
 	// Fetch from store
 	var serr error
@@ -70,13 +67,13 @@ func (a EventController) Query(ctx context.Context, params QueryParams) ([]*type
 
 // Find returns resource associated with given parameters if available to the
 // viewer.
-func (a EventController) Find(ctx context.Context, params QueryParams) (*types.Event, error) {
+func (a EventController) Find(ctx context.Context, entity, check string) (*types.Event, error) {
 	// Find (for events) requires both an entity and check
-	if params["entity"] == "" || params["check"] == "" {
+	if entity == "" || check == "" {
 		return nil, NewErrorf(InvalidArgument, "Find() requires both an entity and a check")
 	}
 
-	result, err := a.Store.GetEventByEntityCheck(ctx, params["entity"], params["check"])
+	result, err := a.Store.GetEventByEntityCheck(ctx, entity, check)
 	if err != nil {
 		return nil, NewError(InternalErr, err)
 	}
@@ -91,9 +88,8 @@ func (a EventController) Find(ctx context.Context, params QueryParams) (*types.E
 }
 
 // Destroy destroys the event indicated by the supplied entity and check.
-func (a EventController) Destroy(ctx context.Context, params QueryParams) error {
+func (a EventController) Destroy(ctx context.Context, entity, check string) error {
 	// Destroy (for events) requires both an entity and check
-	entity, check := params["entity"], params["check"]
 	if entity == "" || check == "" {
 		return NewErrorf(InvalidArgument, "Destroy() requires both an entity and a check")
 	}

--- a/backend/apid/actions/events_test.go
+++ b/backend/apid/actions/events_test.go
@@ -35,7 +35,8 @@ func TestEventQuery(t *testing.T) {
 		name        string
 		ctx         context.Context
 		events      []*types.Event
-		params      QueryParams
+		entity      string
+		check       string
 		expectedLen int
 		storeErr    error
 		expectedErr error
@@ -44,7 +45,6 @@ func TestEventQuery(t *testing.T) {
 			name:        "No Params No Events",
 			ctx:         defaultCtx,
 			events:      []*types.Event{},
-			params:      QueryParams{},
 			expectedLen: 0,
 			storeErr:    nil,
 			expectedErr: nil,
@@ -56,7 +56,6 @@ func TestEventQuery(t *testing.T) {
 				types.FixtureEvent("entity1", "check1"),
 				types.FixtureEvent("entity2", "check2"),
 			},
-			params:      QueryParams{},
 			expectedLen: 2,
 			storeErr:    nil,
 			expectedErr: nil,
@@ -70,7 +69,6 @@ func TestEventQuery(t *testing.T) {
 				types.FixtureEvent("entity1", "check1"),
 				types.FixtureEvent("entity2", "check2"),
 			},
-			params:      QueryParams{},
 			expectedLen: 0,
 			storeErr:    nil,
 			expectedErr: nil,
@@ -81,20 +79,16 @@ func TestEventQuery(t *testing.T) {
 			events: []*types.Event{
 				types.FixtureEvent("entity1", "check1"),
 			},
-			params: QueryParams{
-				"entity": "entity1",
-			},
+			entity:      "entity1",
 			expectedLen: 1,
 			storeErr:    nil,
 			expectedErr: nil,
 		},
 		{
-			name:   "Store Failure",
-			ctx:    defaultCtx,
-			events: nil,
-			params: QueryParams{
-				"entity": "entity1",
-			},
+			name:        "Store Failure",
+			ctx:         defaultCtx,
+			events:      nil,
+			entity:      "entity1",
 			expectedLen: 0,
 			storeErr:    errors.New(""),
 			expectedErr: NewError(InternalErr, errors.New("")),
@@ -114,7 +108,7 @@ func TestEventQuery(t *testing.T) {
 			store.On("GetEventsByEntity", tc.ctx, mock.Anything).Return(tc.events, tc.storeErr)
 
 			// Exec Query
-			results, err := eventController.Query(tc.ctx, tc.params)
+			results, err := eventController.Query(tc.ctx, tc.entity, tc.check)
 
 			// Assert
 			assert.EqualValues(tc.expectedErr, err)
@@ -132,54 +126,46 @@ func TestEventFind(t *testing.T) {
 		name            string
 		ctx             context.Context
 		event           *types.Event
-		params          QueryParams
+		entity          string
+		check           string
 		expected        bool
 		expectedErrCode ErrCode
 	}{
 		{
 			name:            "No Params",
 			ctx:             defaultCtx,
-			params:          QueryParams{},
 			expected:        false,
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name: "Only Entity Param",
-			ctx:  defaultCtx,
-			params: QueryParams{
-				"entity": "entity1",
-			},
+			name:            "Only Entity Param",
+			ctx:             defaultCtx,
+			entity:          "entity1",
 			expected:        false,
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name: "Only Check Param",
-			ctx:  defaultCtx,
-			params: QueryParams{
-				"check": "check1",
-			},
+			name:            "Only Check Param",
+			ctx:             defaultCtx,
+			check:           "check1",
 			expected:        false,
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name:  "Found",
-			ctx:   defaultCtx,
-			event: types.FixtureEvent("entity1", "check1"),
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			name:            "Found",
+			ctx:             defaultCtx,
+			event:           types.FixtureEvent("entity1", "check1"),
+			entity:          "entity1",
+			check:           "check1",
 			expected:        true,
 			expectedErrCode: 0,
 		},
 		{
-			name:  "Not Found",
-			ctx:   defaultCtx,
-			event: nil,
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			name:            "Not Found",
+			ctx:             defaultCtx,
+			event:           nil,
+			entity:          "entity1",
+			check:           "check1",
 			expected:        false,
 			expectedErrCode: NotFound,
 		},
@@ -188,11 +174,9 @@ func TestEventFind(t *testing.T) {
 			ctx: testutil.NewContext(testutil.ContextWithRules(
 				types.FixtureRuleWithPerms(types.RuleTypeEvent, types.RulePermCreate),
 			)),
-			event: types.FixtureEvent("entity1", "check1"),
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			event:           types.FixtureEvent("entity1", "check1"),
+			entity:          "entity1",
+			check:           "check1",
 			expected:        false,
 			expectedErrCode: NotFound,
 		},
@@ -212,7 +196,7 @@ func TestEventFind(t *testing.T) {
 				Return(tc.event, nil)
 
 			// Exec Query
-			result, err := eventController.Find(tc.ctx, tc.params)
+			result, err := eventController.Find(tc.ctx, tc.entity, tc.check)
 
 			inferErr, ok := err.(Error)
 			if ok {
@@ -234,50 +218,42 @@ func TestEventDestroy(t *testing.T) {
 		name            string
 		ctx             context.Context
 		event           *types.Event
-		params          QueryParams
+		entity          string
+		check           string
 		expected        bool
 		expectedErrCode ErrCode
 	}{
 		{
 			name:            "No Params",
 			ctx:             defaultCtx,
-			params:          QueryParams{},
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name: "Only Entity Param",
-			ctx:  defaultCtx,
-			params: QueryParams{
-				"entity": "entity1",
-			},
+			name:            "Only Entity Param",
+			ctx:             defaultCtx,
+			entity:          "entity1",
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name: "Only Check Param",
-			ctx:  defaultCtx,
-			params: QueryParams{
-				"check": "check1",
-			},
+			name:            "Only Check Param",
+			ctx:             defaultCtx,
+			check:           "check1",
 			expectedErrCode: InvalidArgument,
 		},
 		{
-			name:  "Delete",
-			ctx:   defaultCtx,
-			event: types.FixtureEvent("entity1", "check1"),
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			name:            "Delete",
+			ctx:             defaultCtx,
+			event:           types.FixtureEvent("entity1", "check1"),
+			entity:          "entity1",
+			check:           "check1",
 			expectedErrCode: 0,
 		},
 		{
-			name:  "Not Found",
-			ctx:   defaultCtx,
-			event: nil,
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			name:            "Not Found",
+			ctx:             defaultCtx,
+			event:           nil,
+			entity:          "entity1",
+			check:           "check1",
 			expectedErrCode: NotFound,
 		},
 		{
@@ -285,11 +261,9 @@ func TestEventDestroy(t *testing.T) {
 			ctx: testutil.NewContext(testutil.ContextWithRules(
 				types.FixtureRuleWithPerms(types.RuleTypeEvent, types.RulePermCreate),
 			)),
-			event: types.FixtureEvent("entity1", "check1"),
-			params: QueryParams{
-				"entity": "entity1",
-				"check":  "check1",
-			},
+			event:           types.FixtureEvent("entity1", "check1"),
+			entity:          "entity1",
+			check:           "check1",
 			expectedErrCode: NotFound,
 		},
 	}
@@ -311,7 +285,7 @@ func TestEventDestroy(t *testing.T) {
 				Return(nil)
 
 			// Exec Query
-			err := eventController.Destroy(tc.ctx, tc.params)
+			err := eventController.Destroy(tc.ctx, tc.entity, tc.check)
 
 			inferErr, ok := err.(Error)
 			if ok {

--- a/backend/apid/actions/mutators.go
+++ b/backend/apid/actions/mutators.go
@@ -131,7 +131,7 @@ func (c MutatorController) Query(ctx context.Context) ([]*types.Mutator, error) 
 // It returns non-nil error if the params are invalid, delete permissions
 // do not exist, or an internal error occurs while updating the underlying
 // Store.
-func (c MutatorController) Destroy(ctx context.Context, params QueryParams) error {
+func (c MutatorController) Destroy(ctx context.Context, name string) error {
 	policy := c.Policy.WithContext(ctx)
 
 	// Verify permissions
@@ -140,7 +140,6 @@ func (c MutatorController) Destroy(ctx context.Context, params QueryParams) erro
 	}
 
 	// Validate parameters
-	name := params["name"]
 	if name == "" {
 		return NewErrorf(InvalidArgument, "name is undefined")
 	}

--- a/backend/apid/actions/mutators_test.go
+++ b/backend/apid/actions/mutators_test.go
@@ -132,7 +132,7 @@ func TestMutatorDestroy(t *testing.T) {
 	testCases := []struct {
 		name            string
 		ctx             context.Context
-		arguments       QueryParams
+		mutator         string
 		fetchResult     *types.Mutator
 		fetchErr        error
 		deleteErr       error
@@ -142,14 +142,14 @@ func TestMutatorDestroy(t *testing.T) {
 		{
 			name:        "Deleted",
 			ctx:         defaultCtx,
-			arguments:   QueryParams{"name": "mutator1"},
+			mutator:     "mutator1",
 			fetchResult: types.FixtureMutator("mutator1"),
 			expectedErr: false,
 		},
 		{
 			name:            "Does Not Exist",
 			ctx:             defaultCtx,
-			arguments:       QueryParams{"name": "mutator1"},
+			mutator:         "mutator1",
 			fetchResult:     nil,
 			expectedErr:     true,
 			expectedErrCode: NotFound,
@@ -157,7 +157,7 @@ func TestMutatorDestroy(t *testing.T) {
 		{
 			name:            "Store Err on Delete",
 			ctx:             defaultCtx,
-			arguments:       QueryParams{"name": "mutator1"},
+			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
 			deleteErr:       errors.New("dunno"),
 			expectedErr:     true,
@@ -166,7 +166,7 @@ func TestMutatorDestroy(t *testing.T) {
 		{
 			name:            "Store Err on Fetch",
 			ctx:             defaultCtx,
-			arguments:       QueryParams{"name": "mutator1"},
+			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
 			fetchErr:        errors.New("dunno"),
 			expectedErr:     true,
@@ -175,7 +175,7 @@ func TestMutatorDestroy(t *testing.T) {
 		{
 			name:            "No Permission",
 			ctx:             wrongPermsCtx,
-			arguments:       QueryParams{"name": "mutator1"},
+			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
 			expectedErr:     true,
 			expectedErrCode: PermissionDenied,
@@ -198,7 +198,7 @@ func TestMutatorDestroy(t *testing.T) {
 				Return(tc.deleteErr)
 
 			// Exec Query
-			err := actions.Destroy(tc.ctx, tc.arguments)
+			err := actions.Destroy(tc.ctx, tc.mutator)
 
 			if tc.expectedErr {
 				inferErr, ok := err.(Error)

--- a/backend/apid/graphql/viewer.go
+++ b/backend/apid/graphql/viewer.go
@@ -75,7 +75,7 @@ func (r *viewerImpl) Checks(p schema.ViewerChecksFieldResolverParams) (interface
 
 // Events implements response to request for 'events' field.
 func (r *viewerImpl) Events(p schema.ViewerEventsFieldResolverParams) (interface{}, error) {
-	records, err := r.eventsCtrl.Query(p.Context, actions.QueryParams{})
+	records, err := r.eventsCtrl.Query(p.Context, "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -37,7 +38,11 @@ func (r *AssetsRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *AssetsRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	assetPath, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), assetPath)
 	return record, err
 }
 

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -3,6 +3,7 @@ package routers
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -46,7 +47,11 @@ func (r *ChecksRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 	return record, err
 }
 
@@ -72,7 +77,11 @@ func (r *ChecksRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }
 
@@ -83,14 +92,30 @@ func (r *ChecksRouter) addCheckHook(req *http.Request) (interface{}, error) {
 	}
 
 	params := mux.Vars(req)
-	err := r.controller.AddCheckHook(req.Context(), params["id"], cfg)
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.AddCheckHook(req.Context(), id, cfg)
 
 	return nil, err
 }
 
 func (r *ChecksRouter) removeCheckHook(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.RemoveCheckHook(req.Context(), params["id"], params["type"], params["hook"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	typ, err := url.PathUnescape(params["type"])
+	if err != nil {
+		return nil, err
+	}
+	hook, err := url.PathUnescape(params["hook"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.RemoveCheckHook(req.Context(), id, typ, hook)
 	return nil, err
 }
 
@@ -101,7 +126,12 @@ func (r *ChecksRouter) adhocRequest(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	params := mux.Vars(req)
-	if err := r.controller.QueueAdhocRequest(req.Context(), params["id"], &adhocReq); err != nil {
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := r.controller.QueueAdhocRequest(req.Context(), id, &adhocReq); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -32,13 +33,21 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 
 func (r *EntitiesRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }
 
 func (r *EntitiesRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 	return record, err
 }
 

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -33,25 +34,30 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 }
 
 func (r *EventsRouter) list(req *http.Request) (interface{}, error) {
-	records, err := r.controller.Query(req.Context(), actions.QueryParams{})
+	records, err := r.controller.Query(req.Context(), "", "")
 	return records, err
 }
 
 func (r *EventsRouter) listByEntity(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	records, err := r.controller.Query(req.Context(), params)
+	entity := url.PathEscape(params["entity"])
+	records, err := r.controller.Query(req.Context(), entity, "")
 	return records, err
 }
 
 func (r *EventsRouter) find(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	record, err := r.controller.Find(req.Context(), params)
+	entity := url.PathEscape(params["entity"])
+	check := url.PathEscape(params["check"])
+	record, err := r.controller.Find(req.Context(), entity, check)
 	return record, err
 }
 
 func (r *EventsRouter) destroy(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	return nil, r.controller.Destroy(req.Context(), params)
+	entity := url.PathEscape(params["entity"])
+	check := url.PathEscape(params["check"])
+	return nil, r.controller.Destroy(req.Context(), entity, check)
 }
 
 func (r *EventsRouter) create(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -37,7 +38,11 @@ func (r *EventFiltersRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *EventFiltersRouter) find(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	return r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	return r.controller.Find(req.Context(), id)
 }
 
 func (r *EventFiltersRouter) create(req *http.Request) (interface{}, error) {
@@ -62,6 +67,10 @@ func (r *EventFiltersRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *EventFiltersRouter) destroy(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -43,12 +44,20 @@ func (r *HandlersRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *HandlersRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	return nil, r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	return nil, r.controller.Destroy(req.Context(), id)
 }
 
 func (r *HandlersRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	return r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	return r.controller.Find(req.Context(), id)
 }
 
 func (r *HandlersRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -38,7 +39,11 @@ func (r *HooksRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *HooksRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 	return record, err
 }
 
@@ -64,6 +69,10 @@ func (r *HooksRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *HooksRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -37,7 +38,11 @@ func (r *MutatorsRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *MutatorsRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	return r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	return r.controller.Find(req.Context(), id)
 }
 
 func (r *MutatorsRouter) create(req *http.Request) (interface{}, error) {
@@ -62,6 +67,10 @@ func (r *MutatorsRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *MutatorsRouter) destroy(req *http.Request) (interface{}, error) {
 	params := actions.QueryParams(mux.Vars(req))
-	err := r.controller.Destroy(req.Context(), params)
+	name, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), name)
 	return nil, err
 }

--- a/backend/apid/routers/organizations.go
+++ b/backend/apid/routers/organizations.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -38,7 +39,11 @@ func (r *OrganizationsRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *OrganizationsRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 	return record, err
 }
 
@@ -64,6 +69,10 @@ func (r *OrganizationsRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *OrganizationsRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -42,7 +43,11 @@ func (r *RolesRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 	return record, err
 }
 
@@ -68,7 +73,11 @@ func (r *RolesRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *RolesRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Destroy(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }
 
@@ -79,13 +88,25 @@ func (r *RolesRouter) addRule(req *http.Request) (interface{}, error) {
 	}
 
 	params := mux.Vars(req)
-	err := r.controller.AddRule(req.Context(), params["id"], cfg)
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.AddRule(req.Context(), id, cfg)
 
 	return nil, err
 }
 
 func (r *RolesRouter) rmRule(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.RemoveRule(req.Context(), params["id"], params["type"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	typ, err := url.PathUnescape(params["type"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.RemoveRule(req.Context(), id, typ)
 	return nil, err
 }

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -42,7 +43,11 @@ func (r *SilencedRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *SilencedRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	return r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	return r.controller.Find(req.Context(), id)
 }
 
 func (r *SilencedRouter) create(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -52,7 +53,11 @@ func (r *UsersRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *UsersRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	record, err := r.controller.Find(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Find(req.Context(), id)
 
 	// Obfustace users password
 	record.Password = ""
@@ -87,13 +92,21 @@ func (r *UsersRouter) update(req *http.Request) (interface{}, error) {
 
 func (r *UsersRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Disable(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Disable(req.Context(), id)
 	return nil, err
 }
 
 func (r *UsersRouter) reinstate(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.Enable(req.Context(), params["id"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.Enable(req.Context(), id)
 	return nil, err
 }
 
@@ -104,20 +117,40 @@ func (r *UsersRouter) updatePassword(req *http.Request) (interface{}, error) {
 	}
 
 	vars := mux.Vars(req)
-	cfg := types.User{Username: vars["id"], Password: params["password"]}
+	id, err := url.PathUnescape(vars["id"])
+	if err != nil {
+		return nil, err
+	}
+	cfg := types.User{Username: id, Password: params["password"]}
 
-	err := r.controller.Update(req.Context(), cfg)
+	err = r.controller.Update(req.Context(), cfg)
 	return nil, err
 }
 
 func (r *UsersRouter) addRole(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.AddRole(req.Context(), params["id"], params["role"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	role, err := url.PathUnescape(params["role"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.AddRole(req.Context(), id, role)
 	return nil, err
 }
 
 func (r *UsersRouter) removeRole(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
-	err := r.controller.RemoveRole(req.Context(), params["id"], params["role"])
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	role, err := url.PathUnescape(params["role"])
+	if err != nil {
+		return nil, err
+	}
+	err = r.controller.RemoveRole(req.Context(), id, role)
 	return nil, err
 }

--- a/backend/apid/subrouter.go
+++ b/backend/apid/subrouter.go
@@ -31,7 +31,7 @@ func (r *WrappedRouter) Match(req *http.Request, match *mux.RouteMatch) bool {
 // middleware. Eg. you would some routes to require authetication while others
 // you would not.
 func NewSubrouter(r *mux.Route, ms ...middlewares.HTTPMiddleware) *mux.Router {
-	subRouter := r.Subrouter()
+	subRouter := r.Subrouter().UseEncodedPath()
 	wrapper := WrappedRouter{
 		Router:     subRouter,
 		middleware: middlewares.NewStack(ms),

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -28,13 +29,14 @@ func (client *RestClient) ListAssets(org string) ([]types.Asset, error) {
 func (client *RestClient) FetchAsset(name string) (*types.Asset, error) {
 	var asset types.Asset
 
-	res, err := client.R().Get("/assets/" + name)
+	assetPath := fmt.Sprintf("/assets/%s", url.PathEscape(name))
+	res, err := client.R().Get(assetPath)
 	if err != nil {
-		return &asset, err
+		return &asset, fmt.Errorf("GET %q: %s", assetPath, err)
 	}
 
 	if res.StatusCode() >= 400 {
-		return &asset, fmt.Errorf("%v", res.String())
+		return &asset, fmt.Errorf("GET %q: %s", assetPath, res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &asset)
@@ -71,13 +73,14 @@ func (client *RestClient) UpdateAsset(asset *types.Asset) (err error) {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Patch("/assets/" + asset.Name)
+	assetPath := fmt.Sprintf("/assets/%s", url.PathEscape(asset.Name))
+	res, err := client.R().SetBody(bytes).Patch(assetPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("PATCH %q: %s", assetPath, err)
 	}
 
 	if res.StatusCode() >= 400 {
-		return fmt.Errorf("%v", res.String())
+		return fmt.Errorf("PATCH %q: %s", assetPath, res.String())
 	}
 
 	return nil

--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
 	"path"
 
 	"github.com/sensu/sensu-go/types"
@@ -10,8 +12,11 @@ import (
 const checksBasePath = "/checks"
 
 func checksPath(ext ...string) string {
-	components := append([]string{checksBasePath}, ext...)
-	return path.Join(components...)
+	parts := ext
+	for i := range parts {
+		parts[i] = url.PathEscape(parts[i])
+	}
+	return path.Join(append([]string{checksBasePath}, parts...)...)
 }
 
 // CreateCheck creates new check on configured Sensu instance
@@ -40,7 +45,8 @@ func (client *RestClient) UpdateCheck(check *types.CheckConfig) (err error) {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Patch("/checks/" + check.Name)
+	checkPath := fmt.Sprintf("/checks/%s", url.PathEscape(check.Name))
+	res, err := client.R().SetBody(bytes).Patch(checkPath)
 	if err != nil {
 		return err
 	}
@@ -54,7 +60,7 @@ func (client *RestClient) UpdateCheck(check *types.CheckConfig) (err error) {
 
 // DeleteCheck deletes check from configured Sensu instance
 func (client *RestClient) DeleteCheck(check *types.CheckConfig) error {
-	res, err := client.R().Delete("/checks/" + check.Name)
+	res, err := client.R().Delete("/checks/" + url.PathEscape(check.Name))
 
 	if err != nil {
 		return err
@@ -74,7 +80,8 @@ func (client *RestClient) ExecuteCheck(req *types.AdhocRequest) error {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Post("/checks/" + req.Name + "/execute")
+	checkPath := fmt.Sprintf("/checks/%s/execute", url.PathEscape(req.Name))
+	res, err := client.R().SetBody(bytes).Post(checkPath)
 
 	if err != nil {
 		return err
@@ -91,9 +98,10 @@ func (client *RestClient) ExecuteCheck(req *types.AdhocRequest) error {
 func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
 	var check *types.CheckConfig
 
-	res, err := client.R().Get("/checks/" + name)
+	checkPath := fmt.Sprintf("/checks/%s", url.PathEscape(name))
+	res, err := client.R().Get(checkPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GET %q: %s", checkPath, err)
 	}
 
 	if res.StatusCode() >= 400 {

--- a/cli/client/environment.go
+++ b/cli/client/environment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -17,7 +18,7 @@ func (client *RestClient) CreateEnvironment(org string, env *types.Environment) 
 
 	res, err := client.R().
 		SetBody(bytes).
-		Post(fmt.Sprintf("/rbac/organizations/%s/environments", org))
+		Post(fmt.Sprintf("/rbac/organizations/%s/environments", url.PathEscape(org)))
 
 	if err != nil {
 		return err
@@ -32,6 +33,7 @@ func (client *RestClient) CreateEnvironment(org string, env *types.Environment) 
 
 // DeleteEnvironment deletes an environment on configured Sensu instance
 func (client *RestClient) DeleteEnvironment(org, env string) error {
+	org, env = url.PathEscape(org), url.PathEscape(env)
 	res, err := client.R().Delete(
 		fmt.Sprintf("/rbac/organizations/%s/environments/%s", org, env),
 	)
@@ -52,7 +54,7 @@ func (client *RestClient) ListEnvironments(org string) ([]types.Environment, err
 	var envs []types.Environment
 
 	res, err := client.R().Get(
-		fmt.Sprintf("/rbac/organizations/%s/environments", org),
+		fmt.Sprintf("/rbac/organizations/%s/environments", url.PathEscape(org)),
 	)
 	if err != nil {
 		return envs, err
@@ -71,8 +73,8 @@ func (client *RestClient) FetchEnvironment(envName string) (*types.Environment, 
 	var env *types.Environment
 	path := fmt.Sprintf(
 		"/rbac/organizations/%s/environments/%s",
-		client.config.Organization(),
-		envName,
+		url.PathEscape(client.config.Organization()),
+		url.PathEscape(envName),
 	)
 
 	res, err := client.R().Get(path)
@@ -96,7 +98,7 @@ func (client *RestClient) UpdateEnvironment(env *types.Environment) error {
 	}
 
 	path := fmt.Sprintf("/rbac/organizations/%s/environments/%s",
-		env.Organization, env.Name)
+		url.PathEscape(env.Organization), url.PathEscape(env.Name))
 	res, err := client.R().SetBody(b).Patch(path)
 	if err != nil {
 		return err

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/sensu/sensu-go/types"
@@ -10,7 +11,7 @@ import (
 
 func eventPath(entity, check string) string {
 	const path = "/events/%s/%s"
-	return fmt.Sprintf(path, entity, check)
+	return fmt.Sprintf(path, url.PathEscape(entity), url.PathEscape(check))
 }
 
 // FetchEvent fetches a specific event
@@ -33,7 +34,7 @@ func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error)
 func (client *RestClient) ListEvents(org string) ([]types.Event, error) {
 	var events []types.Event
 
-	res, err := client.R().Get("/events?org=" + org)
+	res, err := client.R().Get("/events?org=" + url.QueryEscape(org))
 	if err != nil {
 		return events, err
 	}

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -32,7 +33,7 @@ func (client *RestClient) CreateFilter(filter *types.EventFilter) (err error) {
 
 // DeleteFilter deletes a filter from configured Sensu instance
 func (client *RestClient) DeleteFilter(filter *types.EventFilter) error {
-	res, err := client.R().Delete("/filters/" + filter.Name)
+	res, err := client.R().Delete("/filters/" + url.PathEscape(filter.Name))
 
 	if err != nil {
 		return err
@@ -49,7 +50,7 @@ func (client *RestClient) DeleteFilter(filter *types.EventFilter) error {
 func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 	var filter *types.EventFilter
 
-	res, err := client.R().Get("/filters/" + name)
+	res, err := client.R().Get("/filters/" + url.PathEscape(name))
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +66,7 @@ func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 // ListFilters fetches all filters from configured Sensu instance
 func (client *RestClient) ListFilters(org string) ([]types.EventFilter, error) {
 	var filters []types.EventFilter
-	res, err := client.R().Get("/filters?org=" + org)
+	res, err := client.R().Get("/filters?org=" + url.QueryEscape(org))
 	if err != nil {
 		return filters, err
 	}
@@ -84,7 +85,7 @@ func (client *RestClient) UpdateFilter(f *types.EventFilter) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.R().SetBody(b).Patch(fmt.Sprintf("/filters/%s", f.Name))
+	resp, err := client.R().SetBody(b).Patch(fmt.Sprintf("/filters/%s", url.PathEscape(f.Name)))
 	if err != nil {
 		return err
 	}

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -11,7 +12,7 @@ import (
 func (client *RestClient) ListHandlers(org string) ([]types.Handler, error) {
 	var handlers []types.Handler
 
-	res, err := client.R().Get("/handlers?org=" + org)
+	res, err := client.R().Get("/handlers?org=" + url.QueryEscape(org))
 	if err != nil {
 		return handlers, err
 	}
@@ -45,7 +46,7 @@ func (client *RestClient) CreateHandler(handler *types.Handler) (err error) {
 
 // DeleteHandler deletes given handler from the configured Sensu instance
 func (client *RestClient) DeleteHandler(handler *types.Handler) (err error) {
-	res, err := client.R().Delete("/handlers/" + handler.Name)
+	res, err := client.R().Delete("/handlers/" + url.PathEscape(handler.Name))
 	if err != nil {
 		return err
 	}
@@ -60,7 +61,7 @@ func (client *RestClient) DeleteHandler(handler *types.Handler) (err error) {
 // FetchHandler fetches a specific handler
 func (client *RestClient) FetchHandler(name string) (*types.Handler, error) {
 	var handler *types.Handler
-	res, err := client.R().Get("/handlers/" + name)
+	res, err := client.R().Get("/handlers/" + url.PathEscape(name))
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +81,7 @@ func (client *RestClient) UpdateHandler(handler *types.Handler) (err error) {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Patch("/handlers/" + handler.Name)
+	res, err := client.R().SetBody(bytes).Patch("/handlers/" + url.PathEscape(handler.Name))
 	if err != nil {
 		return err
 	}

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -32,7 +33,7 @@ func (client *RestClient) UpdateHook(hook *types.HookConfig) (err error) {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Patch("/hooks/" + hook.Name)
+	res, err := client.R().SetBody(bytes).Patch("/hooks/" + url.PathEscape(hook.Name))
 	if err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func (client *RestClient) UpdateHook(hook *types.HookConfig) (err error) {
 
 // DeleteHook deletes hook from configured Sensu instance
 func (client *RestClient) DeleteHook(hook *types.HookConfig) error {
-	res, err := client.R().Delete("/hooks/" + hook.Name)
+	res, err := client.R().Delete("/hooks/" + url.PathEscape(hook.Name))
 
 	if err != nil {
 		return err
@@ -63,7 +64,7 @@ func (client *RestClient) DeleteHook(hook *types.HookConfig) error {
 func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
 	var hook *types.HookConfig
 
-	res, err := client.R().Get("/hooks/" + name)
+	res, err := client.R().Get("/hooks/" + url.PathEscape(name))
 	if err != nil {
 		return nil, err
 	}

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -30,7 +31,7 @@ func (client *RestClient) CreateMutator(mutator *types.Mutator) (err error) {
 	if err == nil {
 		_, err = client.R().
 			SetBody(bytes).
-			Put("/mutators/" + mutator.Name)
+			Put("/mutators/" + url.PathEscape(mutator.Name))
 	}
 
 	return

--- a/cli/client/organization.go
+++ b/cli/client/organization.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -36,7 +37,7 @@ func (client *RestClient) UpdateOrganization(org *types.Organization) error {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Patch("/rbac/organizations/" + org.Name)
+	res, err := client.R().SetBody(bytes).Patch("/rbac/organizations/" + url.PathEscape(org.Name))
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,7 @@ func (client *RestClient) UpdateOrganization(org *types.Organization) error {
 
 // DeleteOrganization deletes an organization on configured Sensu instance
 func (client *RestClient) DeleteOrganization(org string) error {
-	res, err := client.R().Delete("/rbac/organizations/" + org)
+	res, err := client.R().Delete("/rbac/organizations/" + url.PathEscape(org))
 
 	if err != nil {
 		return err
@@ -84,7 +85,7 @@ func (client *RestClient) ListOrganizations() ([]types.Organization, error) {
 func (client *RestClient) FetchOrganization(orgName string) (*types.Organization, error) {
 	var org *types.Organization
 
-	res, err := client.R().Get("/rbac/organizations/" + orgName)
+	res, err := client.R().Get("/rbac/organizations/" + url.PathEscape(orgName))
 	if err != nil {
 		return org, err
 	}

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 	"path"
 
 	"github.com/sensu/sensu-go/types"
@@ -10,8 +11,11 @@ import (
 const rolesBasePath = "/rbac/roles"
 
 func rolesPath(ext ...string) string {
-	components := append([]string{rolesBasePath}, ext...)
-	return path.Join(components...)
+	parts := ext
+	for i := range parts {
+		parts[i] = url.PathEscape(parts[i])
+	}
+	return path.Join(append([]string{rolesBasePath}, parts...)...)
 }
 
 // CreateRole creates new role on configured Sensu instance

--- a/cli/client/silenced.go
+++ b/cli/client/silenced.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"path"
 
 	"github.com/sensu/sensu-go/types"
@@ -29,7 +30,7 @@ func (client *RestClient) CreateSilenced(silenced *types.Silenced) error {
 
 // DeleteSilenced deletes a silenced entry.
 func (client *RestClient) DeleteSilenced(id string) error {
-	res, err := client.R().Delete(fmt.Sprintf("/silenced/%s", id))
+	res, err := client.R().Delete(fmt.Sprintf("/silenced/%s", url.PathEscape(id)))
 	if err != nil {
 		return err
 	}
@@ -54,9 +55,9 @@ func (client *RestClient) ListSilenceds(org, sub, check string) ([]types.Silence
 	}
 	endpoint := "/silenced"
 	if sub != "" {
-		endpoint = path.Join(endpoint, "subscriptions", sub)
+		endpoint = path.Join(endpoint, "subscriptions", url.PathEscape(sub))
 	} else if check != "" {
-		endpoint = path.Join(endpoint, "checks", check)
+		endpoint = path.Join(endpoint, "checks", url.PathEscape(check))
 	}
 	resp, err := client.R().SetQueryParam("org", org).Get(endpoint)
 	if err != nil {
@@ -73,7 +74,7 @@ func (client *RestClient) ListSilenceds(org, sub, check string) ([]types.Silence
 
 // FetchSilenced fetches a silenced entry from configured Sensu instance
 func (client *RestClient) FetchSilenced(id string) (*types.Silenced, error) {
-	resp, err := client.R().Get(path.Join("/silenced", id))
+	resp, err := client.R().Get(path.Join("/silenced", url.PathEscape(id)))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (client *RestClient) UpdateSilenced(s *types.Silenced) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.R().SetBody(b).Patch(path.Join("/silenced", s.ID))
+	resp, err := client.R().SetBody(b).Patch(path.Join("/silenced", url.PathEscape(s.ID)))
 	if err != nil {
 		return err
 	}

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -2,12 +2,14 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 
 	"github.com/sensu/sensu-go/types"
 )
 
 // AddRoleToUser adds roles to given user on configured Sensu instance
 func (client *RestClient) AddRoleToUser(username, role string) error {
+	username, role = url.PathEscape(username), url.PathEscape(role)
 	res, err := client.R().Put("/rbac/users/" + username + "/roles/" + role)
 	if err != nil {
 		return err
@@ -36,7 +38,7 @@ func (client *RestClient) CreateUser(user *types.User) error {
 
 // DisableUser disables a user on configured Sensu instance
 func (client *RestClient) DisableUser(username string) error {
-	res, err := client.R().Delete("/rbac/users/" + username)
+	res, err := client.R().Delete("/rbac/users/" + url.PathEscape(username))
 
 	if err != nil {
 		return err
@@ -68,7 +70,7 @@ func (client *RestClient) ListUsers() ([]types.User, error) {
 
 // ReinstateUser reinstates a disabled user on configured Sensu instance
 func (client *RestClient) ReinstateUser(uname string) error {
-	res, err := client.R().Put("/rbac/users/" + uname + "/reinstate")
+	res, err := client.R().Put("/rbac/users/" + url.PathEscape(uname) + "/reinstate")
 
 	if err != nil {
 		return err
@@ -83,6 +85,7 @@ func (client *RestClient) ReinstateUser(uname string) error {
 
 // RemoveRoleFromUser removes role from given user on configured Sensu instance
 func (client *RestClient) RemoveRoleFromUser(username, role string) error {
+	username, role = url.PathEscape(username), url.PathEscape(role)
 	res, err := client.R().Delete("/rbac/users/" + username + "/roles/" + role)
 	if err != nil {
 		return err
@@ -104,7 +107,7 @@ func (client *RestClient) UpdatePassword(username, pwd string) error {
 
 	res, err := client.R().
 		SetBody(bytes).
-		Put("/rbac/users/" + username + "/password")
+		Put("/rbac/users/" + url.PathEscape(username) + "/password")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit supports resources with names that would need to be
percent-encoded in URLs in order to match properly with our mux,
for example 'foo/bar'. To this end, all resource names are
encoded before being sent to the backend, and all resource names
are decoded in the backend before being looked up.

In doing this work, a bug was also found where mutator destroy was
not functioning correctly. This bug has also been fixed.

The default 404 response now writes a JSON-encoded response body,
in order to match the response generated by the rest of the API.

gorilla/mux has been upgraded, just because.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #968 