### PR TITLE
Allow checks and hooks to escape zombie processes that have timed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and yarn are now dependencies for building the backend.
 swallowed. The events are sent through the pipeline.
 - Fixed a bug where the Issued field was never populated.
 - When creating a new statsd server, use the default flush interval if given 0.
+- Allow checks and hooks to escape zombie processes that have timed out.
 
 
 ## [2.0.0-nightly.1] - 2018-03-07

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -74,9 +74,12 @@ func (a *Agent) executeCheck(request *types.CheckRequest) {
 	// Inject the dependenices into PATH, LD_LIBRARY_PATH & CPATH so that they are
 	// availabe when when the command is executed.
 	ex := &command.Execution{
-		Env:     assets.Env(),
-		Command: checkConfig.Command,
-		Timeout: int(checkConfig.Timeout),
+		Env:          assets.Env(),
+		Command:      checkConfig.Command,
+		Timeout:      int(checkConfig.Timeout),
+		InProgress:   a.inProgress,
+		InProgressMu: a.inProgressMu,
+		Name:         checkConfig.Name,
 	}
 
 	// If stdin is true, add JSON event data to command execution.

--- a/agent/hook.go
+++ b/agent/hook.go
@@ -32,7 +32,7 @@ func (a *Agent) ExecuteHooks(request *types.CheckRequest, status int) []*types.H
 				// code and severity (ex. 0, ok)
 				in := hookInList(hookConfig.Name, executedHooks)
 				if !in {
-					hook := a.executeHook(hookConfig)
+					hook := a.executeHook(hookConfig, request.Config.Name)
 					executedHooks = append(executedHooks, hook)
 				}
 			}
@@ -41,7 +41,7 @@ func (a *Agent) ExecuteHooks(request *types.CheckRequest, status int) []*types.H
 	return executedHooks
 }
 
-func (a *Agent) executeHook(hookConfig *types.HookConfig) *types.Hook {
+func (a *Agent) executeHook(hookConfig *types.HookConfig, check string) *types.Hook {
 	// Instantiate Event and Hook
 	event := &types.Event{
 		Check: &types.Check{},
@@ -54,8 +54,11 @@ func (a *Agent) executeHook(hookConfig *types.HookConfig) *types.Hook {
 
 	// Instantiate the execution command
 	ex := &command.Execution{
-		Command: hookConfig.Command,
-		Timeout: int(hookConfig.Timeout),
+		Command:      hookConfig.Command,
+		Timeout:      int(hookConfig.Timeout),
+		InProgress:   a.inProgress,
+		InProgressMu: a.inProgressMu,
+		Name:         check,
 	}
 
 	// If stdin is true, add JSON event data to command execution.

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -24,7 +24,7 @@ func TestExecuteHook(t *testing.T) {
 	truePath := testutil.CommandPath(filepath.Join(toolsDir, "true"))
 	hookConfig.Command = truePath
 
-	hook := agent.executeHook(hookConfig)
+	hook := agent.executeHook(hookConfig, "check")
 
 	assert.NotZero(hook.Executed)
 	assert.Equal(hook.Status, int32(0))
@@ -32,7 +32,7 @@ func TestExecuteHook(t *testing.T) {
 
 	hookConfig.Command = "printf hello"
 
-	hook = agent.executeHook(hookConfig)
+	hook = agent.executeHook(hookConfig, "check")
 
 	assert.NotZero(hook.Executed)
 	assert.Equal(hook.Status, int32(0))


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

A fix to allow checks and hooks to escape zombie processes (likely created by commands with `sudo`) that have timed out.

## Why is this change necessary?

Closes #1194.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Yes, zombies created with `sudo` are inevitable. We need to document our recommendation to avoid command execution's that require `sudo`.