### PR TITLE
Prevent dev build from halting on lint error

### DIFF
--- a/dashboard/config/webpack.config.dev.js
+++ b/dashboard/config/webpack.config.dev.js
@@ -86,7 +86,7 @@ module.exports = {
     // for React Native Web.
     extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
-      
+
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
@@ -117,7 +117,8 @@ module.exports = {
             options: {
               formatter: eslintFormatter,
               eslintPath: require.resolve('eslint'),
-              
+              emitError: false,
+              emitWarning: true,
             },
             loader: require.resolve('eslint-loader'),
           },
@@ -146,7 +147,7 @@ module.exports = {
             include: paths.appSrc,
             loader: require.resolve('babel-loader'),
             options: {
-              
+
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.


### PR DESCRIPTION
## What is this change?

Allow the dev build to continue, resulting in a normal browser reload, in the case that a lint error is detected.

## Why is this change necessary?

This allows running WIP code without worrying about strict lint adherence enabling faster dev cycles.

Detected errors are still reported to the build process output, this change does not silence anything.

Production builds are not affected by this change, and still require passing lint at build-time.
