### PR TITLE
Add distinction between global & local flags in sensuctl usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ code and severity (ex. 0, ok).
 - Govaluate's modifier tokens can now be optionally forbidden.
 - Increase the stack size on Travis CI.
 - Refactor store, queue and ring interfaces, and daemon I/O details.
+- Separated global from local flags in sensuctl usage.
 
 ### Fixed
 - Fixed a bug in time.InWindow that in some cases would cause subdued checks to

--- a/cli/cmd/cobra.go
+++ b/cli/cmd/cobra.go
@@ -10,7 +10,8 @@ func init() {
 	cobra.AddTemplateFunc("hasManagementSubCommands", hasManagementSubCommands)
 	cobra.AddTemplateFunc("operationalSubCommands", operationalSubCommands)
 	cobra.AddTemplateFunc("managementSubCommands", managementSubCommands)
-	cobra.AddTemplateFunc("wrappedFlagUsages", wrappedFlagUsages)
+	cobra.AddTemplateFunc("wrappedInheritedFlagUsages", wrappedInheritedFlagUsages)
+	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
 }
 
 func hasOperationalSubCommands(cmd *cobra.Command) bool {
@@ -41,10 +42,18 @@ func managementSubCommands(cmd *cobra.Command) []*cobra.Command {
 	return cmds
 }
 
-func wrappedFlagUsages(cmd *cobra.Command) string {
+func wrappedInheritedFlagUsages(cmd *cobra.Command) string {
 	width := 80
 	if ws, err := term.GetWinsize(0); err == nil {
 		width = int(ws.Width)
 	}
-	return cmd.Flags().FlagUsagesWrapped(width - 1)
+	return cmd.InheritedFlags().FlagUsagesWrapped(width - 1)
+}
+
+func wrappedLocalFlagUsages(cmd *cobra.Command) string {
+	width := 80
+	if ws, err := term.GetWinsize(0); err == nil {
+		width = int(ws.Width)
+	}
+	return cmd.LocalFlags().FlagUsagesWrapped(width - 1)
 }

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -77,10 +77,17 @@ var usageTemplate = `Usage:
 
 {{ .Short | trim }}
 
-{{- if .HasFlags}}
+{{- if .HasAvailableLocalFlags}}
 
-Options:
-{{ wrappedFlagUsages . | trimRightSpace}}
+Flags:
+{{ wrappedLocalFlagUsages . | trimRightSpace}}
+
+{{- end}}
+
+{{- if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{ wrappedInheritedFlagUsages . | trimRightSpace}}
 
 {{- end}}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds a distinction between the type of flags in sensuctl usage.

Before:
```
$sensuctl check create -h
[...]
Options:
      --api-url string               host URL of Sensu installation
      --cache-dir string             path to directory containing cache & temporary files (default "/Users/splourde/Library/Caches/sensu/sensuctl")
  -c, --command string               the command the check should run
      --config-dir string            path to directory containing configuration files (default "/Users/splourde/.config/sensu/sensuctl")
      --cron string                  the cron schedule at which the check is run
      --environment string           environment in which we perform actions (default "default")
      --handlers string              comma separated list of handlers to invoke when check fails
  -h, --help                         help for create
      --high-flap-threshold string   flap detection high threshold (percent state change) for the check
      --interactive                  Determines if CLI is in interactive mode
  -i, --interval string              interval, in seconds, at which the check is run
      --low-flap-threshold string    flap detection low threshold (percent state change) for the check
      --organization string          organization in which we perform actions (default "default")
      --proxy-entity-id string       the check proxy entity, used to create a proxy entity for an external resource
  -p, --publish                      publish check requests (default true)
  -r, --runtime-assets string        comma separated list of assets this check depends on
      --stdin                        accept event data via STDIN
  -s, --subscriptions string         comma separated list of topics check requests will be sent to
  -t, --timeout string               timeout, in seconds, at which the check has to run
      --ttl string                   time to live in seconds for which a check result is valid
```

Now:
```
$ sensuctl check create -h
[...]
Flags:
  -c, --command string               the command the check should run
      --cron string                  the cron schedule at which the check is run
      --handlers string              comma separated list of handlers to invoke when check fails
  -h, --help                         help for create
      --high-flap-threshold string   flap detection high threshold (percent state change) for the check
      --interactive                  Determines if CLI is in interactive mode
  -i, --interval string              interval, in seconds, at which the check is run
      --low-flap-threshold string    flap detection low threshold (percent state change) for the check
      --proxy-entity-id string       the check proxy entity, used to create a proxy entity for an external resource
  -p, --publish                      publish check requests (default true)
  -r, --runtime-assets string        comma separated list of assets this check depends on
      --stdin                        accept event data via STDIN
  -s, --subscriptions string         comma separated list of topics check requests will be sent to
  -t, --timeout string               timeout, in seconds, at which the check has to run
      --ttl string                   time to live in seconds for which a check result is valid

Global Flags:
      --api-url string        host URL of Sensu installation
      --cache-dir string      path to directory containing cache & temporary files (default "/Users/splourde/Library/Caches/sensu/sensuctl")
      --config-dir string     path to directory containing configuration files (default "/Users/splourde/.config/sensu/sensuctl")
      --environment string    environment in which we perform actions (default "default")
      --organization string   organization in which we perform actions (default "default")
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1122

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!