### PR TITLE
Don't use golint in the build process.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -154,7 +154,7 @@ build_command () {
 linter_commands () {
     echo "Running linter..."
 
-    gometalinter.v1 --vendor --disable-all --enable=vet --enable=golint --enable=ineffassign --enable=goconst --tests ./...
+    gometalinter.v1 --vendor --disable-all --enable=vet --enable=ineffassign --enable=goconst --tests ./...
     if [ $? -ne 0 ]; then
         echo "Linting failed..."
         exit 1


### PR DESCRIPTION
The readme for golint specifically states that we should not be
using golint for build acceptance, so we should respect that and
not include it in ours.

Signed-off-by: Eric Chlebek <eric@sensu.io>