### PR TITLE
Only use one lease per ring

### DIFF
--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -60,6 +60,8 @@ type Ring struct {
 	kv           clientv3.KV
 	backendID    string
 	leaseTimeout int64
+	leaseID      *clientv3.LeaseID
+	mu           sync.Mutex
 }
 
 // New returns a new Ring.
@@ -69,8 +71,28 @@ func New(name string, client *clientv3.Client) *Ring {
 		client:       client,
 		kv:           clientv3.NewKV(client),
 		backendID:    getBackendID(),
-		leaseTimeout: 15, // 15 seconds
+		leaseTimeout: 120, // 120 seconds
 	}
+}
+
+func (r *Ring) getLeaseID() (clientv3.LeaseID, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.leaseID == nil {
+		ctx := context.Background()
+		lease, err := r.client.Grant(ctx, r.leaseTimeout)
+		if err != nil {
+			return 0, err
+		}
+		ch, err := r.client.KeepAlive(ctx, lease.ID)
+		if err != nil {
+			return 0, err
+		}
+		<-ch
+
+		r.leaseID = &lease.ID
+	}
+	return *r.leaseID, nil
 }
 
 func newKey(prefix string) string {
@@ -91,19 +113,19 @@ func (r *Ring) Add(ctx context.Context, value string) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		lease, err := r.client.Grant(ctx, r.leaseTimeout)
+		key := newKey(r.Name)
+		putCmp := clientv3.Compare(clientv3.Version(key), "=", 0)
+		leaseID, err := r.getLeaseID()
 		if err != nil {
 			return err
 		}
-		key := newKey(r.Name)
-		putCmp := clientv3.Compare(clientv3.Version(key), "=", 0)
-		putOp := clientv3.OpPut(key, value, clientv3.WithLease(lease.ID))
+		putOp := clientv3.OpPut(key, value, clientv3.WithLease(leaseID))
 		cmps, ops, err := r.getRemovalOps(ctx, value)
 		if err != nil {
 			return err
 		}
 		ownershipAssertion := clientv3.OpPut(
-			path.Join(r.Name, value), r.backendID, clientv3.WithLease(lease.ID))
+			path.Join(r.Name, value), r.backendID, clientv3.WithLease(leaseID))
 		cmps = append(cmps, putCmp)
 		ops = append(ops, putOp, ownershipAssertion)
 		response, err := r.kv.Txn(ctx).If(cmps...).Then(ops...).Commit()
@@ -111,15 +133,7 @@ func (r *Ring) Add(ctx context.Context, value string) error {
 			return err
 		}
 		if response.Succeeded {
-			ch, err := r.client.KeepAlive(ctx, lease.ID)
-			if err != nil {
-				return err
-			}
-			<-ch
 			return nil
-		}
-		if _, err := r.client.Revoke(ctx, lease.ID); err != nil {
-			return err
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Only uses a single lease, and keepalive, per ring. This keeps us from creating a ton of goroutines.

## Why is this change necessary?

Closes #1163 

## Does your change need a Changelog entry?

Yes