### PR TITLE
Use EntityAgentClass constant when assigning an agent entity's class

### DIFF
--- a/agent/entity.go
+++ b/agent/entity.go
@@ -11,7 +11,7 @@ import (
 func (a *Agent) getAgentEntity() *types.Entity {
 	if a.entity == nil {
 		e := &types.Entity{
-			Class:            "agent",
+			Class:            types.EntityAgentClass,
 			Deregister:       a.config.Deregister,
 			Environment:      a.config.Environment,
 			ID:               a.config.AgentID,


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Uses EntityAgentClass constant when assigning an agent entity's class.

## Why is this change necessary?

It's good practice to use our entity class constants when assigning entities their class.

## Does your change need a Changelog entry?

Probably not.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.