### PR TITLE
[Agent] Fix up typo in agent configuration defaults

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -39,7 +39,7 @@ const (
 	// DefaultBackendURL specifies the default backend URL
 	DefaultBackendURL = "ws://127.0.0.1:8081"
 	// DefaultEnvironment specifies the default environment
-	DefaultEnvironment = "defaut"
+	DefaultEnvironment = "default"
 	// DefaultKeepaliveInterval specifies the default keepalive interval
 	DefaultKeepaliveInterval = 20
 	// DefaultKeepaliveTimeout specifies the default keepalive timeout


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Fix up typo in agent configuration defaults

## Why is this change necessary?

Otherwise by default the agent is configured with the wrong environment. 

## Does your change need a Changelog entry?

I believe the change was introduced after the last release.
