### PR TITLE
[Web UI] Add a mechanism to subscribe to auth token changes

### DIFF
--- a/dashboard/src/utils/authentication/tokens.js
+++ b/dashboard/src/utils/authentication/tokens.js
@@ -1,5 +1,9 @@
 import moment from "moment";
 
+import createDispatcher from "../dispatcher";
+
+const { subscribe, unsubscribe, subscribeOnce, dispatch } = createDispatcher();
+
 // Instantiate new tokens object with defaults.
 export function newTokens(args = {}) {
   return {
@@ -20,8 +24,11 @@ export function get() {
 
 // Swap single authTokens instance for new one
 export function swap(t) {
-  authTokens = t;
+  if (Object.prototype.toString.call(t) !== "[object Object]" || !t) {
+    throw new TypeError("Expected Object");
+  }
+  authTokens = Object.freeze(t);
+  dispatch(authTokens);
 }
 
-// Initialize authTokens w/ empty instance
-swap(newTokens());
+export { subscribe, unsubscribe, subscribeOnce };

--- a/dashboard/src/utils/dispatcher.js
+++ b/dashboard/src/utils/dispatcher.js
@@ -1,0 +1,42 @@
+const createDispatcher = () => {
+  const listeners = [];
+
+  const dispatch = data => {
+    [...listeners].forEach(listener => listener(data));
+  };
+
+  const unsubscribe = listener => {
+    const index = listeners.indexOf(listener);
+    if (index !== -1) {
+      listeners.splice(index, 1);
+    }
+  };
+
+  const subscribe = listener => {
+    if (listeners.indexOf(listener) !== -1) return () => {};
+    listeners.push(listener);
+
+    return () => unsubscribe(listener);
+  };
+
+  const subscribeOnce = handler => {
+    let unsub;
+
+    const listener = data => {
+      handler(data);
+      unsub();
+    };
+
+    unsub = subscribe(listener);
+    return unsub;
+  };
+
+  return {
+    dispatch,
+    unsubscribe,
+    subscribe,
+    subscribeOnce,
+  };
+};
+
+export default createDispatcher;

--- a/dashboard/src/utils/dispatcher.test.js
+++ b/dashboard/src/utils/dispatcher.test.js
@@ -1,0 +1,111 @@
+import createDispatcher from "./dispatcher";
+
+describe("dispatcher", () => {
+  describe("dispatch", () => {
+    it("should notify listeners", () => {
+      const dispatcher = createDispatcher();
+
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+
+      dispatcher.subscribe(listener1);
+      dispatcher.subscribe(listener2);
+
+      const data = { foo: "bar" };
+      dispatcher.dispatch(data);
+
+      expect(listener1.mock.calls.length).toBe(1);
+      expect(listener2.mock.calls.length).toBe(1);
+
+      expect(listener1.mock.calls[0][0]).toBe(data);
+      expect(listener2.mock.calls[0][0]).toBe(data);
+
+      dispatcher.dispatch(data);
+
+      expect(listener1.mock.calls.length).toBe(2);
+      expect(listener2.mock.calls.length).toBe(2);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("should be idempotent", () => {
+      const dispatcher = createDispatcher();
+
+      const listener = jest.fn();
+
+      dispatcher.subscribe(listener);
+      dispatcher.subscribe(listener);
+      dispatcher.subscribe(listener);
+
+      const data = { foo: "bar" };
+      dispatcher.dispatch(data);
+
+      expect(listener.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("should remove listeners", () => {
+      const dispatcher = createDispatcher();
+
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+
+      const unsubscribe1 = dispatcher.subscribe(listener1);
+      dispatcher.subscribe(listener2);
+
+      const data = { foo: "bar" };
+      dispatcher.dispatch(data);
+
+      expect(listener1.mock.calls.length).toBe(1);
+      expect(listener2.mock.calls.length).toBe(1);
+
+      unsubscribe1();
+      dispatcher.unsubscribe(listener2);
+
+      dispatcher.dispatch(data);
+
+      expect(listener1.mock.calls.length).toBe(1);
+      expect(listener2.mock.calls.length).toBe(1);
+    });
+
+    it("should be idempotent", () => {
+      const dispatcher = createDispatcher();
+
+      const listener = jest.fn();
+
+      dispatcher.subscribe(listener);
+
+      const data = { foo: "bar" };
+      dispatcher.dispatch(data);
+
+      expect(listener.mock.calls.length).toBe(1);
+
+      dispatcher.unsubscribe(listener);
+      dispatcher.unsubscribe(listener);
+      dispatcher.unsubscribe(listener);
+
+      dispatcher.dispatch(data);
+
+      expect(listener.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe("subscribeOnce", () => {
+    it("should remove listeners after dispatch", () => {
+      const dispatcher = createDispatcher();
+
+      const listener = jest.fn();
+
+      dispatcher.subscribeOnce(listener);
+
+      const data = { foo: "bar" };
+      dispatcher.dispatch(data);
+
+      expect(listener.mock.calls.length).toBe(1);
+      dispatcher.dispatch(data);
+
+      expect(listener.mock.calls.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## What is this change?

This allows the auth storage utils to behave like a flux store for any components that need the state.

## Why is this change necessary?

Components that depend on the state of user auth (specifically auth-based routes) need to have a mechanism with which to subscribe to auth state changes