### PR TITLE
Don't add namespace flags for create command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and yarn are now dependencies for building the backend.
 - Improved log entries produced by pipelined.
 - Allow the InfluxDB handler to parse the Sensu metric for an InfluxDB field tag
 and measurement.
+- Removed organization and environment flags from create command.
 
 ### Fixed
 - Terminate processes gracefully in e2e tests, allowing ports to be reused.

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -52,6 +52,12 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		extension.HelpCommand(cli),
 	)
 
+	createCmd, _, err := rootCmd.Find([]string{"create"})
+	if err == nil {
+		_ = createCmd.InheritedFlags().MarkHidden("environment")
+		_ = createCmd.InheritedFlags().MarkHidden("organization")
+	}
+
 	for _, cmd := range rootCmd.Commands() {
 		rootCmd.ValidArgs = append(rootCmd.ValidArgs, cmd.Use)
 	}


### PR DESCRIPTION
This commit removes the namespace flags (--organization and
--environment) from the global flags, and instead uses local flags
to implement those features.

This was done so that we could avoid having these flags for the
create command, which does not use them and should not.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1233 

## Were there any complications while making this change?

It was difficult to decide how to do this. I would have preferred to leave the namespace and organization flags as global flags, but there was no way to do that and also drop those flags from the create sub-command. I settled on adding them as local flags to every command with a for loop.