### PR TITLE
Rework WizardBus Subscribe() method to remove subscriber ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Shut down sessions properly when agent connections are disrupted.
 - Fixed shutdown log message in backend
 - Stopped double-writing events in eventd
+- Agents from different orgs/envs with the same ID connected to the same backend
+  no longer overwrite each other's messagebus subscriptions.
 
 ### Added
 - Support for managing mutators via sensuctl.

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -232,7 +232,9 @@ func (s *Session) Stop() {
 	s.wg.Wait()
 
 	for sub := range s.subscriptions {
-		sub.Cancel()
+		if err := sub.Cancel(); err != nil {
+			logger.WithError(err).Error("unable to unsubscribe from message bus")
+		}
 	}
 	close(s.checkChannel)
 }

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -38,6 +38,8 @@ type Session struct {
 	sendq        chan *transport.Message
 	checkChannel chan interface{}
 	bus          messaging.MessageBus
+
+	subscriptions chan messaging.Subscription
 }
 
 func newSessionHandler(s *Session) *handler.MessageHandler {
@@ -77,18 +79,24 @@ func NewSession(cfg SessionConfig, conn transport.Transport, bus messaging.Messa
 	logger.Infof("agent connected: id=%s subscriptions=%s", cfg.AgentID, cfg.Subscriptions)
 
 	s := &Session{
-		ID:           id.String(),
-		conn:         conn,
-		cfg:          cfg,
-		stopping:     make(chan struct{}, 1),
-		wg:           &sync.WaitGroup{},
-		sendq:        make(chan *transport.Message, 10),
-		checkChannel: make(chan interface{}, 100),
-		store:        store,
-		bus:          bus,
+		ID:            id.String(),
+		conn:          conn,
+		cfg:           cfg,
+		stopping:      make(chan struct{}, 1),
+		wg:            &sync.WaitGroup{},
+		sendq:         make(chan *transport.Message, 10),
+		checkChannel:  make(chan interface{}, 100),
+		store:         store,
+		bus:           bus,
+		subscriptions: make(chan messaging.Subscription, len(cfg.Subscriptions)),
 	}
 	s.handler = newSessionHandler(s)
 	return s, nil
+}
+
+// Receiver returns the check channel for the session.
+func (s *Session) Receiver() chan<- interface{} {
+	return s.checkChannel
 }
 
 func (s *Session) recvPump() {
@@ -194,7 +202,7 @@ func (s *Session) Start() (err error) {
 	go s.subPump()
 
 	org, env := s.cfg.Organization, s.cfg.Environment
-	agentID := s.cfg.AgentID
+	agentID := fmt.Sprintf("%s:%s:%s", org, env, s.cfg.AgentID)
 
 	defer func() {
 		if err != nil {
@@ -205,11 +213,14 @@ func (s *Session) Start() (err error) {
 	for _, sub := range s.cfg.Subscriptions {
 		topic := messaging.SubscriptionTopic(org, env, sub)
 		logger.Debugf("Subscribing to topic %q", topic)
-		if err := s.bus.Subscribe(topic, agentID, s.checkChannel); err != nil {
+		subscription, err := s.bus.Subscribe(topic, agentID, s)
+		if err != nil {
 			logger.WithError(err).Error("error starting subscription")
 			return err
 		}
+		s.subscriptions <- subscription
 	}
+	close(s.subscriptions)
 
 	return nil
 }
@@ -220,18 +231,8 @@ func (s *Session) Stop() {
 	close(s.stopping)
 	s.wg.Wait()
 
-	org, env := s.cfg.Organization, s.cfg.Environment
-	agentID := s.cfg.AgentID
-
-	for _, sub := range s.cfg.Subscriptions {
-		topic := messaging.SubscriptionTopic(org, env, sub)
-		logger.Debugf("Unsubscribing from topic %q", topic)
-		if err := s.bus.Unsubscribe(topic, agentID); err != nil {
-			// Bus has stopped running already, no need for further unsubscribe
-			// attempts.
-			logger.Debug(err)
-			break
-		}
+	for sub := range s.subscriptions {
+		sub.Cancel()
 	}
 	close(s.checkChannel)
 }

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -286,7 +286,9 @@ func (e *Eventd) createFailedCheckEvent(ctx context.Context, event *types.Event)
 // Stop eventd.
 func (e *Eventd) Stop() error {
 	logger.Info("shutting down eventd")
-	e.subscription.Cancel()
+	if err := e.subscription.Cancel(); err != nil {
+		logger.WithError(err).Error("unable to unsubscribe from message bus")
+	}
 	close(e.eventChan)
 	close(e.shutdownChan)
 	e.wg.Wait()

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -34,6 +34,7 @@ type Eventd struct {
 	monitorFactory monitor.FactoryFunc
 
 	eventChan    chan interface{}
+	subscription messaging.Subscription
 	errChan      chan error
 	monitors     map[string]monitor.Interface
 	mu           *sync.Mutex
@@ -74,10 +75,16 @@ func New(c Config, opts ...Option) (*Eventd, error) {
 	return e, nil
 }
 
+// Receiver returns the event receiver channel.
+func (e *Eventd) Receiver() chan<- interface{} {
+	return e.eventChan
+}
+
 // Start eventd.
 func (e *Eventd) Start() error {
 	e.wg.Add(e.handlerCount)
-	err := e.bus.Subscribe(messaging.TopicEventRaw, ComponentName, e.eventChan)
+	sub, err := e.bus.Subscribe(messaging.TopicEventRaw, "eventd", e)
+	e.subscription = sub
 	if err != nil {
 		return err
 	}
@@ -279,11 +286,11 @@ func (e *Eventd) createFailedCheckEvent(ctx context.Context, event *types.Event)
 // Stop eventd.
 func (e *Eventd) Stop() error {
 	logger.Info("shutting down eventd")
-	err := e.bus.Unsubscribe(messaging.TopicEventRaw, ComponentName)
+	e.subscription.Cancel()
 	close(e.eventChan)
 	close(e.shutdownChan)
 	e.wg.Wait()
-	return err
+	return nil
 }
 
 // Status returns an error if eventd is unhealthy.

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -87,6 +87,6 @@ func TestEventdMonitor(t *testing.T) {
 	}
 	assert.Equal(t, uint32(1), warnEvent.Check.Status)
 
-	sub.Cancel()
+	assert.NoError(t, sub.Cancel())
 	close(eventChan)
 }

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testReceiver struct {
+	c chan interface{}
+}
+
+func (r testReceiver) Receiver() chan<- interface{} {
+	return r.c
+}
+
 func TestEventdMonitor(t *testing.T) {
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
 		RingGetter: &mockring.Getter{},
@@ -26,7 +34,11 @@ func TestEventdMonitor(t *testing.T) {
 
 	eventChan := make(chan interface{}, 2)
 
-	if err := bus.Subscribe(messaging.TopicEvent, "test", eventChan); err != nil {
+	subscriber := testReceiver{
+		c: eventChan,
+	}
+	sub, err := bus.Subscribe(messaging.TopicEvent, "testReceiver", subscriber)
+	if err != nil {
 		assert.FailNow(t, "failed to subscribe to message bus topic event")
 	}
 
@@ -74,4 +86,7 @@ func TestEventdMonitor(t *testing.T) {
 		assert.FailNow(t, "message type was not an event")
 	}
 	assert.Equal(t, uint32(1), warnEvent.Check.Status)
+
+	sub.Cancel()
+	close(eventChan)
 }

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -27,9 +27,14 @@ func TestKeepaliveMonitor(t *testing.T) {
 
 	eventChan := make(chan interface{}, 2)
 
-	if err := bus.Subscribe(messaging.TopicEventRaw, "test", eventChan); err != nil {
+	tsub := testSubscriber{
+		ch: eventChan,
+	}
+	subscription, err := bus.Subscribe(messaging.TopicEventRaw, "testSubscriber", tsub)
+	if err != nil {
 		assert.FailNow(t, "failed to subscribe to message bus topic event raw")
 	}
+	defer subscription.Cancel()
 
 	store, err := testutil.NewStoreInstance()
 	if err != nil {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -49,6 +49,7 @@ type Keepalived struct {
 	monitors              map[string]monitor.Interface
 	wg                    *sync.WaitGroup
 	keepaliveChan         chan interface{}
+	subscription          messaging.Subscription
 	errChan               chan error
 }
 
@@ -85,16 +86,23 @@ func New(c Config, opts ...Option) (*Keepalived, error) {
 	return k, nil
 }
 
+// Receiver returns the keepalive receiver channel.
+func (k *Keepalived) Receiver() chan<- interface{} {
+	return k.keepaliveChan
+}
+
 // Start starts the daemon, returning an error if preconditions for startup
 // fail.
 func (k *Keepalived) Start() error {
 
-	err := k.bus.Subscribe(messaging.TopicKeepalive, "keepalived", k.keepaliveChan)
+	sub, err := k.bus.Subscribe(messaging.TopicKeepalive, "keepalived", k)
 	if err != nil {
 		return err
 	}
+	k.subscription = sub
+
 	if err := k.initFromStore(); err != nil {
-		_ = k.bus.Unsubscribe(messaging.TopicKeepalive, "keepalived")
+		k.subscription.Cancel()
 		return err
 	}
 
@@ -108,14 +116,14 @@ func (k *Keepalived) Start() error {
 // Stop stops the daemon, returning an error if one was encountered during
 // shutdown.
 func (k *Keepalived) Stop() error {
+	k.subscription.Cancel()
 	close(k.keepaliveChan)
 	k.wg.Wait()
 	for _, monitor := range k.monitors {
 		go monitor.Stop()
 	}
-	err := k.bus.Unsubscribe(messaging.TopicKeepalive, "keepalived")
 	close(k.errChan)
-	return err
+	return nil
 }
 
 // Status returns nil if the Daemon is healthy, otherwise it returns an error.

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -235,7 +235,7 @@ func TestProcessRegistration(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedLen, len(tsub.ch))
-			subscription.Cancel()
+			assert.NoError(t, subscription.Cancel())
 		})
 	}
 }

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -34,12 +34,12 @@ type Subscriber interface {
 // A Subscription is a cancellable subscription to a WizardTopic.
 type Subscription struct {
 	id     string
-	cancel func(string)
+	cancel func(string) error
 }
 
 // Cancel a WizardSubscription.
-func (t Subscription) Cancel() {
-	t.cancel(t.id)
+func (t Subscription) Cancel() error {
+	return t.cancel(t.id)
 }
 
 // MessageBus is the interface to the internal messaging system.

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -21,13 +21,14 @@ const (
 // handler configuration determines which Sensu filters and mutator
 // are used.
 type Pipelined struct {
-	stopping  chan struct{}
-	running   *atomic.Value
-	wg        *sync.WaitGroup
-	errChan   chan error
-	eventChan chan interface{}
-	store     store.Store
-	bus       messaging.MessageBus
+	stopping     chan struct{}
+	running      *atomic.Value
+	wg           *sync.WaitGroup
+	errChan      chan error
+	eventChan    chan interface{}
+	subscription messaging.Subscription
+	store        store.Store
+	bus          messaging.MessageBus
 }
 
 // Config configures a Pipelined.
@@ -58,12 +59,19 @@ func New(c Config, options ...Option) (*Pipelined, error) {
 	return p, nil
 }
 
+// Receiver returns the event channel for pipelined.
+func (p *Pipelined) Receiver() chan<- interface{} {
+	return p.eventChan
+}
+
 // Start pipelined, subscribing to the "event" message bus topic to
 // pass Sensu events to the pipelines for handling (goroutines).
 func (p *Pipelined) Start() error {
-	if err := p.bus.Subscribe(messaging.TopicEvent, "pipelined", p.eventChan); err != nil {
+	sub, err := p.bus.Subscribe(messaging.TopicEvent, "pipelined", p)
+	if err != nil {
 		return err
 	}
+	p.subscription = sub
 
 	p.createPipelines(PipelineCount, p.eventChan)
 
@@ -76,10 +84,10 @@ func (p *Pipelined) Stop() error {
 	close(p.stopping)
 	p.wg.Wait()
 	close(p.errChan)
-	err := p.bus.Unsubscribe(messaging.TopicEvent, "pipelined")
+	p.subscription.Cancel()
 	close(p.eventChan)
 
-	return err
+	return nil
 }
 
 // Status returns an error if pipelined is unhealthy.

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -84,10 +84,10 @@ func (p *Pipelined) Stop() error {
 	close(p.stopping)
 	p.wg.Wait()
 	close(p.errChan)
-	p.subscription.Cancel()
+	err := p.subscription.Cancel()
 	close(p.eventChan)
 
-	return nil
+	return err
 }
 
 // Status returns an error if pipelined is unhealthy.

--- a/testing/mockbus/mock.go
+++ b/testing/mockbus/mock.go
@@ -1,6 +1,9 @@
 package mockbus
 
-import "github.com/stretchr/testify/mock"
+import (
+	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/stretchr/testify/mock"
+)
 
 // MockBus ...
 type MockBus struct {
@@ -32,20 +35,14 @@ func (m *MockBus) Err() <-chan error {
 }
 
 // Subscribe ...
-func (m *MockBus) Subscribe(topic string, consumer string, channel chan<- interface{}) error {
-	args := m.Called(topic, consumer, channel)
-	return args.Error(0)
+func (m *MockBus) Subscribe(topic string, consumer string, subscriber messaging.Subscriber) (messaging.Subscription, error) {
+	args := m.Called(topic, consumer, subscriber)
+	return args.Get(0).(messaging.Subscription), args.Error(1)
 }
 
 // Publish ...
 func (m *MockBus) Publish(topic string, message interface{}) error {
 	args := m.Called(topic, message)
-	return args.Error(0)
-}
-
-// Unsubscribe ...
-func (m *MockBus) Unsubscribe(topic, consumer string) error {
-	args := m.Called(topic, consumer)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Removes the concept of subscriber IDs from the message bus, and instead Subscribe takes a Subscriber and returns a Subscription (which can be later cancelled).


## Why is this change necessary?

This fixes #1097. Rather than simply prolonging the life of user-supplied subscriber IDs, we decided to tackle this bit of tech debt now.

## Does your change need a Changelog entry?

Added.
