### PR TITLE
Govaluate's modifier tokens can now be optionally forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ subcommand.
 code and severity (ex. 0, ok).
 - Updated the sensuctl guidelines.
 - Changed travis badge to use travis-ci.org in README.md.
-
+- Govaluate's modifier tokens can now be optionally forbidden.
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/types/asset.go
+++ b/types/asset.go
@@ -44,7 +44,8 @@ func (a *Asset) Validate() error {
 		return errors.New("URL must be HTTP or HTTPS")
 	}
 
-	return eval.ValidateStatements(a.Filters)
+	// Validate the statements and forbid govaluate's modifier tokens
+	return eval.ValidateStatements(a.Filters, true)
 }
 
 // GetEnvironment refers to the organization the check belongs to

--- a/types/check.go
+++ b/types/check.go
@@ -201,7 +201,7 @@ func (p *ProxyRequests) Validate() error {
 		return errors.New("proxy request splay coverage must be greater than 0 if splay is enabled")
 	}
 
-	return eval.ValidateStatements(p.EntityAttributes)
+	return eval.ValidateStatements(p.EntityAttributes, false)
 }
 
 // ByExecuted implements the sort.Interface for []CheckHistory based on the

--- a/types/filter.go
+++ b/types/filter.go
@@ -41,7 +41,7 @@ func (f *EventFilter) Validate() error {
 		return errors.New("filter must have one or more statements")
 	}
 
-	if err := eval.ValidateStatements(f.Statements); err != nil {
+	if err := eval.ValidateStatements(f.Statements, false); err != nil {
 		return err
 	}
 

--- a/util/eval/eval.go
+++ b/util/eval/eval.go
@@ -29,18 +29,25 @@ func Evaluate(expression string, parameters map[string]interface{}) (bool, error
 }
 
 // ValidateStatements ensure that the given statements can be parsed
-// successfully and that it does not contain any modifier tokens.
-func ValidateStatements(statements []string) error {
+// successfully and, optionally, that it does not contain any modifier tokens.
+func ValidateStatements(statements []string, forbidModifier bool) error {
 	for _, statement := range statements {
 		exp, err := govaluate.NewEvaluableExpression(statement)
 		if err != nil {
 			return fmt.Errorf("invalid statement '%s': %s", statement, err.Error())
 		}
 
-		// Do not allow modifier tokens (eg. +, -, /, *, **, &, etc.)
-		for _, token := range exp.Tokens() {
-			if token.Kind == govaluate.MODIFIER {
-				return fmt.Errorf("forbidden modifier tokens in statement '%s'", statement)
+		// We can optionally forbid modifier tokens if we believe an expression has
+		// no reason to use a modifier operator in its context (e.g. assets
+		// filters). By doing so, we can detect expressions that could possibly
+		// evaluate to something else than a boolean value, and return an error
+		// before saving that expression.
+		if forbidModifier {
+			// Ensure we don't have a modifier tokens (+, -, /, *, **, &, etc.)
+			for _, token := range exp.Tokens() {
+				if token.Kind == govaluate.MODIFIER {
+					return fmt.Errorf("forbidden modifier tokens in statement '%s'", statement)
+				}
 			}
 		}
 	}

--- a/util/eval/eval_test.go
+++ b/util/eval/eval_test.go
@@ -76,14 +76,17 @@ func TestEvaluate(t *testing.T) {
 func TestValidateStatements(t *testing.T) {
 	// Valid statement
 	statements := []string{"10 > 0"}
-	assert.NoError(t, ValidateStatements(statements))
+	assert.NoError(t, ValidateStatements(statements, false))
 
 	// Invalid statement
 	statements = []string{"10. 0"}
-	assert.Error(t, ValidateStatements(statements))
+	assert.Error(t, ValidateStatements(statements, false))
 
 	// Forbidden modifier token
 	statements = []string{"10 + 2 > 0"}
-	assert.Error(t, ValidateStatements(statements))
+	assert.Error(t, ValidateStatements(statements, true))
 
+	// Forbidden modifier token
+	statements = []string{"10 + 2 > 0"}
+	assert.NoError(t, ValidateStatements(statements, false))
 }

--- a/util/eval/eval_test.go
+++ b/util/eval/eval_test.go
@@ -86,7 +86,7 @@ func TestValidateStatements(t *testing.T) {
 	statements = []string{"10 + 2 > 0"}
 	assert.Error(t, ValidateStatements(statements, true))
 
-	// Forbidden modifier token
+	// Allowed modifier token
 	statements = []string{"10 + 2 > 0"}
 	assert.NoError(t, ValidateStatements(statements, false))
 }


### PR DESCRIPTION
## What is this change?

It adds a second boolean argument to `eval.ValidateStatements` so modifier tokens can be optionally forbidden.

## Why is this change necessary?

As per 1.x documentation on filters, arithmetic operators (which are considered as modifiers) can be useful in govaluate expressions: https://sensuapp.org/docs/latest/reference/filters.html#example-handling-repeated-events

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!