### PR TITLE
Audit event polymorphism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Added
-
+- Performed an audit of events and checks. Added `event.HasCheck()` nil checks
+prior to assuming the existence of said check.
 
 ### Changed
 - Add logging around the Sensu event pipeline
 
 ### Fixed
-
+- Fixed a small bug in the opentsdb transformer so that it trims trailing
+whitespace characters.
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added
@@ -118,8 +120,6 @@ swallowed. The events are sent through the pipeline.
 - Include zero-valued integers in JSON output for all types.
 - Check event entities now have a last_seen timestamp.
 - Improved silenced entry display and UX.
-- Fixed a small bug in the opentsdb transformer so that it trims trailing
-whitespace characters.
 
 ## [2.0.0-nightly.1] - 2018-03-07
 ### Added

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -60,7 +60,7 @@ func (a *Agent) getAgentEntity() *types.Entity {
 func (a *Agent) getEntities(event *types.Event) {
 	// Verify if we have an entity in the event, and that it is different from the
 	// agent's entity
-	if event.Entity != nil && event.Entity.ID != a.config.AgentID {
+	if event.Entity != nil && event.HasCheck() && event.Entity.ID != a.config.AgentID {
 		// Identify the event's source as the provided entity so it can be properly
 		// handled by the backend
 		event.Check.ProxyEntityID = event.Entity.ID

--- a/agent/event.go
+++ b/agent/event.go
@@ -16,6 +16,10 @@ func prepareEvent(a *Agent, event *types.Event) error {
 		return fmt.Errorf("an event must be provided")
 	}
 
+	if !event.HasCheck() {
+		return fmt.Errorf("check has not been instantiated for this event")
+	}
+
 	if event.Timestamp == 0 {
 		event.Timestamp = time.Now().Unix()
 	}

--- a/agent/transformers/nagios.go
+++ b/agent/transformers/nagios.go
@@ -39,6 +39,10 @@ func (n NagiosList) Transform() []*types.MetricPoint {
 func ParseNagios(event *types.Event) (NagiosList, error) {
 	nagiosList := NagiosList{}
 
+	if !event.HasCheck() {
+		return nil, errors.New("event must contain a check to parse and extract metrics")
+	}
+
 	// Ensure we have some perfdata metrics and not only human-readable text
 	output := strings.Split(event.Check.Output, "|")
 	if len(output) != 2 {

--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -23,7 +23,7 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 	ctx = context.WithValue(ctx, types.EnvironmentKey, event.Entity.Environment)
 
 	// Verify if a proxy entity id, representing a proxy entity, is defined in the check
-	if event.Check.ProxyEntityID != "" {
+	if event.HasCheck() && event.Check.ProxyEntityID != "" {
 		// Query the store for an entity using the given proxy entity ID
 		entity, err := s.GetEntityByID(ctx, event.Check.ProxyEntityID)
 		if err != nil {

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -115,6 +115,10 @@ func (a EventController) Destroy(ctx context.Context, entity, check string) erro
 
 // Update updates the event indicated by the supplied entity and check.
 func (a EventController) Update(ctx context.Context, event types.Event) error {
+	if !event.HasCheck() {
+		return NewErrorf(InvalidArgument)
+	}
+
 	check := event.Check
 	entity := event.Entity
 
@@ -153,6 +157,10 @@ func (a EventController) Update(ctx context.Context, event types.Event) error {
 // Create creates the event indicated by the supplied entity and check.
 // If an event already exists for the entity and check, it updates that event.
 func (a EventController) Create(ctx context.Context, event types.Event) error {
+	if !event.HasCheck() {
+		return NewErrorf(InvalidArgument)
+	}
+
 	check := event.Check
 	entity := event.Entity
 

--- a/backend/apid/graphql/globalid/events.go
+++ b/backend/apid/graphql/globalid/events.go
@@ -97,14 +97,14 @@ func encodeEvent(event *types.Event) StandardComponents {
 	addMultitenantFields(&components, event.Entity)
 
 	timestamp := strconv.FormatInt(event.Timestamp, 10)
-	if event.Check != nil {
+	if event.HasCheck() {
 		components.resourceType = eventCheckType
 		components.uniqueComponent = encodeUniqueComponents(
 			event.Entity.ID,
 			event.Check.Name,
 			timestamp,
 		)
-	} else if event.Metrics != nil {
+	} else if event.HasMetrics() {
 		components.resourceType = eventMetricType
 		components.uniqueComponent = encodeUniqueComponents(
 			event.Entity.ID,

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -139,7 +139,7 @@ func (r *mutationsImpl) ResolveEvent(p schema.MutationResolveEventFieldResolverP
 		return nil, err
 	}
 
-	if event.Check != nil && event.Check.Status > 0 {
+	if event.HasCheck() && event.Check.Status > 0 {
 		event.Check.Status = 0
 		event.Check.Output = "Resolved manually with " + p.Args.Input.Source
 		event.Timestamp = int64(time.Now().Unix())

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -171,7 +171,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 
 	// Maintain check history.
 	if prevEvent != nil {
-		if prevEvent.Check == nil {
+		if !prevEvent.HasCheck() {
 			return errors.New("invalid previous event")
 		}
 
@@ -225,6 +225,9 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 }
 
 func updateOccurrences(event *types.Event) {
+	if !event.HasCheck() {
+		return
+	}
 	if len(event.Check.History) > 1 && (event.IsIncident() || isFlapping(event)) {
 		historyLen := len(event.Check.History)
 		if event.Check.History[historyLen-1].Status == event.Check.History[historyLen-2].Status {
@@ -273,6 +276,10 @@ func (e *Eventd) HandleFailure(entity *types.Entity, event *types.Event) error {
 }
 
 func (e *Eventd) createFailedCheckEvent(ctx context.Context, event *types.Event) (*types.Event, error) {
+	if !event.HasCheck() {
+		return nil, errors.New("event does not contain a check")
+	}
+
 	lastCheckResult, err := e.store.GetEventByEntityCheck(
 		ctx, event.Entity.ID, event.Check.Name,
 	)

--- a/backend/eventd/flapping.go
+++ b/backend/eventd/flapping.go
@@ -41,11 +41,7 @@ func state(event *types.Event) {
 // totalStateChange calculates the total state change percentage for the
 // history, which is later used for check state flap detection.
 func totalStateChange(event *types.Event) uint32 {
-	if !event.HasCheck() {
-		return 0
-	}
-
-	if len(event.Check.History) < 21 {
+	if !event.HasCheck() || len(event.Check.History) < 21 {
 		return 0
 	}
 

--- a/backend/eventd/flapping.go
+++ b/backend/eventd/flapping.go
@@ -5,6 +5,10 @@ import "github.com/sensu/sensu-go/types"
 // isFlapping determines if the check is flapping, based on the TotalStateChange
 // and configured thresholds
 func isFlapping(event *types.Event) bool {
+	if !event.HasCheck() {
+		return false
+	}
+
 	if event.Check.LowFlapThreshold == 0 || event.Check.HighFlapThreshold == 0 {
 		return false
 	}
@@ -21,6 +25,9 @@ func isFlapping(event *types.Event) bool {
 // state determines the check state based on whether the check is flapping and
 // its status
 func state(event *types.Event) {
+	if !event.HasCheck() {
+		return
+	}
 	if flapping := isFlapping(event); flapping {
 		event.Check.State = types.EventFlappingState
 	} else if event.Check.Status == 0 {
@@ -34,6 +41,10 @@ func state(event *types.Event) {
 // totalStateChange calculates the total state change percentage for the
 // history, which is later used for check state flap detection.
 func totalStateChange(event *types.Event) uint32 {
+	if !event.HasCheck() {
+		return 0
+	}
+
 	if len(event.Check.History) < 21 {
 		return 0
 	}

--- a/backend/eventd/silenced.go
+++ b/backend/eventd/silenced.go
@@ -24,6 +24,9 @@ func addToSilencedBy(id string, ids []string) []string {
 // supporting wildcard silenced entries (e.g. subscription:*)
 func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
 	entries := []*types.Silenced{}
+	if !event.HasCheck() {
+		return nil
+	}
 
 	// Retrieve silenced entries using the entity subscription
 	entitySubscription := types.GetEntitySubscription(event.Entity.ID)
@@ -62,6 +65,9 @@ func getSilenced(ctx context.Context, event *types.Event, s store.Store) error {
 // event and return a list of silenced entry IDs
 func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string {
 	silencedBy := []string{}
+	if !event.HasCheck() {
+		return silencedBy
+	}
 
 	// Loop through every silenced entries in order to determine if it applies to
 	// the given event
@@ -112,7 +118,7 @@ func silencedBy(event *types.Event, silencedEntries []*types.Silenced) []string 
 }
 
 func handleExpireOnResolveEntries(ctx context.Context, event *types.Event, store store.Store) error {
-	if !event.IsResolution() {
+	if !event.HasCheck() || !event.IsResolution() {
 		return nil
 	}
 

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -39,6 +39,10 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 	}
 
 	for _, event := range events {
+		if !event.HasCheck() {
+			return fmt.Errorf("error deleting event without check")
+		}
+
 		if err := adapterPtr.Store.DeleteEventByEntityCheck(
 			ctx, entity.ID, event.Check.Name,
 		); err != nil {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -160,8 +160,10 @@ func (k *Keepalived) initFromStore() error {
 		}
 
 		// if another backend picked it up, it will be passing.
-		if event.Check.Status == 0 {
-			continue
+		if event.HasCheck() {
+			if event.Check.Status == 0 {
+				continue
+			}
 		}
 
 		// Recreate the monitor with a time offset calculated from the keepalive

--- a/backend/pipelined/mutate.go
+++ b/backend/pipelined/mutate.go
@@ -95,7 +95,10 @@ func (p *Pipelined) jsonMutator(event *types.Event) ([]byte, error) {
 // mutator can probably be removed/replaced when 2.0 has extension
 // support.
 func (p *Pipelined) onlyCheckOutputMutator(event *types.Event) []byte {
-	return []byte(event.Check.Output)
+	if event.HasCheck() {
+		return []byte(event.Check.Output)
+	}
+	return nil
 }
 
 // pipeMutator fork/executes a child process for a Sensu mutator

--- a/backend/pipelined/mutate.go
+++ b/backend/pipelined/mutate.go
@@ -31,9 +31,10 @@ func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]b
 	}
 
 	if handler.Mutator == "only_check_output" {
-		eventData := p.onlyCheckOutputMutator(event)
-
-		return eventData, nil
+		if event.HasCheck() {
+			eventData := p.onlyCheckOutputMutator(event)
+			return eventData, nil
+		}
 	}
 
 	ctx := context.WithValue(context.Background(), types.OrganizationKey, event.Entity.Organization)

--- a/handlers/influx-db/main.go
+++ b/handlers/influx-db/main.go
@@ -94,7 +94,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to validate event: %s", err.Error())
 	}
 
-	if event.Metrics == nil {
+	if !event.HasMetrics() {
 		return fmt.Errorf("event does not contain metrics")
 	}
 

--- a/handlers/slack/main.go
+++ b/handlers/slack/main.go
@@ -198,7 +198,7 @@ func validateEvent(event *types.Event) error {
 		return errors.New("entity is missing from event")
 	}
 
-	if event.Check == nil {
+	if !event.HasCheck() {
 		return errors.New("check is missing from event")
 	}
 

--- a/rpc/extension/example/main.go
+++ b/rpc/extension/example/main.go
@@ -20,7 +20,7 @@ var (
 )
 
 func LastCheckStatusZero(event *types.Event) (bool, error) {
-	if event.Check == nil {
+	if !event.HasCheck() {
 		// Filter metrics events as well.
 		return true, nil
 	}
@@ -28,6 +28,9 @@ func LastCheckStatusZero(event *types.Event) (bool, error) {
 }
 
 func FailingCheck(event *types.Event, mutated []byte) error {
+	if !event.HasCheck() {
+		log.Print("event does not contain check")
+	}
 	log.Printf("entity %q: %s is failing", event.Entity.ID, event.Check.Name)
 	return nil
 }

--- a/types/event.go
+++ b/types/event.go
@@ -123,6 +123,10 @@ func (e *Event) IsIncident() bool {
 
 // IsResolution returns true if an event has just transitionned from an incident
 func (e *Event) IsResolution() bool {
+	if !e.HasCheck() {
+		return false
+	}
+
 	// Try to retrieve the previous status in the check history and verify if it
 	// was a non-zero status, therefore indicating a resolution
 	isResolution := (len(e.Check.History) > 0 &&
@@ -134,6 +138,10 @@ func (e *Event) IsResolution() bool {
 
 // IsSilenced determines if an event has any silenced entries
 func (e *Event) IsSilenced() bool {
+	if !e.HasCheck() {
+		return false
+	}
+
 	return len(e.Check.Silenced) > 0
 }
 
@@ -201,7 +209,7 @@ func cmpBySeverity(a, b *Event) bool {
 // and Ok (0) so we shift the check's status. If event is not a check sort to
 // very end.
 func deriveSeverity(e *Event) uint32 {
-	if e.Check != nil {
+	if e.HasCheck() {
 		return (e.Check.Status + 3) % 4
 	}
 	return 4
@@ -229,5 +237,8 @@ func (s *eventSorter) Less(i, j int) bool {
 
 // URIPath returns the path component of a Event URI.
 func (e *Event) URIPath() string {
+	if !e.HasCheck() {
+		return ""
+	}
 	return fmt.Sprintf("/%s/%s", url.PathEscape(e.Entity.ID), url.PathEscape(e.Check.Name))
 }

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -27,5 +27,9 @@ func EventFields(event *types.Event) map[string]interface{} {
 		fields["metric"] = true
 	}
 
+	if event.HasMetrics() {
+		fields["metrics"] = true
+	}
+
 	return fields
 }


### PR DESCRIPTION
## What is this change?

Never assume the presence of a check or metrics in an event (unless you're dealing with the store or cli). Adds nil checks for `event.HasCheck()` and `event.HasMetrics()` before invoking either field.

## Why is this change necessary?

Closes #1484.

## Does your change need a Changelog entry?

Yas. I moved an unreleased changelog entry into the appropriate place too!

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.