### PR TITLE
Fix bug in topic done chan closed on subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ swallowed. The events are sent through the pipeline.
 - Fixed a bug where check and checkconfig handlers and subscriptions are null in rendered JSON.
 - Allow checks and hooks to escape zombie processes that have timed out.
 - Install all dependencies with `dep ensure` in build.sh.
-
+- Fixed an issue in which some agents intermittently miss check requests.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -162,6 +162,7 @@ func (s *Session) subPump() {
 			configBytes, err := json.Marshal(request)
 			if err != nil {
 				logger.WithError(err).Error("session failed to serialize check request")
+				continue
 			}
 
 			msg := transport.NewMessage(types.CheckRequestType, configBytes)

--- a/backend/messaging/wizard_bus.go
+++ b/backend/messaging/wizard_bus.go
@@ -116,11 +116,18 @@ func (b *WizardBus) Subscribe(topic string, consumer string, sub Subscriber) (Su
 	b.topicsMu.Lock()
 	defer b.topicsMu.Unlock()
 
-	if _, ok := b.topics[topic]; !ok {
-		b.topics[topic] = b.createTopic(topic)
+	t, ok := b.topics[topic]
+	if !ok {
+		t = b.createTopic(topic)
+		b.topics[topic] = t
 	}
 
-	subscription, err := b.topics[topic].Subscribe(consumer, sub)
+	if t.IsClosed() {
+		t = b.createTopic(topic)
+		b.topics[topic] = t
+	}
+
+	subscription, err := t.Subscribe(consumer, sub)
 	return subscription, err
 }
 

--- a/backend/messaging/wizard_bus.go
+++ b/backend/messaging/wizard_bus.go
@@ -117,12 +117,7 @@ func (b *WizardBus) Subscribe(topic string, consumer string, sub Subscriber) (Su
 	defer b.topicsMu.Unlock()
 
 	t, ok := b.topics[topic]
-	if !ok {
-		t = b.createTopic(topic)
-		b.topics[topic] = t
-	}
-
-	if t.IsClosed() {
+	if !ok || t.IsClosed() {
 		t = b.createTopic(topic)
 		b.topics[topic] = t
 	}

--- a/backend/messaging/wizard_topic.go
+++ b/backend/messaging/wizard_topic.go
@@ -124,3 +124,12 @@ func (t *wizardTopic) Close() {
 	}
 	t.Unlock()
 }
+
+func (t *wizardTopic) IsClosed() bool {
+	select {
+	case <-t.done:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## What is this change?

Fixes an issue in which agents re-connecting may experience missed or skipped check requests.

## Why is this change necessary?

Closes #1407 

## Does your change need a Changelog entry?

Added under `Fixed`.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

This was a really gnarly bug that took the debugging efforts of myself, @cyphus, and @echlebek to deduce.