### PR TITLE
[Web] Silencing and Resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ set when importing legacy settings.
 - The `sensuctl user change-password` subcommand now accepts flag parameters.
 - Configured and enabled etcd autocompaction.
 - Add event metrics type, implementing the Sensu Metrics Format.
+- Added non-functional selections for resolving and silencing to web ui
 
 ### Changed
 - Refactor Check data structure to not depend on CheckConfig. This is a breaking

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -33,9 +33,11 @@ const styles = theme => ({
     verticalAlign: "top",
     padding: "14px 0",
   },
-  silenceButton: {
+  disclosure: {
     marginRight: 4,
     paddingTop: 14,
+    // TODO add this colour to theme
+    color: "rgba(0, 0, 0, 0.54)",
   },
   content: {
     width: "100%",
@@ -84,8 +86,14 @@ class EventListItem extends React.Component {
     console.log(entity);
     this.setState({ anchorEl: null });
   };
+
   silenceCheck = check => () => {
     console.log(check);
+    this.setState({ anchorEl: null });
+  };
+
+  resolve = event => () => {
+    console.log(event);
     this.setState({ anchorEl: null });
   };
 
@@ -123,10 +131,11 @@ class EventListItem extends React.Component {
             {check.output}
           </Typography>
         </div>
-        <div className={classes.silenceButton}>
+        <div className={classes.disclosure}>
           <Button onClick={this.handleClick}>
             <Disclosure />
           </Button>
+          {/* TODO give these functionality, pass correct value */}
           <Menu
             anchorEl={anchorEl}
             open={Boolean(anchorEl)}
@@ -144,6 +153,9 @@ class EventListItem extends React.Component {
               onClick={this.silenceCheck("entity")}
             >
               Silence Check
+            </MenuItem>
+            <MenuItem key={"resolve"} onClick={this.resolve("event")}>
+              Resolve
             </MenuItem>
           </Menu>
         </div>

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -5,9 +5,12 @@ import { createFragmentContainer, graphql } from "react-relay";
 import moment from "moment";
 import { withStyles } from "material-ui/styles";
 import Typography from "material-ui/Typography";
+import Menu, { MenuItem } from "material-ui/Menu";
+import Button from "material-ui/ButtonBase";
 
 import Checkbox from "material-ui/Checkbox";
 import chevronIcon from "material-ui-icons/ChevronRight";
+import disclosureIcon from "material-ui-icons/MoreVert";
 
 import EventStatus from "./EventStatus";
 
@@ -29,6 +32,10 @@ const styles = theme => ({
     display: "inline-block",
     verticalAlign: "top",
     padding: "14px 0",
+  },
+  silenceButton: {
+    marginRight: 4,
+    paddingTop: 14,
   },
   content: {
     width: "100%",
@@ -55,19 +62,42 @@ class EventListItem extends React.Component {
     // eslint-disable-next-line react/forbid-prop-types
     classes: PropTypes.object.isRequired,
     Chevron: PropTypes.func.isRequired,
+    Disclosure: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
     Chevron: chevronIcon,
+    Disclosure: disclosureIcon,
+  };
+
+  state = { anchorEl: null };
+
+  onClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  handleClick = event => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  silenceEntity = entity => () => {
+    console.log(entity);
+    this.setState({ anchorEl: null });
+  };
+  silenceCheck = check => () => {
+    console.log(check);
+    this.setState({ anchorEl: null });
   };
 
   render() {
     const {
       classes,
       Chevron,
+      Disclosure,
       event: { entity, check, timestamp },
       ...other
     } = this.props;
+    const { anchorEl } = this.state;
     const time = moment(timestamp).fromNow();
 
     return (
@@ -92,6 +122,30 @@ class EventListItem extends React.Component {
           <Typography type="caption" className={classes.command}>
             {check.output}
           </Typography>
+        </div>
+        <div className={classes.silenceButton}>
+          <Button onClick={this.handleClick}>
+            <Disclosure />
+          </Button>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={this.onClose}
+            id="silenceButton"
+          >
+            <MenuItem
+              key={"silence-Entity"}
+              onClick={this.silenceEntity("entity")}
+            >
+              Silence Entity
+            </MenuItem>
+            <MenuItem
+              key={"silence-Check"}
+              onClick={this.silenceCheck("entity")}
+            >
+              Silence Check
+            </MenuItem>
+          </Menu>
         </div>
       </div>
     );

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -9,8 +9,8 @@ import Menu, { MenuItem } from "material-ui/Menu";
 import Button from "material-ui/ButtonBase";
 
 import Checkbox from "material-ui/Checkbox";
-import chevronIcon from "material-ui-icons/ChevronRight";
-import disclosureIcon from "material-ui-icons/MoreVert";
+import Chevron from "material-ui-icons/ChevronRight";
+import Disclosure from "material-ui-icons/MoreVert";
 
 import EventStatus from "./EventStatus";
 
@@ -62,13 +62,6 @@ class EventListItem extends React.Component {
   static propTypes = {
     // eslint-disable-next-line react/forbid-prop-types
     classes: PropTypes.object.isRequired,
-    Chevron: PropTypes.func.isRequired,
-    Disclosure: PropTypes.func.isRequired,
-  };
-
-  static defaultProps = {
-    Chevron: chevronIcon,
-    Disclosure: disclosureIcon,
   };
 
   state = { anchorEl: null };
@@ -82,25 +75,26 @@ class EventListItem extends React.Component {
   };
 
   silenceEntity = entity => () => {
-    console.log(entity);
+    // eslint-disable-next-line
+    console.info("entity", entity);
     this.setState({ anchorEl: null });
   };
 
   silenceCheck = check => () => {
-    console.log(check);
+    // eslint-disable-next-line
+    console.info("check", check);
     this.setState({ anchorEl: null });
   };
 
   resolve = event => () => {
-    console.log(event);
+    // eslint-disable-next-line
+    console.info("event", event);
     this.setState({ anchorEl: null });
   };
 
   render() {
     const {
       classes,
-      Chevron,
-      Disclosure,
       event: { entity, check, timestamp },
       ...other
     } = this.props;

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -36,8 +36,7 @@ const styles = theme => ({
   disclosure: {
     marginRight: 4,
     paddingTop: 14,
-    // TODO add this colour to theme
-    color: "rgba(0, 0, 0, 0.54)",
+    color: theme.palette.action.active,
   },
   content: {
     width: "100%",


### PR DESCRIPTION
## What is this change?
Adds a simple, non-functioning disclosure (3 dots) dropdown for silencing and resolving events. The actions are to be added later.

![image](https://user-images.githubusercontent.com/1707663/36561957-396404d8-17ca-11e8-8b5a-101791f31eea.png)

## Why is this change necessary?
Required for the web ui.

## Does your change need a Changelog entry?
I added one.

## Do you need clarification on anything?
N/A

## Were there any complications while making this change?
Resolving events has yet to be implemented. So this must be revisited when it's available. In addition, the dialog that will appear for silencing requires more thought, so we will revisit that later as well.