### PR TITLE
Don't set GOGC=off for lint jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
         tags: true
 env:
   matrix:
-  - GOARCH=amd64 TEST_SUITE=lint GOGC=off
+  - GOARCH=amd64 TEST_SUITE=lint
   - GOARCH=386 TEST_SUITE=unit GOGC=off
   - GOARCH=amd64 TEST_SUITE=unit GOGC=off
   - GOARCH=386 TEST_SUITE=integration GOGC=off

--- a/cli/commands/mutator/interactive.go
+++ b/cli/commands/mutator/interactive.go
@@ -16,10 +16,6 @@ type mutatorOpts struct {
 	Org     string
 }
 
-const (
-	typeDefault = "pipe"
-)
-
 func newMutatorOpts() *mutatorOpts {
 	opts := mutatorOpts{}
 	return &opts


### PR DESCRIPTION
After some trial and error, I found that the GC was disabled for the lint job. Megacheck uses too much memory for that, so I re-enabled GC for the lint job.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Does your change need a Changelog entry?

No, this isn't really pertinent to the actual software.