### PR TITLE
Remove reference to iteration.txt as it doesn't exist anymore

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -78,13 +78,11 @@ function build_binary([string]$goos, [string]$goarch, [string]$bin, [string]$cmd
     $env:GOARCH = $goarch
 
     $version = (cat version/version.txt) | Out-String
-    $iteration = (cat version/iteration.txt) | Out-String
     $build_date = Get-Date -format "yyyy'-'MM'-'dd'T'T'-'Z"
     $build_sha = (git rev-parse HEAD) | Out-String
 
     $version_pkg = "github.com/sensu/sensu-go/version"
     $ldflags = "-X $version_pkg.Version=$version"
-    $ldflags = $ldflags + " -X $version_pkg.Iteration=$iteration"
     $ldflags = $ldflags + " -X $version_pkg.BuildDate=$build_date"
     $ldflags = $ldflags + " -X $version_pkg.BuildSHA=$build_sha"
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Removes iteration.txt from build.ps1.

## Why is this change necessary?

Closes #1399.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Yas. Appveyor failures are difficult to repro, and fixing one issue usually uncovers another.