### PR TITLE
Fix the manual packaging process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and yarn are now dependencies for building the backend.
 - Stopped double-writing events in eventd
 - Agents from different orgs/envs with the same ID connected to the same backend
   no longer overwrite each other's messagebus subscriptions.
+- Fix the manual packaging process.
 
 ### Added
 - Support for managing mutators via sensuctl.

--- a/Dockerfile.packaging
+++ b/Dockerfile.packaging
@@ -6,7 +6,7 @@ ENV PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 
 RUN apt-get update && \
   apt-get install -y ruby ruby-dev build-essential rpm rpmlint wget git curl && \
-  curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get install -y nodejs && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ build_agent:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) ./build.sh build_agent
 
 build_backend:
-	GOOS=linux GOARCH=amd64 ./build.sh build_dashboard
+	GOOS=linux GOARCH=amd64 ./build.sh dashboard
 	GOOS=$(GOOS) GOARCH=$(GOARCH) ./build.sh build_backend
 
 build_cli:


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes the build process when manually running it. Node 8.x is now required by our dashboard and the `build_dashboard` command does not exist in `build.sh`.

## Why is this change necessary?

So we can manually build the package if required (i.e., load testing).

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!