### PR TITLE
Comment out descriptions of PR template headings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,26 @@
 ## What is this change?
 
-A brief one-sentence-ish description of the change.
+<!-- A brief one-sentence-ish description of the change. -->
 
 
 ## Why is this change necessary?
 
-A brief description of why the change of behavior is necessary.
+<!-- A brief description of why the change of behavior is necessary. -->
 
 ## Does your change need a Changelog entry?
 
+<!--
 Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
+-->
 
 ## Do you need clarification on anything?
 
-Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable.
+<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->
 
 
 ## Were there any complications while making this change?
 
+<!--
 If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:
 
 - refactoring was required
@@ -25,3 +28,4 @@ If anything went awry while working on this change or if you ran into systemic i
 - it was difficult to get the information you needed to complete the issue
 
 Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
+-->


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

This updates the PR template to comment out the descriptions of these heads.

## Why is this change necessary?

We do this in our issue template, so it seems reasonable to be consistent.

## Does your change need a Changelog entry?

As this is a cosmetic change to the PR template and no functional change to the code, it seems reasonable not to have a changelog entry.

## Do you need clarification on anything?

## Were there any complications while making this change?
