### PR TITLE
Trim git describe output

### DIFF
--- a/version/cmd/version/version.go
+++ b/version/cmd/version/version.go
@@ -71,7 +71,8 @@ func getTag() (string, error) {
 			return "", err
 		}
 	}
-	return string(out), nil
+	tag := strings.Trim(string(out), "\n")
+	return tag, nil
 }
 
 func getTags() ([]string, error) {


### PR DESCRIPTION
Regex was failing due to `git describe` output ending with a newline.