### PR TITLE
Optimize check marshaling and add a benchmark for subPump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and yarn are now dependencies for building the backend.
 - Don't allow the bus to drop messages.
 - Events list can properly be viewed on mobile.
 - Updated Sirupsen/logrus to sirupsen/logrus and other applicable dependencies using the former.
+- Optimize check marshaling.
 
 ### Fixed
 - Terminate processes gracefully in e2e tests, allowing ports to be reused.

--- a/backend/agentd/benchmark_test.go
+++ b/backend/agentd/benchmark_test.go
@@ -1,0 +1,58 @@
+package agentd
+
+import (
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/testing/mockring"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/transport"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/mock"
+)
+
+func BenchmarkSubPump(b *testing.B) {
+	conn := &testTransport{
+		sendCh: make(chan *transport.Message, 10),
+	}
+
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
+		RingGetter: &mockring.Getter{},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	st := &mockstore.MockStore{}
+	st.On(
+		"GetEnvironment",
+		mock.Anything,
+		"org",
+		"env",
+	).Return(&types.Environment{}, nil)
+
+	cfg := SessionConfig{
+		AgentID:       "testing",
+		Organization:  "org",
+		Environment:   "env",
+		Subscriptions: []string{"testing"},
+	}
+	session, err := NewSession(cfg, conn, bus, st)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	go func() {
+		for range session.sendq {
+		}
+	}()
+
+	session.wg.Add(1)
+	go session.subPump()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		session.checkChannel <- types.FixtureCheckRequest("checkity-check-check")
+	}
+}

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -2,19 +2,21 @@ package agentd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/handler"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 )
+
+var json = jsoniter.ConfigDefault
 
 // SessionStore specifies the storage requirements of the Session.
 type SessionStore interface {

--- a/types/check.go
+++ b/types/check.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/robfig/cron"
 	"github.com/sensu/sensu-go/types/dynamic"
 	"github.com/sensu/sensu-go/util/eval"
@@ -104,7 +105,21 @@ func (c *Check) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (c *Check) MarshalJSON() ([]byte, error) {
-	return dynamic.Marshal(c)
+	if c == nil {
+		return []byte("null"), nil
+	}
+
+	// Only use dynamic marshaling if there are dynamic attributes.
+	// Otherwise, use default json marshaling.
+	if len(c.ExtendedAttributes) > 0 {
+		return dynamic.Marshal(c)
+	}
+
+	type Clone Check
+	clone := &Clone{}
+	*clone = Clone(*c)
+
+	return jsoniter.Marshal(clone)
 }
 
 // SetExtendedAttributes sets the serialized ExtendedAttributes of c.
@@ -124,7 +139,21 @@ func (c *CheckConfig) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (c *CheckConfig) MarshalJSON() ([]byte, error) {
-	return dynamic.Marshal(c)
+	if c == nil {
+		return []byte("null"), nil
+	}
+
+	// Only use dynamic marshaling if there are dynamic attributes.
+	// Otherwise, use default json marshaling.
+	if len(c.ExtendedAttributes) > 0 {
+		return dynamic.Marshal(c)
+	}
+
+	type Clone CheckConfig
+	clone := &Clone{}
+	*clone = Clone(*c)
+
+	return jsoniter.Marshal(clone)
 }
 
 // SetExtendedAttributes sets the serialized ExtendedAttributes of c.


### PR DESCRIPTION
## What is this change?

```
    This commit significantly reduces the amount of time spent
    marshaling json in agentd. It replaces stdlib encoding/json with
    json-iterator, and it avoids using dynamic.Marshal when there are no
    dynamic attributes to be marshaled.
    
    Profiling performed during load testing shows that json encoding
    and decoding can comprise a substantial portion of time spent in
    the backend. This is most evident when there are many thousands of
    checks being executed per second.
    
    The benchmark results below are for a single iteration of subPump.
    subPump is part of agentd; it receives messages on a channel, and
    forwards them along to the agent. Profiling shows that the majority
    of time in subPump is spent dealing with json rendering. For every
    check that an agent executes, it must process a single subPump
    iteration.
    
    Before:
    26323 ns/op   16770 B/op  149 allocs/op
    
    After:
    5863  ns/op   3822  B/op  40  allocs/op
    
    Note that memory allocations are significantly reduced as well,
    reducing GC pressure by over a factor of 2.
```

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

At scale, Sensu backends will need to process tens of thousands of requests per second. This commit should significantly reduce request latency, while preserving json compatibility.

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

Should we start using protobuf marshaling for backend<->agent communication?