### PR TITLE
[GraphQL] Expose related entities using simple heuristic

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -72,12 +72,14 @@ func (r *entityImpl) Author(p graphql.ResolveParams) (interface{}, error) {
 func (r *entityImpl) Related(p schema.EntityRelatedFieldResolverParams) (interface{}, error) {
 	entity := p.Source.(*types.Entity)
 
+	// fetch
 	ctx := types.SetContextFromResource(p.Context, entity)
 	entities, err := r.entityCtrl.Query(ctx)
 	if err != nil {
 		return []*types.Entity{}, err
 	}
 
+	// sort
 	scores := map[int]int{}
 	for i, en := range entities {
 		matched := strings.Intersect(
@@ -90,13 +92,8 @@ func (r *entityImpl) Related(p schema.EntityRelatedFieldResolverParams) (interfa
 		return scores[i] < scores[j]
 	})
 
-	limit := p.Args.Limit
-	if limit > len(entities) {
-		limit = len(entities)
-	} else if limit < 0 {
-		limit = 0
-	}
-
+	// limit
+	limit := clampInt(p.Args.Limit, 0, len(entities))
 	return entities[0:limit], nil
 }
 

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -1,0 +1,37 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockEntityQuerier struct {
+	els []*types.Entity
+	err error
+}
+
+func (e mockEntityQuerier) Query(ctx context.Context) ([]*types.Entity, error) {
+	return e.els, e.err
+}
+
+func TestEntityTypeRelatedField(t *testing.T) {
+	mock := mockEntityQuerier{els: []*types.Entity{
+		types.FixtureEntity("a"),
+		types.FixtureEntity("b"),
+	}}
+	impl := entityImpl{entityCtrl: mock}
+
+	params := schema.EntityRelatedFieldResolverParams{}
+	params.Source = types.FixtureEntity("c")
+	params.Args.Limit = 10
+
+	res, err := impl.Related(params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, res)
+
+}

--- a/backend/apid/graphql/schema/entity.graphql
+++ b/backend/apid/graphql/schema/entity.graphql
@@ -19,7 +19,10 @@ type Entity implements Node {
   deregistration: Deregistration
   keepaliveTimeout: Int
   authorId: String!
-  author: User! # TODO: Implement w/ user type
+  author: User!
+
+  "Related returns a sorted list of like entities from the same environment."
+  related(limit: Int = 10): [Entity]!
 
   # TODO: Use scalar?
   # "ExtendedAttributes store serialized arbitrary JSON-encoded data"

--- a/util/strings/strings.go
+++ b/util/strings/strings.go
@@ -58,3 +58,20 @@ func Remove(item string, array []string) []string {
 	}
 	return array
 }
+
+// Intersect finds the intersection between two slices of strings.
+func Intersect(a []string, b []string) []string {
+	set := make([]string, 0, len(a))
+	tab := map[string]bool{}
+
+	for _, e := range a {
+		tab[e] = true
+	}
+
+	for _, e := range b {
+		if _, found := tab[e]; found {
+			set = append(set, e)
+		}
+	}
+	return set
+}

--- a/util/strings/strings_test.go
+++ b/util/strings/strings_test.go
@@ -62,3 +62,17 @@ func TestRemove(t *testing.T) {
 	array = Remove("bar", array)
 	assert.Equal(t, []string{}, array)
 }
+
+func TestIntersect(t *testing.T) {
+	a, b := []string{"bar", "qux"}, []string{"foo", "bar"}
+	intr := Intersect(a, b)
+	assert.Equal(t, []string{"bar"}, intr)
+
+	a, b = []string{}, []string{}
+	intr = Intersect(a, b)
+	assert.Equal(t, []string{}, intr)
+
+	a, b = []string{"foo", "qux"}, []string{"baz", "bar"}
+	intr = Intersect(a, b)
+	assert.Equal(t, []string{}, intr)
+}


### PR DESCRIPTION
## What is this change?

Expose related entities using simple heuristic

## Why is this change necessary?

Unblocks #1133 

## Were there any complications while making this change?

Mocking each controller is cumbersome. Took a peak at https://github.com/vektra/mockery to possibly go:generate mocks for the controllers.