### PR TITLE
Upgrade Go to 1.10 for Travis and AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ image:
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.9
+  GOVERSION: 1.10
 
   matrix:
     - GOARCH: 386

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- 1.9.x
+- 1.10.x
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ except that HookConfig is now embedded in Hook.
 subcommand.
 - Agent backend URLs without a port specified will now default to port 8081.
 - Travis encrypted variables have been updated to work with travis-ci.org
+- Upgraded all builds to use Go 1.10.
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -15,8 +15,8 @@ RUN apt-get update && \
   gem install --no-ri --no-rdoc fpm && \
   gem install --no-ri --no-rdoc rake && \
   gem install --no-ri --no-rdoc package_cloud && \
-  wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz && \
-  tar -C /usr/local -zxvf go1.9.linux-amd64.tar.gz && \
+  wget https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz && \
+  tar -C /usr/local -zxvf go1.10.linux-amd64.tar.gz && \
   apt-get clean
 
 WORKDIR /go/src/github.com/sensu/sensu-go

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ Vagrant.configure("2") do |config|
     apt-get install -y ruby ruby-dev build-essential rpm rpmlint
     gem install --no-ri --no-rdoc fpm
     gem install --no-ri --no-rdoc package_cloud
-    wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
-    tar -C /usr/local -zxvf go1.8.3.linux-amd64.tar.gz
+    wget https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
+    tar -C /usr/local -zxvf go1.10.linux-amd64.tar.gz
     chown -R ubuntu:ubuntu /usr/local/go
     chown ubuntu:ubuntu /go
     echo 'export GOROOT="/usr/local/go"' >> /home/ubuntu/.profile

--- a/build.ps1
+++ b/build.ps1
@@ -54,7 +54,7 @@ function build_tool_binary([string]$goos, [string]$goarch, [string]$bin, [string
     $outfile = "target/$goos-$goarch/$subdir/$bin.exe"
     $env:GOOS = $goos
     $env:GOARCH = $goarch
-    go build -i -o $outfile "$REPO_PATH/$subdir/$bin/..."
+    go build -o $outfile "$REPO_PATH/$subdir/$bin/..."
     If ($LASTEXITCODE -ne 0) {
         echo "Failed to build $outfile..."
         exit 1
@@ -96,7 +96,7 @@ function build_binary([string]$goos, [string]$goarch, [string]$bin, [string]$cmd
     $ldflags = $ldflags + " -X $version_pkg.BuildDate=$build_date"
     $ldflags = $ldflags + " -X $version_pkg.BuildSHA=$build_sha"
 
-    go build -ldflags "$ldflags" -i -o $outfile "$REPO_PATH/$bin/cmd/..."
+    go build -ldflags "$ldflags" -o $outfile "$REPO_PATH/$bin/cmd/..."
     If ($LASTEXITCODE -ne 0) {
         echo "Failed to build $outfile..."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ build_tool_binary () {
 
     local outfile="target/${goos}-${goarch}/${subdir}/${cmd}"
 
-    GOOS=$goos GOARCH=$goarch go build -i -o $outfile ${REPO_PATH}/${subdir}/${cmd}/...
+    GOOS=$goos GOARCH=$goarch go build -o $outfile ${REPO_PATH}/${subdir}/${cmd}/...
 
     echo $outfile
 }
@@ -98,7 +98,7 @@ build_binary () {
     local ldflags+=" -X $version_pkg.BuildDate=${build_date}"
     local ldflags+=" -X $version_pkg.BuildSHA=${build_sha}"
 
-    CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -ldflags "${ldflags}" -i -o $outfile ${REPO_PATH}/${cmd}/cmd/...
+    CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -ldflags "${ldflags}" -o $outfile ${REPO_PATH}/${cmd}/cmd/...
 
     echo $outfile
 }


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Go 1.10 has been released, so we should use it. As a side effect, it should fix a build error in a dependency of fileb0x.