### PR TITLE
Add validation for flap thresholds.

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -123,6 +123,10 @@ func (c *Check) Validate() error {
 		}
 	}
 
+	if c.LowFlapThreshold != 0 && c.HighFlapThreshold != 0 && c.LowFlapThreshold >= c.HighFlapThreshold {
+		return errors.New("invalid flap thresholds")
+	}
+
 	return c.Subdue.Validate()
 }
 
@@ -262,6 +266,10 @@ func (c *CheckConfig) Validate() error {
 		if err := ValidateMetricFormat(c.MetricFormat); err != nil {
 			return err
 		}
+	}
+
+	if c.LowFlapThreshold != 0 && c.HighFlapThreshold != 0 && c.LowFlapThreshold >= c.HighFlapThreshold {
+		return errors.New("invalid flap thresholds")
 	}
 
 	return c.Subdue.Validate()

--- a/types/check_test.go
+++ b/types/check_test.go
@@ -203,3 +203,41 @@ func TestCheckConfigHasNonNilHandlers(t *testing.T) {
 	require.NoError(t, json.Unmarshal(b, &c))
 	require.NotNil(t, c.Handlers)
 }
+
+func TestCheckFlapThresholdValidation(t *testing.T) {
+	c := FixtureCheck("foo")
+	// zero-valued flap threshold is valid
+	c.LowFlapThreshold, c.HighFlapThreshold = 0, 0
+	assert.NoError(t, c.Validate())
+
+	// low flap threshold < high flap threshold is valid
+	c.LowFlapThreshold, c.HighFlapThreshold = 5, 10
+	assert.NoError(t, c.Validate())
+
+	// low flap threshold = high flap threshold is invalid
+	c.LowFlapThreshold, c.HighFlapThreshold = 10, 10
+	assert.Error(t, c.Validate())
+
+	// low flap threshold > high flap threshold is invalid
+	c.LowFlapThreshold, c.HighFlapThreshold = 11, 10
+	assert.Error(t, c.Validate())
+}
+
+func TestCheckConfigFlapThresholdValidation(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	// zero-valued flap threshold is valid
+	c.LowFlapThreshold, c.HighFlapThreshold = 0, 0
+	assert.NoError(t, c.Validate())
+
+	// low flap threshold < high flap threshold is valid
+	c.LowFlapThreshold, c.HighFlapThreshold = 5, 10
+	assert.NoError(t, c.Validate())
+
+	// low flap threshold = high flap threshold is invalid
+	c.LowFlapThreshold, c.HighFlapThreshold = 10, 10
+	assert.Error(t, c.Validate())
+
+	// low flap threshold > high flap threshold is invalid
+	c.LowFlapThreshold, c.HighFlapThreshold = 11, 10
+	assert.Error(t, c.Validate())
+}


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Adds some basic validation for flap thresholds.

## Why is this change necessary?

Closes #1235 (working as intended)

## Does your change need a Changelog entry?

No