### PR TITLE
Add filters time windows management in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ event handlers for statsd metrics.
 - Add extension package for building third-party Sensu extensions in Go.
 - Add the `--statsd-disable` flag to sensu-agent which configures the
 statsd listener. The listener is enabled by default.
+- Add 'remove-when' and 'set-when' subcommands to sensuctl filter command.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/backend/apid/actions/filters.go
+++ b/backend/apid/actions/filters.go
@@ -10,6 +10,7 @@ import (
 
 var filterUpdateFields = []string{
 	"Action",
+	"When",
 	"Statements",
 }
 

--- a/cli/commands/filter/help.go
+++ b/cli/commands/filter/help.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/filter/subcommands"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +20,9 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		InfoCommand(cli),
 		ListCommand(cli),
 		UpdateCommand(cli),
+
+		subcommands.RemoveWhenCommand(cli),
+		subcommands.SetWhenCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/filter/subcommands/LICENSE
+++ b/cli/commands/filter/subcommands/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cli/commands/filter/subcommands/remove_when.go
+++ b/cli/commands/filter/subcommands/remove_when.go
@@ -1,0 +1,44 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// RemoveWhenCommand adds a command that allows a user to remove the time
+// windows of a filter
+func RemoveWhenCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "remove-when FILTER",
+		Short:        "removes time windows from a filter",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print usage if we do not receive one argument
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			filter, err := cli.Client.FetchFilter(args[0])
+			if err != nil {
+				return err
+			}
+			filter.When = nil
+
+			if err := filter.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateFilter(filter); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/filter/subcommands/remove_when_test.go
+++ b/cli/commands/filter/subcommands/remove_when_test.go
@@ -1,0 +1,51 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	stest "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRemoveWhenCommand(t *testing.T) {
+	tests := []struct {
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, nil, nil, "Usage", true},
+		{[]string{"foo"}, errors.New("error"), nil, "", true},
+		{[]string{"bar"}, nil, errors.New("error"), "", true},
+		{[]string{"filter1"}, nil, nil, "OK", false},
+	}
+
+	for i, test := range tests {
+		name := ""
+		if len(test.args) > 0 {
+			name = test.args[0]
+		}
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			filter := types.FixtureEventFilter("filter1")
+			cli := stest.NewMockCLI()
+			client := cli.Client.(*client.MockClient)
+			client.On("FetchFilter", name).Return(filter, test.fetchResponse)
+			client.On("UpdateFilter", mock.Anything).Return(test.updateResponse)
+			cmd := RemoveWhenCommand(cli)
+			out, err := stest.RunCmd(cmd, test.args)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, test.expectedOutput, out)
+		})
+	}
+}

--- a/cli/commands/filter/subcommands/set_when.go
+++ b/cli/commands/filter/subcommands/set_when.go
@@ -1,0 +1,74 @@
+package subcommands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/timeutil"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// SetWhenCommand adds a command that allows a user to set time windows for a
+// filter
+func SetWhenCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-when FILTER",
+		Short:        "set time windows for a filter from file or stdin",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print usage if we do not receive one argument
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			filter, err := cli.Client.FetchFilter(args[0])
+			if err != nil {
+				return err
+			}
+
+			timeWindowsPath, _ := cmd.Flags().GetString("file")
+			var in *os.File
+
+			if len(timeWindowsPath) > 0 {
+				in, err = os.Open(timeWindowsPath)
+				if err != nil {
+					return err
+				}
+
+				defer func() { _ = in.Close() }()
+			} else {
+				in = os.Stdin
+			}
+			var timeWindows types.TimeWindowWhen
+			if err := json.NewDecoder(in).Decode(&timeWindows); err != nil {
+				return err
+			}
+			for _, windows := range timeWindows.MapTimeWindows() {
+				for _, window := range windows {
+					if err := timeutil.ConvertToUTC(window); err != nil {
+						return err
+					}
+				}
+			}
+			filter.When = &timeWindows
+			if err := filter.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateFilter(filter); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Time windows definition file")
+
+	return cmd
+}

--- a/cli/commands/filter/subcommands/set_when_test.go
+++ b/cli/commands/filter/subcommands/set_when_test.go
@@ -1,0 +1,87 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	stest "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func fileFromString(t *testing.T, s string) (string, *os.File, func()) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	name := filepath.Join(dir, "timewindows.json")
+	tf, err := os.Create(name)
+	require.NoError(t, err)
+	cleanup := func() {
+		_ = tf.Close()
+		assert.NoError(t, os.RemoveAll(dir))
+	}
+	_, err = fmt.Fprintln(tf, s)
+	require.NoError(t, err)
+	require.NoError(t, tf.Sync())
+	_, err = tf.Seek(0, 0)
+	require.NoError(t, err)
+	return name, tf, cleanup
+}
+
+func TestSetWhenCommand(t *testing.T) {
+	const timeWindowsJSON = `{"days":{"all":[{"begin":"3:00 PM","end":"4:00 PM"}]}}`
+	tests := []struct {
+		args           []string
+		useflag        bool
+		stdin          string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, false, "", nil, nil, "Usage", true},
+		{[]string{"foo"}, false, "", errors.New("error"), nil, "", true},
+		{[]string{"bar"}, false, "", nil, errors.New("error"), "", true},
+		{[]string{"filter1"}, false, "", nil, nil, "", true},
+		{[]string{"filter1"}, false, timeWindowsJSON, nil, nil, "OK", false},
+		{[]string{"filter1"}, false, "invalidjson", nil, nil, "", true},
+		{[]string{"filter1"}, true, timeWindowsJSON, nil, nil, "", false},
+	}
+
+	for i, test := range tests {
+		name := ""
+		if len(test.args) > 0 {
+			name = test.args[0]
+		}
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			filter := types.FixtureEventFilter("filter1")
+			cli := stest.NewMockCLI()
+			client := cli.Client.(*client.MockClient)
+			client.On("FetchFilter", name).Return(filter, test.fetchResponse)
+			client.On("UpdateFilter", mock.Anything).Return(test.updateResponse)
+			cmd := SetWhenCommand(cli)
+			name, stdin, cleanup := fileFromString(t, test.stdin)
+			defer cleanup()
+			if test.useflag {
+				require.NoError(t, stdin.Close())
+				require.NoError(t, cmd.Flags().Set("file", name))
+			} else {
+				os.Stdin = stdin
+			}
+			out, err := stest.RunCmd(cmd, test.args)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, test.expectedOutput, out)
+		})
+	}
+}

--- a/types/filter.go
+++ b/types/filter.go
@@ -64,6 +64,8 @@ func (f *EventFilter) Update(from *EventFilter, fields ...string) error {
 		switch field {
 		case "Action":
 			f.Action = from.Action
+		case "When":
+			f.When = from.When
 		case "Statements":
 			f.Statements = append(f.Statements[0:0], from.Statements...)
 		default:


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds the `remove-when` and `set-when` subcommands to sensuctl filter command.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1121

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Non!

## Were there any complications while making this change?

Non!