### PR TITLE
Improve display and ergonomics of silenced entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ swallowed. The events are sent through the pipeline.
 - Agent statsd daemon listens on IPv4 for Windows.
 - Include zero-valued integers in JSON output for all types.
 - Check event entities now have a last_seen timestamp.
+- Improved silenced entry display and UX.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/cli/commands/silenced/interactive.go
+++ b/cli/commands/silenced/interactive.go
@@ -120,7 +120,7 @@ func (o *silencedOpts) administerQuestionnaire(editing bool) error {
 			Name: "begin",
 			Prompt: &survey.Input{
 				Message: "Begin time:",
-				Default: o.Begin,
+				Default: "now",
 				Help:    "Start silencing events at this time. Format: Jan 02 2006 3:04PM MST",
 			},
 			Validate: func(val interface{}) error {

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -85,10 +85,17 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
+			Title: "Begin",
+			CellTransformer: func(data interface{}) string {
+				s, _ := data.(types.Silenced)
+				return time.Unix(s.Begin, 0).Format(time.RFC822)
+			},
+		},
+		{
 			Title: "Expire",
 			CellTransformer: func(data interface{}) string {
-				silenced, _ := data.(types.Silenced)
-				return (time.Duration(silenced.Expire) * time.Second).String()
+				s, _ := data.(types.Silenced)
+				return expireTime(s.Begin, s.Expire).String()
 			},
 		},
 		{

--- a/cli/commands/timeutil/time.go
+++ b/cli/commands/timeutil/time.go
@@ -42,8 +42,8 @@ func ConvertToUTC(t *types.TimeWindowTimeRange) error {
 // ConvertToUnixUTC takes a string formatted as dateFormat and converts it to
 // UTC in unix epoch form
 func ConvertToUnixUTC(begin string) (int64, error) {
-	if begin == "0" {
-		return 0, nil
+	if begin == "0" || begin == "now" {
+		return time.Now().Unix(), nil
 	}
 	utc, err := offsetTime(begin, dateFormat, dateFormatTZRE)
 	if err != nil {


### PR DESCRIPTION
This commit adds a 'Begin' time to silenced entries so that users
will be able to recognize which entries have already begun and
which haven't. Also, expiry time is computed as an offset from
begin, if the silenced entry hasn't begun yet.

The commit also improves the ergonomics of using the interactive
mode for creating silenced entries, by defaulting the silenced
begin time to 'now'. (Previously, the default was 0, which was
both confusing, and also interpreted as the start of the unix
epoch.)

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1176 