### PR TITLE
[Web UI] Retrieve any stored tokens during the initial load

### DIFF
--- a/dashboard/src/utils/authentication/index.js
+++ b/dashboard/src/utils/authentication/index.js
@@ -65,3 +65,9 @@ export function logout() {
 
   return invalidatePromise;
 }
+
+// Retrieve any stored tokens during the initial app load.
+const storedTokens = storage.retrieve();
+if (storedTokens) {
+  tokens.swap(storedTokens);
+}

--- a/dashboard/src/utils/authentication/tokens.js
+++ b/dashboard/src/utils/authentication/tokens.js
@@ -1,8 +1,5 @@
 import moment from "moment";
 
-// Single instance of authentication info.
-let authTokens = null;
-
 // Instantiate new tokens object with defaults.
 export function newTokens(args = {}) {
   return {
@@ -12,6 +9,9 @@ export function newTokens(args = {}) {
     expiresAt: args.expiresAt || moment(),
   };
 }
+
+// Single instance of authentication info.
+let authTokens = newTokens();
 
 // Return single authTokens instance
 export function get() {


### PR DESCRIPTION
## What is this change?

Any code that access auth tokens immediately at app load will receive the tokens from localstorage.

## Why is this change necessary?

This allows components to access stored tokens without having to call the `getAccessToken` function, avoiding the automatic token refresh behavior.