### PR TITLE
Add e2e test for metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ transformer.
 - Added an InfluxDB Line transformer.
 - Add support for metric extraction from check output for `influxdb_line`
 transformer.
+- Add e2e test for metric extraction.
 
 ### Changed
 - Changed the maximum number of open file descriptors on a system to from 1024

--- a/testing/e2e/metric_extraction_test.go
+++ b/testing/e2e/metric_extraction_test.go
@@ -1,0 +1,56 @@
+package e2e
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricExtraction(t *testing.T) {
+	t.Parallel()
+
+	// Start the backend
+	backend, cleanup := newBackend(t)
+	defer cleanup()
+
+	// Initializes sensuctl
+	sensuctl, cleanup := newSensuCtl(backend.HTTPURL, "default", "default", "admin", "P@ssw0rd!")
+	defer cleanup()
+
+	// Start the agent
+	agentConfig := agentConfig{
+		ID:          "TestMetricExtraction",
+		BackendURLs: []string{backend.WSURL},
+	}
+	agent, cleanup := newAgent(agentConfig, sensuctl, t)
+	defer cleanup()
+
+	// Create a check that publish check requests
+	out, err := sensuctl.run(
+		"check", "create", "nagios-metric",
+		"--publish",
+		"--interval", "1",
+		"--subscriptions", "test",
+		"--command", "echo 'PING ok - Packet loss = 0% | percent_packet_loss=0'",
+		"--metric-format", "nagios_perfdata",
+	)
+	require.NoError(t, err, string(out))
+
+	// FIXME: Give it few seconds to make sure we're not publishing check requests.
+	time.Sleep(15 * time.Second)
+
+	// There should be a stored event for our metric
+	out, err = sensuctl.run("event", "info", agent.ID, "nagios-metric")
+	assert.NoError(t, err, string(out))
+
+	event := types.Event{}
+	require.NoError(t, json.Unmarshal(out, &event))
+	assert.NotNil(t, event)
+	assert.NotZero(t, len(event.Metrics.Points))
+	assert.Equal(t, "percent_packet_loss", event.Metrics.Points[0].Name)
+	assert.Equal(t, 0.0, event.Metrics.Points[0].Value)
+}

--- a/testing/e2e/metric_extraction_test.go
+++ b/testing/e2e/metric_extraction_test.go
@@ -35,7 +35,7 @@ func TestMetricExtraction(t *testing.T) {
 		"--publish",
 		"--interval", "1",
 		"--subscriptions", "test",
-		"--command", "echo 'PING ok - Packet loss = 0% | percent_packet_loss=0'",
+		"--command", `echo "PING ok - Packet loss = 0% | percent_packet_loss=0"`,
 		"--metric-format", "nagios_perfdata",
 	)
 	require.NoError(t, err, string(out))


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds an e2e test for metric extraction functionality.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1389

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Non!

## Were there any complications while making this change?

Non!