### PR TITLE
Pass loop variable into func to prevent capture

### DIFF
--- a/backend/messaging/benchmark_test.go
+++ b/backend/messaging/benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkWizardBusPublish(b *testing.B) {
 		done = make(chan struct{})
 		for i := 0; i < numClients; i++ {
 			ch := make(chan interface{}, 1000)
-			go func(ch chan interface{}) {
+			go func(ch chan interface{}, i int) {
 				_ = bus.Subscribe(topicName, string(i), ch)
 				for {
 					select {
@@ -27,7 +27,7 @@ func BenchmarkWizardBusPublish(b *testing.B) {
 						return
 					}
 				}
-			}(ch)
+			}(ch, i)
 		}
 		return done
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Pass loop variable in via function params so it does not get captured by the function.

## Why is this change necessary?

The lint checks were producing the following error:

```
backend/messaging/benchmark_test.go:20::error: loop variable i captured by func literal (vet)
```

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!