### PR TITLE
Add install instructions for protoc-gen-go to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ brew install protobuf
 ```
 Otherwise, see the **for non-C++ users** [instructions here.](https://github.com/google/protobuf#protocol-compiler-installation)
 
+Install protoc-gen-go.
+```
+go get -u github.com/golang/protobuf/protoc-gen-go
+```
+
 #### Quick Start
 
 Once you make a change to any `*.proto` file within the **types** package, you will need to regenerate the associated `*.pb.go` file. To do so, simply run `go generate` on the package.


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds install instructions for protoc-gen-go.

## Why is this change necessary?

The current instructions are missing this step. It is necessary to be able to run `go generate` on our packages with proto files.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!