### PR TITLE
Default statsd flush interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and yarn are now dependencies for building the backend.
 - Events created from the metrics passed to the statsd listener are no longer
 swallowed. The events are sent through the pipeline.
 - Fixed a bug where the Issued field was never populated.
+- When creating a new statsd server, use the default flush interval if given 0.
 
 
 ## [2.0.0-nightly.1] - 2018-03-07

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -27,6 +27,10 @@ func NewStatsdServer(a *Agent) *statsd.Server {
 		logger.WithError(err).Error("failed to create sensu-statsd backend")
 	}
 	s.Backends = []gostatsd.Backend{backend}
+	if c.FlushInterval == 0 {
+		logger.Error("invalid statsd flush interval of 0, using the default 10s")
+		c.FlushInterval = DefaultStatsdFlushInterval
+	}
 	s.FlushInterval = time.Duration(c.FlushInterval) * time.Second
 	s.MetricsAddr = fmt.Sprintf("%s:%d", c.Host, c.Port)
 	return s


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

When creating a new statsd server, check if the config provided has a flush interval of 0. If so, use the default statsd flush interval.

## Why is this change necessary?

Closes #1345.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.