### PR TITLE
[Web UI] Hide quick navigation when media is too small

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -84,7 +84,7 @@
     "prestart": "yarn precompile",
     "pretest": "yarn precompile",
     "prettier": "./node_module/.bin/prettier --write src/**/*.js",
-    "lint": "./node_modules/.bin/eslint src",
+    "lint": "./node_modules/.bin/eslint src --max-warnings 0",
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",

--- a/dashboard/src/components/AppContent.js
+++ b/dashboard/src/components/AppContent.js
@@ -4,25 +4,16 @@ import { withStyles } from "material-ui/styles";
 
 const styles = theme => ({
   content: theme.mixins.gutters({
-    paddingTop: 100, // TODO: make non-magic number
     flex: "1 1 100%",
     maxWidth: "100%",
     margin: "0 auto",
-    position: "relative",
+    [theme.breakpoints.up("md")]: {
+      paddingTop: theme.spacing.unit * 3,
+    },
+    [theme.breakpoints.up("lg")]: {
+      maxWidth: 1080,
+    },
   }),
-
-  // TODO: Make extra-wide gutter optional. (Maybe configured w/ prop?)
-  [theme.breakpoints.up("sm")]: {
-    content: {
-      paddingLeft: theme.spacing.unit * 3 + 40,
-      paddingRight: theme.spacing.unit * 3 + 40,
-    },
-  },
-  [theme.breakpoints.up(900 + theme.spacing.unit * 6)]: {
-    content: {
-      maxWidth: 1000,
-    },
-  },
 });
 
 class AppContent extends React.Component {

--- a/dashboard/src/components/AppFrame.js
+++ b/dashboard/src/components/AppFrame.js
@@ -35,17 +35,25 @@ const styles = theme => ({
   },
   quicknav: {
     position: "fixed",
-    display: "flex",
     flexDirection: "column",
     alignItems: "center",
     top: 80,
     left: 0,
     width: 72,
+    display: "none",
+    [theme.breakpoints.up("md")]: {
+      display: "flex",
+    },
   },
   maincontainer: {
     position: "relative",
     display: "flex",
     width: "100%",
+    paddingTop: 64,
+    [theme.breakpoints.up("md")]: {
+      paddingLeft: 72,
+      paddingRight: 72,
+    },
   },
 });
 

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import moment from "moment";
 
 import { createFragmentContainer, graphql } from "react-relay";
-import moment from "moment";
 import { withStyles } from "material-ui/styles";
 import Typography from "material-ui/Typography";
 import Menu, { MenuItem } from "material-ui/Menu";
@@ -21,8 +21,7 @@ const styles = theme => ({
     borderColor: theme.palette.divider,
     border: "1px solid",
     borderTop: "none",
-    // TODO revist with typography
-    fontFamily: "SF Pro Text",
+    color: theme.palette.text.primary,
   },
   checkbox: {
     display: "inline-block",
@@ -40,11 +39,16 @@ const styles = theme => ({
     color: theme.palette.action.active,
   },
   content: {
-    width: "100%",
+    width: "calc(100% - 104px)",
     display: "inline-block",
     padding: 14,
   },
-  command: { fontSize: "0.8125rem" },
+  command: {
+    fontSize: "0.8125rem",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
   chevron: {
     verticalAlign: "top",
     marginTop: -2,
@@ -103,7 +107,7 @@ class EventListItem extends React.Component {
     const time = moment(timestamp).fromNow();
 
     return (
-      <div className={classes.row}>
+      <Typography component="div" className={classes.row}>
         <div className={classes.checkbox}>
           <Checkbox />
         </div>
@@ -153,7 +157,7 @@ class EventListItem extends React.Component {
             </MenuItem>
           </Menu>
         </div>
-      </div>
+      </Typography>
     );
   }
 }

--- a/dashboard/src/components/QuickNav.js
+++ b/dashboard/src/components/QuickNav.js
@@ -8,9 +8,9 @@ import DashboardIcon from "material-ui-icons/Dashboard";
 import EventIcon from "material-ui-icons/Notifications";
 import EntityIcon from "material-ui-icons/DesktopMac";
 import CheckIcon from "material-ui-icons/AssignmentTurnedIn";
-import SilenceIcon from "material-ui-icons/VolumeOff";
-import HookIcon from "material-ui-icons/Link";
-import HandlerIcon from "material-ui-icons/CallSplit";
+// import SilenceIcon from "material-ui-icons/VolumeOff";
+// import HookIcon from "material-ui-icons/Link";
+// import HandlerIcon from "material-ui-icons/CallSplit";
 
 import QuickNavButton from "./QuickNavButton";
 
@@ -36,9 +36,11 @@ class QuickNav extends React.Component {
         <QuickNavButton Icon={EventIcon} caption="Events" to="events" />
         <QuickNavButton Icon={EntityIcon} caption="Entities" to="entities" />
         <QuickNavButton Icon={CheckIcon} caption="Checks" to="checks" />
+        {/*
         <QuickNavButton Icon={SilenceIcon} caption="Silences" to="silences" />
         <QuickNavButton Icon={HookIcon} caption="Hooks" to="hooks" />
         <QuickNavButton Icon={HandlerIcon} caption="Handlers" to="handlers" />
+        */}
       </div>
     );
   }

--- a/dashboard/src/components/QuickNav.js
+++ b/dashboard/src/components/QuickNav.js
@@ -3,15 +3,10 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import { withStyles } from "material-ui/styles";
-
 import DashboardIcon from "material-ui-icons/Dashboard";
 import EventIcon from "material-ui-icons/Notifications";
 import EntityIcon from "material-ui-icons/DesktopMac";
 import CheckIcon from "material-ui-icons/AssignmentTurnedIn";
-// import SilenceIcon from "material-ui-icons/VolumeOff";
-// import HookIcon from "material-ui-icons/Link";
-// import HandlerIcon from "material-ui-icons/CallSplit";
-
 import QuickNavButton from "./QuickNavButton";
 
 const styles = {
@@ -36,11 +31,6 @@ class QuickNav extends React.Component {
         <QuickNavButton Icon={EventIcon} caption="Events" to="events" />
         <QuickNavButton Icon={EntityIcon} caption="Entities" to="entities" />
         <QuickNavButton Icon={CheckIcon} caption="Checks" to="checks" />
-        {/*
-        <QuickNavButton Icon={SilenceIcon} caption="Silences" to="silences" />
-        <QuickNavButton Icon={HookIcon} caption="Hooks" to="hooks" />
-        <QuickNavButton Icon={HandlerIcon} caption="Handlers" to="handlers" />
-        */}
       </div>
     );
   }


### PR DESCRIPTION
## What is this change?

Hide quick navigation when media min width becomes too small.

## Why is this change necessary?

Free up more room for app content on smaller screens.