### PR TITLE
Create default read-only user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ metric events are swallowed for the time being.
 - Proper 404 page for web UI.
 - Add sensuctl extension command.
 - Add extensions to pipelined.
+- Add default user with username "sensu" with global, read-only permissions.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/backend/authorization/authorization.go
+++ b/backend/authorization/authorization.go
@@ -3,8 +3,8 @@ package authorization
 import (
 	"net/http"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 )
 
 func hasPermission(rule types.Rule, action string) bool {
@@ -16,10 +16,8 @@ func hasPermission(rule types.Rule, action string) bool {
 	return false
 }
 
-// TODO (JK): this function may end up becoming more complex if
-// we decide to use "*" as more than a way of saying "all resources"
 func matchesRuleType(rule types.Rule, resource string) bool {
-	return rule.Type == resource || rule.Type == "*"
+	return rule.Type == resource || rule.Type == types.RuleTypeAll
 }
 
 func matchesRuleEnvironment(rule types.Rule, environment string) bool {

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -39,14 +39,14 @@ func SeedInitialData(store store.Store) (err error) {
 	}
 	logger.Info("seeding etcd store w/ intial data")
 
-	// Set default role
+	// Set admin role
 	if err := setupAdminRole(store); err != nil {
 		logger.WithError(err).Error("unable to setup admin role")
 		return err
 	}
 
-	// Default user
-	if err := setupDefaultUser(store); err != nil {
+	// Admin user
+	if err := setupAdminUser(store); err != nil {
 		logger.WithError(err).Error("unable to setup admin user")
 		return err
 	}
@@ -73,7 +73,7 @@ func setupAdminRole(store store.Store) error {
 		&types.Role{
 			Name: "admin",
 			Rules: []types.Rule{{
-				Type:         "*",
+				Type:         types.RuleTypeAll,
 				Environment:  "*",
 				Organization: "*",
 				Permissions:  types.RuleAllPerms,
@@ -91,7 +91,7 @@ func setupDefaultOrganization(store store.Store) error {
 		})
 }
 
-func setupDefaultUser(store store.Store) error {
+func setupAdminUser(store store.Store) error {
 	// Set default user
 	admin := &types.User{
 		Username: "admin",

--- a/backend/seeds/seeds_test.go
+++ b/backend/seeds/seeds_test.go
@@ -43,4 +43,12 @@ func TestSeedInitialData(t *testing.T) {
 	defaultEnv, err := st.GetEnvironment(ctx, "default", "default")
 	require.NoError(t, err)
 	assert.NotEmpty(t, defaultEnv, "default environment should be present after seed process")
+
+	sensu, err := st.GetUser(ctx, "sensu")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sensu, "sensu user should be present after seed process")
+
+	readOnlyRole, err := st.GetRoleByName(ctx, "read-only")
+	require.NoError(t, err)
+	assert.NotEmpty(t, readOnlyRole, "read-only role should be present after seed process")
 }


### PR DESCRIPTION
## What is this change?

Seed the sensu RBAC store with a user by the name "sensu" with global read-only permissions.

## Why is this change necessary?

It's useful for customers to have a non-admin user when setting up sensu. It's a common enough use case to warrant creating one by default.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

I did need some clarification on the use of constants in RBAC related code. Ended up creating #1285 to track it.

## Were there any complications while making this change?

Because the RBAC seed functionality was already in place, adding a second user (after the admin user) was straightforward.