### PR TITLE
Install golang dependencies in build.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ swallowed. The events are sent through the pipeline.
 - Fixed a bug where the Issued field was never populated.
 - When creating a new statsd server, use the default flush interval if given 0.
 - Allow checks and hooks to escape zombie processes that have timed out.
+- Install all dependencies with `dep ensure` in build.sh.
 
 
 ## [2.0.0-nightly.1] - 2018-03-07

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ install_deps () {
     go get github.com/jgautheron/goconst/cmd/goconst
     go get honnef.co/go/tools/cmd/megacheck
     go get github.com/golang/lint/golint
+    install_golang_dep
 }
 
 install_golang_dep() {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Install all dependencies with `dep ensure` in build.sh.

## Why is this change necessary?

We need to run `dep ensure` to install new dependencies in build and ci.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.