### PR TITLE
Instantiate empty metrics in the check event

### DIFF
--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -65,7 +65,8 @@ func (a *Agent) executeCheck(request *types.CheckRequest) {
 	check.Executed = time.Now().Unix()
 	check.Issued = request.Issued
 	event := &types.Event{
-		Check: check,
+		Check:   check,
+		Metrics: &types.Metrics{},
 	}
 
 	// Ensure that the asset manager is aware of all the assets required to


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Instantiates an empty Metrics struct inside the check handlers event.

## Why is this change necessary?

Fixes a nil pointer error.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

No, I think this was the result of a bad merge.