### PR TITLE
Prevent app from crashing with expired refresh token

### DIFF
--- a/dashboard/src/pages/RootRedirect.js
+++ b/dashboard/src/pages/RootRedirect.js
@@ -8,14 +8,20 @@ class RootRedirectPage extends React.Component {
   };
 
   componentWillMount() {
-    getAccessToken().then(token => {
+    const handleToken = token => {
       // TODO: Retrieve last environment
       let nextPath = "/default/default";
       if (token === null) {
         nextPath = "/login";
       }
       this.props.router.push(nextPath);
-    });
+    };
+
+    const handleTokenError = () => {
+      this.props.router.push("/login");
+    };
+
+    getAccessToken().then(handleToken, handleTokenError);
   }
 
   render() {


### PR DESCRIPTION
## Why is this change necessary?

When accessing `getAccessToken()`, we need to handle the potential server error in the case that we have a cached invalid refresh token.

This is currently a very naive solution that redirects to "/login" for any error case. We should revisit this we tackle more thorough error handling.

