### PR TITLE
[GraphQL] Change return type of issued field

### DIFF
--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -84,6 +84,12 @@ func (r *checkImpl) Executed(p graphql.ResolveParams) (time.Time, error) {
 	return time.Unix(c.Executed, 0), nil
 }
 
+// Issued implements response to request for 'issued' field.
+func (r *checkImpl) Issued(p graphql.ResolveParams) (time.Time, error) {
+	c := p.Source.(*types.Check)
+	return time.Unix(c.Issued, 0), nil
+}
+
 // History implements response to request for 'history' field.
 func (r *checkImpl) History(p schema.CheckHistoryFieldResolverParams) (interface{}, error) {
 	check := p.Source.(*types.Check)

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -3,8 +3,10 @@ package graphql
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/graphql"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,4 +48,17 @@ func TestCheckTypeHistoryFieldImpl(t *testing.T) {
 			assert.Len(t, res, tc.expectedLen)
 		})
 	}
+}
+
+func TestCheckTypeIssuedFieldImpl(t *testing.T) {
+	now := time.Now()
+	check := types.FixtureCheck("test")
+	check.Issued = now.Unix()
+
+	impl := checkImpl{}
+	params := graphql.ResolveParams{Source: check}
+
+	res, err := impl.Issued(params)
+	require.NoError(t, err)
+	assert.Equal(t, now.Unix(), res.Unix())
 }

--- a/backend/apid/graphql/schema/check.gql.go
+++ b/backend/apid/graphql/schema/check.gql.go
@@ -1087,7 +1087,7 @@ type CheckHistoryFieldResolver interface {
 // CheckIssuedFieldResolver implement to resolve requests for the Check's issued field.
 type CheckIssuedFieldResolver interface {
 	// Issued implements response to request for issued field.
-	Issued(p graphql.ResolveParams) (int, error)
+	Issued(p graphql.ResolveParams) (time.Time, error)
 }
 
 // CheckOutputFieldResolver implement to resolve requests for the Check's output field.
@@ -1382,9 +1382,9 @@ func (_ CheckAliases) History(p CheckHistoryFieldResolverParams) (interface{}, e
 }
 
 // Issued implements response to request for 'issued' field.
-func (_ CheckAliases) Issued(p graphql.ResolveParams) (int, error) {
+func (_ CheckAliases) Issued(p graphql.ResolveParams) (time.Time, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	ret := graphql1.Int.ParseValue(val).(int)
+	ret := val.(time.Time)
 	return ret, err
 }
 
@@ -1717,7 +1717,7 @@ func _ObjectTypeCheckConfigFn() graphql1.ObjectConfig {
 				DeprecationReason: "",
 				Description:       "Issued describes the time in which the check request was issued",
 				Name:              "issued",
-				Type:              graphql1.NewNonNull(graphql1.Int),
+				Type:              graphql1.NewNonNull(graphql1.DateTime),
 			},
 			"lastOK": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},

--- a/backend/apid/graphql/schema/check.graphql
+++ b/backend/apid/graphql/schema/check.graphql
@@ -128,7 +128,7 @@ type Check {
   history(first: Int = 21): [CheckHistory]!
 
   "Issued describes the time in which the check request was issued"
-  issued: Int!
+  issued: DateTime!
 
   "Output from the execution of Command"
   output: String!


### PR DESCRIPTION
## What is this change?

Change the return type of the check type's `issued` field.

## Why is this change necessary?

Unblocks #1130