### PR TITLE
Add autocompaction by revision to the etcd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ non-required fields.
 set when importing legacy settings.
 - Add CPU architecture in system information of entities.
 - The `sensuctl user change-password` subcommand now accepts flag parameters.
+- Configured and enabled etcd autocompaction.
 
 ### Changed
 - Refactor Check data structure to not depend on CheckConfig. This is a breaking

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -192,6 +192,13 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	cfg.InitialCluster = config.InitialCluster
 	cfg.ClusterState = config.InitialClusterState
 
+	// Every 5 minutes, we will prune all values in etcd to only their latest
+	// revision.
+	cfg.AutoCompactionMode = "revision"
+	// This has to stay in ns until https://github.com/coreos/etcd/issues/9337
+	// is resolved.
+	cfg.AutoCompactionRetention = "1ns"
+
 	if config.TLSConfig != nil {
 		cfg.ClientTLSInfo = (transport.TLSInfo)(config.TLSConfig.Info)
 		cfg.PeerTLSInfo = (transport.TLSInfo)(config.TLSConfig.Info)


### PR DESCRIPTION
## What is this change?

This adds etcd autocompaction to the embedded etcd config. Every 5minutes (the schedule for revision-based autocompaction), we'll compact every revision except the newest.

## Why is this change necessary?

Without compaction, we'll retain every version of every key until we hit the db size limit.
