### PR TITLE
Add extension package and extension example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ metric events are swallowed for the time being.
 event handlers for statsd metrics.
 - Add default user with username "sensu" with global, read-only permissions.
 - Add end-to-end test for extensions.
+- Add extension package for building third-party Sensu extensions in Go.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/rpc/extension/LICENSE
+++ b/rpc/extension/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rpc/extension/doc.go
+++ b/rpc/extension/doc.go
@@ -1,0 +1,6 @@
+// Package extension provides types and functions for creating Sensu extensions
+// in Go. The extensions run as servers and use gRPC as a transport.
+//
+// Users only need provide a net.Listener, and one or more of the extension
+// methods, to have a fully working Sensu extension. See example for details.
+package extension

--- a/rpc/extension/example/LICENSE
+++ b/rpc/extension/example/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rpc/extension/example/main.go
+++ b/rpc/extension/example/main.go
@@ -1,0 +1,57 @@
+// This program is a sensu extension. It runs a gRPC server on its specified
+// port. The extension filters all events that have a successful check and
+// logs all events that have a failing check.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+
+	"github.com/sensu/sensu-go/rpc/extension"
+	"github.com/sensu/sensu-go/types"
+)
+
+var (
+	port = flag.Int("port", 31000, "port to run extension server on")
+)
+
+func LastCheckStatusZero(event *types.Event) (bool, error) {
+	if event.Check == nil {
+		// Filter metrics events as well.
+		return true, nil
+	}
+	return event.Check.Status == 0, nil
+}
+
+func FailingCheck(event *types.Event, mutated []byte) error {
+	log.Printf("entity %q: %s is failing", event.Entity.ID, event.Check.Name)
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	ext := extension.New().Filter(LastCheckStatusZero).Handle(FailingCheck)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", *port))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ln.Close()
+
+	server := extension.NewServer(ext, ln)
+	defer server.Stop()
+
+	if err := server.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	<-c
+	log.Println("Shutting down...")
+}

--- a/rpc/extension/extension.go
+++ b/rpc/extension/extension.go
@@ -1,0 +1,76 @@
+package extension
+
+import (
+	"errors"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// ErrNotImplemented is returned by extension methods that haven't been
+// mapped.
+var ErrNotImplemented = errors.New("method not implemented")
+
+type HandlerFunc func(*types.Event, []byte) error
+type MutatorFunc func(*types.Event) ([]byte, error)
+type FilterFunc func(*types.Event) (bool, error)
+
+var _ Interface = &Extension{}
+
+func (h HandlerFunc) HandleEvent(e *types.Event, m []byte) error {
+	return h(e, m)
+}
+
+func (m MutatorFunc) MutateEvent(e *types.Event) ([]byte, error) {
+	return m(e)
+}
+
+func (f FilterFunc) FilterEvent(e *types.Event) (bool, error) {
+	return f(e)
+}
+
+// Interface is the definition of an extension.
+type Interface interface {
+	// FilterEvent filters an event.
+	FilterEvent(*types.Event) (bool, error)
+
+	// MutateEvent mutates an event.
+	MutateEvent(*types.Event) ([]byte, error)
+
+	// HandleEvent handles an event. It is passed both the original event
+	// and the mutated event, if the event was mutated.
+	HandleEvent(*types.Event, []byte) error
+}
+
+// Extension is a convenience type for implementing Interface.
+type Extension struct {
+	HandlerFunc
+	MutatorFunc
+	FilterFunc
+}
+
+// New creates a new Extension.
+func New() *Extension {
+	return &Extension{
+		HandlerFunc: func(*types.Event, []byte) error { return ErrNotImplemented },
+		MutatorFunc: func(*types.Event) ([]byte, error) { return nil, ErrNotImplemented },
+		FilterFunc:  func(*types.Event) (bool, error) { return false, ErrNotImplemented },
+	}
+}
+
+// Handle registers fn as the func to call on HandleEvent.
+func (e *Extension) Handle(fn HandlerFunc) *Extension {
+	e.HandlerFunc = fn
+	return e
+}
+
+// Mutate registers fn as the func to call on MutateEvent.
+func (e *Extension) Mutate(fn MutatorFunc) *Extension {
+	e.MutatorFunc = fn
+	return e
+}
+
+// Filter registers fn as the func to call on FilterEvent.
+func (e *Extension) Filter(fn FilterFunc) *Extension {
+	e.FilterFunc = fn
+	return e
+}

--- a/rpc/extension/server.go
+++ b/rpc/extension/server.go
@@ -1,0 +1,93 @@
+package extension
+
+import (
+	"context"
+	"net"
+
+	"github.com/sensu/sensu-go/rpc"
+	"google.golang.org/grpc"
+)
+
+var _ rpc.ExtensionServer = &Server{}
+
+// Server is a Sensu extension.
+//
+// Create new extensions that will run on a local port with NewServer, and
+// then supply any of HandlerFunc, MutatorFunc or FilterFunc via the Handler
+// Mutator
+type Server struct {
+	ext    Interface
+	ln     net.Listener
+	server *grpc.Server
+}
+
+// NewServer creates a new server that will run on the provided listener.
+func NewServer(extension Interface, ln net.Listener) *Server {
+	return &Server{
+		ln:     ln,
+		server: grpc.NewServer(),
+		ext:    extension,
+	}
+}
+
+// Start starts the extension service.
+func (s *Server) Start() error {
+	rpc.RegisterExtensionServer(s.server, s)
+	go func() {
+		// TODO: add error handling once gRPC errors are a little less
+		// noisy.
+		_ = s.server.Serve(s.ln)
+	}()
+	return nil
+}
+
+// HandleEvent is called by gRPC.
+func (s *Server) HandleEvent(ctx context.Context, req *rpc.HandleEventRequest) (*rpc.HandleEventResponse, error) {
+	err := s.ext.HandleEvent(req.Event, req.MutatedEvent)
+	if err == ErrNotImplemented {
+		return nil, err
+	}
+	resp := rpc.HandleEventResponse{}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return &resp, nil
+}
+
+// MutateEvent is called by gRPC.
+func (s *Server) MutateEvent(ctx context.Context, req *rpc.MutateEventRequest) (*rpc.MutateEventResponse, error) {
+	mutated, err := s.ext.MutateEvent(req.Event)
+	if err == ErrNotImplemented {
+		return nil, err
+	}
+	resp := rpc.MutateEventResponse{
+		MutatedEvent: mutated,
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return &resp, nil
+}
+
+// FilterEvent is called by gRPC.
+func (s *Server) FilterEvent(ctx context.Context, req *rpc.FilterEventRequest) (*rpc.FilterEventResponse, error) {
+	filtered, err := s.ext.FilterEvent(req.Event)
+	if err == ErrNotImplemented {
+		return nil, err
+	}
+	resp := rpc.FilterEventResponse{
+		Filtered: filtered,
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return &resp, nil
+}
+
+// Stop stops the extension. If the extension's listener was pass in to the
+// extension  with NewServerWithListener, then the listener will not be
+// closed by Stop.
+func (s *Server) Stop() error {
+	s.server.GracefulStop()
+	return s.ln.Close()
+}


### PR DESCRIPTION
The extension package contains convenience types and functions for
writing third-party Sensu extensions in Go. An example is also provided.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #341 

## Does your change need a Changelog entry?

Yes