### PR TITLE
[GraphQL] Add root field to query events

### DIFF
--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -1,6 +1,9 @@
 package graphql
 
 import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/graphql"
@@ -9,19 +12,25 @@ import (
 
 var _ schema.QueryFieldResolvers = (*queryImpl)(nil)
 
+type eventFetcher interface {
+	Find(ctx context.Context, entity, check string) (*types.Event, error)
+}
+
 //
 // Implement QueryFieldResolvers
 //
 
 type queryImpl struct {
-	store        store.Store
-	nodeResolver *nodeResolver
+	store           store.Store
+	eventController eventFetcher
+	nodeResolver    *nodeResolver
 }
 
 func newQueryImpl(store store.Store, resolver *nodeResolver) *queryImpl {
 	return &queryImpl{
-		store:        store,
-		nodeResolver: resolver,
+		store:           store,
+		eventController: actions.NewEventController(store, nil),
+		nodeResolver:    resolver,
 	}
 }
 
@@ -37,6 +46,13 @@ func (r *queryImpl) Environment(p schema.QueryEnvironmentFieldResolverParams) (i
 		Organization: p.Args.Organization,
 	}
 	return &env, nil
+}
+
+// Event implements response to request for 'event' field.
+func (r *queryImpl) Event(p schema.QueryEventFieldResolverParams) (interface{}, error) {
+	ctx := types.SetContextFromResource(p.Context, p.Args.Ns)
+	event, err := r.eventController.Find(ctx, p.Args.Entity, p.Args.Check)
+	return handleControllerResults(event, err)
 }
 
 // Node implements response to request for 'node' field.

--- a/backend/apid/graphql/query_test.go
+++ b/backend/apid/graphql/query_test.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockQueryEventFetcher struct {
+	record *types.Event
+	err    error
+}
+
+func (m mockQueryEventFetcher) Find(ctx context.Context, entity, check string) (*types.Event, error) {
+	return m.record, m.err
+}
+
+func TestQueryTypeEventField(t *testing.T) {
+	mock := mockQueryEventFetcher{&types.Event{}, nil}
+	impl := queryImpl{eventController: mock}
+
+	args := schema.QueryEventFieldResolverArgs{Ns: schema.NewNamespaceInput("a", "b")}
+	params := schema.QueryEventFieldResolverParams{Args: args}
+
+	res, err := impl.Event(params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, res)
+}

--- a/backend/apid/graphql/schema/mutations.go
+++ b/backend/apid/graphql/schema/mutations.go
@@ -1,5 +1,13 @@
 package schema
 
+// NewNamespaceInput returns new instance using given values.
+func NewNamespaceInput(org, env string) *NamespaceInput {
+	return &NamespaceInput{
+		Organization: org,
+		Environment:  env,
+	}
+}
+
 // GetOrganization returns organization
 func (ns *NamespaceInput) GetOrganization() string {
 	return ns.Organization

--- a/backend/apid/graphql/schema/schema.graphql
+++ b/backend/apid/graphql/schema/schema.graphql
@@ -19,6 +19,11 @@ type Query {
   environment(environment: String!, organization: String!): Environment
 
   """
+  Event fetches the event associated with the given set of arguments.
+  """
+  event(ns: NamespaceInput!, entity: String! check: String): Event
+
+  """
   Node fetches an object given its ID.
   """
   node(


### PR DESCRIPTION
## What is this change?

Add an event field to Query type so that a consumer can retrieve an event given an entity and check.  

<img width="677" alt="screen shot 2018-04-12 at 10 55 51 am" src="https://user-images.githubusercontent.com/194892/38695068-1f982344-3e40-11e8-98c0-6ed1a8e0d3a6.png">

## Why is this change necessary?

Directly unblocks development of #1130 & #835 

## Does your change need a Changelog entry?

unlikely.