### PR TITLE
Add custom functions to govaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ set when importing legacy settings.
 of a successful check.
 - Added GraphQL explorer to web UI.
 - Added check occurrences and occurrences_watermark attributes from Sensu 1.x.
+- Added custom functions to evaluate a unix timestamp in govaluate.
 
 ### Changed
 - Refactor Check data structure to not depend on CheckConfig. This is a breaking

--- a/util/eval/predicate_test.go
+++ b/util/eval/predicate_test.go
@@ -58,6 +58,66 @@ func TestEvaluatePredicate(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "negative hour",
+			args: args{
+				expression: "hour(timestamp) == 19",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913, // Monday, March 5, 2018 6:51:53 PM UTC
+				},
+			},
+			want: false,
+		},
+		{
+			name: "positive hour",
+			args: args{
+				expression: "hour(timestamp) == 18",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913, // Monday, March 5, 2018 6:51:53 PM UTC
+				},
+			},
+			want: true,
+		},
+		{
+			name: "positive between hour",
+			args: args{
+				expression: "hour(timestamp) >= 17 && hour(timestamp) <= 19",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913, // Monday, March 5, 2018 6:51:53 PM UTC
+				},
+			},
+			want: true,
+		},
+		{
+			name: "positive weekday",
+			args: args{
+				expression: "weekday(timestamp) == 1",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913, // Monday, March 5, 2018 6:51:53 PM UTC
+				},
+			},
+			want: true,
+		},
+		{
+			name: "negative weekday",
+			args: args{
+				expression: "weekday(timestamp) == 2",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913, // Monday, March 5, 2018 6:51:53 PM UTC
+				},
+			},
+			want: false,
+		},
+		{
+			name: "positive weekday array",
+			args: args{
+				expression: "weekday(timestamp) in (1, 2, 3, 4, 5)",
+				parameters: map[string]interface{}{
+					"timestamp": 1520275913,
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What is this change?

It adds custom functions to govaluate, in order to support evaluation of an event timestamp.


## Why is this change necessary?

In order to reproduce the 1.x filters functionalities.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!