### PR TITLE
backend/eventd: don't double write events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.
 - Fixed shutdown log message in backend
+- Stopped double-writing events in eventd
 
 ### Added
 - Support for managing mutators via sensuctl.

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -208,11 +208,6 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 		return mon.HandleUpdate(event)
 	}
 
-	err = e.store.UpdateEvent(ctx, event)
-	if err != nil {
-		return err
-	}
-
 	return e.bus.Publish(messaging.TopicEvent, event)
 }
 


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Only write an event once when handling it in eventd.

## Why is this change necessary?

We were erroneously double-writing all events.