### PR TITLE
Trim whitespace from check output in opentsdb transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ swallowed. The events are sent through the pipeline.
 - Include zero-valued integers in JSON output for all types.
 - Check event entities now have a last_seen timestamp.
 - Improved silenced entry display and UX.
+- Fixed a small bug in the opentsdb transformer so that it trims trailing
+whitespace characters.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/agent/transformers/influx_db_test.go
+++ b/agent/transformers/influx_db_test.go
@@ -46,7 +46,7 @@ func TestParseInflux(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			metric: "weather,location=us-midwest,season=summer temperature=82,humidity=30 1465839830100400200\nweather temperature=82 1465839830100400200",
+			metric: "weather,location=us-midwest,season=summer temperature=82,humidity=30 1465839830100400200\nweather temperature=82 1465839830100400200\n",
 			expectedFormat: InfluxList{
 				{
 					Measurement: "weather",

--- a/agent/transformers/nagios_test.go
+++ b/agent/transformers/nagios_test.go
@@ -43,6 +43,23 @@ func TestParseNagios(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "single perfdata metric with newline",
+			event: &types.Event{
+				Check: &types.Check{
+					Executed: 12345,
+					Output:   "PING ok - Packet loss = 0% | percent_packet_loss=0\n",
+				},
+			},
+			want: NagiosList{
+				Nagios{
+					Label:     "percent_packet_loss",
+					Value:     0.0,
+					Timestamp: 12345,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "multiple perfdata metrics",
 			event: &types.Event{
 				Check: &types.Check{

--- a/agent/transformers/opentsdb.go
+++ b/agent/transformers/opentsdb.go
@@ -39,6 +39,7 @@ func ParseOpenTSDB(output string) (OpenTSDBList, error) {
 	openTSDBList := OpenTSDBList{}
 
 	// Split each line of the output into its own metric
+	output = strings.TrimSpace(output)
 	metrics := strings.Split(output, "\n")
 
 	for _, metric := range metrics {

--- a/agent/transformers/opentsdb_test.go
+++ b/agent/transformers/opentsdb_test.go
@@ -34,6 +34,28 @@ func TestParseOpenTSDB(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:   "standard opentsdb metric with whitespace",
+			output: "sys.cpu.user 1356998400 42.5 host=webserver01 cpu=0\n",
+			want: OpenTSDBList{
+				OpenTSDB{
+					Name: "sys.cpu.user",
+					TagSet: []*types.MetricTag{
+						&types.MetricTag{
+							Name:  "host",
+							Value: "webserver01",
+						},
+						&types.MetricTag{
+							Name:  "cpu",
+							Value: "0",
+						},
+					},
+					Timestamp: 1356998400,
+					Value:     42.5,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:   "timestamp with millisecond precision",
 			output: "sys.cpu.user 1356998400000 42.5 host=webserver01",
 			want: OpenTSDBList{


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixed a small bug in the opentsdb transformer so that it trims trailing whitespace characters.

## Why is this change necessary?

Check output containing one or multiple metrics in opentsdb metric format can also contain trailing whitespace or newline characters. We should not attempt to parse the newline character for a metric, rather we should ignore it.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.