### PR TITLE
[GraphQL] Implement node resolver for events

### DIFF
--- a/backend/apid/graphql/schema/entity.gql.go
+++ b/backend/apid/graphql/schema/entity.gql.go
@@ -465,7 +465,8 @@ func _ObjectTypeEntityConfigFn() graphql1.ObjectConfig {
 				Type:              graphql.OutputType("System"),
 			},
 		},
-		Interfaces: []*graphql1.Interface{},
+		Interfaces: []*graphql1.Interface{
+			graphql.Interface("Node")},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of

--- a/backend/apid/graphql/schema/entity.graphql
+++ b/backend/apid/graphql/schema/entity.graphql
@@ -2,7 +2,7 @@
 Entity is the Entity supplying the event. The default Entity for any
 Event is the running Agent process--if the Event is sent by an Agent.
 """
-type Entity {
+type Entity implements Node {
   "The globally unique identifier of the record"
   id: ID!
 

--- a/backend/apid/graphql/schema/event.gql.go
+++ b/backend/apid/graphql/schema/event.gql.go
@@ -379,7 +379,8 @@ func _ObjectTypeEventConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.NewNonNull(graphql1.DateTime),
 			},
 		},
-		Interfaces: []*graphql1.Interface{},
+		Interfaces: []*graphql1.Interface{
+			graphql.Interface("Node")},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of

--- a/backend/apid/graphql/schema/event.graphql
+++ b/backend/apid/graphql/schema/event.graphql
@@ -1,7 +1,7 @@
 """
 An Event is the encapsulating type sent across the Sensu websocket transport.
 """
-type Event {
+type Event implements Node {
   "The globally unique identifier of the record."
   id: ID!
 

--- a/backend/apid/graphql/schema/handler.gql.go
+++ b/backend/apid/graphql/schema/handler.gql.go
@@ -434,7 +434,8 @@ func _ObjectTypeHandlerConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.NewNonNull(graphql1.String),
 			},
 		},
-		Interfaces: []*graphql1.Interface{},
+		Interfaces: []*graphql1.Interface{
+			graphql.Interface("Node")},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of

--- a/backend/apid/graphql/schema/handler.graphql
+++ b/backend/apid/graphql/schema/handler.graphql
@@ -1,7 +1,7 @@
 """
 A Handler is a handler specification.
 """
-type Handler {
+type Handler implements Node {
   "The globally unique identifier of the record."
   id: ID!
 

--- a/backend/apid/graphql/schema/hook.gql.go
+++ b/backend/apid/graphql/schema/hook.gql.go
@@ -297,7 +297,8 @@ func _ObjectTypeHookConfigConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.Int,
 			},
 		},
-		Interfaces: []*graphql1.Interface{},
+		Interfaces: []*graphql1.Interface{
+			graphql.Interface("Node")},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of

--- a/backend/apid/graphql/schema/hook.graphql
+++ b/backend/apid/graphql/schema/hook.graphql
@@ -1,7 +1,7 @@
 """
 HookConfig is the specification of a hook
 """
-type HookConfig {
+type HookConfig implements Node {
   "The globally unique identifier of the record"
   id: ID!
 

--- a/backend/apid/graphql/schema/rbac.gql.go
+++ b/backend/apid/graphql/schema/rbac.gql.go
@@ -441,7 +441,8 @@ func _ObjectTypeRoleConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Rule")))),
 			},
 		},
-		Interfaces: []*graphql1.Interface{},
+		Interfaces: []*graphql1.Interface{
+			graphql.Interface("Node")},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of

--- a/backend/apid/graphql/schema/rbac.graphql
+++ b/backend/apid/graphql/schema/rbac.graphql
@@ -13,7 +13,7 @@ type Rule {
 """
 Role describes set of rules
 """
-type Role {
+type Role implements Node {
   id: ID!
   name: String!
   rules: [Rule!]!


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Implement a node resolver for events so that they can be easily re-queried.

<img width="400" alt="screen shot 2018-03-07 at 11 27 54 am" src="https://user-images.githubusercontent.com/194892/37113652-d7e924fa-21fa-11e8-91a0-d0390cc06ac0.png">

## Why is this change necessary?

Unblock @dabria on #1130.
