### PR TITLE
Remove short description

### DIFF
--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -75,8 +75,6 @@ var usageTemplate = `Usage:
 {{- if not .HasSubCommands}}	{{.UseLine}}{{end}}
 {{- if .HasSubCommands}}	{{ .CommandPath}} COMMAND{{end}}
 
-{{ .Short | trim }}
-
 {{- if .HasAvailableLocalFlags}}
 
 Flags:


### PR DESCRIPTION
## What is this change?

Removes the short description from the usage template.

## Why is this change necessary?

Fixes duplicate description in the help text.

## Does your change need a Changelog entry?

It's really minor and doesn't affect usage, so I didn't add one.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!