### PR TITLE
Add CLI support for metric_format and metric_handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ statsd listener. The listener is enabled by default.
 - Added a Graphite Plain Text transformer.
 - Add support for `metric_format` and `metric_handlers` fields in the Check and
 CheckConfig structs.
+- Add CLI support for `metric_format` and `metric_handlers` fields in `sensuctl`.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/cli/commands/check/create.go
+++ b/cli/commands/check/create.go
@@ -95,6 +95,8 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd.Flags().String("ttl", "", "time to live in seconds for which a check result is valid")
 	cmd.Flags().String("high-flap-threshold", "", "flap detection high threshold (percent state change) for the check")
 	cmd.Flags().String("low-flap-threshold", "", "flap detection low threshold (percent state change) for the check")
+	cmd.Flags().String("metric-handlers", "", "comma separated list of handlers to invoke for check output metric extraction")
+	cmd.Flags().String("metric-format", "", "the metric format to be used to parse check output for metric extraction")
 
 	helpers.AddInteractiveFlag(cmd.Flags())
 	return cmd

--- a/cli/commands/check/help.go
+++ b/cli/commands/check/help.go
@@ -40,6 +40,8 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		// cannot remove subscriptions, required field
 		subcommands.RemoveTTLCommand(cli),
 		subcommands.RemoveTimeoutCommand(cli),
+		subcommands.RemoveMetricHandlersCommand(cli),
+		subcommands.RemoveMetricFormatCommand(cli),
 
 		// Set commands (update fields)
 		subcommands.SetCheckHooksCommand(cli),
@@ -58,6 +60,8 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		subcommands.SetSubscriptionsCommand(cli),
 		subcommands.SetTTLCommand(cli),
 		subcommands.SetTimeoutCommand(cli),
+		subcommands.SetMetricHandlersCommand(cli),
+		subcommands.SetMetricFormatCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/check/info.go
+++ b/cli/commands/check/info.go
@@ -115,6 +115,14 @@ func printCheckToList(r *types.CheckConfig, writer io.Writer) error {
 				Label: "Environment",
 				Value: r.Environment,
 			},
+			{
+				Label: "Metric Format",
+				Value: r.MetricFormat,
+			},
+			{
+				Label: "Metric Handlers",
+				Value: strings.Join(r.MetricHandlers, ", "),
+			},
 		},
 	}
 

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -138,6 +138,20 @@ func printToTable(results interface{}, writer io.Writer) {
 				return strconv.FormatBool(check.Stdin)
 			},
 		},
+		{
+			Title: "Metric Format",
+			CellTransformer: func(data interface{}) string {
+				check, _ := data.(types.CheckConfig)
+				return check.MetricFormat
+			},
+		},
+		{
+			Title: "Metric Handlers",
+			CellTransformer: func(data interface{}) string {
+				check, _ := data.(types.CheckConfig)
+				return strings.Join(check.MetricHandlers, ",")
+			},
+		},
 	})
 
 	table.Render(writer, results)

--- a/cli/commands/check/subcommands/remove_metric_format.go
+++ b/cli/commands/check/subcommands/remove_metric_format.go
@@ -1,0 +1,44 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// RemoveMetricFormatCommand adds a command that allows a user to remove the
+// metric format of a check
+func RemoveMetricFormatCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "remove-metric-format [NAME]",
+		Short:        "removes metric format from a check",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print usage if we do not receive one argument
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			check, err := cli.Client.FetchCheck(args[0])
+			if err != nil {
+				return err
+			}
+			check.MetricFormat = ""
+
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/check/subcommands/remove_metric_format_test.go
+++ b/cli/commands/check/subcommands/remove_metric_format_test.go
@@ -1,0 +1,51 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	stest "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRemoveMetricFormatCommand(t *testing.T) {
+	tests := []struct {
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, nil, nil, "Usage", true},
+		{[]string{"foo"}, errors.New("error"), nil, "", true},
+		{[]string{"bar"}, nil, errors.New("error"), "", true},
+		{[]string{"check1"}, nil, nil, "OK", false},
+	}
+
+	for i, test := range tests {
+		name := ""
+		if len(test.args) > 0 {
+			name = test.args[0]
+		}
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			check := types.FixtureCheckConfig("check1")
+			cli := stest.NewMockCLI()
+			client := cli.Client.(*client.MockClient)
+			client.On("FetchCheck", name).Return(check, test.fetchResponse)
+			client.On("UpdateCheck", mock.Anything).Return(test.updateResponse)
+			cmd := RemoveMetricFormatCommand(cli)
+			out, err := stest.RunCmd(cmd, test.args)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, test.expectedOutput, out)
+		})
+	}
+}

--- a/cli/commands/check/subcommands/remove_metric_handlers.go
+++ b/cli/commands/check/subcommands/remove_metric_handlers.go
@@ -1,0 +1,44 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// RemoveMetricHandlersCommand adds a command that allows a user to remove the
+// metric handlers of a check
+func RemoveMetricHandlersCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "remove-metric-handlers [NAME]",
+		Short:        "removes metric handlers from a check",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Print usage if we do not receive one argument
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			check, err := cli.Client.FetchCheck(args[0])
+			if err != nil {
+				return err
+			}
+			check.MetricHandlers = nil
+
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/check/subcommands/remove_metric_handlers_test.go
+++ b/cli/commands/check/subcommands/remove_metric_handlers_test.go
@@ -1,0 +1,51 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	stest "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestRemoveMetricHandlersCommand(t *testing.T) {
+	tests := []struct {
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{[]string{}, nil, nil, "Usage", true},
+		{[]string{"foo"}, errors.New("error"), nil, "", true},
+		{[]string{"bar"}, nil, errors.New("error"), "", true},
+		{[]string{"check1"}, nil, nil, "OK", false},
+	}
+
+	for i, test := range tests {
+		name := ""
+		if len(test.args) > 0 {
+			name = test.args[0]
+		}
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			check := types.FixtureCheckConfig("check1")
+			cli := stest.NewMockCLI()
+			client := cli.Client.(*client.MockClient)
+			client.On("FetchCheck", name).Return(check, test.fetchResponse)
+			client.On("UpdateCheck", mock.Anything).Return(test.updateResponse)
+			cmd := RemoveMetricHandlersCommand(cli)
+			out, err := stest.RunCmd(cmd, test.args)
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, test.expectedOutput, out)
+		})
+	}
+}

--- a/cli/commands/check/subcommands/set_metric_format.go
+++ b/cli/commands/check/subcommands/set_metric_format.go
@@ -1,0 +1,45 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// SetMetricFormatCommand updates the metric format of a check
+func SetMetricFormatCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-metric-format [NAME] [VALUE]",
+		Short:        "set metric-format of a check",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			checkName := args[0]
+			value := args[1]
+
+			check, err := cli.Client.FetchCheck(checkName)
+			if err != nil {
+				return err
+			}
+			check.MetricFormat = value
+
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Updated")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/check/subcommands/set_metric_format_test.go
+++ b/cli/commands/check/subcommands/set_metric_format_test.go
@@ -1,0 +1,62 @@
+package subcommands
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSetMetricFormatCommand(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{"no args", []string{}, nil, nil, "Usage", true},
+		{"fetch error", []string{"checky", "foo"}, fmt.Errorf("error"), nil, "", true},
+		{"update error", []string{"checky", "bar"}, nil, fmt.Errorf("error"), "", true},
+		{"invalid input", []string{"checky"}, nil, nil, "", true},
+		{"valid input", []string{"checky", types.GraphiteMetricFormat}, nil, nil, "Updated", false},
+	}
+
+	for _, tc := range testCases {
+		var name string
+		if len(tc.args) > 0 {
+			name = tc.args[0]
+		}
+
+		t.Run(tc.testName, func(t *testing.T) {
+			check := types.FixtureCheckConfig("checky")
+			cli := test.NewMockCLI()
+
+			client := cli.Client.(*client.MockClient)
+			client.On(
+				"FetchCheck",
+				name,
+			).Return(check, tc.fetchResponse)
+
+			client.On(
+				"UpdateCheck",
+				mock.Anything,
+			).Return(tc.updateResponse)
+
+			cmd := SetMetricFormatCommand(cli)
+			out, err := test.RunCmd(cmd, tc.args)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, tc.expectedOutput, out)
+		})
+	}
+}

--- a/cli/commands/check/subcommands/set_metric_handlers.go
+++ b/cli/commands/check/subcommands/set_metric_handlers.go
@@ -1,0 +1,46 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// SetMetricHandlersCommand updates the metric handlers of a check
+func SetMetricHandlersCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-metric-handlers [NAME] [VALUE]",
+		Short:        "set metric handlers of a check",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			checkName := args[0]
+			value := args[1]
+
+			check, err := cli.Client.FetchCheck(checkName)
+			if err != nil {
+				return err
+			}
+			check.MetricHandlers = helpers.SafeSplitCSV(value)
+
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Updated")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/check/subcommands/set_metric_handlers_test.go
+++ b/cli/commands/check/subcommands/set_metric_handlers_test.go
@@ -1,0 +1,62 @@
+package subcommands
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSetMetricHandlersCommand(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{"no args", []string{}, nil, nil, "Usage", true},
+		{"fetch error", []string{"checky", "foo"}, fmt.Errorf("error"), nil, "", true},
+		{"update error", []string{"checky", "bar"}, nil, fmt.Errorf("error"), "", true},
+		{"invalid input", []string{"checky"}, nil, nil, "", true},
+		{"valid input", []string{"checky", "handler1,handler2"}, nil, nil, "Updated", false},
+	}
+
+	for _, tc := range testCases {
+		var name string
+		if len(tc.args) > 0 {
+			name = tc.args[0]
+		}
+
+		t.Run(tc.testName, func(t *testing.T) {
+			check := types.FixtureCheckConfig("checky")
+			cli := test.NewMockCLI()
+
+			client := cli.Client.(*client.MockClient)
+			client.On(
+				"FetchCheck",
+				name,
+			).Return(check, tc.fetchResponse)
+
+			client.On(
+				"UpdateCheck",
+				mock.Anything,
+			).Return(tc.updateResponse)
+
+			cmd := SetMetricHandlersCommand(cli)
+			out, err := test.RunCmd(cmd, tc.args)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, tc.expectedOutput, out)
+		})
+	}
+}

--- a/types/check.go
+++ b/types/check.go
@@ -343,19 +343,21 @@ func FixtureCheckConfig(id string) *CheckConfig {
 	timeout := uint32(0)
 
 	return &CheckConfig{
-		Name:          id,
-		Interval:      interval,
-		Subscriptions: []string{"linux"},
-		Command:       "command",
-		Handlers:      []string{},
-		RuntimeAssets: []string{"ruby-2-4-2"},
-		CheckHooks:    []HookList{*FixtureHookList("hook1")},
-		Environment:   "default",
-		Organization:  "default",
-		Publish:       true,
-		Cron:          "",
-		Ttl:           0,
-		Timeout:       timeout,
+		Name:           id,
+		Interval:       interval,
+		Subscriptions:  []string{"linux"},
+		Command:        "command",
+		Handlers:       []string{},
+		RuntimeAssets:  []string{"ruby-2-4-2"},
+		CheckHooks:     []HookList{*FixtureHookList("hook1")},
+		Environment:    "default",
+		Organization:   "default",
+		Publish:        true,
+		Cron:           "",
+		Ttl:            0,
+		Timeout:        timeout,
+		MetricHandlers: []string{},
+		MetricFormat:   "",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds CLI support and CRUD operations for the `metric_format` and `metric_handlers` fields of a check in `sensuctl`. Check commands have been updated and check subcommands have been created.

## Why is this change necessary?

Closes #1382.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.