### PR TITLE
Refactor tests to not use testify.Suite.

### DIFF
--- a/agent/assetmanager/store_test.go
+++ b/agent/assetmanager/store_test.go
@@ -4,59 +4,59 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type StoreTestSuite struct {
-	suite.Suite
+type storeTest struct {
 	store      *AssetStore
 	newAssetFn func(*types.Asset) *RuntimeAsset
 	newSetFn   func([]*RuntimeAsset) *RuntimeAssetSet
 }
 
-func (suite *StoreTestSuite) SetupTest() {
-	suite.store = NewAssetStore()
-	suite.newAssetFn = func(a *types.Asset) *RuntimeAsset {
-		return NewRuntimeAsset(a, "")
-	}
-	suite.newSetFn = func(a []*RuntimeAsset) *RuntimeAssetSet {
-		return NewRuntimeAssetSet(a, []string{})
+func newStoreTest() *storeTest {
+	return &storeTest{
+		store: NewAssetStore(),
+		newAssetFn: func(a *types.Asset) *RuntimeAsset {
+			return NewRuntimeAsset(a, "")
+		},
+		newSetFn: func(a []*RuntimeAsset) *RuntimeAssetSet {
+			return NewRuntimeAssetSet(a, []string{})
+		},
 	}
 }
 
-func (suite *StoreTestSuite) TestNew() {
+func TestNew(t *testing.T) {
 	store := NewAssetStore()
-	suite.NotNil(store)
-	suite.Empty(store.assets)
-	suite.Empty(store.assetSets)
-	suite.NotNil(store.rwMutex)
+	assert.NotNil(t, store)
+	assert.Empty(t, store.assets)
+	assert.Empty(t, store.assetSets)
+	assert.NotNil(t, store.rwMutex)
 }
 
-func (suite *StoreTestSuite) TestFetchAsset() {
+func TestFetchAsset(t *testing.T) {
 	asset := types.FixtureAsset("name")
-	runtimeAsset := suite.store.FetchAsset(asset, suite.newAssetFn)
-	suite.NotNil(runtimeAsset)
+	test := newStoreTest()
+	runtimeAsset := test.store.FetchAsset(asset, test.newAssetFn)
+	assert.NotNil(t, runtimeAsset)
 
-	secondRun := suite.store.FetchAsset(asset, suite.newAssetFn)
-	suite.Equal(&runtimeAsset, &secondRun)
+	secondRun := test.store.FetchAsset(asset, test.newAssetFn)
+	assert.Equal(t, &runtimeAsset, &secondRun)
 }
 
-func (suite *StoreTestSuite) TestFetchSet() {
+func TestFetchSet(t *testing.T) {
 	asset := types.FixtureAsset("name")
 	runtimeAssets := []*RuntimeAsset{&RuntimeAsset{asset: asset}}
-	assetSet := suite.store.FetchSet(runtimeAssets, suite.newSetFn)
-	suite.NotNil(assetSet)
+	test := newStoreTest()
+	assetSet := test.store.FetchSet(runtimeAssets, test.newSetFn)
+	assert.NotNil(t, assetSet)
 
-	secondRun := suite.store.FetchSet(runtimeAssets, suite.newSetFn)
-	suite.Equal(&assetSet, &secondRun)
+	secondRun := test.store.FetchSet(runtimeAssets, test.newSetFn)
+	assert.Equal(t, &assetSet, &secondRun)
 }
 
-func (suite *StoreTestSuite) TestFetchClear() {
-	suite.store.Clear()
-	suite.Empty(suite.store.assets)
-	suite.Empty(suite.store.assetSets)
-}
-
-func TestStore(t *testing.T) {
-	suite.Run(t, new(StoreTestSuite))
+func TestFetchClear(t *testing.T) {
+	test := newStoreTest()
+	test.store.Clear()
+	assert.Empty(t, test.store.assets)
+	assert.Empty(t, test.store.assetSets)
 }

--- a/cli/commands/completion/cmd_test.go
+++ b/cli/commands/completion/cmd_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommand(t *testing.T) {
@@ -20,104 +20,110 @@ func TestCommand(t *testing.T) {
 	assert.Regexp("shell completion code", cmd.Short)
 }
 
-type ExecutorSuite struct {
-	suite.Suite
+type executorTest struct {
 	exec    *completionExecutor
 	rootCmd *cobra.Command
 	cmd     *cobra.Command
 	out     *exWriter
 }
 
-func (suite *ExecutorSuite) SetupTest() {
-	suite.rootCmd = &cobra.Command{
+func newExecutorTest() *executorTest {
+	test := &executorTest{}
+	test.rootCmd = &cobra.Command{
 		Use:          "sensuctl",
 		Short:        "sensuctl test test tests",
 		SilenceUsage: true,
 	}
-	suite.cmd = Command(suite.rootCmd)
-	suite.exec = &completionExecutor{rootCmd: suite.rootCmd}
+	test.cmd = Command(test.rootCmd)
+	test.exec = &completionExecutor{rootCmd: test.rootCmd}
 
-	suite.out = &exWriter{}
-	suite.cmd.SetOutput(suite.out)
-	suite.rootCmd.SetOutput(suite.out)
+	test.out = &exWriter{}
+	test.cmd.SetOutput(test.out)
+	test.rootCmd.SetOutput(test.out)
+
+	return test
 }
 
-func (suite *ExecutorSuite) TestRunWithNoArguments() {
-	err := suite.exec.run(suite.cmd, []string{})
-	out := suite.out.result
+func TestRunWithNoArguments(t *testing.T) {
+	test := newExecutorTest()
+	err := test.exec.run(test.cmd, []string{})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "help")
-	suite.Nil(err)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "help")
 }
 
-func (suite *ExecutorSuite) TestRunWithArgZsh() {
-	err := suite.exec.run(suite.cmd, []string{"zsh"})
-	out := suite.out.result
+func TestRunWithArgZsh(t *testing.T) {
+	test := newExecutorTest()
+	err := test.exec.run(test.cmd, []string{"zsh"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "BASH_COMPLETION_EOF")
-	suite.Contains(out, "convert_bash_to_zsh")
-	suite.Nil(err)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "BASH_COMPLETION_EOF")
+	assert.Contains(t, out, "convert_bash_to_zsh")
 }
 
-func (suite *ExecutorSuite) TestRunWithArgBash() {
-	err := suite.exec.run(suite.cmd, []string{"bash"})
-	out := suite.out.result
+func TestRunWithArgBash(t *testing.T) {
+	test := newExecutorTest()
+	err := test.exec.run(test.cmd, []string{"bash"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "_init_completion")
-	suite.NoError(err)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "_init_completion")
 }
 
-func (suite *ExecutorSuite) TestRunWithBadArg() {
-	err := suite.exec.run(suite.cmd, []string{"fish"})
-	out := suite.out.result
+func TestRunWithBadArg(t *testing.T) {
+	test := newExecutorTest()
+	err := test.exec.run(test.cmd, []string{"fish"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "unknown shell")
-	suite.Contains(out, "usage")
-	suite.Nil(err)
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "unknown shell")
+	assert.Contains(t, out, "usage")
 }
 
-func (suite *ExecutorSuite) TestHelpWithNoArgs() {
-	suite.exec.runHelp(suite.cmd, []string{"completion"})
-	out := suite.out.result
+func TestHelpWithNoArgs(t *testing.T) {
+	test := newExecutorTest()
+	test.exec.runHelp(test.cmd, []string{"completion"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "Output shell completion code for the given shell")
-	suite.Contains(out, "help")
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "Output shell completion code for the given shell")
+	assert.Contains(t, out, "help")
 }
 
-func (suite *ExecutorSuite) TestHelpWithZsh() {
-	suite.exec.runHelp(suite.cmd, []string{"completion", "zsh"})
-	out := suite.out.result
+func TestHelpWithZsh(t *testing.T) {
+	test := newExecutorTest()
+	test.exec.runHelp(test.cmd, []string{"completion", "zsh"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "Add the following")
-	suite.Contains(out, "zshrc")
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "Add the following")
+	assert.Contains(t, out, "zshrc")
 }
 
-func (suite *ExecutorSuite) TestHelpWithBash() {
-	suite.exec.runHelp(suite.cmd, []string{"completion", "bash"})
-	out := suite.out.result
+func TestHelpWithBash(t *testing.T) {
+	test := newExecutorTest()
+	test.exec.runHelp(test.cmd, []string{"completion", "bash"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "add the following")
-	suite.Contains(out, "bash_profile")
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "add the following")
+	assert.Contains(t, out, "bash_profile")
 }
 
-func (suite *ExecutorSuite) TestHelpWithBadArg() {
-	suite.exec.runHelp(suite.cmd, []string{"completion", "fish"})
-	out := suite.out.result
+func TestHelpWithBadArg(t *testing.T) {
+	test := newExecutorTest()
+	test.exec.runHelp(test.cmd, []string{"completion", "fish"})
+	out := test.out.result
 
-	suite.NotEmpty(out)
-	suite.Contains(out, "unknown shell")
-	suite.Contains(out, "help")
-}
-
-func TestRunExecSuite(t *testing.T) {
-	suite.Run(t, new(ExecutorSuite))
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "unknown shell")
+	assert.Contains(t, out, "help")
 }
 
 type exWriter struct {

--- a/cli/elements/list/list_test.go
+++ b/cli/elements/list/list_test.go
@@ -4,121 +4,126 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 )
 
-type ListDetailsRowSuite struct {
-	suite.Suite
+type listDetailsRowTest struct {
 	out *exWriter
 	row *rowElem
 }
 
-func (suite *ListDetailsRowSuite) SetupTest() {
-	suite.out = &exWriter{}
-	suite.row = &rowElem{
-		label: "repo size",
-		value: "16.2 GB",
+func newListDetailsRowTest() *listDetailsRowTest {
+	return &listDetailsRowTest{
+		out: &exWriter{},
+		row: &rowElem{
+			label: "repo size",
+			value: "16.2 GB",
+		},
 	}
 }
 
-func (suite *ListDetailsRowSuite) TestStyleLabel() {
+func TestStyleLabel(t *testing.T) {
 	// When a formatter is not configured default is used
-	suite.row.label = "repo size"
-	suite.Equal("Repo Size: ", suite.row.styleLabel())
+	test := newListDetailsRowTest()
+	test.row.label = "repo size"
+	assert.Equal(t, "Repo Size: ", test.row.styleLabel())
 
 	// When a formatter /is/ configured
-	suite.row.label = "repo size"
-	suite.row.labelStyle = func(_ string) string { return "cake" }
-	suite.Equal("cake", suite.row.styleLabel())
+	test.row.label = "repo size"
+	test.row.labelStyle = func(_ string) string { return "cake" }
+	assert.Equal(t, "cake", test.row.styleLabel())
 }
 
-func (suite *ListDetailsRowSuite) TestStyledLabel() {
+func TestStyledLabel(t *testing.T) {
 	// Returns styled label & memo val initially unset
-	suite.row.label = "repo size"
-	suite.Empty(suite.row.labelMemo)
-	suite.Equal("Repo Size: ", suite.row.styledLabel())
+	test := newListDetailsRowTest()
+	test.row.label = "repo size"
+	assert.Empty(t, test.row.labelMemo)
+	assert.Equal(t, "Repo Size: ", test.row.styledLabel())
 
 	// Result is memoized
-	suite.row.label = "something way diff"
-	suite.NotEmpty(suite.row.labelMemo)
-	suite.Equal("Repo Size: ", suite.row.labelMemo)
-	suite.Equal("Repo Size: ", suite.row.styledLabel())
+	test.row.label = "something way diff"
+	assert.NotEmpty(t, test.row.labelMemo)
+	assert.Equal(t, "Repo Size: ", test.row.labelMemo)
+	assert.Equal(t, "Repo Size: ", test.row.styledLabel())
 }
 
-func (suite *ListDetailsRowSuite) TestWrite() {
-	suite.row.label = "repo size"
-	suite.Equal(11, suite.row.labelLen())
+func TestWriteListDetailsRow(t *testing.T) {
+	test := newListDetailsRowTest()
+	test.row.label = "repo size"
+	assert.Equal(t, 11, test.row.labelLen())
 }
 
-func (suite *ListDetailsRowSuite) TestLabelLen() {
-	suite.row.label = "repo size"
-	suite.row.value = "12GB"
+func TestLabelLen(t *testing.T) {
+	test := newListDetailsRowTest()
+	test.row.label = "repo size"
+	test.row.value = "12GB"
 
-	suite.row.write(suite.out, 11)
-	suite.Equal("Repo Size: 12GB\n", suite.out.result)
+	test.row.write(test.out, 11)
+	assert.Equal(t, "Repo Size: 12GB\n", test.out.result)
 
-	suite.out.Clean()
-	suite.row.write(suite.out, 20)
-	suite.Equal("Repo Size:          12GB\n", suite.out.result)
+	test.out.Clean()
+	test.row.write(test.out, 20)
+	assert.Equal(t, "Repo Size:          12GB\n", test.out.result)
 }
 
-func (suite *ListDetailsRowSuite) TestFormattedValue() {
+func TestFormattedValue(t *testing.T) {
 	// When a formatter is not configured
-	suite.row.value = "smrt"
-	suite.Equal("smrt", suite.row.formattedValue())
+	test := newListDetailsRowTest()
+	test.row.value = "smrt"
+	assert.Equal(t, "smrt", test.row.formattedValue())
 
 	// When a formatter /is/ configured
-	suite.row.value = "smrt"
-	suite.row.valueFormatter = func(_ string) string { return "smart" }
-	suite.Equal("smart", suite.row.formattedValue())
+	test.row.value = "smrt"
+	test.row.valueFormatter = func(_ string) string { return "smart" }
+	assert.Equal(t, "smart", test.row.formattedValue())
 }
 
-type ListDetailsSuite struct {
-	suite.Suite
+type listDetailsTest struct {
 	out  *exWriter
 	list *listElem
 }
 
-func (suite *ListDetailsSuite) SetupTest() {
-	suite.out = &exWriter{}
-	suite.list = &listElem{
-		title: "Check",
-		rows: []*rowElem{
-			{
-				label: "repo size",
-				value: "16.2 GB",
+func newListDetailsTest() *listDetailsTest {
+	return &listDetailsTest{
+		out: &exWriter{},
+		list: &listElem{
+			title: "Check",
+			rows: []*rowElem{
+				{
+					label: "repo size",
+					value: "16.2 GB",
+				},
 			},
 		},
 	}
 }
 
-func (suite *ListDetailsSuite) TestLongestLabel() {
+func TestLongestLabel(t *testing.T) {
 	// When a formatter is not configured
-	suite.list.rows[0].labelStyle = func(_ string) string { return "1234:" }
-	suite.Equal(5, suite.list.longestLabel())
+	test := newListDetailsTest()
+	test.list.rows[0].labelStyle = func(_ string) string { return "1234:" }
+	assert.Equal(t, 5, test.list.longestLabel())
 }
 
-func (suite *ListDetailsSuite) TestWriteTitle() {
-	suite.list.title = "Check 'disk_full'"
-	suite.list.writeTitle(suite.out)
-	suite.NotEmpty(suite.out.result)
-	suite.Regexp("^=== ", suite.out.result)
-	suite.Regexp("disk_full", suite.out.result)
+func TestWriteTitle(t *testing.T) {
+	test := newListDetailsTest()
+	test.list.title = "Check 'disk_full'"
+	test.list.writeTitle(test.out)
+	assert.NotEmpty(t, test.out.result)
+	assert.Regexp(t, "^=== ", test.out.result)
+	assert.Regexp(t, "disk_full", test.out.result)
 }
 
-func (suite *ListDetailsSuite) TestWriteRows() {
-	suite.list.writeRows(suite.out)
-	suite.NotEmpty(suite.out.result)
+func TestWriteRows(t *testing.T) {
+	test := newListDetailsTest()
+	test.list.writeRows(test.out)
+	assert.NotEmpty(t, test.out.result)
 }
 
-func (suite *ListDetailsSuite) TestWrite() {
-	suite.list.write(suite.out)
-	suite.NotEmpty(suite.out.result)
-}
-
-func TestRunSuites(t *testing.T) {
-	suite.Run(t, new(ListDetailsRowSuite))
-	suite.Run(t, new(ListDetailsSuite))
+func TestWriteListDetails(t *testing.T) {
+	test := newListDetailsTest()
+	test.list.write(test.out)
+	assert.NotEmpty(t, test.out.result)
 }
 
 func TestPrint(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Removes all uses of testify's suite package. I did not use subtests, instead favouring a light refactoring that involved creating a test struct in most cases.

## Why is this change necessary?

Closes #939 