### PR TITLE
Updated etcd to 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Move Hooks and Silenced out of Event and into Check.
 - Handle round-robin scheduling in wizardbus.
 - Added informational logging for failed entity keepalives.
+- Updated etcd to 3.3.2 from 3.3.1 to fix an issue with autocompaction settings.
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -114,8 +114,8 @@
     "wal",
     "wal/walpb"
   ]
-  revision = "28f3f26c0e303392556035b694f75768d449d33d"
-  version = "v3.3.1"
+  revision = "c9d46ab3799b7f2174268e75f72d01e6d6aac953"
+  version = "v3.3.2"
 
 [[projects]]
   name = "github.com/coreos/go-semver"
@@ -550,8 +550,7 @@
   packages = [
     "assert",
     "mock",
-    "require",
-    "suite"
+    "require"
   ]
   revision = "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f"
 
@@ -712,6 +711,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4896971be68d4cc9956d44ff68d70559206444b3b855c15dfd01b73a238c72a0"
+  inputs-digest = "77eb53019a0b9a5ee6653e3f38ba8b3ad2e39bdf05960f4d022db4ddc331d78b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -134,7 +134,7 @@ required = ["github.com/shirou/w32"]
 
 [[constraint]]
   name = "github.com/coreos/etcd"
-  version = "3.3.1"
+  version = "3.3.2"
 
 [[constraint]]
   name = "github.com/robfig/cron"

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -197,7 +197,7 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	cfg.AutoCompactionMode = "revision"
 	// This has to stay in ns until https://github.com/coreos/etcd/issues/9337
 	// is resolved.
-	cfg.AutoCompactionRetention = "1ns"
+	cfg.AutoCompactionRetention = "1"
 	// Default to 4G etcd size. TODO: make this configurable.
 	cfg.QuotaBackendBytes = int64(4 * 1024 * 1024 * 1024)
 


### PR DESCRIPTION
## What is this change?

Updates etcd to 3.3.2 so we can set autocompaction revision to an actual int instead of a time-based value.

## Why is this change necessary?

Closes #1069 

## Does your change need a Changelog entry?

Added a note under Changed section.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!