### PR TITLE
Provide a means of configuring event handlers for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ metric events are swallowed for the time being.
 - Proper 404 page for web UI.
 - Add sensuctl extension command.
 - Add extensions to pipelined.
+- Add the `--statsd-event-handlers` flag to sensu-agent which configures the
+event handlers for statsd metrics.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -113,6 +113,7 @@ type StatsdServerConfig struct {
 	Host          string
 	Port          int
 	FlushInterval int
+	Handlers      []string
 }
 
 // SocketConfig contains the Socket configuration
@@ -145,6 +146,7 @@ func FixtureConfig() *Config {
 			Host:          DefaultStatsdMetricsHost,
 			Port:          DefaultStatsdMetricsPort,
 			FlushInterval: DefaultStatsdFlushInterval,
+			Handlers:      []string{},
 		},
 		User: DefaultUser,
 	}

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -10,12 +10,12 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/types/dynamic"
 	"github.com/sensu/sensu-go/util/path"
 	"github.com/sensu/sensu-go/util/url"
 	"github.com/sensu/sensu-go/version"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -47,6 +47,7 @@ const (
 	flagRedact                = "redact"
 	flagSocketHost            = "socket-host"
 	flagSocketPort            = "socket-port"
+	flagStatsdEventHandlers   = "statsd-event-handlers"
 	flagStatsdFlushInterval   = "statsd-flush-interval"
 	flagStatsdMetricsHost     = "statsd-metrics-host"
 	flagStatsdMetricsPort     = "statsd-metrics-port"
@@ -156,6 +157,14 @@ func newStartCommand() *cobra.Command {
 				cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
 			}
 
+			// Get a single or a list of statsd event handlers
+			handlers := viper.GetString(flagStatsdEventHandlers)
+			if handlers != "" {
+				cfg.StatsdServer.Handlers = splitAndTrim(handlers)
+			} else {
+				cfg.StatsdServer.Handlers = viper.GetStringSlice(flagStatsdEventHandlers)
+			}
+
 			sensuAgent := agent.NewAgent(cfg)
 			if err := sensuAgent.Run(); err != nil {
 				return err
@@ -225,6 +234,7 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagStatsdFlushInterval, agent.DefaultStatsdFlushInterval)
 	viper.SetDefault(flagStatsdMetricsHost, agent.DefaultStatsdMetricsHost)
 	viper.SetDefault(flagStatsdMetricsPort, agent.DefaultStatsdMetricsPort)
+	viper.SetDefault(flagStatsdEventHandlers, "")
 	viper.SetDefault(flagSubscriptions, []string{})
 	viper.SetDefault(flagUser, agent.DefaultUser)
 	viper.SetDefault(flagDisableAPI, false)
@@ -249,6 +259,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagPassword, viper.GetString(flagPassword), "agent password")
 	cmd.Flags().String(flagRedact, viper.GetString(flagRedact), "comma-delimited customized list of fields to redact")
 	cmd.Flags().String(flagSocketHost, viper.GetString(flagSocketHost), "address to bind the Sensu client socket to")
+	cmd.Flags().String(flagStatsdEventHandlers, viper.GetString(flagStatsdEventHandlers), "comma-delimited list of event handlers for statsd metrics")
 	cmd.Flags().Int(flagStatsdFlushInterval, viper.GetInt(flagStatsdFlushInterval), "number of seconds between statsd flush")
 	cmd.Flags().String(flagStatsdMetricsHost, viper.GetString(flagStatsdMetricsHost), "address used for the statsd metrics server")
 	cmd.Flags().String(flagStatsdMetricsPort, viper.GetString(flagStatsdMetricsPort), "port used for the statsd metrics server")

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -234,7 +234,7 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagStatsdFlushInterval, agent.DefaultStatsdFlushInterval)
 	viper.SetDefault(flagStatsdMetricsHost, agent.DefaultStatsdMetricsHost)
 	viper.SetDefault(flagStatsdMetricsPort, agent.DefaultStatsdMetricsPort)
-	viper.SetDefault(flagStatsdEventHandlers, "")
+	viper.SetDefault(flagStatsdEventHandlers, []string{})
 	viper.SetDefault(flagSubscriptions, []string{})
 	viper.SetDefault(flagUser, agent.DefaultUser)
 	viper.SetDefault(flagDisableAPI, false)

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -126,6 +126,7 @@ func newStartCommand() *cobra.Command {
 			cfg.StatsdServer.FlushInterval = viper.GetInt(flagStatsdFlushInterval)
 			cfg.StatsdServer.Host = viper.GetString(flagStatsdMetricsHost)
 			cfg.StatsdServer.Port = viper.GetInt(flagStatsdMetricsPort)
+			cfg.StatsdServer.Handlers = viper.GetStringSlice(flagStatsdEventHandlers)
 			cfg.User = viper.GetString(flagUser)
 
 			agentID := viper.GetString(flagAgentID)
@@ -155,14 +156,6 @@ func newStartCommand() *cobra.Command {
 				cfg.Subscriptions = splitAndTrim(subscriptions)
 			} else {
 				cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
-			}
-
-			// Get a single or a list of statsd event handlers
-			handlers := viper.GetString(flagStatsdEventHandlers)
-			if handlers != "" {
-				cfg.StatsdServer.Handlers = splitAndTrim(handlers)
-			} else {
-				cfg.StatsdServer.Handlers = viper.GetStringSlice(flagStatsdEventHandlers)
 			}
 
 			sensuAgent := agent.NewAgent(cfg)
@@ -259,7 +252,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagPassword, viper.GetString(flagPassword), "agent password")
 	cmd.Flags().String(flagRedact, viper.GetString(flagRedact), "comma-delimited customized list of fields to redact")
 	cmd.Flags().String(flagSocketHost, viper.GetString(flagSocketHost), "address to bind the Sensu client socket to")
-	cmd.Flags().String(flagStatsdEventHandlers, viper.GetString(flagStatsdEventHandlers), "comma-delimited list of event handlers for statsd metrics")
+	cmd.Flags().StringSlice(flagStatsdEventHandlers, viper.GetStringSlice(flagStatsdEventHandlers), "comma-delimited list of event handlers for statsd metrics")
 	cmd.Flags().Int(flagStatsdFlushInterval, viper.GetInt(flagStatsdFlushInterval), "number of seconds between statsd flush")
 	cmd.Flags().String(flagStatsdMetricsHost, viper.GetString(flagStatsdMetricsHost), "address used for the statsd metrics server")
 	cmd.Flags().String(flagStatsdMetricsPort, viper.GetString(flagStatsdMetricsPort), "port used for the statsd metrics server")

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -103,7 +103,8 @@ func (c Client) sendMetrics(points []*types.MetricPoint) (retErr error) {
 	}
 
 	metrics := &types.Metrics{
-		Points: points,
+		Points:   points,
+		Handlers: c.agent.config.StatsdServer.Handlers,
 	}
 	event := &types.Event{
 		Entity:    c.agent.getAgentEntity(),


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the `--statsd-event-handlers` flag to sensu-agent which configures the event handlers for statsd metrics.

## Why is this change necessary?

Closes #1127.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.