### PR TITLE
InfluxDB Handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ swallowed. The events are sent through the pipeline.
 - Fixed a bug where the Issued field was never populated.
 - When creating a new statsd server, use the default flush interval if given 0.
 - Allow checks and hooks to escape zombie processes that have timed out.
+- Install all dependencies with `dep ensure` in build.sh.
 
 
 ## [2.0.0-nightly.1] - 2018-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ event handlers for statsd metrics.
 statsd listener. The listener is enabled by default.
 - Added an influx-db handler for events containing metrics.
 - Add 'remove-when' and 'set-when' subcommands to sensuctl filter command.
-- Added an influx-db handler for events containing metrics.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ event handlers for statsd metrics.
 - Add the `--statsd-disable` flag to sensu-agent which configures the
 statsd listener. The listener is enabled by default.
 - Add 'remove-when' and 'set-when' subcommands to sensuctl filter command.
+- Added an influx-db handler for events containing metrics.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,12 @@
   version = "v1.0"
 
 [[projects]]
+  name = "github.com/influxdata/influxdb"
+  packages = ["client/v2","models","pkg/escape"]
+  revision = "02d7d4f043b34ecb4e9b2dbec298c6f9450c2a32"
+  version = "v1.5.2"
+
+[[projects]]
   name = "github.com/jonboulle/clockwork"
   packages = ["."]
   revision = "2eee05ed794112d45db504eb05aa693efd2b8b09"
@@ -353,7 +359,7 @@
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = ["cpu","host","internal/common","mem","net","process"]
+  packages = ["host","internal/common","net","process"]
   revision = "a452de7c734a0fa0f16d2e5725b0fa5934d9fbec"
   version = "v2.17.08"
 
@@ -525,6 +531,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dc03e71373f86d75075d5c97a6ca4d166967cff4e7ebb759316dc1a2957a9372"
+  inputs-digest = "d44947b60540c1ef94c403688d17a80c31838e867517b07559868c8b7e0525cc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -167,3 +167,7 @@ required = ["github.com/shirou/w32"]
 [[constraint]]
   name = "github.com/atlassian/gostatsd"
   version = "2.4.0"
+
+[[constraint]]
+  name = "github.com/influxdata/influxdb"
+  version = "1.5.2"

--- a/build.ps1
+++ b/build.ps1
@@ -112,7 +112,7 @@ function build_tools
         build_tool $bin "tools"
     }
 
-    ForEach ($bin in "slack") {
+    ForEach ($bin in "slack","influx-db") {
         build_tool $bin "handlers"
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -112,7 +112,7 @@ build_tools () {
         build_tool $cmd "tools"
     done
 
-    for cmd in slack; do
+    for cmd in slack influx-db; do
         build_tool $cmd "handlers"
     done
 }
@@ -239,7 +239,7 @@ docker_commands () {
         build_tool_binary linux amd64 $cmd "tools"
     done
 
-    for cmd in slack; do
+    for cmd in slack influx-db; do
         echo "Building handlers/$cmd for linux-amd64"
         build_tool_binary linux amd64 $cmd "handlers"
     done

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ install_deps () {
     go get github.com/jgautheron/goconst/cmd/goconst
     go get honnef.co/go/tools/cmd/megacheck
     go get github.com/golang/lint/golint
+    install_golang_dep
 }
 
 install_golang_dep() {

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ RACE=""
 
 VERSION_CMD="go run ./version/cmd/version/version.go"
 
+HANDLERS=(slack influx-db)
+
 set_race_flag() {
     if [ "$GOARCH" == "amd64" ]; then
         RACE="-race"
@@ -112,7 +114,7 @@ build_tools () {
         build_tool $cmd "tools"
     done
 
-    for cmd in slack influx-db; do
+    for cmd in ${HANDLERS[@]}; do
         build_tool $cmd "handlers"
     done
 }
@@ -239,7 +241,7 @@ docker_commands () {
         build_tool_binary linux amd64 $cmd "tools"
     done
 
-    for cmd in slack influx-db; do
+    for cmd in ${HANDLERS[@]}; do
         echo "Building handlers/$cmd for linux-amd64"
         build_tool_binary linux amd64 $cmd "handlers"
     done

--- a/handlers/influx-db/LICENSE
+++ b/handlers/influx-db/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/handlers/influx-db/main.go
+++ b/handlers/influx-db/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/influxdata/influxdb/client/v2"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	addr     string
+	dbName   string
+	username string
+	password string
+	stdin    *os.File
+)
+
+func main() {
+	rootCmd := configureRootCommand()
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err.Error())
+	}
+}
+
+func configureRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "handler-influx-db",
+		Short: "an influx-db handler built for use with sensu",
+		RunE:  run,
+	}
+
+	cmd.Flags().StringVarP(&addr,
+		"addr",
+		"a",
+		"",
+		"The address of the influx-db server")
+
+	cmd.Flags().StringVarP(&dbName,
+		"db-name",
+		"d",
+		"",
+		"The influx-db to send metrics to")
+
+	cmd.Flags().StringVarP(&username,
+		"username",
+		"u",
+		"",
+		"The username for the given db")
+
+	cmd.Flags().StringVarP(&password,
+		"password",
+		"p",
+		"",
+		"The password for the given db")
+
+	_ = cmd.MarkFlagRequired("addr")
+	_ = cmd.MarkFlagRequired("db-name")
+	_ = cmd.MarkFlagRequired("username")
+	_ = cmd.MarkFlagRequired("password")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		_ = cmd.Help()
+		return errors.New("invalid argument(s) received")
+	}
+
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+
+	eventJSON, err := ioutil.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read stdin: %s", err.Error())
+	}
+
+	event := &types.Event{}
+	err = json.Unmarshal(eventJSON, event)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal stdin data: %s", err.Error())
+	}
+
+	if err = event.Validate(); err != nil {
+		return fmt.Errorf("failed to validate event: %s", err.Error())
+	}
+
+	if event.Metrics == nil {
+		return fmt.Errorf("event does not contain metrics")
+	}
+
+	return sendMetrics(event)
+}
+
+func sendMetrics(event *types.Event) error {
+	var pt *client.Point
+	c, err := client.NewHTTPClient(client.HTTPConfig{
+		Addr:     addr,
+		Username: username,
+		Password: password,
+	})
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:  dbName,
+		Precision: "s",
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, point := range event.Metrics.Points {
+		name := point.Name
+		timestamp := time.Unix(0, point.Timestamp)
+		fields := map[string]interface{}{"value": point.Value}
+		tags := make(map[string]string)
+		for _, tag := range point.Tags {
+			tags[tag.Name] = tag.Value
+		}
+
+		pt, err = client.NewPoint(name, tags, fields, timestamp)
+		if err != nil {
+			return err
+		}
+		bp.AddPoint(pt)
+	}
+
+	if err = c.Write(bp); err != nil {
+		return err
+	}
+
+	return c.Close()
+}

--- a/handlers/influx-db/main_test.go
+++ b/handlers/influx-db/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMetrics(t *testing.T) {
+	assert := assert.New(t)
+	event := types.FixtureEvent("entity1", "check1")
+	event.Check = nil
+	event.Metrics = types.FixtureMetrics()
+
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		expectedBody := `answer,foo=bar value=42`
+		assert.Contains(string(body), expectedBody)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"ok": true}`))
+		require.NoError(t, err)
+	}))
+
+	addr = apiStub.URL
+	err := sendMetrics(event)
+	assert.NoError(err)
+}
+
+func TestMain(t *testing.T) {
+	assert := assert.New(t)
+	file, _ := ioutil.TempFile(os.TempDir(), "sensu-handler-influx-db-")
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
+
+	event := types.FixtureEvent("entity1", "check1")
+	event.Check = nil
+	event.Metrics = types.FixtureMetrics()
+	eventJSON, _ := json.Marshal(event)
+	_, err := file.WriteString(string(eventJSON))
+	require.NoError(t, err)
+	require.NoError(t, file.Sync())
+	_, err = file.Seek(0, 0)
+	require.NoError(t, err)
+	stdin = file
+	requestReceived := false
+
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived = true
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"ok": true}`))
+		require.NoError(t, err)
+	}))
+
+	oldArgs := os.Args
+	os.Args = []string{"influx-db", "-a", apiStub.URL, "-d", "foo", "-u", "bar", "-p", "baz"}
+	defer func() { os.Args = oldArgs }()
+
+	main()
+	assert.True(requestReceived)
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds an influx-db event handler.

## Why is this change necessary?

Allows users to configure an event handler which will write sensu metrics to an influx-db of their choice!

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.