### PR TITLE
[GraphQL] Use string to represent ID scalar

### DIFF
--- a/backend/apid/graphql/asset.go
+++ b/backend/apid/graphql/asset.go
@@ -12,7 +12,7 @@ type assetImpl struct {
 }
 
 // ID implements response to request for 'id' field.
-func (*assetImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*assetImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.AssetTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -29,7 +29,7 @@ func newCheckCfgImpl(store store.Store) *checkCfgImpl {
 }
 
 // ID implements response to request for 'id' field.
-func (r *checkCfgImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (r *checkCfgImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.CheckTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -48,7 +48,7 @@ func newEntityImpl(store store.Store) *entityImpl {
 }
 
 // ID implements response to request for 'id' field.
-func (*entityImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*entityImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.EntityTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -43,7 +43,7 @@ func newEnvImpl(store store.Store, getter types.QueueGetter) *envImpl {
 }
 
 // ID implements response to request for 'id' field.
-func (r *envImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (r *envImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.EnvironmentTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/event.go
+++ b/backend/apid/graphql/event.go
@@ -20,7 +20,7 @@ type eventImpl struct {
 }
 
 // ID implements response to request for 'id' field.
-func (r *eventImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (r *eventImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.EventTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/handler.go
+++ b/backend/apid/graphql/handler.go
@@ -31,7 +31,7 @@ func newHandlerImpl(store store.Store) *handlerImpl {
 }
 
 // ID implements response to request for 'id' field.
-func (*handlerImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*handlerImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.HandlerTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/hook.go
+++ b/backend/apid/graphql/hook.go
@@ -34,7 +34,7 @@ type hookCfgImpl struct {
 }
 
 // ID implements response to request for 'id' field.
-func (*hookCfgImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*hookCfgImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.HookTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -62,7 +62,7 @@ func (r *mutationsImpl) CreateCheck(p schema.MutationCreateCheckFieldResolverPar
 // UpdateCheck implements response to request for the 'updateCheck' field.
 func (r *mutationsImpl) UpdateCheck(p schema.MutationUpdateCheckFieldResolverParams) (interface{}, error) {
 	inputs := p.Args.Input
-	components, _ := globalid.Decode(inputs.ID.(string))
+	components, _ := globalid.Decode(inputs.ID)
 
 	var check types.CheckConfig
 	check.Name = components.UniqueComponent()
@@ -82,7 +82,7 @@ func (r *mutationsImpl) UpdateCheck(p schema.MutationUpdateCheckFieldResolverPar
 
 // DeleteCheck implements response to request for the 'deleteCheck' field.
 func (r *mutationsImpl) DeleteCheck(p schema.MutationDeleteCheckFieldResolverParams) (interface{}, error) {
-	components, _ := globalid.Decode(p.Args.Input.ID.(string))
+	components, _ := globalid.Decode(p.Args.Input.ID)
 	ctx := setContextFromComponents(p.Context, components)
 
 	err := r.checkController.Destroy(ctx, components.UniqueComponent())
@@ -121,7 +121,7 @@ func (*mutationsImpl) IsTypeOf(s interface{}, p graphql.IsTypeOfParams) bool {
 
 // ResolveEvent implements response to request for the 'resolveEvent' field.
 func (r *mutationsImpl) ResolveEvent(p schema.MutationResolveEventFieldResolverParams) (interface{}, error) {
-	components, _ := globalid.Decode(p.Args.Input.ID.(string))
+	components, _ := globalid.Decode(p.Args.Input.ID)
 	ctx := setContextFromComponents(p.Context, components)
 
 	evComponents, ok := components.(globalid.EventComponents)

--- a/backend/apid/graphql/organization.go
+++ b/backend/apid/graphql/organization.go
@@ -28,7 +28,7 @@ func newOrgImpl(store store.EnvironmentStore) *orgImpl {
 }
 
 // ID implements response to request for 'id' field.
-func (r *orgImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (r *orgImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.OrganizationTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -59,8 +59,7 @@ func (r *queryImpl) Event(p schema.QueryEventFieldResolverParams) (interface{}, 
 // Node implements response to request for 'node' field.
 func (r *queryImpl) Node(p schema.QueryNodeFieldResolverParams) (interface{}, error) {
 	resolver := r.nodeResolver
-	id := p.Args.ID.(string)
-	return resolver.Find(p.Context, id, p.Info)
+	return resolver.Find(p.Context, p.Args.ID, p.Info)
 }
 
 //

--- a/backend/apid/graphql/rbac.go
+++ b/backend/apid/graphql/rbac.go
@@ -38,7 +38,7 @@ type roleImpl struct {
 }
 
 // ID implements response to request for 'id' field.
-func (*roleImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*roleImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.RoleTranslator.EncodeToString(p.Source), nil
 }
 

--- a/backend/apid/graphql/schema/asset.gql.go
+++ b/backend/apid/graphql/schema/asset.gql.go
@@ -11,7 +11,7 @@ import (
 // AssetIDFieldResolver implement to resolve requests for the Asset's id field.
 type AssetIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // AssetNamespaceFieldResolver implement to resolve requests for the Asset's namespace field.
@@ -162,9 +162,10 @@ type AssetFieldResolvers interface {
 type AssetAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ AssetAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ AssetAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/check.gql.go
+++ b/backend/apid/graphql/schema/check.gql.go
@@ -13,7 +13,7 @@ import (
 // CheckConfigIDFieldResolver implement to resolve requests for the CheckConfig's id field.
 type CheckConfigIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // CheckConfigNamespaceFieldResolver implement to resolve requests for the CheckConfig's namespace field.
@@ -234,9 +234,10 @@ type CheckConfigFieldResolvers interface {
 type CheckConfigAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ CheckConfigAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ CheckConfigAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/entity.gql.go
+++ b/backend/apid/graphql/schema/entity.gql.go
@@ -13,7 +13,7 @@ import (
 // EntityIDFieldResolver implement to resolve requests for the Entity's id field.
 type EntityIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // EntityNamespaceFieldResolver implement to resolve requests for the Entity's namespace field.
@@ -231,9 +231,10 @@ type EntityFieldResolvers interface {
 type EntityAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ EntityAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ EntityAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/environment.gql.go
+++ b/backend/apid/graphql/schema/environment.gql.go
@@ -12,7 +12,7 @@ import (
 // EnvironmentIDFieldResolver implement to resolve requests for the Environment's id field.
 type EnvironmentIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // EnvironmentDescriptionFieldResolver implement to resolve requests for the Environment's description field.
@@ -240,9 +240,10 @@ type EnvironmentFieldResolvers interface {
 type EnvironmentAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ EnvironmentAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ EnvironmentAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Description implements response to request for 'description' field.

--- a/backend/apid/graphql/schema/event.gql.go
+++ b/backend/apid/graphql/schema/event.gql.go
@@ -12,7 +12,7 @@ import (
 // EventIDFieldResolver implement to resolve requests for the Event's id field.
 type EventIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // EventNamespaceFieldResolver implement to resolve requests for the Event's namespace field.
@@ -184,9 +184,10 @@ type EventFieldResolvers interface {
 type EventAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ EventAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ EventAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/handler.gql.go
+++ b/backend/apid/graphql/schema/handler.gql.go
@@ -11,7 +11,7 @@ import (
 // HandlerIDFieldResolver implement to resolve requests for the Handler's id field.
 type HandlerIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // HandlerNamespaceFieldResolver implement to resolve requests for the Handler's namespace field.
@@ -197,9 +197,10 @@ type HandlerFieldResolvers interface {
 type HandlerAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ HandlerAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ HandlerAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/hook.gql.go
+++ b/backend/apid/graphql/schema/hook.gql.go
@@ -11,7 +11,7 @@ import (
 // HookConfigIDFieldResolver implement to resolve requests for the HookConfig's id field.
 type HookConfigIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // HookConfigNamespaceFieldResolver implement to resolve requests for the HookConfig's namespace field.
@@ -162,9 +162,10 @@ type HookConfigFieldResolvers interface {
 type HookConfigAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ HookConfigAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ HookConfigAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -388,7 +388,7 @@ type DeleteRecordPayloadClientMutationIDFieldResolver interface {
 // DeleteRecordPayloadDeletedIDFieldResolver implement to resolve requests for the DeleteRecordPayload's deletedId field.
 type DeleteRecordPayloadDeletedIDFieldResolver interface {
 	// DeletedID implements response to request for deletedId field.
-	DeletedID(p graphql.ResolveParams) (interface{}, error)
+	DeletedID(p graphql.ResolveParams) (string, error)
 }
 
 //
@@ -512,9 +512,10 @@ func (_ DeleteRecordPayloadAliases) ClientMutationID(p graphql.ResolveParams) (s
 }
 
 // DeletedID implements response to request for 'deletedId' field.
-func (_ DeleteRecordPayloadAliases) DeletedID(p graphql.ResolveParams) (interface{}, error) {
+func (_ DeleteRecordPayloadAliases) DeletedID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // DeleteRecordPayloadType Generic container for deleted record payload.
@@ -584,7 +585,7 @@ type DeleteRecordInput struct {
 	// ClientMutationID - A unique identifier for the client performing the mutation.
 	ClientMutationID string
 	// ID - Global ID of the check to update.
-	ID interface{}
+	ID string
 }
 
 // DeleteRecordInputType Generic input used when deleting records.
@@ -949,7 +950,7 @@ type UpdateCheckInput struct {
 	// ClientMutationID - A unique identifier for the client performing the mutation.
 	ClientMutationID string
 	// ID - Global ID of the check to update.
-	ID interface{}
+	ID string
 	// Props - properties of the check
 	Props *CheckConfigInputs
 }
@@ -1190,7 +1191,7 @@ type ResolveEventInput struct {
 	// ClientMutationID - A unique identifier for the client performing the mutation.
 	ClientMutationID string
 	// ID - Global ID of the event to resolve.
-	ID interface{}
+	ID string
 	// Source - The source of the resolve request
 	Source string
 }

--- a/backend/apid/graphql/schema/mutator.gql.go
+++ b/backend/apid/graphql/schema/mutator.gql.go
@@ -11,7 +11,7 @@ import (
 // MutatorIDFieldResolver implement to resolve requests for the Mutator's id field.
 type MutatorIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // MutatorNamespaceFieldResolver implement to resolve requests for the Mutator's namespace field.
@@ -162,9 +162,10 @@ type MutatorFieldResolvers interface {
 type MutatorAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ MutatorAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ MutatorAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/schema/organization.gql.go
+++ b/backend/apid/graphql/schema/organization.gql.go
@@ -11,7 +11,7 @@ import (
 // OrganizationIDFieldResolver implement to resolve requests for the Organization's id field.
 type OrganizationIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // OrganizationDescriptionFieldResolver implement to resolve requests for the Organization's description field.
@@ -155,9 +155,10 @@ type OrganizationFieldResolvers interface {
 type OrganizationAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ OrganizationAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ OrganizationAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Description implements response to request for 'description' field.

--- a/backend/apid/graphql/schema/rbac.gql.go
+++ b/backend/apid/graphql/schema/rbac.gql.go
@@ -241,7 +241,7 @@ var _ObjectTypeRuleDesc = graphql.ObjectDesc{
 // RoleIDFieldResolver implement to resolve requests for the Role's id field.
 type RoleIDFieldResolver interface {
 	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (interface{}, error)
+	ID(p graphql.ResolveParams) (string, error)
 }
 
 // RoleNameFieldResolver implement to resolve requests for the Role's name field.
@@ -371,9 +371,10 @@ type RoleFieldResolvers interface {
 type RoleAliases struct{}
 
 // ID implements response to request for 'id' field.
-func (_ RoleAliases) ID(p graphql.ResolveParams) (interface{}, error) {
+func (_ RoleAliases) ID(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret := fmt.Sprint(val)
+	return ret, err
 }
 
 // Name implements response to request for 'name' field.

--- a/backend/apid/graphql/schema/schema.gql.go
+++ b/backend/apid/graphql/schema/schema.gql.go
@@ -71,7 +71,7 @@ type QueryEventFieldResolver interface {
 
 // QueryNodeFieldResolverArgs contains arguments provided to node when selected
 type QueryNodeFieldResolverArgs struct {
-	ID interface{} // ID - The ID of an object.
+	ID string // ID - The ID of an object.
 }
 
 // QueryNodeFieldResolverParams contains contextual info to resolve node field

--- a/backend/apid/graphql/user.go
+++ b/backend/apid/graphql/user.go
@@ -18,7 +18,7 @@ type userImpl struct {
 }
 
 // ID implements response to request for 'id' field.
-func (*userImpl) ID(p graphql.ResolveParams) (interface{}, error) {
+func (*userImpl) ID(p graphql.ResolveParams) (string, error) {
 	return globalid.UserTranslator.EncodeToString(p.Source), nil
 }
 

--- a/graphql/generator/object.go
+++ b/graphql/generator/object.go
@@ -773,9 +773,7 @@ func genFieldResolverTypeCoercion(t ast.Type, i info, nullable bool) jen.Code {
 		return jen.Qual(defsPkg, "Int").Op(".").Id("ParseValue").Call(jen.Id("val")).Assert(jen.Int())
 	case graphql.Float.Name():
 		return jen.Qual(defsPkg, "Float").Op(".").Id("ParseValue").Call(jen.Id("val")).Assert(jen.Float64())
-	case graphql.ID.Name():
-		fallthrough
-	case graphql.String.Name():
+	case graphql.String.Name(), graphql.ID.Name():
 		return jen.Qual("fmt", "Sprint").Call(jen.Id("val"))
 	case graphql.Boolean.Name():
 		return mkAssert(jen.Id("bool"))

--- a/graphql/generator/object.go
+++ b/graphql/generator/object.go
@@ -656,6 +656,9 @@ func genFieldResolverSignature(field *ast.FieldDefinition, i info) jen.Code {
 //
 //   GraphQL => Go
 //
+//   ID         => string
+//   ID!        => string
+//   [ID]       => []string
 //   String     => string
 //   [String]   => []string
 //   [Int]      => []int
@@ -770,6 +773,8 @@ func genFieldResolverTypeCoercion(t ast.Type, i info, nullable bool) jen.Code {
 		return jen.Qual(defsPkg, "Int").Op(".").Id("ParseValue").Call(jen.Id("val")).Assert(jen.Int())
 	case graphql.Float.Name():
 		return jen.Qual(defsPkg, "Float").Op(".").Id("ParseValue").Call(jen.Id("val")).Assert(jen.Float64())
+	case graphql.ID.Name():
+		fallthrough
 	case graphql.String.Name():
 		return jen.Qual("fmt", "Sprint").Call(jen.Id("val"))
 	case graphql.Boolean.Name():

--- a/graphql/generator/types.go
+++ b/graphql/generator/types.go
@@ -90,6 +90,20 @@ func genConcreteTypeReference(t ast.Type, i info) jen.Code {
 
 func genBuiltinTypeReference(t *ast.Named) jen.Code {
 	switch t.Name.Value {
+	//
+	// The `ID` scalar type represents a unique identifier, often used to
+	// refetch an object or as key for a cache. The ID type appears in a JSON
+	// response as a String; however, it is not intended to be human-readable.
+	// When expected as an input type, any string (such as `\"4\"`) or integer
+	// (such as `4`) input value will be accepted as an ID.
+	//
+	// As such, when resolving a field we can safely assume the value encountered
+	// will always be a string value.
+	//
+	// Spec: http://facebook.github.io/graphql/October2016/#sec-ID
+	//
+	case "ID":
+		return jen.String()
 	case "Int":
 		return jen.Int()
 	case "Float":


### PR DESCRIPTION
## What is this change?

The `ID` scalar type represents a unique identifier, often used to
refetch an object or as key for a cache. The ID type appears in a JSON
response as a String; however, it is not intended to be human-readable.
When expected as an input type, any string (such as ) or integer
(such as `4`) input value will be accepted as an ID.

As such, when resolving a field we can safely assume the value
encountered will always be a string value.

Spec: http://facebook.github.io/graphql/October2016/#sec-ID

## Why is this change necessary?

Unblocks #837 

## Does your change need a Changelog entry?

Unlikely

## Do you need clarification on anything?

nada 

## Were there any complications while making this change?

nada