### PR TITLE
Increase etcd default storage to 4GB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024
 (default) to 65535.
+- Increased the default etcd size limit from 2GB to 4GB.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -198,6 +198,8 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	// This has to stay in ns until https://github.com/coreos/etcd/issues/9337
 	// is resolved.
 	cfg.AutoCompactionRetention = "1ns"
+	// Default to 4G etcd size. TODO: make this configurable.
+	cfg.QuotaBackendBytes = int64(4 * 1024 * 1024 * 1024)
 
 	if config.TLSConfig != nil {
 		cfg.ClientTLSInfo = (transport.TLSInfo)(config.TLSConfig.Info)


### PR DESCRIPTION
## What is this change?

Fixes #1143. 

## Why is this change necessary?

This change allows us to recover a sensu-backend whose db has grown past the default etcd limit of 2GB.

## Does your change need a Changelog entry?

Added note in unreleased.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!