### PR TITLE
Remove erroneous check validation statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ set when importing legacy settings.
 - Configured and enabled etcd autocompaction.
 - Add event metrics type, implementing the Sensu Metrics Format.
 - Added non-functional selections for resolving and silencing to web ui
-- Add LastOk to check type. This will be updated to reflect the last timestamp of a succesful check 
+- Add LastOk to check type. This will be updated to reflect the last timestamp
+of a successful check.
 
 ### Changed
 - Refactor Check data structure to not depend on CheckConfig. This is a breaking
@@ -48,6 +49,7 @@ characters.
 erroneously expire.
 - Resolved a bug in how an executor processes checks. If a check contains proxy
 requests, the check should not duplicately execute after the proxy requests.
+- Removed an erroneous validation statement in check handler.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -136,12 +136,6 @@ func (a *Agent) prepareCheck(cfg *types.CheckConfig) bool {
 		return false
 	}
 
-	// Special case for agents
-	if check.Interval < 1 {
-		a.sendFailure(event, errors.New("given check is invalid: missing interval"))
-		return false
-	}
-
 	// Extract the extended attributes from the entity and combine them at the
 	// top-level so they can be easily accessed using token substitution
 	synthesizedEntity, err := dynamic.Synthesize(a.getAgentEntity())

--- a/types/check.go
+++ b/types/check.go
@@ -66,6 +66,10 @@ func (c *Check) Validate() error {
 		if _, err := cron.ParseStandard(c.Cron); err != nil {
 			return errors.New("check cron string is invalid")
 		}
+	} else {
+		if c.Interval < 1 {
+			return errors.New("check interval must be greater than or equal to 1")
+		}
 	}
 
 	if c.Ttl > 0 && c.Ttl <= int64(c.Interval) {

--- a/types/check_test.go
+++ b/types/check_test.go
@@ -15,6 +15,11 @@ func TestCheckValidate(t *testing.T) {
 	assert.Error(t, c.Validate())
 	c.Status = 0
 
+	// Invalid interval
+	c.Interval = 0
+	assert.Error(t, c.Validate())
+	c.Interval = 10
+
 	c.Name = "test"
 
 	assert.NoError(t, c.Validate())


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Removes an erroneous check validation statement in check handler. Cron and interval are mutually exclusive, so interval _may_ be < 1.

## Why is this change necessary?

Fixes the error that came up in @jamesdphillips demo.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.