### PR TITLE
Nightly build fixes

### DIFF
--- a/build-gcs-release.sh
+++ b/build-gcs-release.sh
@@ -38,7 +38,6 @@ clean_target_dir() {
 build_supported_binaries() {
   clean_target_dir
 
-  ./build.sh build_dashboard
   GOOS=darwin GOARCH=amd64 ./build.sh build_cli
   GOOS=linux GOARCH=amd64 ./build.sh build_cli
   GOOS=linux GOARCH=386 ./build.sh build_cli

--- a/build.sh
+++ b/build.sh
@@ -344,7 +344,7 @@ deploy() {
     make clean
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
     docker pull sensuapp/sensu-go-build
-    docker run -it -v `pwd`:/go/src/github.com/sensu/sensu-go sensuapp/sensu-go-build
+    docker run -it -e SENSU_BUILD_ITERATION=$SENSU_BUILD_ITERATION -v `pwd`:/go/src/github.com/sensu/sensu-go sensuapp/sensu-go-build
     docker run -it -v `pwd`:/go/src/github.com/sensu/sensu-go -e PACKAGECLOUD_TOKEN="$PACKAGECLOUD_TOKEN" sensuapp/sensu-go-build publish_travis
 
     # Deploy Docker images to the Docker Hub


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Pass the `SENSU_BUILD_ITERATION` environment variable into the packaging docker container. Remove `build_dashboard` from `build-gcs-release.sh`.

## Why is this change necessary?

The packaging docker container needs access to the build iteration env var.

`build_dashboard` is no longer a valid `build.sh` command. The dashboard is built with the backend now.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!