### PR TITLE
Support adding rules to role on creation via cli.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and yarn are now dependencies for building the backend.
 - Updated etcd to 3.3.2 from 3.3.1 to fix an issue with autocompaction settings.
 - Updated and corrected logging style for variable fields.
 - Build protobufs with go generate.
+- Creating roles via sensuctl now supports passing flags for setting permissions
+  rules.
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.

--- a/cli/commands/role/create_test.go
+++ b/cli/commands/role/create_test.go
@@ -8,6 +8,7 @@ import (
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateCommand(t *testing.T) {
@@ -22,7 +23,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.Regexp("roles", cmd.Short)
 }
 
-func TestListCommandRunEClosureSucess(t *testing.T) {
+func TestCreateCommandRunEClosureSucess(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 
@@ -30,13 +31,34 @@ func TestListCommandRunEClosureSucess(t *testing.T) {
 	client.On("CreateRole", mock.AnythingOfType("*types.Role")).Return(nil)
 
 	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("type", "*"))
+	require.NoError(t, cmd.Flags().Set("create", "t"))
 	out, err := test.RunCmd(cmd, []string{"my-name"})
 
 	assert.Contains(out, "Created")
 	assert.NoError(err)
 }
 
-func TestListCommandRunEClosureServerErr(t *testing.T) {
+func TestCreateCommandRunEClosureWithAllFlags(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	client := cli.Client.(*clientmock.MockClient)
+	client.On("CreateRole", mock.AnythingOfType("*types.Role")).Return(nil)
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("type", "*"))
+	require.NoError(t, cmd.Flags().Set("create", "t"))
+	require.NoError(t, cmd.Flags().Set("delete", "t"))
+	require.NoError(t, cmd.Flags().Set("read", "t"))
+	require.NoError(t, cmd.Flags().Set("update", "t"))
+	out, err := test.RunCmd(cmd, []string{"my-name"})
+
+	assert.Regexp("Created", out)
+	assert.Nil(err)
+}
+
+func TestCreateCommandRunEClosureServerErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 
@@ -50,7 +72,25 @@ func TestListCommandRunEClosureServerErr(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestListCommandRunEClosureMissingArgs(t *testing.T) {
+func TestCreateCommandRunEClosureMissingType(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	client := cli.Client.(*clientmock.MockClient)
+	client.On("CreateRole", mock.AnythingOfType("*types.Role")).Return(nil)
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("create", "t"))
+	require.NoError(t, cmd.Flags().Set("delete", "t"))
+	require.NoError(t, cmd.Flags().Set("read", "t"))
+	require.NoError(t, cmd.Flags().Set("update", "t"))
+	out, err := test.RunCmd(cmd, []string{"hello"})
+
+	assert.Empty(out)
+	assert.Error(err)
+}
+
+func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 

--- a/testing/e2e/rbac_test.go
+++ b/testing/e2e/rbac_test.go
@@ -172,20 +172,14 @@ func TestRBAC(t *testing.T) {
 
 	// Create roles for every environment
 	defaultRole := types.FixtureRole("default", "default", "default")
-	output, err = adminctl.run("role", "create", defaultRole.Name)
-	assert.NoError(t, err, string(output))
-	output, err = adminctl.run("role", "add-rule", defaultRole.Name,
+	output, err = adminctl.run("role", "create", defaultRole.Name,
 		"--type", defaultRole.Rules[0].Type,
-		"--organization", defaultRole.Rules[0].Organization,
-		"--environment", defaultRole.Rules[0].Environment,
 		"-crud",
 	)
 	assert.NoError(t, err, string(output))
 
 	devRole := types.FixtureRole("dev", "acme", "dev")
-	output, err = adminctl.run("role", "create", devRole.Name)
-	assert.NoError(t, err, string(output))
-	output, err = adminctl.run("role", "add-rule", devRole.Name,
+	output, err = adminctl.run("role", "create", devRole.Name,
 		"--type", devRole.Rules[0].Type,
 		"--organization", devRole.Rules[0].Organization,
 		"--environment", devRole.Rules[0].Environment,
@@ -194,9 +188,7 @@ func TestRBAC(t *testing.T) {
 	assert.NoError(t, err, string(output))
 
 	prodRole := types.FixtureRole("prod", "acme", "prod")
-	output, err = adminctl.run("role", "create", prodRole.Name)
-	assert.NoError(t, err, string(output))
-	output, err = adminctl.run("role", "add-rule", prodRole.Name,
+	output, err = adminctl.run("role", "create", prodRole.Name,
 		"--type", prodRole.Rules[0].Type,
 		"--organization", prodRole.Rules[0].Organization,
 		"--environment", prodRole.Rules[0].Environment,


### PR DESCRIPTION
Signed-off-by: Mercedes Coyle <mercedes@sensu.io>

## What is this change?

Adds type, create, read, update, delete flags to role creation in
sensuctl.

## Why is this change necessary?

Closes #1196 

## Does your change need a Changelog entry?

Added a note to the **Changed** section.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

This command is laid out slightly differently than our other commands, in add_rule.go takes the place of interactive.go in our other commands. I'm thinking that add_rule should really be a subcommand, and we create an interactive.go for create/update etc. Thoughts? This is also something we can refactor later if we choose to.