### PR TITLE
Terminate processes gracefully in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and yarn are now dependencies for building the backend.
 - Events list can properly be viewed on mobile.
 
 ### Fixed
+- Terminate processes gracefully in e2e tests, allowing ports to be reused.
 - Shut down sessions properly when agent connections are disrupted.
 - Fixed shutdown log message in backend
 - Stopped double-writing events in eventd

--- a/testing/e2e/agent_reconnection_test.go
+++ b/testing/e2e/agent_reconnection_test.go
@@ -41,8 +41,8 @@ func TestAgentReconnection(t *testing.T) {
 	require.NoError(t, json.Unmarshal(output, &event1))
 	assert.NotNil(t, event1)
 
-	// Now kill the backend
-	require.NoError(t, backend.Kill())
+	// Now terminate the backend
+	require.NoError(t, backend.Terminate())
 
 	// Restart the backend
 	if err := backend.Start(); err != nil {

--- a/testing/e2e/keepalive_test.go
+++ b/testing/e2e/keepalive_test.go
@@ -209,11 +209,8 @@ func TestKeepaliveTimeout(t *testing.T) {
 	assert.Equal(t, "passing", event.Check.State)
 	assert.Equal(t, uint32(0), event.Check.Status)
 
-	// Kill the agent, and restart with a new KeepaliveTimeout
-	assert.NoError(t, agent.Kill())
-
-	// Allow time agent connection to be killed
-	time.Sleep(10 * time.Second)
+	// Stop the agent, and restart with a new KeepaliveTimeout
+	assert.NoError(t, agent.Terminate())
 
 	agentConfig.KeepaliveTimeout = 1
 	agentConfig.KeepaliveInterval = 2

--- a/testing/e2e/process_test.go
+++ b/testing/e2e/process_test.go
@@ -163,7 +163,7 @@ func (b *backendProcess) Start() error {
 }
 
 func (b *backendProcess) Terminate() error {
-	return terminate_helper(b.cmd.Process)
+	return terminateProcess(b.cmd.Process)
 }
 
 type agentProcess struct {
@@ -299,7 +299,7 @@ func (a *agentProcess) Start(t *testing.T) error {
 }
 
 func (a *agentProcess) Terminate() error {
-	return terminate_helper(a.cmd.Process)
+	return terminateProcess(a.cmd.Process)
 }
 
 type sensuCtl struct {
@@ -355,7 +355,7 @@ func (s *sensuCtl) SetStdin(r io.Reader) {
 // Terminate a Process by sending SIGTERM and waiting for it to exit cleanly.
 // On Windows, there is no way to ask a program to exit cleanly. Instead, it
 // must be killed with SIGKILL.
-func terminate_helper(p *os.Process) error {
+func terminateProcess(p *os.Process) error {
 	signal := syscall.SIGTERM
 	// Windows doesn't support SIGTERM, fall back to SIGKILL
 	if runtime.GOOS == "windows" {

--- a/testing/e2e/process_test.go
+++ b/testing/e2e/process_test.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/sensu/sensu-go/testing/testutil"
@@ -63,7 +65,7 @@ func newBackend(t *testing.T) (*backendProcess, func()) {
 
 	return backend, func() {
 		cleanup()
-		if err := backend.Kill(); err != nil {
+		if err := backend.Terminate(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -160,11 +162,8 @@ func (b *backendProcess) Start() error {
 	return nil
 }
 
-func (b *backendProcess) Kill() error {
-	if err := b.cmd.Process.Kill(); err != nil {
-		return err
-	}
-	return b.cmd.Process.Release()
+func (b *backendProcess) Terminate() error {
+	return terminate_helper(b.cmd.Process)
 }
 
 type agentProcess struct {
@@ -205,7 +204,7 @@ func newAgent(config agentConfig, sensuctl *sensuCtl, t *testing.T) (*agentProce
 	}
 
 	return agent, func() {
-		if err := agent.Kill(); err != nil {
+		if err := agent.Terminate(); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -299,11 +298,8 @@ func (a *agentProcess) Start(t *testing.T) error {
 	return nil
 }
 
-func (a *agentProcess) Kill() error {
-	if err := a.cmd.Process.Kill(); err != nil {
-		return err
-	}
-	return a.cmd.Process.Release()
+func (a *agentProcess) Terminate() error {
+	return terminate_helper(a.cmd.Process)
 }
 
 type sensuCtl struct {
@@ -354,4 +350,22 @@ func (s *sensuCtl) run(args ...string) ([]byte, error) {
 
 func (s *sensuCtl) SetStdin(r io.Reader) {
 	s.stdin = r
+}
+
+// Terminate a Process by sending SIGTERM and waiting for it to exit cleanly.
+// On Windows, there is no way to ask a program to exit cleanly. Instead, it
+// must be killed with SIGKILL.
+func terminate_helper(p *os.Process) error {
+	signal := syscall.SIGTERM
+	// Windows doesn't support SIGTERM, fall back to SIGKILL
+	if runtime.GOOS == "windows" {
+		signal = syscall.SIGKILL
+	}
+
+	if err := p.Signal(signal); err != nil {
+		return err
+	}
+	// allow the process to exit cleanly
+	_, err := p.Wait()
+	return err
 }

--- a/testing/e2e/rbac_test.go
+++ b/testing/e2e/rbac_test.go
@@ -328,6 +328,6 @@ func TestRBAC(t *testing.T) {
 
 	// Make sure we are properly authenticated
 	output, err = adminctl.run("user", "list")
-	assert.NoError(t, err, output)
+	assert.NoError(t, err, string(output))
 
 }

--- a/testing/e2e/rbac_test.go
+++ b/testing/e2e/rbac_test.go
@@ -316,7 +316,7 @@ func TestRBAC(t *testing.T) {
 
 	// Now we want to restart the backend to make sure the JWT will continue
 	// to work and prevent an issue like https://github.com/sensu/sensu-go/issues/502
-	require.NoError(t, backend.Kill())
+	require.NoError(t, backend.Terminate())
 	err = backend.Start()
 	if err != nil {
 		log.Panic(err)


### PR DESCRIPTION
## What is this change?

Terminate processes gracefully in e2e tests, allowing ports to be reused.


## Why is this change necessary?

Fixes #1228 

## Does your change need a Changelog entry?

Yes:

### Fixes
- Terminate processes gracefully in e2e tests, allowing ports to be reused.

## Do you need clarification on anything?

I need clarification on the hardest part: naming things. If there is a name or place for `terminate_helper` that would fit project conventions better, I'd love to hear about it.


## Were there any complications while making this change?

I spent some time trying to find a way to gracefully terminate CLI processes on Windows -- sadly there is no supported way to do this in Windows.