### PR TITLE
Add logging around event pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+
+### Changed
+- Add logging around the Sensu event pipeline
+
+### Fixed
+
+
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added
 - Add Ubuntu 18.04 repository

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -23,6 +23,8 @@ func EventFields(event *types.Event) map[string]interface{} {
 	// adding the check name
 	if event.HasCheck() {
 		fields["check"] = event.Check.Name
+	} else if event.HasMetrics() {
+		fields["metric"] = true
 	}
 
 	return fields


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds some useful log entries, using the `INFO` level, around the Sensu pipeline, so users can more easily understand the progress of their events through the pipeline.

## Why is this change necessary?

During our QA party, Eric and I tracked what we thought was a bug during few hours, because we couldn't see events from statsd UDP socket. Turns out we simply forgot to configure the `--statsd-event-handlers` flag on the agent and since metrics are not stored in the store and no log entries for this event were added, it took us a long time to realize that.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

I feel like the messages I added could be improved, open to suggestions!

## Were there any complications while making this change?

Non!