### PR TITLE
Handle round-robin scheduling through WizardBus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 (default) to 65535.
 - Increased the default etcd size limit from 2GB to 4GB.
 - Move Hooks and Silenced out of Event and into Check.
+- Handle round-robin scheduling in wizardbus.
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -45,17 +45,15 @@ type Agentd struct {
 	store      Store
 	bus        messaging.MessageBus
 	tls        *types.TLSOptions
-	ringGetter types.RingGetter
 }
 
 // Config configures an Agentd.
 type Config struct {
-	Host       string
-	Port       int
-	Bus        messaging.MessageBus
-	Store      store.Store
-	RingGetter types.RingGetter
-	TLS        *types.TLSOptions
+	Host  string
+	Port  int
+	Bus   messaging.MessageBus
+	Store store.Store
+	TLS   *types.TLSOptions
 }
 
 // Option is a functional option.
@@ -64,16 +62,15 @@ type Option func(*Agentd) error
 // New creates a new Agentd.
 func New(c Config, opts ...Option) (*Agentd, error) {
 	a := &Agentd{
-		Host:       c.Host,
-		Port:       c.Port,
-		bus:        c.Bus,
-		store:      c.Store,
-		tls:        c.TLS,
-		ringGetter: c.RingGetter,
-		stopping:   make(chan struct{}, 1),
-		running:    &atomic.Value{},
-		wg:         &sync.WaitGroup{},
-		errChan:    make(chan error, 1),
+		Host:     c.Host,
+		Port:     c.Port,
+		bus:      c.Bus,
+		store:    c.Store,
+		tls:      c.TLS,
+		stopping: make(chan struct{}, 1),
+		running:  &atomic.Value{},
+		wg:       &sync.WaitGroup{},
+		errChan:  make(chan error, 1),
 	}
 	handler := middlewares.BasicAuthentication(http.HandlerFunc(a.webSocketHandler), a.store)
 	a.httpServer = &http.Server{
@@ -156,7 +153,7 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 
 	cfg.Subscriptions = addEntitySubscription(cfg.AgentID, cfg.Subscriptions)
 
-	session, err := NewSession(cfg, transport.NewTransport(conn), a.bus, a.store, a.ringGetter)
+	session, err := NewSession(cfg, transport.NewTransport(conn), a.bus, a.store)
 	if err != nil {
 		logger.Error("failed to create session: ", err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -55,7 +55,10 @@ func TestGoodSessionConfig(t *testing.T) {
 		sendCh: make(chan *transport.Message, 10),
 	}
 
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, bus.Start())
 
 	st := &mockstore.MockStore{}
@@ -72,8 +75,7 @@ func TestGoodSessionConfig(t *testing.T) {
 		Environment:   "env",
 		Subscriptions: []string{"testing"},
 	}
-	getter := &mockring.Getter{}
-	session, err := NewSession(cfg, conn, bus, st, getter)
+	session, err := NewSession(cfg, conn, bus, st)
 	assert.NotNil(t, session)
 	assert.NoError(t, err)
 }
@@ -83,7 +85,10 @@ func TestBadSessionConfig(t *testing.T) {
 		sendCh: make(chan *transport.Message, 10),
 	}
 
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, bus.Start())
 
 	st := &mockstore.MockStore{}
@@ -102,8 +107,7 @@ func TestBadSessionConfig(t *testing.T) {
 	cfg := SessionConfig{
 		Subscriptions: []string{"testing"},
 	}
-	getter := &mockring.Getter{}
-	session, err := NewSession(cfg, conn, bus, st, getter)
+	session, err := NewSession(cfg, conn, bus, st)
 	assert.Nil(t, session)
 	assert.Error(t, err)
 }

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/testing/mockmonitor"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,10 @@ import (
 )
 
 func TestEventHandling(t *testing.T) {
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, bus.Start())
 
 	mockStore := &mockstore.MockStore{}
@@ -72,7 +76,10 @@ func TestEventHandling(t *testing.T) {
 }
 
 func TestEventMonitor(t *testing.T) {
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, bus.Start())
 
 	mockStore := &mockstore.MockStore{}

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -8,13 +8,17 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEventdMonitor(t *testing.T) {
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 
 	if err := bus.Start(); err != nil {
 		assert.FailNow(t, "message bus failed to start")

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -9,13 +9,17 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKeepaliveMonitor(t *testing.T) {
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 
 	if err := bus.Start(); err != nil {
 		assert.FailNow(t, "message bus failed to start")

--- a/backend/messaging/benchmark_test.go
+++ b/backend/messaging/benchmark_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+
+	"github.com/sensu/sensu-go/testing/mockring"
 )
 
 func BenchmarkWizardBusPublish(b *testing.B) {
@@ -34,7 +36,9 @@ func BenchmarkWizardBusPublish(b *testing.B) {
 
 	for _, tc := range tt {
 		b.Run(fmt.Sprintf("%d-clients", tc), func(b *testing.B) {
-			bus := &WizardBus{}
+			bus, _ := NewWizardBus(WizardBusConfig{
+				RingGetter: &mockring.Getter{},
+			})
 			_ = bus.Start()
 
 			wg := &sync.WaitGroup{}

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -50,6 +50,11 @@ type MessageBus interface {
 
 	// Publish sends a message to a topic.
 	Publish(topic string, message interface{}) error
+
+	// PublishDirect routes a message to a single consumer of a topic.
+	// Implementations should make an effort for this to be fairly balanced
+	// between consumers.
+	PublishDirect(topic string, message interface{}) error
 }
 
 // SubscriptionTopic is a helper to determine the proper topic name for a

--- a/backend/messaging/wizard_bus_test.go
+++ b/backend/messaging/wizard_bus_test.go
@@ -6,17 +6,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWizardBus(t *testing.T) {
-	b := &WizardBus{}
+	b, err := NewWizardBus(WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, b.Start())
 
 	// Should be able to publish with no subscribers.
-	err := b.Publish("topic", "message1")
-	assert.NoError(t, err)
+	require.NoError(t, b.Publish("topic", "message1"))
 
 	c1 := make(chan interface{}, 100)
 	c2 := make(chan interface{}, 100)
@@ -77,7 +81,9 @@ func BenchmarkSubscribe(b *testing.B) {
 	rand.Seed(time.Now().UnixNano())
 
 	for _, tc := range testCases {
-		bus := &WizardBus{}
+		bus, _ := NewWizardBus(WizardBusConfig{
+			RingGetter: &mockring.Getter{},
+		})
 		_ = bus.Start()
 		b.Run(fmt.Sprintf("%d subscribers", tc), func(b *testing.B) {
 			b.SetParallelism(tc)
@@ -90,5 +96,48 @@ func BenchmarkSubscribe(b *testing.B) {
 			})
 		})
 		_ = bus.Stop()
+	}
+}
+
+func TestPublishDirect(t *testing.T) {
+	ring := &mockring.Ring{}
+	ring.On("Add", mock.Anything, mock.Anything).Return(nil)
+	ring.On("Next", mock.Anything).Return("a", nil)
+	getter := &mockring.Getter{"topic": ring}
+	bus, err := NewWizardBus(WizardBusConfig{
+		RingGetter: getter,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, bus.Start())
+	defer bus.Stop()
+
+	subscribers := map[string]chan interface{}{
+		"a": make(chan interface{}, 1),
+		"b": make(chan interface{}, 1),
+		"c": make(chan interface{}, 1),
+	}
+	for sub, ch := range subscribers {
+		require.NoError(t, bus.Subscribe("topic", sub, ch))
+	}
+	require.NoError(t, bus.PublishDirect("topic", "hello, world"))
+	select {
+	case msg := <-subscribers["a"]:
+		assert.Equal(t, msg, "hello, world")
+	case <-subscribers["b"]:
+		t.Error("got message on b")
+	case <-subscribers["c"]:
+		t.Error("got message on c")
+	default:
+		t.Error("no message sent")
+	}
+	select {
+	case <-subscribers["a"]:
+		t.Error("got message on a")
+	case <-subscribers["b"]:
+		t.Error("got message on b")
+	case <-subscribers["c"]:
+		t.Error("got message on c")
+	default:
 	}
 }

--- a/backend/messaging/wizard_topic.go
+++ b/backend/messaging/wizard_topic.go
@@ -12,6 +12,7 @@ type WizardTopic struct {
 // Send a message to all subscribers to this topic.
 func (wTopic *WizardTopic) Send(msg interface{}) {
 	wTopic.RLock()
+	defer wTopic.RUnlock()
 
 	for _, ch := range wTopic.Bindings {
 		select {
@@ -20,8 +21,6 @@ func (wTopic *WizardTopic) Send(msg interface{}) {
 			continue
 		}
 	}
-
-	wTopic.RUnlock()
 }
 
 // Subscribe a channel, identified by a consumer name, to this topic.

--- a/backend/pipelined/pipelined_test.go
+++ b/backend/pipelined/pipelined_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,10 @@ import (
 )
 
 func TestPipelined(t *testing.T) {
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	require.NoError(t, bus.Start())
 	store := &mockstore.MockStore{}
 

--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -31,7 +31,7 @@ var (
 	backendID   string
 	backendOnce sync.Once
 
-	leaseIDCache map[string]clientv3.LeaseID = make(map[string]clientv3.LeaseID)
+	leaseIDCache = make(map[string]clientv3.LeaseID)
 	pkgMu        sync.Mutex
 )
 

--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/sensu/sensu-go/backend/messaging"
-	"github.com/sensu/sensu-go/types"
 	sensutime "github.com/sensu/sensu-go/util/time"
 )
 
@@ -23,7 +22,6 @@ type CheckScheduler struct {
 	bus           messaging.MessageBus
 	wg            *sync.WaitGroup
 	logger        *logrus.Entry
-	ringGetter    types.RingGetter
 	ctx           context.Context
 	cancel        context.CancelFunc
 }
@@ -48,7 +46,7 @@ func (s *CheckScheduler) Start() error {
 			timer = NewIntervalTimer(s.checkName, uint(s.checkInterval))
 		}
 
-		executor := NewCheckExecutor(s.bus, newRoundRobinScheduler(s.ctx, s.bus, s.ringGetter), s.checkOrg, s.checkEnv)
+		executor := NewCheckExecutor(s.bus, newRoundRobinScheduler(s.ctx, s.bus), s.checkOrg, s.checkEnv)
 
 		// TODO(greg): Refactor this part to make the code more easily tested.
 		timer.Start()

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -9,9 +9,11 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestCheckScheduler struct {
@@ -34,7 +36,11 @@ func newScheduler(t *testing.T) *TestCheckScheduler {
 	scheduler.check = request.Config
 	scheduler.check.Interval = 1
 
-	scheduler.msgBus = &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
+	scheduler.msgBus = bus
 	schedulerState := &SchedulerState{}
 
 	manager := NewStateManager(&mockstore.MockStore{})

--- a/backend/schedulerd/executor_test.go
+++ b/backend/schedulerd/executor_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/queue"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
+	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdhocExecutor(t *testing.T) {
@@ -21,7 +23,10 @@ func TestAdhocExecutor(t *testing.T) {
 	if err != nil {
 		assert.FailNow(t, err.Error())
 	}
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	newAdhocExec := NewAdhocRequestExecutor(context.Background(), store, &queue.Memory{}, bus)
 	defer newAdhocExec.Stop()
 	assert.NoError(t, newAdhocExec.bus.Start())

--- a/backend/schedulerd/round_robin_scheduler_test.go
+++ b/backend/schedulerd/round_robin_scheduler_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/testing/mockbus"
-	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -15,13 +14,8 @@ func TestRoundRobinScheduler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bus := mockbus.MockBus{}
-	bus.On("Publish", "sensu:check:default:default:entity:agent1", mock.Anything).Return(nil)
-	ring := mockring.Ring{}
-	getter := mockring.Getter{
-		"subscription/ramen-vending-machine": &ring,
-	}
-	ring.On("Next", mock.Anything).Return("agent1", nil)
-	sched := newRoundRobinScheduler(ctx, &bus, getter)
+	bus.On("PublishDirect", "ramen-vending-machine", mock.Anything).Return(nil)
+	sched := newRoundRobinScheduler(ctx, &bus)
 	msg := &roundRobinMessage{
 		req:          types.FixtureCheckRequest("foo"),
 		subscription: "ramen-vending-machine",
@@ -29,6 +23,5 @@ func TestRoundRobinScheduler(t *testing.T) {
 	wg, err := sched.Schedule(msg)
 	require.NoError(t, err)
 	wg.Wait()
-	ring.AssertCalled(t, "Next", mock.Anything)
-	bus.AssertCalled(t, "Publish", "sensu:check:default:default:entity:agent1", msg.req)
+	bus.AssertCalled(t, "PublishDirect", "ramen-vending-machine", msg.req)
 }

--- a/backend/schedulerd/schedule_manager.go
+++ b/backend/schedulerd/schedule_manager.go
@@ -20,7 +20,7 @@ type ScheduleManager struct {
 }
 
 // NewScheduleManager creates a new ScheduleManager.
-func NewScheduleManager(msgBus messaging.MessageBus, stateMngr *StateManager, rg types.RingGetter) *ScheduleManager {
+func NewScheduleManager(msgBus messaging.MessageBus, stateMngr *StateManager) *ScheduleManager {
 	wg := &sync.WaitGroup{}
 	stopped := &atomic.Value{}
 
@@ -35,7 +35,6 @@ func NewScheduleManager(msgBus messaging.MessageBus, stateMngr *StateManager, rg
 			bus:           msgBus,
 			wg:            wg,
 			stateManager:  stateMngr,
-			ringGetter:    rg,
 		}
 	}
 

--- a/backend/schedulerd/schedulerd.go
+++ b/backend/schedulerd/schedulerd.go
@@ -12,7 +12,6 @@ import (
 // configured interval and publishing to the message bus.
 type Schedulerd struct {
 	store                store.Store
-	ringGetter           types.RingGetter
 	queueGetter          types.QueueGetter
 	bus                  messaging.MessageBus
 	stateManager         *StateManager
@@ -27,7 +26,6 @@ type Option func(*Schedulerd) error
 // Config configures Schedulerd.
 type Config struct {
 	Store       store.Store
-	RingGetter  types.RingGetter
 	QueueGetter types.QueueGetter
 	Bus         messaging.MessageBus
 }
@@ -36,13 +34,12 @@ type Config struct {
 func New(c Config, opts ...Option) (*Schedulerd, error) {
 	s := &Schedulerd{
 		store:        c.Store,
-		ringGetter:   c.RingGetter,
 		queueGetter:  c.QueueGetter,
 		bus:          c.Bus,
 		errChan:      make(chan error, 1),
 		stateManager: NewStateManager(c.Store),
 	}
-	s.schedulerManager = NewScheduleManager(s.bus, s.stateManager, s.ringGetter)
+	s.schedulerManager = NewScheduleManager(s.bus, s.stateManager)
 	for _, o := range opts {
 		if err := o(s); err != nil {
 			return nil, err

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -16,7 +16,10 @@ import (
 
 func TestSchedulerd(t *testing.T) {
 	// Setup wizard bus
-	bus := &messaging.WizardBus{}
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	require.NoError(t, err)
 	if berr := bus.Start(); berr != nil {
 		assert.FailNow(t, berr.Error())
 	}
@@ -36,7 +39,6 @@ func TestSchedulerd(t *testing.T) {
 
 	checker, err := New(Config{
 		Store:       st,
-		RingGetter:  mockring.Getter{},
 		QueueGetter: queue.NewMemoryGetter(),
 		Bus:         bus,
 	})

--- a/testing/mockbus/mock.go
+++ b/testing/mockbus/mock.go
@@ -48,3 +48,9 @@ func (m *MockBus) Unsubscribe(topic, consumer string) error {
 	args := m.Called(topic, consumer)
 	return args.Error(0)
 }
+
+// PublishDirect ...
+func (m *MockBus) PublishDirect(topic string, message interface{}) error {
+	args := m.Called(topic, message)
+	return args.Error(0)
+}


### PR DESCRIPTION
* Add PublishDirect method to messaging.MessageBus.
* Use ring for WizardBus PublishDirect implementation.
* Refactor codebase to use messaging.NewWizardBus.
* Remove ring-specific code from schedulerd.
* Remove ring-specific code from agentd.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1165 

## Does your change need a Changelog entry?

Affirmative