### PR TITLE
Prevent etcd client goroutine leaks in queue tests

### DIFF
--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -19,6 +19,7 @@ func TestEnqueue(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testenq", client)
@@ -32,6 +33,7 @@ func TestDequeueSingleItem(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testdeq", client)
@@ -54,6 +56,7 @@ func TestDequeueFIFO(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testfifo", client)
@@ -80,6 +83,7 @@ func TestDequeueParallel(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testparallel", client)
@@ -153,6 +157,7 @@ func TestNack(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testnack", client)
@@ -177,6 +182,7 @@ func TestAck(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testack", client)
@@ -202,6 +208,7 @@ func TestOnce(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testonce", client)
@@ -227,6 +234,7 @@ func TestNackExpired(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
+	defer client.Close()
 	require.NoError(t, err)
 
 	queue := New("testexpired", client)
@@ -247,6 +255,7 @@ func TestNackExpired(t *testing.T) {
 
 	// create a new client and queue
 	newClient, err := e.NewClient()
+	defer newClient.Close()
 	require.NoError(t, err)
 
 	// wait to make sure the item has timed out
@@ -268,6 +277,7 @@ func TestEtcdKilled(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	client, err := e.NewClient()
+	defer client.Close()
 	// Stop Etcd before client gets a chance to connect
 	cleanup()
 	require.NoError(t, err)

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -270,30 +270,3 @@ func TestNackExpired(t *testing.T) {
 
 	require.Equal(t, "test item", item.Value())
 }
-
-// queue.Enqueue should not block indefinitely when the Etcd server is killed
-func TestEtcdKilled(t *testing.T) {
-	t.Parallel()
-
-	e, cleanup := etcd.NewTestEtcd(t)
-	client, err := e.NewClient()
-	defer client.Close()
-	// Stop Etcd before client gets a chance to connect
-	cleanup()
-	require.NoError(t, err)
-	defer client.Close()
-
-	queue := New("testetcdkilled", client)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	errc := make(chan error)
-	go func() {
-		errc <- queue.Enqueue(ctx, "test item")
-	}()
-	select {
-	case err := <-errc:
-		require.Error(t, err)
-	case <-time.After(5 * time.Second):
-		t.Error("queue.Enqueue did not return in time")
-	}
-}


### PR DESCRIPTION
## What is this change?

Clean up the etcd client in queue tests.

closes #1280 

## Why is this change necessary?

See #1280 for context and info.

## Does your change need a Changelog entry?

Nope, this change is test-only.

## Do you need clarification on anything?

Do we want to take the time to report this bug to etcd? Doing so would require making a minimal set of code to reproduce the issue.


## Were there any complications while making this change?

There were certainly complications in reproducing this bug, but the change is minor and straightforward.