### PR TITLE
Separate Travis CI deploy job into multiple jobs

### DIFF
--- a/.travis-wrapper.sh
+++ b/.travis-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [[ "x$TRAVIS_TAG" != "x" || $TRAVIS_EVENT_TYPE == "api" ]]; then
+    echo "versioned"
+    if [[ "x$TRAVIS_TAG" == "x" && $1 == "deploy_binaries" ]]; then
+        echo "Nightlies do not support binary builds yet. Skipping."
+        exit 0
+    fi
+    ./build.sh $1 versioned
+elif [[ $TRAVIS_BRANCH == "master" ]]; then
+    if [[ $1 == "deploy_docker" ]]; then
+        ./build.sh $1 master
+    else
+        echo "./build.sh $1 is only run for tags & nightlies. Skipping."
+    fi
+else
+    echo "Deployments not supported for this configuration. Skipping."
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,20 @@ jobs:
   include:
   - stage: deploy
     env: GOARCH=amd64 TEST_SUITE=none
-    script: skip
-    deploy:
-    - provider: script
-      skip_cleanup: true
-      script: "./build.sh docker push master"
-      on:
-        branch: master
-    - provider: script
-      skip_cleanup: true
-      script: "./build.sh deploy versioned"
-      on:
-        tags: true
-        branch: master
-    - provider: script
-      skip_cleanup: true
-      script: "./build.sh deploy nightly"
-      on:
-        condition: $TRAVIS_EVENT_TYPE = api
+    script: "./build.sh deploy_binaries"
+    if: tag IS present
+  - stage: deploy
+    env: GOARCH=amd64 TEST_SUITE=none
+    script: "./build.sh deploy_packages"
+    if: tag IS present OR type IS api
+  - stage: deploy
+    env: GOARCH=amd64 TEST_SUITE=none
+    script: "./build.sh deploy_docker master"
+    if: branch IS master AND type NOT api AND tag IS blank
+  - stage: deploy
+    env: GOARCH=amd64 TEST_SUITE=none
+    script: "./build.sh deploy_docker versioned"
+    if: tag IS present OR type IS api
 env:
   matrix:
   - GOARCH=amd64 TEST_SUITE=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,21 +28,14 @@ script: "./build.sh $TEST_SUITE"
 jobs:
   include:
   - stage: deploy
-    env: GOARCH=amd64 TEST_SUITE=none
-    script: "./build.sh deploy_binaries"
-    if: tag IS present
+    env: GOARCH=amd64
+    script: "./.travis-wrapper.sh deploy_binaries"
   - stage: deploy
-    env: GOARCH=amd64 TEST_SUITE=none
-    script: "./build.sh deploy_packages"
-    if: tag IS present OR type IS api
+    env: GOARCH=amd64
+    script: "./.travis-wrapper.sh deploy_packages"
   - stage: deploy
-    env: GOARCH=amd64 TEST_SUITE=none
-    script: "./build.sh deploy_docker master"
-    if: branch IS master AND type NOT api AND tag IS blank
-  - stage: deploy
-    env: GOARCH=amd64 TEST_SUITE=none
-    script: "./build.sh deploy_docker versioned"
-    if: tag IS present OR type IS api
+    env: GOARCH=amd64
+    script: "./.travis-wrapper.sh deploy_docker"
 env:
   matrix:
   - GOARCH=amd64 TEST_SUITE=lint


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Splits the single Travis CI deploy job into multiple jobs for our various deployments.

## Why is this change necessary?

If a deploy job script fails, any subsequent scripts will not run. This can lead to scenarios where we won't deploy docker images after package building has failed.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!