### PR TITLE
Only deploy on appveyor if building tag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,14 +13,13 @@ environment:
   GOVERSION: 1.9
 
   matrix:
-    - GOARCH: amd64
-      TEST_SUITE: wait_for_appveyor_jobs
+    - GOARCH: 386
+      TEST_SUITE: unit
+      MSI_BUILDER: true
+      GOGC: off
       TIME_OUT_MINS: 30
       APPVEYOR_API_TOKEN:
         secure: rkeQYUjyfquA6N33QIUU46tWQMgnxZfHvn1Y6WiZm6o=
-    - GOARCH: 386
-      TEST_SUITE: unit
-      GOGC: off
     - GOARCH: amd64
       TEST_SUITE: unit
       GOGC: off
@@ -56,7 +55,7 @@ build_script:
   - ps: .\build.ps1 $env:TEST_SUITE
 
 before_deploy:
-  - ps: .\build.ps1 package_agent
+  - ps: .\build.ps1 wait_for_appveyor_jobs
 
 deploy:
   provider: GitHub
@@ -69,4 +68,3 @@ deploy:
   prerelease: true
   on:
     appveyor_repo_tag: true
-    good_to_deploy: true

--- a/build.ps1
+++ b/build.ps1
@@ -226,8 +226,6 @@ function wait_for_appveyor_jobs {
     }
 
     if (!$success) {throw "Test jobs were not finished in $env:TIME_OUT_MINS minutes"}
-
-    $env:good_to_deploy = "true"
 }
 
 function build_package([string]$package, [string]$arch)
@@ -301,17 +299,18 @@ ElseIf ($cmd -eq "integration") {
     integration_test_commands
 }
 ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
-    $env:GOARCH = "amd64"
-    build_command "agent"
+    If (($env:APPVEYOR_REPO_TAG -eq $true) -and ($env:MSI_BUILDER -eq $true)) {
+        $env:GOARCH = "amd64"
+        build_command "agent"
 
-    $env:GOARCH = "386"
-    build_command "agent"
+        $env:GOARCH = "386"
+        build_command "agent"
 
-    wait_for_appveyor_jobs
-}
-ElseIf ($cmd -eq "package_agent") {
-    build_package "agent" "x64"
-    build_package "agent" "x86"
+        wait_for_appveyor_jobs
+
+        build_package "agent" "x64"
+        build_package "agent" "x86"
+    }
 }
 Else {
     install_deps


### PR DESCRIPTION
## What is this change?

Changes the `wait_for_appveyor_jobs` task to exit as soon as possible upon detecting that a build is not tagged.

## Why is this change necessary?

We're currently wasting an AppVeyor worker during non-tagged builds.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!