### PR TITLE
Checks should not duplicately execute after its proxy requests have executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,12 @@ subcommand.
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to
 be executed.
-  be executed.
-- Fixed a bug in the HTTP API where resource names could not contain special characters.
-- Resolved a bug in the keepalive monitor timer which was causing it to erroneously expire.
+- Fixed a bug in the HTTP API where resource names could not contain special
+characters.
+- Resolved a bug in the keepalive monitor timer which was causing it to
+erroneously expire.
+- Resolved a bug in how an executor processes checks. If a check contains proxy
+requests, the check should not duplicately execute after the proxy requests.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -281,10 +281,12 @@ func processCheck(ctx context.Context, executor Executor, check *types.CheckConf
 		if matchedEntities := matchEntities(entities, check.ProxyRequests); len(matchedEntities) != 0 {
 			if err := executor.publishProxyCheckRequests(matchedEntities, check); err != nil {
 				logger.Error(err)
-			} else {
-				logger.Info("no matching entities, check will not be published")
 			}
+		} else {
+			logger.Info("no matching entities, check will not be published")
 		}
+	} else {
+		return executor.execute(check)
 	}
-	return executor.execute(check)
+	return nil
 }

--- a/testing/e2e/proxy_checks_test.go
+++ b/testing/e2e/proxy_checks_test.go
@@ -93,7 +93,7 @@ func TestProxyChecks(t *testing.T) {
 	output, err = sensuctl.run("event", "info", source, checkProxy.Name)
 	assert.NoError(t, err, string(output))
 
-	// Make sure the agent's entity did not produced an event for our proxy check
+	// Make sure the agent's entity did not produce an event for our proxy check
 	// request, because it shouldn't have matched the entity_attributes
 	output, err = sensuctl.run("event", "info", agent.ID, checkProxy.Name)
 	assert.Error(t, err, string(output))


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Resolves a bug in how an executor processes checks. If a check contains proxy requests, the check should not duplicately execute after the proxy requests.

## Why is this change necessary?

Closes #1054.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Copying and pasting code is deadly.. glad this is resolved and interfaced! Also, this is another intermittent failure which after this change did not reproduce on 200 attempts under medium load locally.