### PR TITLE
Avoid building nightly binaries for now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -335,9 +335,11 @@ deploy() {
     echo "Deploying..."
 
     # Authenticate to Google Cloud and deploy binaries
-    openssl aes-256-cbc -K $encrypted_abd14401c428_key -iv $encrypted_abd14401c428_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d
-    gcloud auth activate-service-account --key-file=gcs-service-account.json
-    ./build-gcs-release.sh
+    if [[ "${release}" != "nightly" ]]; then
+        openssl aes-256-cbc -K $encrypted_abd14401c428_key -iv $encrypted_abd14401c428_iv -in gcs-service-account.json.enc -out gcs-service-account.json -d
+        gcloud auth activate-service-account --key-file=gcs-service-account.json
+        ./build-gcs-release.sh
+    fi
 
     # Deploy system packages to PackageCloud
     gem install package_cloud


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Disables GCS binary releases for nightly builds.

## Why is this change necessary?

The `build-gcs-release.sh` script will need to be refactored to support nightly builds.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!