### PR TITLE
Fix HookList validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ subcommand.
 - Use megacheck instead of errcheck.
 - Cleaned agent configuration.
 - We no longer duplicate hook execution for types that fall into both an exit
-code and severity (ex. 0, non-zero).
+code and severity (ex. 0, ok).
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ subcommand.
 - Upgraded all builds to use Go 1.10.
 - Use megacheck instead of errcheck.
 - Cleaned agent configuration.
+- We no longer duplicate hook execution for types that fall into both an exit
+code and severity (ex. 0, non-zero).
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to
@@ -55,6 +57,8 @@ erroneously expire.
 - Resolved a bug in how an executor processes checks. If a check contains proxy
 requests, the check should not duplicately execute after the proxy requests.
 - Removed an erroneous validation statement in check handler.
+- Fixed HookList `hooks` validation and updated `type` validation message to
+allow "0" as a valid type.
 
 ## [2.0.0-alpha.17] - 2018-02-13
 ### Added

--- a/agent/hook.go
+++ b/agent/hook.go
@@ -29,7 +29,7 @@ func (a *Agent) ExecuteHooks(request *types.CheckRequest, status int) []*types.H
 					continue
 				}
 				// Do not duplicate hook execution for types that fall into both an exit
-				// code and severity (ex. 0, non-zero)
+				// code and severity (ex. 0, ok)
 				in := hookInList(hookConfig.Name, executedHooks)
 				if !in {
 					hook := a.executeHook(hookConfig)

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -57,3 +57,48 @@ func TestPrepareHook(t *testing.T) {
 	hook.Command = "{{ .ID }}"
 	assert.True(agent.prepareHook(hook))
 }
+
+func TestHookInList(t *testing.T) {
+	assert := assert.New(t)
+	hook1 := types.FixtureHook("hook1")
+	hook2 := types.FixtureHook("hook2")
+
+	testCases := []struct {
+		name     string
+		hookName string
+		hookList []*types.Hook
+		expected bool
+	}{
+		{
+			name:     "Empty list",
+			hookName: "hook1",
+			hookList: []*types.Hook{},
+			expected: false,
+		},
+		{
+			name:     "Hook in populated list",
+			hookName: "hook1",
+			hookList: []*types.Hook{hook2, hook1},
+			expected: true,
+		},
+		{
+			name:     "Hook not in populated list",
+			hookName: "hook1",
+			hookList: []*types.Hook{hook2, hook2},
+			expected: false,
+		},
+		{
+			name:     "No hook name provided",
+			hookName: "",
+			hookList: []*types.Hook{hook1, hook2},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := hookInList(tc.hookName, tc.hookList)
+			assert.Equal(tc.expected, in)
+		})
+	}
+}

--- a/cli/commands/check/subcommands/set_hooks_test.go
+++ b/cli/commands/check/subcommands/set_hooks_test.go
@@ -33,6 +33,7 @@ func TestSetCheckHooksCommandRunEClosureSucess(t *testing.T) {
 
 	cmd := SetCheckHooksCommand(cli)
 	require.NoError(t, cmd.Flags().Set("type", "non-zero"))
+	require.NoError(t, cmd.Flags().Set("hooks", "hook"))
 
 	out, err := test.RunCmd(cmd, []string{"name"})
 	require.NoError(t, err)

--- a/types/hook.go
+++ b/types/hook.go
@@ -63,9 +63,13 @@ func (h *HookList) Validate() error {
 		return errors.New("type cannot be empty")
 	}
 
+	if h.Hooks == nil || len(h.Hooks) == 0 {
+		return errors.New("hooks cannot be empty")
+	}
+
 	if !(CheckHookRegex.MatchString(h.Type) || isSeverity(h.Type)) {
 		return errors.New(
-			"valid check hook types are \"1\"-\"255\", \"ok\", \"warning\", \"critical\", \"unknown\", and \"non-zero\"",
+			"valid check hook types are \"0\"-\"255\", \"ok\", \"warning\", \"critical\", \"unknown\", and \"non-zero\"",
 		)
 	}
 

--- a/types/hook_test.go
+++ b/types/hook_test.go
@@ -28,6 +28,30 @@ func TestHookValidate(t *testing.T) {
 	assert.NoError(t, h.Validate())
 }
 
+func TestHookListValidate(t *testing.T) {
+	var h HookList
+
+	// Invalid hooks
+	h.Hooks = nil
+	assert.Error(t, h.Validate())
+
+	// Invalid hooks
+	h.Hooks = []string{}
+	assert.Error(t, h.Validate())
+
+	// Invalid without type
+	h.Hooks = append(h.Hooks, "hook")
+	assert.Error(t, h.Validate())
+
+	// Invalid type
+	h.Type = "invalid"
+	assert.Error(t, h.Validate())
+
+	// Valid
+	h.Type = "0"
+	assert.NoError(t, h.Validate())
+}
+
 func TestHookConfig(t *testing.T) {
 	var h HookConfig
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes HookList validation and messages, and ensures we do not duplicate hook execution for return codes that may fall under multiple types (ex. 0, ok).

## Why is this change necessary?

This clarifies confusion around an oversight on documentation. "0" and "ok" are valid types of check hooks!

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.