### PR TITLE
[GraphQL] Fixup bug where env could not found

### DIFF
--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -45,7 +45,7 @@ func (r *queryImpl) Viewer(p graphql.ResolveParams) (interface{}, error) {
 
 // Environment implements response to request for 'environment' field.
 func (r *queryImpl) Environment(p schema.QueryEnvironmentFieldResolverParams) (interface{}, error) {
-	env, err := r.environmentCtrl.Find(p.Context, p.Args.Environment, p.Args.Organization)
+	env, err := r.environmentCtrl.Find(p.Context, p.Args.Organization, p.Args.Environment)
 	return handleControllerResults(env, err)
 }
 

--- a/backend/apid/graphql/query_test.go
+++ b/backend/apid/graphql/query_test.go
@@ -25,6 +25,9 @@ type mockQueryEnvironmentFetcher struct {
 }
 
 func (m mockQueryEnvironmentFetcher) Find(ctx context.Context, org, env string) (*types.Environment, error) {
+	if org != "bobs-burgers" || env != "us-west-2" {
+		return nil, nil
+	}
 	return m.record, m.err
 }
 
@@ -45,8 +48,8 @@ func TestQueryTypeEnvironmentField(t *testing.T) {
 	impl := queryImpl{environmentCtrl: mock}
 
 	params := schema.QueryEnvironmentFieldResolverParams{}
-	params.Args.Environment = "default"
-	params.Args.Organization = "default"
+	params.Args.Environment = "us-west-2"
+	params.Args.Organization = "bobs-burgers"
 
 	res, err := impl.Environment(params)
 	require.NoError(t, err)


### PR DESCRIPTION
## What is this change?

Fix bug where environment could not be found.

## Why is this change necessary?

Allow web UI (or any consumer of GraphQL service) to fetch environments.

## Were there any complications while making this change?

🤔 this might be where a smattering of APId integration tests may be helpful useful.