### PR TITLE
Use each port only once during e2e tests.

### DIFF
--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -1,14 +1,19 @@
 package testutil
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
+
+// dirty hack to prevent port collisions
+var lastPort int64 = 30000
 
 // TempDir provides a test with a temporary directory (under os.TempDir())
 // returning the absolute path to the directory and a remove() function
@@ -23,25 +28,47 @@ func TempDir(t *testing.T) (tmpDir string, remove func()) {
 	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }
 }
 
-// RandomPorts generates len(p) random ports and assigns them to elements of p.
+// ReservePort reserves a port, as long as this process is the only one
+// on the system opening ports. Introduced to avoid port collisions in
+// our end-to-end tests. A total hack, and will probably need replacing
+// one day.
+func ReservePort() (int, error) {
+	for {
+		port := atomic.AddInt64(&lastPort, 1)
+		if port > 65535 {
+			return 0, errors.New("port allocation failed")
+		}
+		ln, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			if oe, ok := err.(*net.OpError); ok {
+				if oe.Timeout() {
+					return 0, err
+				}
+			}
+			continue
+		}
+		for {
+			err, ok := ln.Close().(*net.OpError)
+			if err == nil {
+				return int(port), nil
+			}
+			if ok && err.Temporary() {
+				continue
+			}
+			return 0, err
+		}
+	}
+}
+
+// RandomPorts reserves len(p) ports and assigns them to elements of p.
+// It calls ReservePort repeatedly.
 func RandomPorts(p []int) (err error) {
 	for i := range p {
-		l, err := net.Listen("tcp", "127.0.0.1:0")
+		port, err := ReservePort()
 		if err != nil {
 			return err
 		}
-		defer func() {
-			e := l.Close()
-			if err == nil {
-				err = e
-			}
-		}()
-
-		addr, err := net.ResolveTCPAddr("tcp", l.Addr().String())
-		if err != nil {
-			return err
-		}
-		p[i] = addr.Port
+		p[i] = port
 	}
 	return nil
 }


### PR DESCRIPTION
The previous port allocation strategy could lead to collisions
in rare circumstances.

Closes #1237

Signed-off-by: Eric Chlebek <eric@sensu.io>

EDIT: Also closes https://github.com/sensu/sensu-go/issues/791