### PR TITLE
Revert build.sh docker changes from b7dbfdf8; rm node_modules in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -299,6 +299,7 @@ install_yarn() {
 install_dashboard_deps() {
     bail_unless_yarn_is_present
     pushd "${DASHBOARD_PATH}"
+    rm -rf dashboard/node_modules
     yarn install
     yarn precompile
     popd
@@ -393,7 +394,7 @@ case "$cmd" in
         install_deps
         ;;
     "docker")
-        docker_commands nopush master "${@:2}"
+        docker_commands "${@:2}"
         ;;
     "e2e")
         # Accepts specific test name. E.g.: ./build.sh e2e -run TestAgentKeepalives


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Reverts a change to build.sh that was breaking the deploy step. Removes the `node_modules` directory before running `yarn install` to simulate a cleanroom environment between builds.

## Why is this change necessary?

Deploy stage was broken due to a change in https://github.com/sensu/sensu-go/commit/b7dbfdf8a9d4aead3ddf99d92012a3b5e0178f88.

We were running into another issue during the during the deploy stage that was failing due to files already existing:

```
error An unexpected error occurred: "EACCES: permission denied, unlink '/home/travis/gopath/src/github.com/sensu/sensu-go/dashboard/node_modules/.bin/acorn'".
```

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!