### PR TITLE
[Web UI] Avoid relative imports with module-resolver plugin

### DIFF
--- a/dashboard/.babelrc
+++ b/dashboard/.babelrc
@@ -1,0 +1,70 @@
+{
+  "presets": [
+    ["babel-preset-env", {
+      "targets": {
+        // React parses on ie 9, so we should too.
+        "ie": 9,
+      },
+      // Disable polyfill transforms.
+      "useBuiltIns": false,
+      // Do not transform es6 modules, required for webpack "tree shaking".
+      "modules": false,
+    }],
+    "babel-preset-react",
+  ],
+  "plugins": [
+    "transform-es2015-destructuring",
+    ["transform-class-properties", {
+      "loose": true,
+    }],
+    ["transform-object-rest-spread", {
+      "useBuiltIns": true,
+    }],
+    ["transform-react-jsx", {
+      "useBuiltIns": true,
+    }],
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "regenerator": true,
+    }],
+    ["transform-regenerator", {
+      "async": false,
+    }],
+    ["module-resolver", {
+      "alias": {
+        "": "./src",
+      },
+    }],
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        // These plugins can be removed after migrating to @babel/preset-react 7
+        // with the `development` option set.
+        "transform-react-jsx-source",
+        "transform-react-jsx-self",
+      ],
+    },
+    "test": {
+      "presets": [
+        ["babel-preset-env", {
+          "targets": {
+            "node": "current",
+          },
+          // Disable polyfill transforms.
+          "useBuiltIns": false,
+          // Transform modules to CJS for node runtime.
+          "modules": "commonjs",
+        }]
+      ],
+    },
+    "production": {
+      "plugins": [
+        ["transform-react-remove-prop-types", {
+          "removeImport": true,
+        }],
+      ],
+    },
+  }
+}

--- a/dashboard/.eslintrc.yml
+++ b/dashboard/.eslintrc.yml
@@ -13,8 +13,7 @@ env:
   browser: true
 settings:
   import/resolver:
-    webpack:
-      config: 'config/webpack.config.dev.js'
+    babel-module:
 rules:
   # While I personally prefer stateless functional components, since not every
   # component can be one, I'd rather be consistent and extend React.Component.
@@ -32,6 +31,9 @@ rules:
 
   # We use underscores to prefix "private" class methods
   no-underscore-dangle: 0
+
+  # babel-plugin-module-resolver aliases absolute paths to the src directory
+  import/no-absolute-path: 0
 
   # https://github.com/apollographql/eslint-plugin-graphql
   graphql/template-strings:

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,7 +18,18 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^22.1",
     "babel-loader": "^7.1.1",
-    "babel-preset-react-app": "^3.1",
+    "babel-plugin-module-resolver": "^3.1.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
+    "babel-plugin-transform-react-jsx-self": "^6.22.0",
+    "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
+    "babel-plugin-transform-regenerator": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
     "babel-runtime": "^6.23.0",
     "brcast": "^3.0.1",
     "case-sensitive-paths-webpack-plugin": "^2.1.1",
@@ -33,6 +44,7 @@
     "eslint-config-airbnb": "^15.1.0",
     "eslint-config-prettier": "^2.6.0",
     "eslint-config-react-app": "^2.1",
+    "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-graphql": "^1.5.0",
@@ -136,11 +148,6 @@
       "web.jsx",
       "jsx",
       "node"
-    ]
-  },
-  "babel": {
-    "presets": [
-      "react-app"
     ]
   },
   "proxy": {

--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -9,13 +9,13 @@ import {
 } from "apollo-cache-inmemory";
 import ApolloClient from "apollo-client";
 
-import { getAccessToken } from "../utils/authentication";
+import { getAccessToken } from "/utils/authentication";
 
 // TODO: Filter out out any type information unrelated to unions or interfaces
 // prior to importing `schema.json`. IntrospectionFragmentMatcher only needs
 // a subset of the schema.
 // see: apollographql.com/docs/react/advanced/fragments.html#fragment-matcher
-import { data as introspectionQueryResultData } from "../schema.json";
+import { data as introspectionQueryResultData } from "/schema.json";
 
 const createClient = () => {
   const fragmentMatcher = new IntrospectionFragmentMatcher({

--- a/dashboard/src/components/AppBar.js
+++ b/dashboard/src/components/AppBar.js
@@ -7,8 +7,8 @@ import Typography from "material-ui/Typography";
 import IconButton from "material-ui/IconButton";
 import { withStyles } from "material-ui/styles";
 import MenuIcon from "material-ui-icons/Menu";
-import EnvironmentLabel from "./EnvironmentLabel";
-import Wordmark from "../icons/SensuWordmark";
+import EnvironmentLabel from "/components/EnvironmentLabel";
+import Wordmark from "/icons/SensuWordmark";
 
 class AppBar extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/AppFrame.js
+++ b/dashboard/src/components/AppFrame.js
@@ -4,10 +4,10 @@ import { withStyles } from "material-ui/styles";
 import gql from "graphql-tag";
 import { Route } from "react-router-dom";
 
-import AppBar from "./AppBar";
-import Drawer from "./Drawer";
-import QuickNav from "./QuickNav";
-import Loader from "./Loader";
+import AppBar from "/components/AppBar";
+import Drawer from "/components/Drawer";
+import QuickNav from "/components/QuickNav";
+import Loader from "/components/Loader";
 
 class AppFrame extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/AppRoot.js
+++ b/dashboard/src/components/AppRoot.js
@@ -6,18 +6,18 @@ import { ApolloProvider } from "react-apollo";
 import { withStyles } from "material-ui/styles";
 import { Switch, Route, withRouter } from "react-router-dom";
 
-import AppThemeProvider from "./AppThemeProvider";
-import ResetStyles from "./ResetStyles";
-import ThemeStyles from "./ThemeStyles";
+import AppThemeProvider from "/components/AppThemeProvider";
+import ResetStyles from "/components/ResetStyles";
+import ThemeStyles from "/components/ThemeStyles";
 
-import AuthenticatedRoute from "./util/AuthenticatedRoute";
-import UnauthenticatedRoute from "./util/UnauthenticatedRoute";
+import AuthenticatedRoute from "/components/util/AuthenticatedRoute";
+import UnauthenticatedRoute from "/components/util/UnauthenticatedRoute";
 
-import DefaultRedirect from "./util/DefaultRedirect";
+import DefaultRedirect from "/components/util/DefaultRedirect";
 
-import EnvironmentView from "./views/EnvironmentView";
-import LoginView from "./views/LoginView";
-import NotFoundView from "./views/NotFoundView";
+import EnvironmentView from "/components/views/EnvironmentView";
+import LoginView from "/components/views/LoginView";
+import NotFoundView from "/components/views/NotFoundView";
 
 class AppRoot extends React.PureComponent {
   static propTypes = {

--- a/dashboard/src/components/AppThemeProvider.js
+++ b/dashboard/src/components/AppThemeProvider.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
-import ThemeProvider from "./ThemeProvider";
+import ThemeProvider from "/components/ThemeProvider";
 
 class AppThemeProvider extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/AppWrapper.js
+++ b/dashboard/src/components/AppWrapper.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
 
-import AppFrame from "./AppFrame";
+import AppFrame from "/components/AppFrame";
 
 class AppWrapper extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/CheckList.js
+++ b/dashboard/src/components/CheckList.js
@@ -11,9 +11,9 @@ import Table, {
   TableRow,
 } from "material-ui/Table";
 import Checkbox from "material-ui/Checkbox";
-import Row from "./CheckRow";
+import Row from "/components/CheckRow";
 
-import Loader from "./Loader";
+import Loader from "/components/Loader";
 
 class CheckList extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/Drawer.js
+++ b/dashboard/src/components/Drawer.js
@@ -17,15 +17,16 @@ import FeedbackIcon from "material-ui-icons/Feedback";
 import LogoutIcon from "material-ui-icons/ExitToApp";
 import IconButton from "material-ui/IconButton";
 import MenuIcon from "material-ui-icons/Menu";
-import WandIcon from "../icons/Wand";
-import EnvironmentIcon from "./EnvironmentIcon";
-import Wordmark from "../icons/SensuWordmark";
 
-import { logout } from "../utils/authentication";
-import DrawerButton from "./DrawerButton";
-import NamespaceSelector from "./NamespaceSelector";
-import Preferences from "./Preferences";
-import Loader from "./Loader";
+import WandIcon from "/icons/Wand";
+import Wordmark from "/icons/SensuWordmark";
+import { logout } from "/utils/authentication";
+
+import EnvironmentIcon from "/components/EnvironmentIcon";
+import DrawerButton from "/components/DrawerButton";
+import NamespaceSelector from "/components/NamespaceSelector";
+import Preferences from "/components/Preferences";
+import Loader from "/components/Loader";
 
 const linkPath = (params, path) => {
   const { organization, environment } = params;

--- a/dashboard/src/components/EnvironmentIcon/EnvironmentIconBase.js
+++ b/dashboard/src/components/EnvironmentIcon/EnvironmentIconBase.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { OrganizationIconBase as Icon } from "../OrganizationIcon";
-import { EnvironmentSymbolBase as Symbol } from "../EnvironmentSymbol";
+import { OrganizationIconBase as Icon } from "/components/OrganizationIcon";
+import { EnvironmentSymbolBase as Symbol } from "/components/EnvironmentSymbol";
 
 class EnvironmentIcon extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/EnvironmentLabel/EnvironmentLabelBase.js
+++ b/dashboard/src/components/EnvironmentLabel/EnvironmentLabelBase.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Typography from "material-ui/Typography";
 import { withStyles } from "material-ui/styles";
 
-import { EnvironmentIconBase as Icon } from "../EnvironmentIcon";
+import { EnvironmentIconBase as Icon } from "/components/EnvironmentIcon";
 
 class EnvironmentLabelBase extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/EnvironmentSymbol/EnvironmentSymbolBase.js
+++ b/dashboard/src/components/EnvironmentSymbol/EnvironmentSymbolBase.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import TagOrb from "../TagOrb";
+import TagOrb from "/components/TagOrb";
 
 const colours = {
   BLUE: "#8AB8D0",

--- a/dashboard/src/components/EventsContainer.js
+++ b/dashboard/src/components/EventsContainer.js
@@ -14,18 +14,18 @@ import { MenuItem } from "material-ui/Menu";
 import { ListItemText, ListItemIcon } from "material-ui/List";
 import Checkbox from "material-ui/Checkbox";
 
-import EventsListItem from "./EventsListItem";
-import EventStatus from "./EventStatus";
-import ResolveEventMutation from "../mutations/ResolveEventMutation";
+import EventsListItem from "/components/EventsListItem";
+import EventStatus from "/components/EventStatus";
+import ResolveEventMutation from "/mutations/ResolveEventMutation";
 import TableList, {
   TableListHeader,
   TableListBody,
   TableListSelect,
   TableListEmptyState,
   TableListButton as Button,
-} from "./TableList";
+} from "/components/TableList";
 
-import Loader from "./Loader";
+import Loader from "/components/Loader";
 
 const styles = theme => {
   const toolbar = theme.mixins.toolbar;

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -13,9 +13,9 @@ import Button from "material-ui/ButtonBase";
 import Checkbox from "material-ui/Checkbox";
 import Disclosure from "material-ui-icons/MoreVert";
 
-import ResolveEventMutation from "../mutations/ResolveEventMutation";
-import EventStatus from "./EventStatus";
-import { TableListItem } from "./TableList";
+import ResolveEventMutation from "/mutations/ResolveEventMutation";
+import EventStatus from "/components/EventStatus";
+import { TableListItem } from "/components/TableList";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/ExteriorWrapper.js
+++ b/dashboard/src/components/ExteriorWrapper.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { withStyles } from "material-ui/styles";
-import ThemeProvider from "../components/ThemeProvider";
+import ThemeProvider from "/components/ThemeProvider";
 
 class ExteriorWrapper extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/Loader.js
+++ b/dashboard/src/components/Loader.js
@@ -5,7 +5,7 @@ import ResizeObserver from "react-resize-observer";
 import { Motion, spring, presets } from "react-motion";
 import classnames from "classnames";
 
-import AnimatedLogo from "./AnimatedLogo";
+import AnimatedLogo from "/components/AnimatedLogo";
 
 const LOADER_OPACITY = 1;
 const OVERLAY_OPACITY = 0.8;

--- a/dashboard/src/components/NamespaceSelector.js
+++ b/dashboard/src/components/NamespaceSelector.js
@@ -6,8 +6,8 @@ import gql from "graphql-tag";
 import { withStyles } from "material-ui/styles";
 import Button from "material-ui/ButtonBase";
 
-import NamespaceSelectorBuilder from "./NamespaceSelectorBuilder";
-import NamespaceSelectorMenu from "./NamespaceSelectorMenu";
+import NamespaceSelectorBuilder from "/components/NamespaceSelectorBuilder";
+import NamespaceSelectorMenu from "/components/NamespaceSelectorMenu";
 
 const styles = {
   button: {

--- a/dashboard/src/components/NamespaceSelectorMenu.js
+++ b/dashboard/src/components/NamespaceSelectorMenu.js
@@ -8,8 +8,8 @@ import gql from "graphql-tag";
 import Menu, { MenuItem } from "material-ui/Menu";
 import { ListItemIcon, ListItemText } from "material-ui/List";
 import Divider from "material-ui/Divider";
-import OrganizationIcon from "./OrganizationIcon";
-import EnvironmentSymbol from "./EnvironmentSymbol";
+import OrganizationIcon from "/components/OrganizationIcon";
+import EnvironmentSymbol from "/components/EnvironmentSymbol";
 
 const styles = () => ({
   envIcon: {

--- a/dashboard/src/components/OrganizationIcon/OrganizationIconBase.js
+++ b/dashboard/src/components/OrganizationIcon/OrganizationIconBase.js
@@ -7,14 +7,14 @@ import DonutSmall from "material-ui-icons/DonutSmall";
 import Explore from "material-ui-icons/Explore";
 import Visibility from "material-ui-icons/Visibility";
 import Emoticon from "material-ui-icons/InsertEmoticon";
-import Hot from "../../icons/Hot";
-import Donut from "../../icons/Donut";
-import Briefcase from "../../icons/Briefcase";
-import Heart from "../../icons/Heart";
-import HalfHeart from "../../icons/HalfHeart";
-import HeartMug from "../../icons/HeartMug";
-import Espresso from "../../icons/Espresso";
-import Poly from "../../icons/Poly";
+import Hot from "/icons/Hot";
+import Donut from "/icons/Donut";
+import Briefcase from "/icons/Briefcase";
+import Heart from "/icons/Heart";
+import HalfHeart from "/icons/HalfHeart";
+import HeartMug from "/icons/HeartMug";
+import Espresso from "/icons/Espresso";
+import Poly from "/icons/Poly";
 
 const icons = {
   BRIEFCASE: Briefcase,

--- a/dashboard/src/components/QuickNav.js
+++ b/dashboard/src/components/QuickNav.js
@@ -7,7 +7,8 @@ import DashboardIcon from "material-ui-icons/Dashboard";
 import EventIcon from "material-ui-icons/Notifications";
 import EntityIcon from "material-ui-icons/DesktopMac";
 import CheckIcon from "material-ui-icons/AssignmentTurnedIn";
-import QuickNavButton from "./QuickNavButton";
+
+import QuickNavButton from "/components/QuickNavButton";
 
 const styles = {
   quickNavContainer: {},

--- a/dashboard/src/components/ResetStyles.js
+++ b/dashboard/src/components/ResetStyles.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { withStyles } from "material-ui/styles";
 
-import reset from "../reset.css";
+import reset from "/reset.css";
 
 class ResetStyles extends React.PureComponent {
   render() {

--- a/dashboard/src/components/ThemeProvider.js
+++ b/dashboard/src/components/ThemeProvider.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { MuiThemeProvider } from "material-ui/styles";
-import * as themes from "../themes";
+import * as themes from "/themes";
 
 class ThemeProvider extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/util/AuthenticatedRoute.js
+++ b/dashboard/src/components/util/AuthenticatedRoute.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import ConditionalRoute from "./ConditionalRoute";
-import withAuthTokens from "./withAuthTokens";
+import ConditionalRoute from "/components/util/ConditionalRoute";
+import withAuthTokens from "/components/util/withAuthTokens";
 
 class AuthenticatedRoute extends React.PureComponent {
   static propTypes = {

--- a/dashboard/src/components/util/DefaultRedirect.js
+++ b/dashboard/src/components/util/DefaultRedirect.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Redirect } from "react-router-dom";
 
-import withAuthTokens from "./withAuthTokens";
+import withAuthTokens from "/components/util/withAuthTokens";
 
 class DefaultRedirect extends React.PureComponent {
   static propTypes = {

--- a/dashboard/src/components/util/UnauthenticatedRoute.js
+++ b/dashboard/src/components/util/UnauthenticatedRoute.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import ConditionalRoute from "./ConditionalRoute";
-import withAuthTokens from "./withAuthTokens";
+import ConditionalRoute from "/components/util/ConditionalRoute";
+import withAuthTokens from "/components/util/withAuthTokens";
 
 class UnauthenticatedRoute extends React.PureComponent {
   static propTypes = {

--- a/dashboard/src/components/util/withAuthTokens.js
+++ b/dashboard/src/components/util/withAuthTokens.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { hoistStatics } from "recompose";
 
-import * as tokenStore from "../../utils/authentication/tokens";
+import * as tokenStore from "/utils/authentication/tokens";
 
 const withAuthTokens = hoistStatics(Component => {
   class WithAuthTokens extends React.PureComponent {

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -4,10 +4,10 @@ import { Query } from "react-apollo";
 import gql from "graphql-tag";
 import Paper from "material-ui/Paper";
 
-import AppContent from "../../AppContent";
-import CheckList from "../../CheckList";
+import AppContent from "/components/AppContent";
+import CheckList from "/components/CheckList";
 
-import NotFoundView from "../../views/NotFoundView";
+import NotFoundView from "/components/views/NotFoundView";
 
 class ChecksContent extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/views/EnvironmentView/DashboardContent.js
+++ b/dashboard/src/components/views/EnvironmentView/DashboardContent.js
@@ -6,7 +6,7 @@ import Typography from "material-ui/Typography";
 import Grid from "material-ui/Grid";
 import Paper from "material-ui/Paper";
 
-import AppContent from "../../AppContent";
+import AppContent from "/components/AppContent";
 
 const styles = () => ({
   root: {

--- a/dashboard/src/components/views/EnvironmentView/EnvironmentView.js
+++ b/dashboard/src/components/views/EnvironmentView/EnvironmentView.js
@@ -2,9 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Switch, Route, Redirect } from "react-router-dom";
 
-import AppWrapper from "../../AppWrapper";
-
-import NotFoundView from "../../views/NotFoundView";
+import AppWrapper from "/components/AppWrapper";
+import NotFoundView from "/components/views/NotFoundView";
 
 import DashboardContent from "./DashboardContent";
 import ChecksContent from "./ChecksContent";

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -5,11 +5,11 @@ import gql from "graphql-tag";
 import { withStyles } from "material-ui/styles";
 import Typography from "material-ui/Typography";
 
-import AppContent from "../../AppContent";
-import EventsContainer from "../../EventsContainer";
-import SearchBox from "../../SearchBox";
+import AppContent from "/components/AppContent";
+import EventsContainer from "/components/EventsContainer";
+import SearchBox from "/components/SearchBox";
 
-import NotFoundView from "../../views/NotFoundView";
+import NotFoundView from "/components/views/NotFoundView";
 
 // If none given default expression is used.
 const defaultExpression = "HasCheck && IsIncident";

--- a/dashboard/src/components/views/LoginView.js
+++ b/dashboard/src/components/views/LoginView.js
@@ -7,9 +7,9 @@ import Button from "material-ui/Button";
 import TextField from "material-ui/TextField";
 import Typography from "material-ui/Typography";
 
-import Logo from "../../icons/SensuLogoGraphic";
-import Wordmark from "../../icons/SensuWordmark";
-import { authenticate } from "../../utils/authentication";
+import Logo from "/icons/SensuLogoGraphic";
+import Wordmark from "/icons/SensuWordmark";
+import { authenticate } from "/utils/authentication";
 
 class LoginView extends React.Component {
   static propTypes = {

--- a/dashboard/src/index.js
+++ b/dashboard/src/index.js
@@ -3,13 +3,13 @@ import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import injectTapEventPlugin from "react-tap-event-plugin";
 
-import createClient from "./apollo/client";
+import createClient from "/apollo/client";
 
-import createStore from "./store";
-import reducer from "./reducer";
-import registerServiceWorker from "./registerServiceWorker";
+import createStore from "/store";
+import reducer from "/reducer";
+import registerServiceWorker from "/registerServiceWorker";
 
-import AppRoot from "./components/AppRoot";
+import AppRoot from "/components/AppRoot";
 
 // Fonts
 import "typeface-roboto"; // eslint-disable-line

--- a/dashboard/src/themes/Bubblegum.js
+++ b/dashboard/src/themes/Bubblegum.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "dark") =>
   createTheme({

--- a/dashboard/src/themes/Sensu.js
+++ b/dashboard/src/themes/Sensu.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "dark") =>
   createTheme({

--- a/dashboard/src/themes/bubblegum.js
+++ b/dashboard/src/themes/bubblegum.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "dark") =>
   createTheme({

--- a/dashboard/src/themes/classic.js
+++ b/dashboard/src/themes/classic.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "light") =>
   createTheme({

--- a/dashboard/src/themes/createTheme.js
+++ b/dashboard/src/themes/createTheme.js
@@ -2,6 +2,7 @@ import deepmerge from "deepmerge";
 import createMuiTheme from "material-ui/styles/createMuiTheme";
 import createPalette from "material-ui/styles/createPalette";
 import createTypography from "material-ui/styles/createTypography";
+
 import defaults from "./defaults";
 
 function getTypography(typography, palette) {

--- a/dashboard/src/themes/dva.js
+++ b/dashboard/src/themes/dva.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const shadowKeyUmbraOpacity = 0.2;
 const shadowKeyPenumbraOpacity = 0.14;

--- a/dashboard/src/themes/sensu.js
+++ b/dashboard/src/themes/sensu.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "dark") =>
   createTheme({

--- a/dashboard/src/themes/uchiwa.js
+++ b/dashboard/src/themes/uchiwa.js
@@ -1,5 +1,5 @@
-import createTheme from "./createTheme";
-import colors from "../colors";
+import createTheme from "/themes/createTheme";
+import colors from "/colors";
 
 const theme = (type = "light") =>
   createTheme({

--- a/dashboard/src/utils/authentication/tokens.js
+++ b/dashboard/src/utils/authentication/tokens.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 
-import createDispatcher from "../dispatcher";
+import createDispatcher from "/utils/dispatcher";
 
 const { subscribe, unsubscribe, subscribeOnce, dispatch } = createDispatcher();
 

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -658,14 +658,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-dynamic-import-node@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.1.0.tgz#bd1d88ac7aaf98df4917c384373b04d971a2b37a"
-  dependencies:
-    babel-plugin-syntax-dynamic-import "^6.18.0"
-    babel-template "^6.26.0"
-    babel-types "^6.26.0"
-
 babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
@@ -682,6 +674,16 @@ babel-plugin-jest-hoist@^22.1.0:
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.1.0.tgz#c1281dd7887d77a1711dc760468c3b8285dde9ee"
 
+babel-plugin-module-resolver@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -689,10 +691,6 @@ babel-plugin-syntax-async-functions@^6.8.0:
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-
-babel-plugin-syntax-dynamic-import@6.18.0, babel-plugin-syntax-dynamic-import@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -722,7 +720,7 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-class-properties@6.24.1:
+babel-plugin-transform-class-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
   dependencies:
@@ -774,7 +772,7 @@ babel-plugin-transform-es2015-computed-properties@^6.22.0:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@6.23.0, babel-plugin-transform-es2015-destructuring@^6.23.0:
+babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
@@ -914,18 +912,12 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@6.26.0:
+babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.26.0"
-
-babel-plugin-transform-react-constant-elements@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz#2f119bf4d2cdd45eb9baaae574053c604f6147dd"
-  dependencies:
-    babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
@@ -933,21 +925,21 @@ babel-plugin-transform-react-display-name@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-jsx-self@6.22.0, babel-plugin-transform-react-jsx-self@^6.22.0:
+babel-plugin-transform-react-jsx-self@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"
   dependencies:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-jsx-source@6.22.0, babel-plugin-transform-react-jsx-source@^6.22.0:
+babel-plugin-transform-react-jsx-source@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz#66ac12153f5cd2d17b3c19268f4bf0197f44ecd6"
   dependencies:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.1:
+babel-plugin-transform-react-jsx@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz#840a028e7df460dfc3a2d29f0c0d91f6376e66a3"
   dependencies:
@@ -955,13 +947,17 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6.22.0:
+babel-plugin-transform-react-remove-prop-types@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
+
+babel-plugin-transform-regenerator@^6.22.0, babel-plugin-transform-regenerator@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@6.23.0:
+babel-plugin-transform-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
   dependencies:
@@ -974,7 +970,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-env@1.6.1:
+babel-preset-env@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
   dependencies:
@@ -1029,25 +1025,7 @@ babel-preset-jest@^22.1.0:
     babel-plugin-jest-hoist "^22.1.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-preset-react-app@^3.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-app/-/babel-preset-react-app-3.1.1.tgz#d3f06a79742f0e89d7afcb72e282d9809c850920"
-  dependencies:
-    babel-plugin-dynamic-import-node "1.1.0"
-    babel-plugin-syntax-dynamic-import "6.18.0"
-    babel-plugin-transform-class-properties "6.24.1"
-    babel-plugin-transform-es2015-destructuring "6.23.0"
-    babel-plugin-transform-object-rest-spread "6.26.0"
-    babel-plugin-transform-react-constant-elements "6.23.0"
-    babel-plugin-transform-react-jsx "6.24.1"
-    babel-plugin-transform-react-jsx-self "6.22.0"
-    babel-plugin-transform-react-jsx-source "6.22.0"
-    babel-plugin-transform-regenerator "6.26.0"
-    babel-plugin-transform-runtime "6.23.0"
-    babel-preset-env "1.6.1"
-    babel-preset-react "6.24.1"
-
-babel-preset-react@6.24.1:
+babel-preset-react@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react/-/babel-preset-react-6.24.1.tgz#ba69dfaea45fc3ec639b6a4ecea6e17702c91380"
   dependencies:
@@ -2599,6 +2577,13 @@ eslint-config-react-app@^2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz#23c909f71cbaff76b945b831d2d814b8bde169eb"
 
+eslint-import-resolver-babel-module@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-babel-module/-/eslint-import-resolver-babel-module-4.0.0.tgz#1c596f7fb9815050292c8750d523b27a5444b4bf"
+  dependencies:
+    pkg-up "^2.0.0"
+    resolve "^1.4.0"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -3105,6 +3090,13 @@ finalhandler@1.1.0:
     parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
+
+find-babel-config@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^0.1.1:
   version "0.1.1"
@@ -5942,6 +5934,12 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -6933,6 +6931,10 @@ requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6965,6 +6967,12 @@ resolve-url@^0.2.1:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.4.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
 
 resolve@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
## What is this change?

Any absolute es6 import statement is resolved relative to the `src` directory. 
Compared to a set of webpack aliases to specific directories within the project, this approach is more flexible, less fragile, and easier to reason.

## Why is this change necessary?

This avoids the need to use deep relative paths that reference a file's current location making the app far easier to organize. This effectively allows any file in `src` to be referenced as a namespaced module, akin to any of the npm dependencies.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

In order to use `eslint-import-resolver-babel-module`, `babel-preset-react-app` had to be abandoned. The new `.babelrc` file is a simplified copy of that preset preserving compatibility.