### PR TITLE
Parse multiple lines of graphite plain text in transformer

### DIFF
--- a/agent/transformers/graphite.go
+++ b/agent/transformers/graphite.go
@@ -43,20 +43,20 @@ func ParseGraphite(metric string) (GraphiteList, error) {
 		g := Graphite{}
 		args := strings.Split(line, " ")
 		if len(args) != 3 {
-			return []Graphite{}, errors.New("graphite plain text format requires exactly 3 arguments")
+			return GraphiteList{}, errors.New("graphite plain text format requires exactly 3 arguments")
 		}
 
 		g.Path = args[0]
 
 		f, err := strconv.ParseFloat(args[1], 64)
 		if err != nil {
-			return []Graphite{}, errors.New("metric value is invalid, second argument must be a float")
+			return GraphiteList{}, errors.New("metric value is invalid, second argument must be a float")
 		}
 		g.Value = f
 
 		i, err := strconv.ParseInt(args[2], 10, 64)
 		if err != nil {
-			return []Graphite{}, errors.New("metric timestamp is invalid, third argument must be an int")
+			return GraphiteList{}, errors.New("metric timestamp is invalid, third argument must be an int")
 		}
 		g.Timestamp = i
 		graphites = append(graphites, g)

--- a/agent/transformers/graphite.go
+++ b/agent/transformers/graphite.go
@@ -8,6 +8,9 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+// GraphiteList contains a list of Graphite values
+type GraphiteList []Graphite
+
 // Graphite contains values of graphite plain text metric format
 type Graphite struct {
 	Path      string
@@ -17,37 +20,46 @@ type Graphite struct {
 
 // Transform transforms a metric in graphite plain text format to Sensu Metric
 // Format
-func (g Graphite) Transform() []*types.MetricPoint {
-	mp := &types.MetricPoint{
-		Name:      g.Path,
-		Value:     g.Value,
-		Timestamp: g.Timestamp,
-		Tags:      []*types.MetricTag{},
+func (g GraphiteList) Transform() []*types.MetricPoint {
+	var points []*types.MetricPoint
+	for _, graphite := range g {
+		mp := &types.MetricPoint{
+			Name:      graphite.Path,
+			Value:     graphite.Value,
+			Timestamp: graphite.Timestamp,
+			Tags:      []*types.MetricTag{},
+		}
+		points = append(points, mp)
 	}
-	return []*types.MetricPoint{mp}
+	return points
 }
 
 // ParseGraphite parses a graphite plain text string into a Graphite struct
-func ParseGraphite(metric string) (Graphite, error) {
-	g := Graphite{}
-	args := strings.Split(metric, " ")
-	if len(args) != 3 {
-		return Graphite{}, errors.New("graphite plain text format requires exactly 3 arguments")
+func ParseGraphite(metric string) (GraphiteList, error) {
+	var graphites GraphiteList
+	lines := strings.Split(metric, "\n")
+	for _, line := range lines {
+		g := Graphite{}
+		args := strings.Split(line, " ")
+		if len(args) != 3 {
+			return []Graphite{}, errors.New("graphite plain text format requires exactly 3 arguments")
+		}
+
+		g.Path = args[0]
+
+		f, err := strconv.ParseFloat(args[1], 64)
+		if err != nil {
+			return []Graphite{}, errors.New("metric value is invalid, second argument must be a float")
+		}
+		g.Value = f
+
+		i, err := strconv.ParseInt(args[2], 10, 64)
+		if err != nil {
+			return []Graphite{}, errors.New("metric timestamp is invalid, third argument must be an int")
+		}
+		g.Timestamp = i
+		graphites = append(graphites, g)
 	}
 
-	g.Path = args[0]
-
-	f, err := strconv.ParseFloat(args[1], 64)
-	if err != nil {
-		return Graphite{}, errors.New("metric value is invalid, second argument must be a float")
-	}
-	g.Value = f
-
-	i, err := strconv.ParseInt(args[2], 10, 64)
-	if err != nil {
-		return Graphite{}, errors.New("metric timestamp is invalid, third argument must be an int")
-	}
-	g.Timestamp = i
-
-	return g, nil
+	return graphites, nil
 }

--- a/agent/transformers/graphite.go
+++ b/agent/transformers/graphite.go
@@ -37,6 +37,7 @@ func (g GraphiteList) Transform() []*types.MetricPoint {
 // ParseGraphite parses a graphite plain text string into a Graphite struct
 func ParseGraphite(metric string) (GraphiteList, error) {
 	var graphites GraphiteList
+	metric = strings.TrimSpace(metric)
 	lines := strings.Split(metric, "\n")
 	for _, line := range lines {
 		g := Graphite{}

--- a/agent/transformers/graphite_test.go
+++ b/agent/transformers/graphite_test.go
@@ -12,31 +12,54 @@ func TestParseGraphite(t *testing.T) {
 
 	testCases := []struct {
 		metric         string
-		expectedFormat Graphite
+		expectedFormat GraphiteList
 		expectedErr    bool
 	}{
 		{
 			metric: "metric.value 1 123456789",
-			expectedFormat: Graphite{
-				Path:      "metric.value",
-				Value:     1,
-				Timestamp: 123456789,
+			expectedFormat: GraphiteList{
+				{
+					Path:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+				},
 			},
 			expectedErr: false,
 		},
 		{
+			metric: "metric.value 1 123456789\nmetric.value 0 0",
+			expectedFormat: GraphiteList{
+				{
+					Path:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+				},
+				{
+					Path:      "metric.value",
+					Value:     0,
+					Timestamp: 0,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			metric:         "",
+			expectedFormat: GraphiteList{},
+			expectedErr:    true,
+		},
+		{
 			metric:         "foo bar",
-			expectedFormat: Graphite{},
+			expectedFormat: GraphiteList{},
 			expectedErr:    true,
 		},
 		{
 			metric:         "metric.value one 123456789",
-			expectedFormat: Graphite{},
+			expectedFormat: GraphiteList{},
 			expectedErr:    true,
 		},
 		{
 			metric:         "metric.value 1 noon",
-			expectedFormat: Graphite{},
+			expectedFormat: GraphiteList{},
 			expectedErr:    true,
 		},
 	}
@@ -58,14 +81,16 @@ func TestTransformGraphite(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		metric         Graphite
+		metric         GraphiteList
 		expectedFormat []*types.MetricPoint
 	}{
 		{
-			metric: Graphite{
-				Path:      "metric.value",
-				Value:     1,
-				Timestamp: 123456789,
+			metric: GraphiteList{
+				{
+					Path:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+				},
 			},
 			expectedFormat: []*types.MetricPoint{
 				{
@@ -77,10 +102,57 @@ func TestTransformGraphite(t *testing.T) {
 			},
 		},
 		{
-			metric: Graphite{
-				Path:      "",
-				Value:     0,
-				Timestamp: 0,
+			metric: GraphiteList{
+				{
+					Path:      "",
+					Value:     0,
+					Timestamp: 0,
+				},
+			},
+			expectedFormat: []*types.MetricPoint{
+				{
+					Name:      "",
+					Value:     0,
+					Timestamp: 0,
+					Tags:      []*types.MetricTag{},
+				},
+			},
+		},
+		{
+			metric: GraphiteList{
+				{
+					Path:      "",
+					Value:     0,
+					Timestamp: 0,
+				},
+				{
+					Path:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+				},
+			},
+			expectedFormat: []*types.MetricPoint{
+				{
+					Name:      "",
+					Value:     0,
+					Timestamp: 0,
+					Tags:      []*types.MetricTag{},
+				},
+				{
+					Name:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+					Tags:      []*types.MetricTag{},
+				},
+			},
+		},
+		{
+			metric: GraphiteList{
+				{
+					Path:      "",
+					Value:     0,
+					Timestamp: 0,
+				},
 			},
 			expectedFormat: []*types.MetricPoint{
 				{
@@ -132,6 +204,28 @@ func TestParseAndTransformGraphite(t *testing.T) {
 				},
 			},
 			expectedErr: false,
+		},
+		{
+			metric: "metric.value 1 123456789\nmetric.value 0 0",
+			expectedFormat: []*types.MetricPoint{
+				{
+					Name:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+					Tags:      []*types.MetricTag{},
+				},
+				{
+					Name:      "metric.value",
+					Value:     0,
+					Timestamp: 0,
+					Tags:      []*types.MetricTag{},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			metric:      "",
+			expectedErr: true,
 		},
 		{
 			metric:      "foo bar",

--- a/agent/transformers/graphite_test.go
+++ b/agent/transformers/graphite_test.go
@@ -27,6 +27,17 @@ func TestParseGraphite(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			metric: "metric.value 1 123456789\n",
+			expectedFormat: GraphiteList{
+				{
+					Path:      "metric.value",
+					Value:     1,
+					Timestamp: 123456789,
+				},
+			},
+			expectedErr: false,
+		},
+		{
 			metric: "metric.value 1 123456789\nmetric.value 0 0",
 			expectedFormat: GraphiteList{
 				{
@@ -194,7 +205,7 @@ func TestParseAndTransformGraphite(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			metric: "metric.value 0 0",
+			metric: "metric.value 0 0\n",
 			expectedFormat: []*types.MetricPoint{
 				{
 					Name:      "metric.value",


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Allows the graphite plain text transformer to parse multiple lines of text, and extract multiple metric points.

## Why is this change necessary?

Sensu 1.x supports multiple lines of graphite plain text values.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.