### PR TITLE
Do not attempt to handle keepalive events until the monitor has started.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ subcommand.
 be executed.
   be executed.
 - Fixed a bug in the HTTP API where resource names could not contain special characters.
+- Resolved a data race between starting a keepalive monitor and handling keepalive events.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Resolves a data race between starting a keepalive monitor and handling keepalive events.

## Why is this change necessary?

Closes #997.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

You basically have to loop the test to reproduce, as it is intermittent. But out of 100 iterations, I've been unable to reproduce with these changes!