### PR TITLE
Update build.ps1 to use version tool

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,25 +16,19 @@ environment:
     - GOARCH: 386
       TEST_SUITE: unit
       MSI_BUILDER: true
-      GOGC: off
       TIME_OUT_MINS: 30
       APPVEYOR_API_TOKEN:
         secure: rkeQYUjyfquA6N33QIUU46tWQMgnxZfHvn1Y6WiZm6o=
     - GOARCH: amd64
       TEST_SUITE: unit
-      GOGC: off
     - GOARCH: 386
       TEST_SUITE: integration
-      GOGC: off
     - GOARCH: amd64
       TEST_SUITE: integration
-      GOGC: off
     - GOARCH: 386
       TEST_SUITE: e2e
-      GOGC: off
     - GOARCH: amd64
       TEST_SUITE: e2e
-      GOGC: off
 
 install:
   - rmdir c:\go /s /q


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Updates build.ps1 to use the version tool like we're currently doing in build.sh.

## Why is this change necessary?

Closes #1409.

Consistency between our CI platforms.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!
