### PR TITLE
Make sensu-{backend,agent} sysvinit compat for centos 6 family

### DIFF
--- a/packaging/services/sensu-agent/sysvinit/etc/init.d/sensu-agent
+++ b/packaging/services/sensu-agent/sysvinit/etc/init.d/sensu-agent
@@ -1,3 +1,14 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          sensu-agent
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start sensu-agent
+# Description:       Enable the Sensu Agent service
+### END INIT INFO
+
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export PATH
 

--- a/packaging/services/sensu-backend/sysvinit/etc/init.d/sensu-backend
+++ b/packaging/services/sensu-backend/sysvinit/etc/init.d/sensu-backend
@@ -1,3 +1,14 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          sensu-backend
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start sensu-backend
+# Description:       Enable the Sensu Backend service
+### END INIT INFO
+
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export PATH
 


### PR DESCRIPTION
Centos 6, perhaps others, using chkconfig to enable services fail if
missing the "chkconfig" line or LSB in the head comment to set runlevels and
priority. The longer LSB style form is also supported by Ubuntu 14.04 init, in theory

Resolves the following error on centos 6:

  STDERR: service sensu-backend does not support chkconfig

ref:
- https://linux.die.net/man/8/chkconfig (heading: Runlevel Files)

Signed-off-by: Sean Escriva <sean.escriva@gmail.com>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

Updates the sysv init scripts 

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
Testing for chef cookbook development on centos 6 revealed this issue and it seemed possibly better to fix upstream instead of patching the initscripts with the cookbook.

## Does your change need a Changelog entry?
Maybe? I didn't want to presume.
<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?
Don't think so.
<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?
Nope. 
<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->