### PR TITLE
Bugfix: Keepalive monitor timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ subcommand.
 be executed.
   be executed.
 - Fixed a bug in the HTTP API where resource names could not contain special characters.
+- Resolved a bug in the keepalive monitor timer which was causing it to erroneously expire.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added

--- a/backend/monitor/monitor.go
+++ b/backend/monitor/monitor.go
@@ -93,7 +93,7 @@ func (m *Monitor) start() {
 		return
 	}
 
-	timerDuration := m.Timeout * time.Second
+	timerDuration := m.Timeout
 	m.timer = time.NewTimer(timerDuration)
 	m.resetChan = make(chan time.Duration)
 	go func() {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Resolves a bug in the keepalive monitor timer which was causing it to erroneously expire.

## Why is this change necessary?

Closes #997.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah, but added everyone who seemed interested in this bug to review, even though its incredibly small.

## Were there any complications while making this change?

The issue is intermittent, so its very hard to reproduce. This change passed tests 200/200 times under medium load locally.