### PR TITLE
Option to configure statsd listener with statsd-disable flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ metric events are swallowed for the time being.
 - Add the `--statsd-event-handlers` flag to sensu-agent which configures the
 event handlers for statsd metrics.
 - Add default user with username "sensu" with global, read-only permissions.
+- Add the `--statsd-disable` flag to sensu-agent which configures the
+statsd listener. The listener is enabled by default.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -47,6 +47,7 @@ const (
 	flagRedact                = "redact"
 	flagSocketHost            = "socket-host"
 	flagSocketPort            = "socket-port"
+	flagStatsdDisable         = "statsd-disable"
 	flagStatsdEventHandlers   = "statsd-event-handlers"
 	flagStatsdFlushInterval   = "statsd-flush-interval"
 	flagStatsdMetricsHost     = "statsd-metrics-host"
@@ -123,6 +124,7 @@ func newStartCommand() *cobra.Command {
 			cfg.Password = viper.GetString(flagPassword)
 			cfg.Socket.Host = viper.GetString(flagSocketHost)
 			cfg.Socket.Port = viper.GetInt(flagSocketPort)
+			cfg.StatsdServer.Disable = viper.GetBool(flagStatsdDisable)
 			cfg.StatsdServer.FlushInterval = viper.GetInt(flagStatsdFlushInterval)
 			cfg.StatsdServer.Host = viper.GetString(flagStatsdMetricsHost)
 			cfg.StatsdServer.Port = viper.GetInt(flagStatsdMetricsPort)
@@ -224,6 +226,7 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagRedact, dynamic.DefaultRedactFields)
 	viper.SetDefault(flagSocketHost, agent.DefaultSocketHost)
 	viper.SetDefault(flagSocketPort, agent.DefaultSocketPort)
+	viper.SetDefault(flagStatsdDisable, agent.DefaultStatsdDisable)
 	viper.SetDefault(flagStatsdFlushInterval, agent.DefaultStatsdFlushInterval)
 	viper.SetDefault(flagStatsdMetricsHost, agent.DefaultStatsdMetricsHost)
 	viper.SetDefault(flagStatsdMetricsPort, agent.DefaultStatsdMetricsPort)
@@ -252,6 +255,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagPassword, viper.GetString(flagPassword), "agent password")
 	cmd.Flags().String(flagRedact, viper.GetString(flagRedact), "comma-delimited customized list of fields to redact")
 	cmd.Flags().String(flagSocketHost, viper.GetString(flagSocketHost), "address to bind the Sensu client socket to")
+	cmd.Flags().Bool(flagStatsdDisable, viper.GetBool(flagStatsdDisable), "disables the statsd listener and metrics server")
 	cmd.Flags().StringSlice(flagStatsdEventHandlers, viper.GetStringSlice(flagStatsdEventHandlers), "comma-delimited list of event handlers for statsd metrics")
 	cmd.Flags().Int(flagStatsdFlushInterval, viper.GetInt(flagStatsdFlushInterval), "number of seconds between statsd flush")
 	cmd.Flags().String(flagStatsdMetricsHost, viper.GetString(flagStatsdMetricsHost), "address used for the statsd metrics server")


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Add the `--statsd-disable` flag to sensu-agent which configures the statsd listener. The listener is enabled by default.

## Why is this change necessary?

Closes #1128.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.