### PR TITLE
Ensure event entity has a last_seen time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ swallowed. The events are sent through the pipeline.
 - Allow checks and hooks to escape zombie processes that have timed out.
 - Install all dependencies with `dep ensure` in build.sh.
 - Fixed an issue in which some agents intermittently miss check requests.
+- Check event entities now have a last_seen timestamp.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/sensu/sensu-go/system"
 	"github.com/sensu/sensu-go/types"
@@ -16,6 +17,7 @@ func (a *Agent) getAgentEntity() *types.Entity {
 			Environment:      a.config.Environment,
 			ID:               a.config.AgentID,
 			KeepaliveTimeout: a.config.KeepaliveTimeout,
+			LastSeen:         time.Now().Unix(),
 			Organization:     a.config.Organization,
 			Redact:           a.config.Redact,
 			Subscriptions:    a.config.Subscriptions,


### PR DESCRIPTION
Signed-off-by: Mercedes Coyle <mercedes@sensu.io>

## What is this change?

Adds a timestamp to `LastSeen` when an entity is created for an event on the agent.

## Why is this change necessary?

Closes #1377.

## Does your change need a Changelog entry?

Added a note in bug fixes.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

There was some discussion as to what the source of truth should be for determining an entity's last seen time. This fix does not update the last_seen time in the store, so the entity may have multiple last_seen times depending on where it is viewed. I've opened #1434 to address that.