### PR TITLE
Fix a deadlock in the monitor.

### DIFF
--- a/backend/monitor/monitor.go
+++ b/backend/monitor/monitor.go
@@ -95,7 +95,9 @@ func (m *Monitor) start() {
 
 	timerDuration := m.Timeout
 	m.timer = time.NewTimer(timerDuration)
-	m.resetChan = make(chan time.Duration)
+	// resetChan needs a buffer, otherwise we could end up holding onto m's
+	// mutex indefinitely.
+	m.resetChan = make(chan time.Duration, 1)
 	go func() {
 		timer := m.timer
 


### PR DESCRIPTION
The deadlock only occurs under load; in testing, it took around
5500 agent sessions to expose the problem.

On reset, the monitor acquires a mutex and then performs a channel
send. However, if another select case in the monitor is trying to
acquire the mutex, then the channel send will never occur.

Adding a buffer to the resetChan fixes the problem.

Signed-off-by: Eric Chlebek <eric@sensu.io>

Closes #1264 