### PR TITLE
Change travis badge to travis-ci.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ subcommand.
 - We no longer duplicate hook execution for types that fall into both an exit
 code and severity (ex. 0, ok).
 - Updated the sensuctl guidelines.
+- Changed travis badge to use travis-ci.org in README.md.
+
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sensu 2.0
 
-[![Build Status](https://travis-ci.com/sensu/sensu-go.svg?branch=master)](https://travis-ci.com/sensu/sensu-go)
+[![Build Status](https://travis-ci.org/sensu/sensu-go.svg?branch=master)](https://travis-ci.org/sensu/sensu-go)
 
 ## Contributing/Development
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It replaces the Travis badge from travis-ci.com with the good one from travis-ci.org.

Additionally, I removed the sensu/sensu-go repository from the list of enabled repos in order to prevent confusion. 

## Why is this change necessary?

So the build badge reflects the right status.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!