### PR TITLE
http_check.sh hides its output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and yarn are now dependencies for building the backend.
   no longer overwrite each other's messagebus subscriptions.
 - Fix the manual packaging process.
 - Properly log the event being handled in pipelined
+- The http_check.sh example script now hides its output
 
 ### Added
 - Support for managing mutators via sensuctl.

--- a/examples/checks/http_check.sh
+++ b/examples/checks/http_check.sh
@@ -2,7 +2,7 @@
 
 target=$1
 
-curl --connect-timeout 5 $target
+curl --silent --connect-timeout 5 $target > /dev/null
 if [ $? -ne 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

I'm using this script in our proxy entities guide and it's currently outputting the entire HTML code of a page in the event output, so I simply moved the output to `/dev/null`.  git

## Why is this change necessary?

Documentation!

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!