### PR TITLE
Build version-bin in build.sh after dep installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,12 +41,17 @@ install_deps () {
     go get honnef.co/go/tools/cmd/megacheck
     go get github.com/golang/lint/golint
     install_golang_dep
+    build_version_bin
 }
 
 install_golang_dep() {
     go get github.com/golang/dep/cmd/dep
     echo "Running dep ensure..."
     dep ensure -v -vendor-only
+}
+
+build_version_bin () {
+    go build -o version-bin ./version/cmd/version/version.go
 }
 
 cmd_name_map() {


### PR DESCRIPTION
## What is this change?

Builds version-bin in build.sh after dep installation.

## Why is this change necessary?

We're trying to use version-bin before it's built.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!