### PR TITLE
Build version-bin in Makefile first-pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ jobs:
         branch: master
     - provider: script
       skip_cleanup: true
-      script: "./build.sh deploy"
+      script: "./build.sh deploy versioned"
       on:
         tags: true
         branch: master
     - provider: script
       skip_cleanup: true
-      script: "./build.sh deploy"
+      script: "./build.sh deploy nightly"
       on:
         condition: $DEPLOY = true
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default version clean
+.PHONY: default clean
 .PHONY: android darwin dragonfly freebsd linux netbsd openbsd plan9 solaris windows
 .PHONY: sensu_agent sensu_backend sensu_cli
 .PHONY: hooks packages rpms debs
@@ -18,6 +18,7 @@ WINDOWS_ARCHITECTURES   := 386 amd64
 # Setup
 ##
 $(shell mkdir -p out)
+VERSION_BIN := $(shell go build -o version-bin ./version/cmd/version/version.go)
 
 ##
 # FPM
@@ -73,10 +74,7 @@ HOOKS_VALUES+= common_files=os-functions,group-functions,user-functions,other-fu
 ##
 default: all
 
-all: version_bin linux
-
-version_bin:
-	go build -o version-bin ./version/cmd/version/version.go
+all: linux
 
 clean:
 	rm -r out/


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Only builds version-bin once in the first-pass of the Makefile.

## Why is this change necessary?

We need version-bin in the first-pass of the Makefile but it was being built in the second-pass.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!