### PR TITLE
[Web UI] Rename 'Configuration' card to 'Summary' 

### DIFF
--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -7,7 +7,7 @@ import Loader from "/components/Loader";
 import ButtonSet from "/components/ButtonSet";
 import RelatedEntitiesCard from "/components/partials/RelatedEntitiesCard";
 import CheckResult from "./EventDetailsCheckResult";
-import Configuration from "./EventDetailsConfiguration";
+import Summary from "./EventDetailsSummary";
 import DeleteAction from "./EventDetailsDeleteAction";
 import ResolveAction from "./EventDetailsResolveAction";
 
@@ -33,20 +33,20 @@ class EventDetailsContainer extends React.PureComponent {
 
         check {
           ...EventDetailsCheckResult_check
-          ...EventDetailsConfiguration_check
+          ...EventDetailsSummary_check
         }
         entity {
           ...EventDetailsCheckResult_entity
           ...RelatedEntitiesCard_entity
-          ...EventDetailsConfiguration_entity
+          ...EventDetailsSummary_entity
         }
       }
 
       ${CheckResult.fragments.check}
       ${CheckResult.fragments.entity}
       ${RelatedEntitiesCard.fragments.entity}
-      ${Configuration.fragments.check}
-      ${Configuration.fragments.entity}
+      ${Summary.fragments.check}
+      ${Summary.fragments.entity}
       ${DeleteAction.fragments.event}
       ${ResolveAction.fragments.event}
     `,
@@ -98,7 +98,7 @@ class EventDetailsContainer extends React.PureComponent {
                   <RelatedEntitiesCard entity={event.entity} />
                 </Grid>
                 <Grid item xs={12} md={6}>
-                  <Configuration check={event.check} entity={event.entity} />
+                  <Summary check={event.check} entity={event.entity} />
                 </Grid>
               </Grid>
             </Content>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -13,7 +13,7 @@ import RelativeDate from "/components/RelativeDate";
 import Monospaced from "/components/Monospaced";
 import Maybe from "/components/Maybe";
 
-class EventDetailsConfiguration extends React.Component {
+class EventDetailsSummary extends React.Component {
   static propTypes = {
     check: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -21,7 +21,7 @@ class EventDetailsConfiguration extends React.Component {
 
   static fragments = {
     entity: gql`
-      fragment EventDetailsConfiguration_entity on Entity {
+      fragment EventDetailsSummary_entity on Entity {
         name
         class
         system {
@@ -32,7 +32,7 @@ class EventDetailsConfiguration extends React.Component {
       }
     `,
     check: gql`
-      fragment EventDetailsConfiguration_check on Check {
+      fragment EventDetailsSummary_check on Check {
         name
         command
         interval
@@ -49,8 +49,29 @@ class EventDetailsConfiguration extends React.Component {
       <Card>
         <CardContent>
           <Typography variant="headline" paragraph>
-            Configuration
+            Check Summary
           </Typography>
+          <Dictionary>
+            <DictionaryEntry>
+              <DictionaryKey>Check</DictionaryKey>
+              <DictionaryValue>{check.name}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Interval</DictionaryKey>
+              <DictionaryValue>{check.interval}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Timeout</DictionaryKey>
+              <DictionaryValue>{check.timeout}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>TTL</DictionaryKey>
+              <DictionaryValue>{check.ttl}</DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </CardContent>
+        <Divider />
+        <CardContent>
           <Dictionary>
             <DictionaryEntry>
               <DictionaryKey>Entity</DictionaryKey>
@@ -80,34 +101,19 @@ class EventDetailsConfiguration extends React.Component {
             </DictionaryEntry>
           </Dictionary>
         </CardContent>
-        <Divider />
-        <CardContent>
-          <Dictionary>
-            <DictionaryEntry>
-              <DictionaryKey>Check</DictionaryKey>
-              <DictionaryValue>{check.name}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Interval</DictionaryKey>
-              <DictionaryValue>{check.interval}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Timeout</DictionaryKey>
-              <DictionaryValue>{check.timeout}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>TTL</DictionaryKey>
-              <DictionaryValue>{check.ttl}</DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
-        </CardContent>
-        <Divider />
-        <Monospaced background>
-          <CardContent>{`# Executed command\n$ ${check.command}`}</CardContent>
-        </Monospaced>
+        {check.command && (
+          <React.Fragment>
+            <Divider />
+            <Monospaced background>
+              <CardContent>
+                {`# Executed command\n$ ${check.command}`}
+              </CardContent>
+            </Monospaced>
+          </React.Fragment>
+        )}
       </Card>
     );
   }
 }
 
-export default EventDetailsConfiguration;
+export default EventDetailsSummary;

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -12,6 +12,7 @@ import Dictionary, {
 import RelativeDate from "/components/RelativeDate";
 import Monospaced from "/components/Monospaced";
 import Maybe from "/components/Maybe";
+import InlineLink from "/components/InlineLink";
 
 class EventDetailsSummary extends React.Component {
   static propTypes = {
@@ -22,11 +23,16 @@ class EventDetailsSummary extends React.Component {
   static fragments = {
     entity: gql`
       fragment EventDetailsSummary_entity on Entity {
-        name
-        class
+        ns: namespace {
+          org: organization
+          env: environment
+        }
         system {
           platform
         }
+
+        name
+        class
         lastSeen
         subscriptions
       }
@@ -44,7 +50,9 @@ class EventDetailsSummary extends React.Component {
   };
 
   render() {
-    const { entity, check } = this.props;
+    const { entity: entityProp, check } = this.props;
+    const { ns, ...entity } = entityProp;
+
     return (
       <Card>
         <CardContent>
@@ -75,7 +83,11 @@ class EventDetailsSummary extends React.Component {
           <Dictionary>
             <DictionaryEntry>
               <DictionaryKey>Entity</DictionaryKey>
-              <DictionaryValue>{entity.name}</DictionaryValue>
+              <DictionaryValue>
+                <InlineLink to={`/${ns.org}/${ns.env}/entities/${entity.name}`}>
+                  {entity.name}
+                </InlineLink>
+              </DictionaryValue>
             </DictionaryEntry>
             <DictionaryEntry>
               <DictionaryKey>Class</DictionaryKey>


### PR DESCRIPTION
## What is this change?

As 'Configuration' was both wrong and confusing; rename card to 'Summary'. 

## Why is this change necessary?

From discussion with @portertech on Friday.

## Does your change need a Changelog entry?

unlikely

## Do you need clarification on anything?

`undefined`

## Were there any complications while making this change?

`undefined`