### PR TITLE
[Agent statsd] Additional unit and integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ metric events are swallowed for the time being.
 - Proper 404 page for web UI.
 - Add sensuctl extension command.
 - Add extensions to pipelined.
+- Added more tests surrounding the sensu-agent's statsd server and udp port.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -53,7 +53,8 @@ func NewClient(a *Agent) (*Client, error) {
 // the sensu-agent, preparing payload synchronously but doing the send asynchronously.
 // Must not read/write MetricMap asynchronously.
 func (c Client) SendMetricsAsync(ctx context.Context, metrics *gostatsd.MetricMap, cb gostatsd.SendCallback) {
-	metricsPoints := prepareMetrics(metrics)
+	now := time.Now().UnixNano()
+	metricsPoints := prepareMetrics(now, metrics)
 	go func() {
 		cb([]error{c.sendMetrics(metricsPoints)})
 	}()
@@ -71,8 +72,7 @@ func (Client) Name() string {
 	return BackendName
 }
 
-func prepareMetrics(metrics *gostatsd.MetricMap) []*types.MetricPoint {
-	now := time.Now().Unix()
+func prepareMetrics(now int64, metrics *gostatsd.MetricMap) []*types.MetricPoint {
 	var metricsPoints []*types.MetricPoint
 	metrics.Counters.Each(func(key, tagsKey string, counter gostatsd.Counter) {
 		tags := composeMetricTags(tagsKey)

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,12 +1,16 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/atlassian/gostatsd"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewStatsdServer(t *testing.T) {
@@ -70,13 +74,7 @@ func TestComposeCounterPoints(t *testing.T) {
 	now := time.Now().UnixNano()
 	key := "foo:bar"
 	tags := composeMetricTags("boo:baz")
-	counter := gostatsd.Counter{
-		PerSecond: 2,
-		Value:     3,
-		Timestamp: gostatsd.Nanotime(now),
-		Hostname:  "host",
-		Tags:      gostatsd.Tags{"foo:bar"},
-	}
+	counter := FixtureCounter(now)
 
 	points := composeCounterPoints(counter, key, tags, now)
 	assert.Equal(t, len(points), 2)
@@ -92,22 +90,7 @@ func TestComposeTimerPoints(t *testing.T) {
 	now := time.Now().UnixNano()
 	key := "foo:bar"
 	tags := composeMetricTags("boo:baz")
-	timer := gostatsd.Timer{
-		Count:       2,
-		PerSecond:   3,
-		Mean:        4,
-		Median:      5,
-		Min:         6,
-		Max:         7,
-		StdDev:      8,
-		Sum:         9,
-		SumSquares:  10,
-		Values:      []float64{1, 2, 3},
-		Percentiles: []gostatsd.Percentile{{Float: 4, Str: "str"}},
-		Timestamp:   gostatsd.Nanotime(now),
-		Hostname:    "host",
-		Tags:        gostatsd.Tags{"foo:bar"},
-	}
+	timer := FixtureTimer(now)
 
 	points := composeTimerPoints(timer, key, tags, now)
 	assert.Equal(t, len(points), 10)
@@ -123,12 +106,7 @@ func TestComposeGaugePoints(t *testing.T) {
 	now := time.Now().UnixNano()
 	key := "foo:bar"
 	tags := composeMetricTags("boo:baz")
-	gauge := gostatsd.Gauge{
-		Value:     3,
-		Timestamp: gostatsd.Nanotime(now),
-		Hostname:  "host",
-		Tags:      gostatsd.Tags{"foo:bar"},
-	}
+	gauge := FixtureGauge(now)
 
 	points := composeGaugePoints(gauge, key, tags, now)
 	assert.Equal(t, len(points), 1)
@@ -144,12 +122,7 @@ func TestComposeSetPoints(t *testing.T) {
 	now := time.Now().UnixNano()
 	key := "foo:bar"
 	tags := composeMetricTags("boo:baz")
-	set := gostatsd.Set{
-		Values:    map[string]struct{}{"foo": struct{}{}},
-		Timestamp: gostatsd.Nanotime(now),
-		Hostname:  "host",
-		Tags:      gostatsd.Tags{"foo:bar"},
-	}
+	set := FixtureSet(now)
 
 	points := composeSetPoints(set, key, tags, now)
 	assert.Equal(t, len(points), 1)
@@ -158,5 +131,152 @@ func TestComposeSetPoints(t *testing.T) {
 		assert.NotNil(t, point.Value)
 		assert.Equal(t, point.Timestamp, now)
 		assert.Equal(t, point.Tags, tags)
+	}
+}
+
+func TestPreparePoints(t *testing.T) {
+	now := time.Now().UnixNano()
+	metrics := FixtureMetricMap(now)
+
+	points := prepareMetrics(now, &metrics)
+	assert.Equal(t, len(points), 14)
+	for _, point := range points {
+		assert.Contains(t, point.Name, "test")
+		assert.Equal(t, point.Timestamp, now)
+	}
+}
+
+func TestReceiveMetrics(t *testing.T) {
+	assert := assert.New(t)
+
+	cfg := FixtureConfig()
+	ta := NewAgent(cfg)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	go ta.statsdServer.Run(ctx)
+
+	udpClient, err := net.Dial("udp", ta.statsdServer.MetricsAddr)
+	if err != nil {
+		assert.FailNow("failed to create UDP connection")
+	}
+
+	now := time.Now().UnixNano()
+	metrics := FixtureMetricMap(now)
+	bytes, _ := json.Marshal(metrics)
+
+	_, err = udpClient.Write(bytes)
+	require.NoError(t, err)
+	require.NoError(t, udpClient.Close())
+
+	// TODO: test metric event creation https://github.com/sensu/sensu-go/issues/1247
+	// msg := <-ta.sendq
+	// assert.NotEmpty(msg)
+	// assert.Equal("event", msg.Type)
+	//
+	// var event types.Event
+	// err = json.Unmarshal(msg.Payload, &event)
+	// if err != nil {
+	// 	assert.FailNow("failed to unmarshal event json")
+	// }
+	//
+	// assert.NotNil(event.Entity)
+	// assert.NotNil(event.Metrics)
+	// assert.Nil(event.Check)
+	// for _, point := range event.Metrics.Points {
+	// 	assert.Equal(now, point.Timestamp)
+	// }
+}
+
+func FixtureCounter(now int64) gostatsd.Counter {
+	return gostatsd.Counter{
+		PerSecond: 2,
+		Value:     3,
+		Timestamp: gostatsd.Nanotime(now),
+		Hostname:  "host",
+		Tags:      gostatsd.Tags{"foo:bar"},
+	}
+}
+
+func FixtureCounters(now int64) gostatsd.Counters {
+	counters := make(map[string]map[string]gostatsd.Counter)
+	counter := make(map[string]gostatsd.Counter)
+	c := FixtureCounter(now)
+	counter["c1"] = c
+	counters["test"] = counter
+	return counters
+}
+
+func FixtureTimer(now int64) gostatsd.Timer {
+	return gostatsd.Timer{
+		Count:       2,
+		PerSecond:   3,
+		Mean:        4,
+		Median:      5,
+		Min:         6,
+		Max:         7,
+		StdDev:      8,
+		Sum:         9,
+		SumSquares:  10,
+		Values:      []float64{1, 2, 3},
+		Percentiles: []gostatsd.Percentile{{Float: 4, Str: "str"}},
+		Timestamp:   gostatsd.Nanotime(now),
+		Hostname:    "host",
+		Tags:        gostatsd.Tags{"foo:bar"},
+	}
+}
+
+func FixtureTimers(now int64) gostatsd.Timers {
+	timers := make(map[string]map[string]gostatsd.Timer)
+	timer := make(map[string]gostatsd.Timer)
+	t := FixtureTimer(now)
+	timer["t1"] = t
+	timers["test"] = timer
+	return timers
+}
+
+func FixtureGauge(now int64) gostatsd.Gauge {
+	return gostatsd.Gauge{
+		Value:     3,
+		Timestamp: gostatsd.Nanotime(now),
+		Hostname:  "host",
+		Tags:      gostatsd.Tags{"foo:bar"},
+	}
+}
+
+func FixtureGauges(now int64) gostatsd.Gauges {
+	gauges := make(map[string]map[string]gostatsd.Gauge)
+	gauge := make(map[string]gostatsd.Gauge)
+	g := FixtureGauge(now)
+	gauge["g1"] = g
+	gauges["test"] = gauge
+	return gauges
+}
+
+func FixtureSet(now int64) gostatsd.Set {
+	return gostatsd.Set{
+		Values:    map[string]struct{}{"foo": struct{}{}},
+		Timestamp: gostatsd.Nanotime(now),
+		Hostname:  "host",
+		Tags:      gostatsd.Tags{"foo:bar"},
+	}
+}
+
+func FixtureSets(now int64) gostatsd.Sets {
+	sets := make(map[string]map[string]gostatsd.Set)
+	set := make(map[string]gostatsd.Set)
+	s := FixtureSet(now)
+	set["s1"] = s
+	sets["test"] = set
+	return sets
+}
+
+func FixtureMetricMap(now int64) gostatsd.MetricMap {
+	return gostatsd.MetricMap{
+		Counters: FixtureCounters(now),
+		Timers:   FixtureTimers(now),
+		Gauges:   FixtureGauges(now),
+		Sets:     FixtureSets(now),
 	}
 }

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package agent
 
 import (
@@ -156,6 +158,8 @@ func TestReceiveMetrics(t *testing.T) {
 	defer cancel()
 
 	go ta.statsdServer.Run(ctx)
+	// Give the server a second to start up
+	time.Sleep(time.Second * 1)
 
 	udpClient, err := net.Dial("udp", ta.statsdServer.MetricsAddr)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a unit test and integration test surrounding the sensu-agent's statsd server and udp port. Refactors some reusable code into "fixture" functions.

## Why is this change necessary?

Testing is 🔑 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Part of the test is blocked by #1247 but a `TODO` has been created.