### PR TITLE
Use a package level cache for ring leases.

### DIFF
--- a/backend/ring/ring_test.go
+++ b/backend/ring/ring_test.go
@@ -21,6 +21,7 @@ func TestAdd(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	ring := EtcdGetter{client}.GetRing("testadd")
 	err = ring.Add(context.Background(), "foo")
@@ -35,6 +36,7 @@ func TestRemove(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	ring := EtcdGetter{client}.GetRing("testremove")
 	require.NoError(t, ring.Add(context.Background(), "foo"))
@@ -49,6 +51,7 @@ func TestNext(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	ring := EtcdGetter{client}.GetRing("testnext")
 
@@ -82,6 +85,7 @@ func TestPeek(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	ring := EtcdGetter{client}.GetRing("testpeek")
 
@@ -107,6 +111,7 @@ func TestBlockOnNext(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	getter := EtcdGetter{client}
 
@@ -154,6 +159,7 @@ func TestTransferOwnership(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	getter := EtcdGetter{client}
 
@@ -185,6 +191,7 @@ func TestErrNotOwner(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	getter := EtcdGetter{client}
 
@@ -204,6 +211,7 @@ func TestExpire(t *testing.T) {
 
 	client, err := e.NewClient()
 	require.NoError(t, err)
+	defer client.Close()
 
 	ring := EtcdGetter{client}.GetRing("testexpire").(*Ring)
 	ring.leaseTimeout = 1
@@ -213,7 +221,7 @@ func TestExpire(t *testing.T) {
 	}
 
 	// Simulate the client dying
-	if _, err := ring.client.Revoke(context.Background(), *ring.leaseID); err != nil {
+	if _, err := ring.client.Revoke(context.Background(), leaseIDCache[ring.Name]); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Because new rings are made again and again, even for rings that
already exist, checking for a ring-scoped lease ID is not useful.
Instead, keep a cache of the lease IDs at the package scope,
keyed by ring ID.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Closes #1163 

## Why is this change necessary?

The previous fix was suboptimal.