### PR TITLE
Add informational logging for entity keepalives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Increased the default etcd size limit from 2GB to 4GB.
 - Move Hooks and Silenced out of Event and into Check.
 - Handle round-robin scheduling in wizardbus.
+- Added informational logging for failed entity keepalives.
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -74,5 +74,6 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 		return adapterPtr.MessageBus.Publish(messaging.TopicEvent, deregistrationEvent)
 	}
 
+	logger.Infof("entity %s deregistered", entity.GetID())
 	return nil
 }

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -348,6 +348,7 @@ func (k *Keepalived) HandleFailure(entity *types.Entity, _ *types.Event) error {
 		return err
 	}
 
+	logger.Infof("keepalive timed out, creating keepalive event for entity %s", entity.GetID())
 	timeout := time.Now().Unix() + int64(entity.KeepaliveTimeout)
 	return k.store.UpdateFailingKeepalive(ctx, entity, timeout)
 }


### PR DESCRIPTION
## What is this change?

Adds some logging to Keepalived in case of monitor timeout or entity de-registration.

## Why is this change necessary?

Closes #1179 

## Does your change need a Changelog entry?

Added note under Changed.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!
