### PR TITLE
Add cli support for CRUD mutators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Changed the maximum number of open file descriptors on a system to from 1024
 (default) to 65535.
 - Increased the default etcd size limit from 2GB to 4GB.
+### Added
+- Support for managing mutators via sensuctl.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -107,7 +107,10 @@ type HookAPIClient interface {
 // MutatorAPIClient client methods for mutators
 type MutatorAPIClient interface {
 	CreateMutator(*types.Mutator) error
-	ListMutators() ([]types.Mutator, error)
+	ListMutators(string) ([]types.Mutator, error)
+	DeleteMutator(*types.Mutator) error
+	FetchMutator(string) (*types.Mutator, error)
+	UpdateMutator(*types.Mutator) error
 }
 
 // OrganizationAPIClient client methods for organizations

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -8,11 +8,11 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-// ListMutators fetches all mutators from configured Sensu instance
-func (client *RestClient) ListMutators() ([]types.Mutator, error) {
+// ListMutators fetches all mutators from the configured Sensu instance
+func (client *RestClient) ListMutators(org string) ([]types.Mutator, error) {
 	var mutators []types.Mutator
 
-	res, err := client.R().Get("/mutators")
+	res, err := client.R().Get("/mutators?org=" + url.QueryEscape(org))
 	if err != nil {
 		return mutators, err
 	}
@@ -25,14 +25,71 @@ func (client *RestClient) ListMutators() ([]types.Mutator, error) {
 	return mutators, err
 }
 
-// CreateMutator creates new mutator on configured Sensu instance
+// CreateMutator creates new mutator on the configured Sensu instance
 func (client *RestClient) CreateMutator(mutator *types.Mutator) (err error) {
 	bytes, err := json.Marshal(mutator)
-	if err == nil {
-		_, err = client.R().
-			SetBody(bytes).
-			Put("/mutators/" + url.PathEscape(mutator.Name))
+	if err != nil {
+		return err
+
+	}
+	res, err := client.R().SetBody(bytes).Post("/mutators")
+	if err != nil {
+		return err
+
 	}
 
-	return
+	if res.StatusCode() >= 400 {
+		return unmarshalError(res)
+	}
+	return nil
+}
+
+// DeleteMutator deletes the given mutator from the configured Sensu instance
+func (client *RestClient) DeleteMutator(mutator *types.Mutator) (err error) {
+	res, err := client.R().Delete("/mutators/" + url.PathEscape(mutator.Name))
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return fmt.Errorf("%v", res.String())
+	}
+
+	return nil
+}
+
+// FetchMutator fetches a specific handler from the configured Sensu instance
+func (client *RestClient) FetchMutator(name string) (*types.Mutator, error) {
+	var mutator *types.Mutator
+
+	res, err := client.R().Get("/mutators/" + url.PathEscape(name))
+	if err != nil {
+		return mutator, err
+	}
+
+	if res.StatusCode() >= 400 {
+		return mutator, fmt.Errorf("%v", res.String())
+	}
+
+	err = json.Unmarshal(res.Body(), &mutator)
+	return mutator, err
+}
+
+// UpdateMutator updates a given mutator on a configured Sensu instance
+func (client *RestClient) UpdateMutator(mutator *types.Mutator) (err error) {
+	bytes, err := json.Marshal(mutator)
+	if err != nil {
+		return err
+	}
+
+	res, err := client.R().SetBody(bytes).Patch("/mutators/" + url.PathEscape(mutator.Name))
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return unmarshalError(res)
+	}
+
+	return nil
 }

--- a/cli/client/testing/mock_mutator_client.go
+++ b/cli/client/testing/mock_mutator_client.go
@@ -2,14 +2,32 @@ package testing
 
 import "github.com/sensu/sensu-go/types"
 
-// ListMutators for use with mock lib
-func (c *MockClient) ListMutators() ([]types.Mutator, error) {
-	args := c.Called()
-	return args.Get(0).([]types.Mutator), args.Error(1)
-}
-
 // CreateMutator for use with mock package
 func (c *MockClient) CreateMutator(m *types.Mutator) error {
 	args := c.Called(m)
 	return args.Error(0)
+}
+
+// DeleteMutator for use with mock package
+func (c *MockClient) DeleteMutator(m *types.Mutator) error {
+	args := c.Called(m)
+	return args.Error(0)
+}
+
+// FetchMutator for use with mock package
+func (c *MockClient) FetchMutator(name string) (*types.Mutator, error) {
+	args := c.Called(name)
+	return args.Get(0).(*types.Mutator), args.Error(1)
+}
+
+// UpdateMutator for use with mock package
+func (c *MockClient) UpdateMutator(m *types.Mutator) error {
+	args := c.Called(m)
+	return args.Error(0)
+}
+
+// ListMutators for use with mock lib
+func (c *MockClient) ListMutators(org string) ([]types.Mutator, error) {
+	args := c.Called(org)
+	return args.Get(0).([]types.Mutator), args.Error(1)
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/hook"
 	"github.com/sensu/sensu-go/cli/commands/importer"
 	"github.com/sensu/sensu-go/cli/commands/logout"
+	"github.com/sensu/sensu-go/cli/commands/mutator"
 	"github.com/sensu/sensu-go/cli/commands/organization"
 	"github.com/sensu/sensu-go/cli/commands/role"
 	"github.com/sensu/sensu-go/cli/commands/silenced"
@@ -40,6 +41,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		filter.HelpCommand(cli),
 		handler.HelpCommand(cli),
 		hook.HelpCommand(cli),
+		mutator.HelpCommand(cli),
 		organization.HelpCommand(cli),
 		role.HelpCommand(cli),
 		user.HelpCommand(cli),

--- a/cli/commands/handler/interactive.go
+++ b/cli/commands/handler/interactive.go
@@ -54,7 +54,7 @@ func (opts *handlerOpts) withHandler(handler *types.Handler) {
 
 func (opts *handlerOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Command, _ = flags.GetString("command")
-	opts.Filters, _ = flags.GetString("handlers")
+	opts.Filters, _ = flags.GetString("filters")
 	opts.Handlers, _ = flags.GetString("handlers")
 	opts.Mutator, _ = flags.GetString("mutator")
 	opts.SocketHost, _ = flags.GetString("socket-host")

--- a/cli/commands/mutator/create.go
+++ b/cli/commands/mutator/create.go
@@ -1,0 +1,76 @@
+package mutator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// CreateCommand adds command that allows the user to create new mutators
+func CreateCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create [NAME]",
+		Short:        "create new mutators",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+			if !isInteractive {
+				// Mark flags are required for bash-completions
+				_ = cmd.MarkFlagRequired("command")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+
+			opts := newMutatorOpts()
+
+			if len(args) > 0 {
+				opts.Name = args[0]
+			}
+
+			opts.Org = cli.Config.Organization()
+			opts.Env = cli.Config.Environment()
+
+			if isInteractive {
+				if err := opts.administerQuestionnaire(false); err != nil {
+					return err
+				}
+			} else {
+				opts.withFlags(cmd.Flags())
+			}
+
+			mutator := types.Mutator{}
+			opts.Copy(&mutator)
+
+			if err := mutator.Validate(); err != nil {
+				if !isInteractive {
+					return errors.New("invalid argument(s) received")
+				}
+				return err
+			}
+
+			err := cli.Client.CreateMutator(&mutator)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("command", "c", "", "command to be executed. The event data is passed to the process via STDIN")
+	cmd.Flags().StringP("timeout", "t", "", "execution duration timeout in seconds (hard stop)")
+	helpers.AddInteractiveFlag(cmd.Flags())
+	return cmd
+}

--- a/cli/commands/mutator/create_test.go
+++ b/cli/commands/mutator/create_test.go
@@ -1,0 +1,67 @@
+package mutator
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("create", cmd.Use)
+	assert.Regexp("mutators", cmd.Short)
+}
+
+func TestCreateCommandRunEClosureWithoutFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"hello"})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+}
+
+func TestCreateCommandRunEClosureWithAllFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateMutator", mock.AnythingOfType("*types.Mutator")).Return(nil)
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("command", "echo 'I like turtles'"))
+	require.NoError(t, cmd.Flags().Set("timeout", "60"))
+	out, err := test.RunCmd(cmd, []string{"can-holla"})
+
+	assert.Regexp("OK", out)
+	assert.Nil(err)
+}
+
+func TestCreateCommandRunEClosureWithServerErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateMutator", mock.AnythingOfType("*types.Mutator")).Return(errors.New("whoops"))
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("command", "echo 'I like turtles'"))
+	out, err := test.RunCmd(cmd, []string{"can-holla"})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("whoops", err.Error())
+}

--- a/cli/commands/mutator/delete.go
+++ b/cli/commands/mutator/delete.go
@@ -1,0 +1,48 @@
+package mutator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCommand adds a command that allows user to delete handlers
+func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete [NAME]",
+		Short:        "delete mutator given name",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If no name is present print out usage
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			name := args[0]
+			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
+				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
+					return nil
+				}
+			}
+
+			mutator := &types.Mutator{Name: name}
+			err := cli.Client.DeleteMutator(mutator)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("skip-confirm", false, "skip interactive confirmation prompt")
+
+	return cmd
+}

--- a/cli/commands/mutator/delete_test.go
+++ b/cli/commands/mutator/delete_test.go
@@ -1,0 +1,78 @@
+package mutator
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("delete", cmd.Use)
+	assert.Regexp("mutator", cmd.Short)
+}
+
+func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.Regexp("Usage", out) // usage should print out
+	assert.Error(err)
+}
+
+func TestDeleteCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteMutator", mock.AnythingOfType("*types.Mutator")).Return(nil)
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo"})
+
+	assert.Regexp("OK", out)
+	assert.Nil(err)
+}
+
+func TestDeleteCommandRunEClosureWithServerErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteMutator", mock.AnythingOfType("*types.Mutator")).Return(errors.New("oh noes"))
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo"})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("oh noes", err.Error())
+}
+
+func TestDeleteCommandRunEFailConfirm(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"foo"})
+
+	assert.Contains(out, "Canceled")
+	assert.NoError(err)
+}

--- a/cli/commands/mutator/help.go
+++ b/cli/commands/mutator/help.go
@@ -1,0 +1,25 @@
+package mutator
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new parent
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mutator",
+		Short: "Manage mutators",
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		CreateCommand(cli),
+		DeleteCommand(cli),
+		InfoCommand(cli),
+		ListCommand(cli),
+		UpdateCommand(cli),
+	)
+
+	return cmd
+}

--- a/cli/commands/mutator/info.go
+++ b/cli/commands/mutator/info.go
@@ -1,0 +1,77 @@
+package mutator
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/list"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// InfoCommand defines the 'mutator info' subcommand
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info [NAME]",
+		Short:        "show detailed mutator information",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("format")
+
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			// Fetch the mutator from API
+			name := args[0]
+			r, err := cli.Client.FetchMutator(name)
+			if err != nil {
+				return err
+			}
+
+			if format == "json" {
+				return helpers.PrintJSON(r, cmd.OutOrStdout())
+			}
+			printToList(r, cmd.OutOrStdout())
+			return nil
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+
+	return cmd
+}
+
+func printToList(mutator *types.Mutator, writer io.Writer) {
+	cfg := &list.Config{
+		Title: mutator.Name,
+		Rows: []*list.Row{
+			{
+				Label: "Name",
+				Value: mutator.Name,
+			},
+			{
+				Label: "Command",
+				Value: mutator.Command,
+			},
+			{
+				Label: "Timeout",
+				Value: strconv.FormatUint(uint64(mutator.Timeout), 10),
+			},
+			{
+				Label: "Organization",
+				Value: mutator.Organization,
+			},
+			{
+				Label: "Environment",
+				Value: mutator.Environment,
+			},
+		},
+	}
+
+	list.Print(writer, cfg)
+}

--- a/cli/commands/mutator/info_test.go
+++ b/cli/commands/mutator/info_test.go
@@ -1,0 +1,85 @@
+package mutator
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShowCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	cmd := InfoCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("info", cmd.Use)
+	assert.Regexp("mutator", cmd.Short)
+}
+
+func TestShowCommandRunEClosure(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchMutator", "in").Return(types.FixtureMutator("name-one"), nil)
+
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"in"})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "name-one")
+	assert.Nil(err)
+}
+
+func TestShowCommandRunMissingArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "Usage")
+	assert.Error(err)
+}
+
+func TestShowCommandRunEClosureWithTable(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchMutator", "in").Return(types.FixtureMutator("name-one"), nil)
+
+	cmd := InfoCommand(cli)
+	require.NoError(t, cmd.Flags().Set("format", "tabular"))
+
+	out, err := test.RunCmd(cmd, []string{"in"})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "Name")
+	assert.Contains(out, "Command")
+	assert.Contains(out, "Timeout")
+	assert.Nil(err)
+}
+
+func TestShowCommandRunEClosureWithErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("FetchMutator", "in").Return(&types.Mutator{}, errors.New("my-err"))
+
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"in"})
+
+	assert.NotNil(err)
+	assert.Equal("my-err", err.Error())
+	assert.Empty(out)
+}

--- a/cli/commands/mutator/interactive.go
+++ b/cli/commands/mutator/interactive.go
@@ -1,0 +1,110 @@
+package mutator
+
+import (
+	"strconv"
+
+	"github.com/AlecAivazis/survey"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/pflag"
+)
+
+type mutatorOpts struct {
+	Name    string `survey:"name"`
+	Command string `survey:"command"`
+	Timeout string `survey:"timeout"`
+	Env     string
+	Org     string
+}
+
+const (
+	typeDefault = "pipe"
+)
+
+func newMutatorOpts() *mutatorOpts {
+	opts := mutatorOpts{}
+	return &opts
+}
+
+func (opts *mutatorOpts) withMutator(mutator *types.Mutator) {
+	opts.Name = mutator.Name
+	opts.Env = mutator.Environment
+	opts.Org = mutator.Organization
+
+	opts.Command = mutator.Command
+	opts.Timeout = strconv.FormatUint(uint64(mutator.Timeout), 10)
+}
+
+func (opts *mutatorOpts) withFlags(flags *pflag.FlagSet) {
+	opts.Command, _ = flags.GetString("command")
+	opts.Timeout, _ = flags.GetString("timeout")
+
+	if org, _ := flags.GetString("organization"); org != "" {
+		opts.Org = org
+	}
+	if env, _ := flags.GetString("environment"); env != "" {
+		opts.Env = env
+	}
+}
+
+func (opts *mutatorOpts) administerQuestionnaire(editing bool) error {
+	var qs []*survey.Question
+	if !editing {
+		qs = append(qs, []*survey.Question{
+			{
+				Name: "name",
+				Prompt: &survey.Input{
+					Message: "Mutator Name:",
+					Default: opts.Name},
+				Validate: survey.Required,
+			},
+			{
+				Name: "org",
+				Prompt: &survey.Input{
+					Message: "Organization:",
+					Default: opts.Org,
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "env",
+				Prompt: &survey.Input{
+					Message: "Environment:",
+					Default: opts.Env,
+				},
+				Validate: survey.Required,
+			},
+		}...)
+	}
+	qs = append(qs, []*survey.Question{
+		{Name: "command",
+			Prompt: &survey.Input{
+				Message: "Command:",
+				Default: opts.Command,
+			},
+		},
+		{
+			Name: "timeout",
+			Prompt: &survey.Input{
+				Message: "Timeout:",
+				Default: opts.Timeout,
+			},
+		},
+	}...)
+
+	return survey.Ask(qs, opts)
+}
+
+func (opts *mutatorOpts) Copy(mutator *types.Mutator) {
+	mutator.Name = opts.Name
+	mutator.Environment = opts.Env
+	mutator.Organization = opts.Org
+
+	mutator.Command = opts.Command
+
+	if len(opts.Timeout) > 0 {
+		t, _ := strconv.ParseUint(opts.Timeout, 10, 32)
+		mutator.Timeout = uint32(t)
+	} else {
+		mutator.Timeout = 0
+	}
+}

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -1,0 +1,78 @@
+package mutator
+
+import (
+	"errors"
+	"io"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/table"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// ListCommand defines the 'mutator list' subcommand
+func ListCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list mutators",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+			org := cli.Config.Organization()
+			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
+				org = "*"
+			}
+
+			// Fetch mutators from the API
+			results, err := cli.Client.ListMutators(org)
+			if err != nil {
+				return err
+			}
+
+			// Print the results based on the user preferences
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+	helpers.AddAllOrganization(cmd.Flags())
+
+	return cmd
+}
+
+func printToTable(results interface{}, writer io.Writer) {
+	table := table.New([]*table.Column{
+		{
+			Title:       "Name",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				mutator, _ := data.(types.Mutator)
+				return mutator.Name
+			},
+		},
+		{
+			Title:       "Command",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				mutator, _ := data.(types.Mutator)
+				return mutator.Command
+			},
+		},
+		{
+			Title:       "Timeout",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				mutator, _ := data.(types.Mutator)
+				timeout := strconv.FormatUint(uint64(mutator.Timeout), 10)
+				return timeout
+			},
+		},
+	})
+	table.Render(writer, results)
+}

--- a/cli/commands/mutator/list_test.go
+++ b/cli/commands/mutator/list_test.go
@@ -1,0 +1,139 @@
+package mutator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/cli"
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	cmd := ListCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list", cmd.Use)
+	assert.Regexp("mutators", cmd.Short)
+}
+
+func TestListCommandRunEClosure(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("ListMutators", mock.Anything).Return([]types.Mutator{
+		*types.FixtureMutator("name-one"),
+		*types.FixtureMutator("name-two"),
+	}, nil)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set("format", "json"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "name-one")
+	assert.Contains(out, "name-two")
+	assert.Nil(err)
+}
+
+func TestListCommandRunEClosureWithAll(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("ListMutators", "*").Return([]types.Mutator{
+		*types.FixtureMutator("name-one"),
+	}, nil)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
+	require.NoError(t, cmd.Flags().Set(flags.AllOrgs, "t"))
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Nil(err)
+}
+
+func TestListCommandRunEClosureWithTable(t *testing.T) {
+	assert := assert.New(t)
+	cli := newCLI()
+
+	mutator := types.FixtureMutator("name-one")
+
+	client := cli.Client.(*client.MockClient)
+	client.On("ListMutators", mock.Anything).Return([]types.Mutator{*mutator}, nil)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set("format", "none"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "Name")    // heading
+	assert.Contains(out, "Command") // heading
+	assert.Contains(out, "Timeout") // heading
+	assert.Nil(err)
+}
+
+// Test to ensure check command list output does not escape alphanumeric chars
+func TestListCommandRunEClosureWithErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("ListMutators", mock.Anything).Return([]types.Mutator{}, errors.New("my-err"))
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotNil(err)
+	assert.Equal("my-err", err.Error())
+	assert.Empty(out)
+}
+
+func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	client := cli.Client.(*client.MockClient)
+	mutator := types.FixtureMutator("name-one")
+	mutator.Command = "echo foo && exit 1"
+	client.On("ListMutators", "*").Return([]types.Mutator{*mutator}, nil)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
+	require.NoError(t, cmd.Flags().Set(flags.AllOrgs, "t"))
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Contains(out, "echo foo && exit 1")
+	assert.Nil(err)
+}
+
+func TestListFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newCLI()
+	cmd := ListCommand(cli)
+
+	flag := cmd.Flag("all-organizations")
+	assert.NotNil(flag)
+
+	flag = cmd.Flag("format")
+	assert.NotNil(flag)
+}
+
+func newCLI() *cli.SensuCli {
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("json")
+
+	return cli
+}

--- a/cli/commands/mutator/update.go
+++ b/cli/commands/mutator/update.go
@@ -1,0 +1,55 @@
+package mutator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// UpdateCommand defines the 'mutator update' subcommand
+func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "update [NAME]",
+		Short:        "update mutators",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print out usage if we do not receive one argument
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			// Fetch the requested mutator from the API
+			name := args[0]
+			mutator, err := cli.Client.FetchMutator(name)
+			if err != nil {
+				return err
+			}
+
+			// Administer questionnaire
+			opts := newMutatorOpts()
+			opts.withMutator(mutator)
+			if err := opts.administerQuestionnaire(true); err != nil {
+				return err
+			}
+
+			// Apply given arguments to mutator
+			opts.Copy(mutator)
+
+			if err := mutator.Validate(); err != nil {
+				return err
+			}
+
+			if err := cli.Client.UpdateMutator(mutator); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/mutator/update_test.go
+++ b/cli/commands/mutator/update_test.go
@@ -1,0 +1,63 @@
+package mutator
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpdateCommand(t *testing.T) {
+	testCases := []struct {
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, nil, nil, "Usage", true},
+		{[]string{"foo"}, fmt.Errorf("error"), nil, "", true},
+		{[]string{"bar"}, nil, fmt.Errorf("error"), "", true},
+	}
+
+	for _, tc := range testCases {
+		name := ""
+		if len(tc.args) > 0 {
+			name = tc.args[0]
+		}
+
+		testName := fmt.Sprintf(
+			"update the mutator %s",
+			name,
+		)
+		t.Run(testName, func(t *testing.T) {
+			mutator := types.FixtureMutator("my-id")
+			cli := test.NewMockCLI()
+
+			client := cli.Client.(*client.MockClient)
+			client.On(
+				"FetchMutator",
+				name,
+			).Return(mutator, tc.fetchResponse)
+
+			client.On(
+				"CreateMutator",
+				mock.Anything,
+			).Return(tc.updateResponse)
+
+			cmd := UpdateCommand(cli)
+			out, err := test.RunCmd(cmd, tc.args)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, tc.expectedOutput, out)
+		})
+	}
+}

--- a/types/mutator.go
+++ b/types/mutator.go
@@ -10,7 +10,6 @@ func (m *Mutator) Validate() error {
 	if err := ValidateName(m.Name); err != nil {
 		return errors.New("mutator name " + err.Error())
 	}
-
 	if m.Command == "" {
 		return errors.New("mutator command must be set")
 	}


### PR DESCRIPTION
## What is this change?

Adds support for mutators to the cli.

## Why is this change necessary?

Closes #1119 

## Does your change need a Changelog entry?

Yup!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

I also noticed an incorrect flag for filters in the handler interactive code, so I fixed it.