### PR TITLE
Fixup panic when resolving events

### DIFF
--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -61,6 +61,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		queueGetter:   c.QueueGetter,
 		tls:           c.TLS,
 		backendStatus: c.BackendStatus,
+		bus:           c.Bus,
 		stopping:      make(chan struct{}, 1),
 		running:       &atomic.Value{},
 		wg:            &sync.WaitGroup{},

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -136,7 +136,7 @@ func (r *mutationsImpl) ResolveEvent(p schema.MutationResolveEventFieldResolverP
 
 	if event.Check != nil && event.Check.Status > 0 {
 		event.Check.Status = 0
-		event.Check.Output = "Manually resolved manually with " + p.Args.Input.Source
+		event.Check.Output = "Resolved manually with " + p.Args.Input.Source
 		event.Timestamp = int64(time.Now().Unix())
 
 		err = r.eventController.CreateOrReplace(ctx, *event)

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -139,7 +139,7 @@ func (r *mutationsImpl) ResolveEvent(p schema.MutationResolveEventFieldResolverP
 		event.Check.Output = "Manually resolved manually with " + p.Args.Input.Source
 		event.Timestamp = int64(time.Now().Unix())
 
-		err = r.eventController.Create(ctx, *event)
+		err = r.eventController.CreateOrReplace(ctx, *event)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -30,8 +30,8 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 	routes.path("{entity}", r.listByEntity).Methods(http.MethodGet)
 	routes.path("{entity}/{check}", r.find).Methods(http.MethodGet)
 	routes.path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
+	routes.path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
 	routes.post(r.create)
-	routes.put(r.createOrReplace)
 }
 
 func (r *EventsRouter) list(req *http.Request) (interface{}, error) {

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -70,7 +70,7 @@ func (client *RestClient) ResolveEvent(event *types.Event) error {
 		return err
 	}
 
-	res, err := client.R().SetBody(bytes).Post("/events")
+	res, err := client.R().SetBody(bytes).Put("/events/" + event.Entity.ID + "/" + event.Check.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Message bus was not being passed down to the events router, causing a panic when the controller attempted to publish the event.

## Why is this change necessary?

Unable to resolve events.

## Does your change need a Changelog entry?

I believe the bug was introduced prior to last release.