### PR TITLE
[GraphQL] Expose an environment's check history

### DIFF
--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -88,13 +88,14 @@ func (r *checkImpl) Executed(p graphql.ResolveParams) (time.Time, error) {
 func (r *checkImpl) History(p schema.CheckHistoryFieldResolverParams) (interface{}, error) {
 	check := p.Source.(*types.Check)
 	history := check.History
-	last := p.Args.Last
-	if last > len(history) {
-		last = len(history)
-	} else if last < 0 {
-		last = 0
+
+	length := p.Args.First
+	if length > len(history) {
+		length = len(history)
+	} else if length < 0 {
+		length = 0
 	}
-	return history[0:last], nil
+	return history[0:length], nil
 }
 
 //

--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -89,12 +89,7 @@ func (r *checkImpl) History(p schema.CheckHistoryFieldResolverParams) (interface
 	check := p.Source.(*types.Check)
 	history := check.History
 
-	length := p.Args.First
-	if length > len(history) {
-		length = len(history)
-	} else if length < 0 {
-		length = 0
-	}
+	length := constrainInt(p.Args.First, len(history))
 	return history[0:length], nil
 }
 

--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -89,7 +89,7 @@ func (r *checkImpl) History(p schema.CheckHistoryFieldResolverParams) (interface
 	check := p.Source.(*types.Check)
 	history := check.History
 
-	length := constrainInt(p.Args.First, len(history))
+	length := clampInt(p.Args.First, 0, len(history))
 	return history[0:length], nil
 }
 

--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -84,6 +84,19 @@ func (r *checkImpl) Executed(p graphql.ResolveParams) (time.Time, error) {
 	return time.Unix(c.Executed, 0), nil
 }
 
+// History implements response to request for 'history' field.
+func (r *checkImpl) History(p schema.CheckHistoryFieldResolverParams) (interface{}, error) {
+	check := p.Source.(*types.Check)
+	history := check.History
+	last := p.Args.Last
+	if last > len(history) {
+		last = len(history)
+	} else if last < 0 {
+		last = 0
+	}
+	return history[0:last], nil
+}
+
 //
 // Implement CheckHistoryFieldResolvers
 //
@@ -100,10 +113,4 @@ func (r *checkHistoryImpl) Status(p graphql.ResolveParams) (int, error) {
 func (r *checkHistoryImpl) Executed(p graphql.ResolveParams) (time.Time, error) {
 	h := p.Source.(types.CheckHistory)
 	return time.Unix(h.Executed, 0), nil
-}
-
-// IsTypeOf is used to determine if a given value is associated with the type
-func (r *checkHistoryImpl) IsTypeOf(s interface{}, p graphql.IsTypeOfParams) bool {
-	_, ok := s.(types.CheckHistory)
-	return ok
 }

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -13,23 +13,23 @@ import (
 func TestCheckTypeHistoryFieldImpl(t *testing.T) {
 	testCases := []struct {
 		expectedLen int
-		lastArg     int
+		firstArg    int
 	}{
 		{
 			expectedLen: 21,
-			lastArg:     50,
+			firstArg:    50,
 		},
 		{
 			expectedLen: 10,
-			lastArg:     10,
+			firstArg:    10,
 		},
 		{
 			expectedLen: 0,
-			lastArg:     0,
+			firstArg:    0,
 		},
 		{
 			expectedLen: 0,
-			lastArg:     -10,
+			firstArg:    -10,
 		},
 	}
 
@@ -38,7 +38,7 @@ func TestCheckTypeHistoryFieldImpl(t *testing.T) {
 		t.Run(fmt.Sprintf("w/ argument of %d", tc.expectedLen), func(t *testing.T) {
 			params := schema.CheckHistoryFieldResolverParams{}
 			params.Source = check
-			params.Args.Last = tc.lastArg
+			params.Args.First = tc.firstArg
 
 			impl := checkImpl{}
 			res, err := impl.History(params)

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -1,0 +1,49 @@
+package graphql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckTypeHistoryFieldImpl(t *testing.T) {
+	testCases := []struct {
+		expectedLen int
+		lastArg     int
+	}{
+		{
+			expectedLen: 21,
+			lastArg:     50,
+		},
+		{
+			expectedLen: 10,
+			lastArg:     10,
+		},
+		{
+			expectedLen: 0,
+			lastArg:     0,
+		},
+		{
+			expectedLen: 0,
+			lastArg:     -10,
+		},
+	}
+
+	check := types.FixtureCheck("test")
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("w/ argument of %d", tc.expectedLen), func(t *testing.T) {
+			params := schema.CheckHistoryFieldResolverParams{}
+			params.Source = check
+			params.Args.Last = tc.lastArg
+
+			impl := checkImpl{}
+			res, err := impl.History(params)
+			require.NoError(t, err)
+			assert.Len(t, res, tc.expectedLen)
+		})
+	}
+}

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -212,6 +212,6 @@ func (r *envImpl) CheckHistory(p schema.EnvironmentCheckHistoryFieldResolverPara
 	sort.Sort(types.ByExecuted(history))
 
 	// Limit
-	limit := constrainInt(p.Args.Limit, len(history))
+	limit := clampInt(p.Args.Limit, 0, len(history))
 	return history[0:limit], nil
 }

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -212,12 +212,6 @@ func (r *envImpl) CheckHistory(p schema.EnvironmentCheckHistoryFieldResolverPara
 	sort.Sort(types.ByExecuted(history))
 
 	// Limit
-	limit := p.Args.Limit
-	if limit < 0 {
-		limit = 0
-	} else if limit > len(history) {
-		limit = len(history)
-	}
-
+	limit := constrainInt(p.Args.Limit, len(history))
 	return history[0:limit], nil
 }

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -17,7 +17,7 @@ import (
 
 var _ schema.EnvironmentFieldResolvers = (*envImpl)(nil)
 
-type eventQueryable interface {
+type eventQuerier interface {
 	Query(ctx context.Context, entity, check string) ([]*types.Event, error)
 }
 
@@ -29,7 +29,7 @@ type envImpl struct {
 	orgCtrl    actions.OrganizationsController
 	checksCtrl actions.CheckController
 	entityCtrl actions.EntityController
-	eventsCtrl eventQueryable
+	eventsCtrl eventQuerier
 }
 
 func newEnvImpl(store store.Store, getter types.QueueGetter) *envImpl {

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -200,6 +200,11 @@ func (r *envImpl) CheckHistory(p schema.EnvironmentCheckHistoryFieldResolverPara
 		if record.Check == nil {
 			continue
 		}
+		latest := types.CheckHistory{
+			Executed: record.Check.Executed,
+			Status:   record.Check.Status,
+		}
+		history = append(history, latest)
 		history = append(history, record.Check.History...)
 	}
 

--- a/backend/apid/graphql/environment_test.go
+++ b/backend/apid/graphql/environment_test.go
@@ -1,12 +1,25 @@
 package graphql
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/graphql"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type eventFinder struct {
+	collection []*types.Event
+	err        error
+}
+
+func (f eventFinder) Query(ctx context.Context, entity, check string) ([]*types.Event, error) {
+	return f.collection, f.err
+}
 
 func TestEnvColourID(t *testing.T) {
 	handler := &envImpl{}
@@ -15,4 +28,34 @@ func TestEnvColourID(t *testing.T) {
 	colour, err := handler.ColourID(graphql.ResolveParams{Source: &env})
 	assert.NoError(t, err)
 	assert.Equal(t, string(colour), "BLUE")
+}
+
+func TestEnvironmentTypeCheckHistoryField(t *testing.T) {
+	env := types.Environment{Name: "pink"}
+	events := []*types.Event{
+		types.FixtureEvent("a", "b"),
+		types.FixtureEvent("b", "c"),
+		types.FixtureEvent("c", "d"),
+	}
+
+	finder := eventFinder{collection: events, err: nil}
+	impl := &envImpl{eventsCtrl: finder}
+
+	// Params
+	params := schema.EnvironmentCheckHistoryFieldResolverParams{}
+	params.Source = &env
+
+	// limit: 30
+	params.Args.Limit = 30
+	history, err := impl.CheckHistory(params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, history)
+	assert.Len(t, history, 30)
+
+	// store err
+	impl.eventsCtrl = eventFinder{err: errors.New("test")}
+	history, err = impl.CheckHistory(params)
+	require.NotNil(t, history)
+	assert.Error(t, err)
+	assert.Empty(t, history)
 }

--- a/backend/apid/graphql/schema/check.gql.go
+++ b/backend/apid/graphql/schema/check.gql.go
@@ -1069,7 +1069,7 @@ type CheckExecutedFieldResolver interface {
 
 // CheckHistoryFieldResolverArgs contains arguments provided to history when selected
 type CheckHistoryFieldResolverArgs struct {
-	Last int // Last - self descriptive
+	First int // First - self descriptive
 }
 
 // CheckHistoryFieldResolverParams contains contextual info to resolve history field
@@ -1584,7 +1584,7 @@ func _ObjectTypeCheckConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.Int,
 			},
 			"history": &graphql1.Field{
-				Args: graphql1.FieldConfigArgument{"last": &graphql1.ArgumentConfig{
+				Args: graphql1.FieldConfigArgument{"first": &graphql1.ArgumentConfig{
 					DefaultValue: 21,
 					Description:  "self descriptive",
 					Type:         graphql1.Int,

--- a/backend/apid/graphql/schema/check.gql.go
+++ b/backend/apid/graphql/schema/check.gql.go
@@ -5,6 +5,7 @@ package schema
 import (
 	fmt "fmt"
 	graphql1 "github.com/graphql-go/graphql"
+	mapstructure "github.com/mitchellh/mapstructure"
 	graphql "github.com/sensu/sensu-go/graphql"
 	time "time"
 )
@@ -1066,10 +1067,21 @@ type CheckExecutedFieldResolver interface {
 	Executed(p graphql.ResolveParams) (time.Time, error)
 }
 
+// CheckHistoryFieldResolverArgs contains arguments provided to history when selected
+type CheckHistoryFieldResolverArgs struct {
+	Last int // Last - self descriptive
+}
+
+// CheckHistoryFieldResolverParams contains contextual info to resolve history field
+type CheckHistoryFieldResolverParams struct {
+	graphql.ResolveParams
+	Args CheckHistoryFieldResolverArgs
+}
+
 // CheckHistoryFieldResolver implement to resolve requests for the Check's history field.
 type CheckHistoryFieldResolver interface {
 	// History implements response to request for history field.
-	History(p graphql.ResolveParams) (interface{}, error)
+	History(p CheckHistoryFieldResolverParams) (interface{}, error)
 }
 
 // CheckIssuedFieldResolver implement to resolve requests for the Check's issued field.
@@ -1329,7 +1341,7 @@ func (_ CheckAliases) Executed(p graphql.ResolveParams) (time.Time, error) {
 }
 
 // History implements response to request for 'history' field.
-func (_ CheckAliases) History(p graphql.ResolveParams) (interface{}, error) {
+func (_ CheckAliases) History(p CheckHistoryFieldResolverParams) (interface{}, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
 	return val, err
 }
@@ -1479,7 +1491,13 @@ func _ObjTypeCheckExecutedHandler(impl interface{}) graphql1.FieldResolveFn {
 
 func _ObjTypeCheckHistoryHandler(impl interface{}) graphql1.FieldResolveFn {
 	resolver := impl.(CheckHistoryFieldResolver)
-	return func(frp graphql1.ResolveParams) (interface{}, error) {
+	return func(p graphql1.ResolveParams) (interface{}, error) {
+		frp := CheckHistoryFieldResolverParams{ResolveParams: p}
+		err := mapstructure.Decode(p.Args, &frp.Args)
+		if err != nil {
+			return nil, err
+		}
+
 		return resolver.History(frp)
 	}
 }
@@ -1566,7 +1584,11 @@ func _ObjectTypeCheckConfigFn() graphql1.ObjectConfig {
 				Type:              graphql1.Int,
 			},
 			"history": &graphql1.Field{
-				Args:              graphql1.FieldConfigArgument{},
+				Args: graphql1.FieldConfigArgument{"last": &graphql1.ArgumentConfig{
+					DefaultValue: 21,
+					Description:  "self descriptive",
+					Type:         graphql1.Int,
+				}},
 				DeprecationReason: "",
 				Description:       "History is the check state history.",
 				Name:              "history",
@@ -1873,14 +1895,14 @@ func _ObjectTypeCheckHistoryConfigFn() graphql1.ObjectConfig {
 				DeprecationReason: "",
 				Description:       "Executed describes the time in which the check request was executed",
 				Name:              "executed",
-				Type:              graphql1.DateTime,
+				Type:              graphql1.NewNonNull(graphql1.DateTime),
 			},
 			"status": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
 				Description:       "Status is the exit status code produced by the check.",
 				Name:              "status",
-				Type:              graphql1.Int,
+				Type:              graphql1.NewNonNull(graphql1.Int),
 			},
 		},
 		Interfaces: []*graphql1.Interface{},

--- a/backend/apid/graphql/schema/check.graphql
+++ b/backend/apid/graphql/schema/check.graphql
@@ -125,7 +125,7 @@ type Check {
   executed: DateTime
 
   "History is the check state history."
-  history: [CheckHistory]!
+  history(last: Int = 21): [CheckHistory]!
 
   "Issued describes the time in which the check request was issued"
   issued: Int!
@@ -151,8 +151,8 @@ CheckHistory is a record of a check execution and its status
 """
 type CheckHistory {
   "Status is the exit status code produced by the check."
-  status: Int
+  status: Int!
 
   "Executed describes the time in which the check request was executed"
-  executed: DateTime
+  executed: DateTime!
 }

--- a/backend/apid/graphql/schema/check.graphql
+++ b/backend/apid/graphql/schema/check.graphql
@@ -125,7 +125,7 @@ type Check {
   executed: DateTime
 
   "History is the check state history."
-  history(last: Int = 21): [CheckHistory]!
+  history(first: Int = 21): [CheckHistory]!
 
   "Issued describes the time in which the check request was issued"
   issued: Int!

--- a/backend/apid/graphql/schema/environment.gql.go
+++ b/backend/apid/graphql/schema/environment.gql.go
@@ -85,8 +85,8 @@ type EnvironmentEventsFieldResolverArgs struct {
 	Last    int             // Last - self descriptive
 	Before  string          // Before - self descriptive
 	After   string          // After - self descriptive
-	Filter  string          // Filter - self descriptive
 	OrderBy EventsListOrder // OrderBy - self descriptive
+	Filter  string          // Filter reduces the set using the given Sensu Query Expression predicate.
 }
 
 // EnvironmentEventsFieldResolverParams contains contextual info to resolve events field
@@ -435,7 +435,7 @@ func _ObjectTypeEnvironmentConfigFn() graphql1.ObjectConfig {
 						Type:        graphql1.String,
 					},
 					"filter": &graphql1.ArgumentConfig{
-						Description: "self descriptive",
+						Description: "Filter reduces the set using the given Sensu Query Expression predicate.",
 						Type:        graphql1.String,
 					},
 					"first": &graphql1.ArgumentConfig{

--- a/backend/apid/graphql/schema/environment.gql.go
+++ b/backend/apid/graphql/schema/environment.gql.go
@@ -101,6 +101,24 @@ type EnvironmentEventsFieldResolver interface {
 	Events(p EnvironmentEventsFieldResolverParams) (interface{}, error)
 }
 
+// EnvironmentCheckHistoryFieldResolverArgs contains arguments provided to checkHistory when selected
+type EnvironmentCheckHistoryFieldResolverArgs struct {
+	Filter string // Filter reduces the set using the given Sensu Query Expression predicate.
+	Limit  int    // Limit adds optional limit to the number of entries returned.
+}
+
+// EnvironmentCheckHistoryFieldResolverParams contains contextual info to resolve checkHistory field
+type EnvironmentCheckHistoryFieldResolverParams struct {
+	graphql.ResolveParams
+	Args EnvironmentCheckHistoryFieldResolverArgs
+}
+
+// EnvironmentCheckHistoryFieldResolver implement to resolve requests for the Environment's checkHistory field.
+type EnvironmentCheckHistoryFieldResolver interface {
+	// CheckHistory implements response to request for checkHistory field.
+	CheckHistory(p EnvironmentCheckHistoryFieldResolverParams) (interface{}, error)
+}
+
 //
 // EnvironmentFieldResolvers represents a collection of methods whose products represent the
 // response values of the 'Environment' type.
@@ -171,6 +189,7 @@ type EnvironmentFieldResolvers interface {
 	EnvironmentEntitiesFieldResolver
 	EnvironmentChecksFieldResolver
 	EnvironmentEventsFieldResolver
+	EnvironmentCheckHistoryFieldResolver
 }
 
 // EnvironmentAliases implements all methods on EnvironmentFieldResolvers interface by using reflection to
@@ -271,6 +290,12 @@ func (_ EnvironmentAliases) Events(p EnvironmentEventsFieldResolverParams) (inte
 	return val, err
 }
 
+// CheckHistory implements response to request for 'checkHistory' field.
+func (_ EnvironmentAliases) CheckHistory(p EnvironmentCheckHistoryFieldResolverParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
 // EnvironmentType Environment represents a Sensu environment in RBAC
 var EnvironmentType = graphql.NewType("Environment", graphql.ObjectKind)
 
@@ -354,10 +379,40 @@ func _ObjTypeEnvironmentEventsHandler(impl interface{}) graphql1.FieldResolveFn 
 	}
 }
 
+func _ObjTypeEnvironmentCheckHistoryHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(EnvironmentCheckHistoryFieldResolver)
+	return func(p graphql1.ResolveParams) (interface{}, error) {
+		frp := EnvironmentCheckHistoryFieldResolverParams{ResolveParams: p}
+		err := mapstructure.Decode(p.Args, &frp.Args)
+		if err != nil {
+			return nil, err
+		}
+
+		return resolver.CheckHistory(frp)
+	}
+}
+
 func _ObjectTypeEnvironmentConfigFn() graphql1.ObjectConfig {
 	return graphql1.ObjectConfig{
 		Description: "Environment represents a Sensu environment in RBAC",
 		Fields: graphql1.Fields{
+			"checkHistory": &graphql1.Field{
+				Args: graphql1.FieldConfigArgument{
+					"filter": &graphql1.ArgumentConfig{
+						Description: "Filter reduces the set using the given Sensu Query Expression predicate.",
+						Type:        graphql1.String,
+					},
+					"limit": &graphql1.ArgumentConfig{
+						DefaultValue: 10000,
+						Description:  "Limit adds optional limit to the number of entries returned.",
+						Type:         graphql1.Int,
+					},
+				},
+				DeprecationReason: "",
+				Description:       "All check history associated with the environment.",
+				Name:              "checkHistory",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql.OutputType("CheckHistory"))),
+			},
 			"checks": &graphql1.Field{
 				Args: graphql1.FieldConfigArgument{
 					"after": &graphql1.ArgumentConfig{
@@ -499,6 +554,7 @@ func _ObjectTypeEnvironmentConfigFn() graphql1.ObjectConfig {
 var _ObjectTypeEnvironmentDesc = graphql.ObjectDesc{
 	Config: _ObjectTypeEnvironmentConfigFn,
 	FieldHandlers: map[string]graphql.FieldHandler{
+		"checkHistory": _ObjTypeEnvironmentCheckHistoryHandler,
 		"checks":       _ObjTypeEnvironmentChecksHandler,
 		"colourId":     _ObjTypeEnvironmentColourIDHandler,
 		"description":  _ObjTypeEnvironmentDescriptionHandler,

--- a/backend/apid/graphql/schema/environment.gql.go
+++ b/backend/apid/graphql/schema/environment.gql.go
@@ -409,7 +409,7 @@ func _ObjectTypeEnvironmentConfigFn() graphql1.ObjectConfig {
 					},
 				},
 				DeprecationReason: "",
-				Description:       "All check history associated with the environment.",
+				Description:       "checkHistory includes all persisted check execution results associated with\nthe environment. Unlike the Check type's history this field includes the most\nrecent result.",
 				Name:              "checkHistory",
 				Type:              graphql1.NewNonNull(graphql1.NewList(graphql.OutputType("CheckHistory"))),
 			},

--- a/backend/apid/graphql/schema/environment.graphql
+++ b/backend/apid/graphql/schema/environment.graphql
@@ -24,7 +24,15 @@ type Environment implements Node {
   checks(first: Int = 10, last: Int = 10, before: String, after: String): CheckConfigConnection
 
   "All events associated with the environment."
-  events(first: Int = 10, last: Int = 10, before: String, after: String, filter: String, orderBy: EventsListOrder = SEVERITY): EventConnection
+  events(
+    first: Int = 10,
+    last: Int = 10,
+    before: String,
+    after: String,
+    orderBy: EventsListOrder = SEVERITY
+    "Filter reduces the set using the given Sensu Query Expression predicate."
+    filter: String,
+  ): EventConnection
 }
 
 enum EventsListOrder {

--- a/backend/apid/graphql/schema/environment.graphql
+++ b/backend/apid/graphql/schema/environment.graphql
@@ -34,7 +34,11 @@ type Environment implements Node {
     filter: String,
   ): EventConnection
 
-  "All check history associated with the environment."
+  """
+  checkHistory includes all persisted check execution results associated with
+  the environment. Unlike the Check type's history this field includes the most
+  recent result.
+  """
   checkHistory(
     "Filter reduces the set using the given Sensu Query Expression predicate."
     filter: String

--- a/backend/apid/graphql/schema/environment.graphql
+++ b/backend/apid/graphql/schema/environment.graphql
@@ -33,6 +33,14 @@ type Environment implements Node {
     "Filter reduces the set using the given Sensu Query Expression predicate."
     filter: String,
   ): EventConnection
+
+  "All check history associated with the environment."
+  checkHistory(
+    "Filter reduces the set using the given Sensu Query Expression predicate."
+    filter: String
+    "Limit adds optional limit to the number of entries returned."
+    limit: Int = 10000
+  ): [CheckHistory]!
 }
 
 enum EventsListOrder {

--- a/backend/apid/graphql/util.go
+++ b/backend/apid/graphql/util.go
@@ -1,0 +1,11 @@
+package graphql
+
+// constrainInt returns int within range.
+func constrainInt(num, min, max int) int {
+	if num < min {
+		return min
+	} else if num > max {
+		return max
+	}
+	return num
+}

--- a/backend/apid/graphql/util.go
+++ b/backend/apid/graphql/util.go
@@ -1,7 +1,7 @@
 package graphql
 
-// constrainInt returns int within range.
-func constrainInt(num, min, max int) int {
+// clampInt returns int within given range.
+func clampInt(num, min, max int) int {
 	if num < min {
 		return min
 	} else if num > max {


### PR DESCRIPTION
## What is this change?

Expose an environment's check history for use in web UI's history graph. (And more! maybe.)

## Why is this change necessary?

Unblocks #1132 

## Were there any complications while making this change?

Same "complication" as mentioned in #1296.

> Mocking each controller is cumbersome. Took a peak at https://github.com/vektra/mockery to possibly go:generate mocks for the controllers.