### PR TITLE
Fixed shutting down message to not include %s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.
+- Fixed shutdown log message in backend
 
 ### Added
 - Support for managing mutators via sensuctl.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -188,7 +188,7 @@ type stopGroup []daemonStopper
 
 func (s stopGroup) Stop() (err error) {
 	for _, stopper := range s {
-		logger.Info("shutting down %s", stopper.Name)
+		logger.Info("shutting down ", stopper.Name)
 		e := stopper.Stop()
 		if err == nil {
 			err = e


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Removes an unnecessary format string parameter in backend shutdown messages.

## Why is this change necessary?

Cosmetics.