### PR TITLE
[GraphQL] Snip extra value from environment id

### DIFF
--- a/backend/apid/graphql/globalid/environments.go
+++ b/backend/apid/graphql/globalid/environments.go
@@ -11,11 +11,30 @@ var environmentName = "environments"
 // EnvironmentTranslator global ID resource
 var EnvironmentTranslator = commonTranslator{
 	name:       environmentName,
-	encodeFunc: standardEncoder(environmentName, "Name"), // TODO: Include org.
 	decodeFunc: standardDecoder,
 	isResponsibleFunc: func(record interface{}) bool {
 		_, ok := record.(*types.Environment)
 		return ok
+	},
+
+	//
+	// Example output:
+	//
+	//   srn:environments:myorg:myenv
+	//   srn:environments:myotherorg:myproductionenv
+	//
+	encodeFunc: func(record interface{}) Components {
+		env, ok := record.(*types.Environment)
+		if !ok {
+			return nil
+		}
+
+		components := StandardComponents{
+			resource:        environmentName,
+			organization:    env.Organization,
+			uniqueComponent: env.Name,
+		}
+		return &components
 	},
 }
 

--- a/backend/apid/graphql/globalid/environments_test.go
+++ b/backend/apid/graphql/globalid/environments_test.go
@@ -1,0 +1,26 @@
+package globalid
+
+import (
+	"testing"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentTranslator(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := &types.Environment{Name: "myenv", Organization: "myorg"}
+
+	// Encode
+	gid := EnvironmentTranslator.EncodeToString(env)
+	assert.Equal("srn:environments:myorg:myenv", gid)
+
+	// Decode
+	idComponents, err := Parse(gid)
+	require.NoError(err)
+	assert.Empty(idComponents.Environment())
+	assert.Equal("myorg", idComponents.Organization())
+	assert.Equal("myenv", idComponents.UniqueComponent())
+}


### PR DESCRIPTION
## What is this change?

Have environment global match intended format.

## Why is this change necessary?

Previously the environment's name was duplicated in the id. eg. `srn:environments:org:env:env`.