### PR TITLE
[GraphQL] Retrieve environment from the store

### DIFF
--- a/backend/apid/graphql/query_test.go
+++ b/backend/apid/graphql/query_test.go
@@ -19,14 +19,36 @@ func (m mockQueryEventFetcher) Find(ctx context.Context, entity, check string) (
 	return m.record, m.err
 }
 
+type mockQueryEnvironmentFetcher struct {
+	record *types.Environment
+	err    error
+}
+
+func (m mockQueryEnvironmentFetcher) Find(ctx context.Context, org, env string) (*types.Environment, error) {
+	return m.record, m.err
+}
+
 func TestQueryTypeEventField(t *testing.T) {
 	mock := mockQueryEventFetcher{&types.Event{}, nil}
-	impl := queryImpl{eventController: mock}
+	impl := queryImpl{eventCtrl: mock}
 
 	args := schema.QueryEventFieldResolverArgs{Ns: schema.NewNamespaceInput("a", "b")}
 	params := schema.QueryEventFieldResolverParams{Args: args}
 
 	res, err := impl.Event(params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, res)
+}
+
+func TestQueryTypeEnvironmentField(t *testing.T) {
+	mock := mockQueryEnvironmentFetcher{&types.Environment{}, nil}
+	impl := queryImpl{environmentCtrl: mock}
+
+	params := schema.QueryEnvironmentFieldResolverParams{}
+	params.Args.Environment = "default"
+	params.Args.Organization = "default"
+
+	res, err := impl.Environment(params)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }


### PR DESCRIPTION
## What is this change?

Instead of simply instantiating the `Environment` instance on the fly, we retrieve it from store. This ensures that the description is present and implicitly validates whether the environment exists.

## Why is this change necessary?

Unblocks #1292. Not found page can now be displayed if the requested environment cannot be found.