### PR TITLE
Remove -c check flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and yarn are now dependencies for building the backend.
 - Build protobufs with go generate.
 - Creating roles via sensuctl now supports passing flags for setting permissions
   rules.
+- Removed -c (check) flag in sensuctl check execute command.
 
 ### Fixed
 - Shut down sessions properly when agent connections are disrupted.

--- a/cli/commands/check/execute.go
+++ b/cli/commands/check/execute.go
@@ -26,13 +26,6 @@ func ExecuteCommand(cli *cli.SensuCli) *cobra.Command {
 		Use:          "execute [NAME]",
 		Short:        "request a check execution",
 		SilenceUsage: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
-			if !isInteractive {
-				// Mark flags are required for bash-completions
-				_ = cmd.MarkFlagRequired("check")
-			}
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
 				_ = cmd.Help()
@@ -80,7 +73,6 @@ func ExecuteCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("check", "c", "", "name of the check")
 	cmd.Flags().StringP("reason", "r", "", "optional reason for requesting a check execution")
 	cmd.Flags().StringP("subscriptions", "s", "", "optional comma separated list of subscriptions to override the check configuration")
 


### PR DESCRIPTION
Signed-off-by: Mercedes Coyle <mercedes@sensu.io>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->
Removes the -c (check) flag from the execute command.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

Check name is already taken as the first arg to the command, so this
additional flag is redundant and a little confusing as it is marked
required. Removing it in favor of passing check name as the first arg
fits with the conventions of our other commands.

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->
Added note under changed.

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

Nope!

## Were there any complications while making this change?

Nope!

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->