### PR TITLE
Run go generate using host's GOOS & GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ WINDOWS_ARCHITECTURES   := 386 amd64
 ##
 $(shell mkdir -p out)
 VERSION_BIN := $(shell go build -o version-bin ./version/cmd/version/version.go)
+HOST_GOOS := $(shell go env GOOS)
+HOST_GOARCH := $(shell go env GOARCH)
 
 ##
 # FPM

--- a/build.sh
+++ b/build.sh
@@ -157,7 +157,7 @@ build_cli() {
 
 build_dashboard() {
     check_for_presence_of_yarn
-    go generate $@ ./dashboard
+    GOOS=$HOST_GOOS GOARCH=$HOST_GOARCH go generate $@ ./dashboard
 }
 
 build_command () {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Prepends GOOS and GOARCH with the host's values to `go generate` to build the webui.

## Why is this change necessary?

Using GOOS / GOARCH values with `go generate` that do not match the host's values will not work.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!