### PR TITLE
Backout/port experiment

### DIFF
--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -1,19 +1,14 @@
 package testutil
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
 	"strings"
-	"sync/atomic"
 	"testing"
 )
-
-// dirty hack to prevent port collisions
-var lastPort int64 = 30000
 
 // TempDir provides a test with a temporary directory (under os.TempDir())
 // returning the absolute path to the directory and a remove() function
@@ -28,47 +23,25 @@ func TempDir(t *testing.T) (tmpDir string, remove func()) {
 	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }
 }
 
-// ReservePort reserves a port, as long as this process is the only one
-// on the system opening ports. Introduced to avoid port collisions in
-// our end-to-end tests. A total hack, and will probably need replacing
-// one day.
-func ReservePort() (int, error) {
-	for {
-		port := atomic.AddInt64(&lastPort, 1)
-		if port > 65535 {
-			return 0, errors.New("port allocation failed")
-		}
-		ln, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", port))
-		if err != nil {
-			if oe, ok := err.(*net.OpError); ok {
-				if oe.Timeout() {
-					return 0, err
-				}
-			}
-			continue
-		}
-		for {
-			err, ok := ln.Close().(*net.OpError)
-			if err == nil {
-				return int(port), nil
-			}
-			if ok && err.Temporary() {
-				continue
-			}
-			return 0, err
-		}
-	}
-}
-
-// RandomPorts reserves len(p) ports and assigns them to elements of p.
-// It calls ReservePort repeatedly.
+// RandomPorts generates len(p) random ports and assigns them to elements of p.
 func RandomPorts(p []int) (err error) {
 	for i := range p {
-		port, err := ReservePort()
+		l, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			return err
 		}
-		p[i] = port
+		defer func() {
+			e := l.Close()
+			if err == nil {
+				err = e
+			}
+		}()
+
+		addr, err := net.ResolveTCPAddr("tcp", l.Addr().String())
+		if err != nil {
+			return err
+		}
+		p[i] = addr.Port
 	}
 	return nil
 }


### PR DESCRIPTION
## What is this change?

Backs out two changesets that try to allocate ports for tests differently.

## Why is this change necessary?

The build is failing even more often now.