### PR TITLE
Pin dep version to 4.1.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,9 @@ install:
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
+  - mkdir %GOPATH%\bin
+  - appveyor DownloadFile https://github.com/golang/dep/releases/download/v0.4.1/dep-windows-amd64.exe
+  - move dep-windows-amd64.exe %GOPATH%\bin\dep.exe
   - ps: .\build.ps1 deps
   - ps: .\build.ps1 build_tools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ cache:
   - backend/dashboardd/node_modules
   - vendor
 before_install:
-- echo -e "machine github.com\n login $GITHUB_TOKEN" >> ~/.netrc
-- ulimit -s 1082768
+  - echo -e "machine github.com\n login $GITHUB_TOKEN" >> ~/.netrc
+  - ulimit -s 1082768
+  - curl -L -s https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
 install:
 - "git fetch --tags"
 - "./build.sh deps"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ information on the DCO, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Development
 
+Sensu is written in Go, and targets the latest stable release of the Go
+compiler. To work on Sensu, you will need the latest release of Go.
+
+[Go installation instructions](https://golang.org/doc/install)
+
 ### Protobuf
 
 #### Overview
@@ -168,12 +173,15 @@ Once you make a change to any `*.proto` file within the **types** package, you w
 ### Dependencies
 
 Sensu uses [golang/dep](https://github.com/golang/dep) for managing its
-dependencies.
+dependencies. You will need to install the latest stable version of dep in
+order to install Sensu's dependencies.
+
+[Dep releases](https://github.com/golang/dep/releases)
 
 #### Usage
 
-Running the following will install `dep` (if it is not already) and pull all
-required dependencies.
+Running the following will pull all required dependencies, including static
+analysis and linter tools.
 
 ```shell
 ./build.sh deps

--- a/build.ps1
+++ b/build.ps1
@@ -38,14 +38,7 @@ function install_deps
     go get github.com/jgautheron/goconst/cmd/goconst
     go get github.com/kisielk/errcheck
     go get github.com/golang/lint/golint
-    install_golang_dep
-}
-
-function install_golang_dep
-{
-    go get github.com/golang/dep/cmd/dep
-    echo "Running dep ensure..."
-    dep ensure -v -vendor-only
+    C:\gopath\bin\dep.exe ensure -v -vendor-only
 }
 
 function build_tool_binary([string]$goos, [string]$goarch, [string]$bin, [string]$subdir)

--- a/build.sh
+++ b/build.sh
@@ -44,12 +44,6 @@ install_deps () {
     go get github.com/jgautheron/goconst/cmd/goconst
     go get honnef.co/go/tools/cmd/megacheck
     go get github.com/golang/lint/golint
-    install_golang_dep
-}
-
-install_golang_dep() {
-    go get github.com/golang/dep/cmd/dep
-    echo "Running dep ensure..."
     dep ensure -v -vendor-only
 }
 


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

It makes sure we are using a specific dep version to build our PRs.

## Why is this change necessary?

Previously we were using master of dep.

## Does your change need a Changelog entry?

NEIN

## Do you need clarification on anything?

NEIN

## Were there any complications while making this change?

There probably will be tbh