### PR TITLE
Hardcode SENSU_BUILD_ITERATION for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
       skip_cleanup: true
       script: "./build.sh deploy nightly"
       on:
-        condition: $DEPLOY = true
+        condition: $TRAVIS_EVENT_TYPE = api
 env:
   matrix:
   - GOARCH=amd64 TEST_SUITE=lint
@@ -57,6 +57,7 @@ env:
   - GOARCH=amd64 TEST_SUITE=e2e GOGC=off
   - TEST_SUITE=dashboard-ci GOGC=off
   global:
+  - SENSU_BUILD_ITERATION=1
   # Docker Username (DOCKER_USERNAME)
   - secure: "MFxHUNzPqyYaoQcWtHFi1NdxMEWkoU66xh9J0M9du/uOgFt3URfelPPFAFtjPfhXqMUuNKTopc5H2SiBfazyZw8IswAbbRHn0AKOSux5WuqHwIz4/PoNYnQihmvYo87DdWSeyKaR0da7ks142zatfkUy71ae7RdsAzHtKGdIfEn+lBLkPfVG65faDyWoQvRwJd0uRcvzRSj2eUP9REdTenKDNM8OBeoZAhFm7xhV6d8K54EnMf2JfPgzXNH/LttTpWH0/XtyT1C4Lsz7DWEMWr6z4OavC1M2EysrNCK7g75SHguFZYKjbHmpjSBQcQs8T26UhHVWEPnXwaFuQKuogBM0AzN+7qUWmhqxVQF9Z3GQBdCyhP1Cet1cR8UHYiYkTkPCF/YVXRG6MgKxnW/UOkjOUQCQf1Nr5o2pP7vBrdevMIXfT2268aR60289scQSDMzFuwmYqeJ6mLWJal9rfpl6GumUv7ois7V/gvKRDI6LPTAVv9z42v29ZaQoqDi1Csuyi+ShTmeAQI3flgAb3Wg01nEyaQtQMLwVVMDfPJjhALM7cu7XbPkOTvSQBYdKgqRXs2c4jN4cTN/G2yMiRrGrkxSZR/eygipZXJW2Fb+zc+loo+SrjKB38yiPYjuVA22GVqHHezRzbgNZQKn/RknR5iNd9SUdB/xFrK+ccyY="
   # Docker Password (DOCKER_PASSWORD)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Hardcode SENSU_BUILD_ITERATION and use TRAVIS_EVENT_TYPE to determine if a nightly build should be run.

## Why is this change necessary?

The `deep_merge` functionality in Travis CI's API doesn't seem to work with global environment variables. I have reached out to Travis CI last week but have not received a response yet. This is an attempt at a workaround until we know if it's possible for global environment variables provided by API requests to be merged with `.travis.yml`.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!