### PR TITLE
Fix handler validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add logging around the Sensu event pipeline
 
 ### Fixed
-
+- Fix handler validation routine
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/types/handler.go
+++ b/types/handler.go
@@ -31,8 +31,8 @@ func (h *Handler) Validate() error {
 		return errors.New("handler name " + err.Error())
 	}
 
-	if err := validateHandlerType(h.Type); err != nil {
-		return errors.New("handler type " + err.Error())
+	if err := h.validateType(); err != nil {
+		return err
 	}
 
 	if h.Environment == "" {
@@ -43,6 +43,34 @@ func (h *Handler) Validate() error {
 		return errors.New("organization must be set")
 	}
 
+	return nil
+}
+
+func (h *Handler) validateType() error {
+	if h.Type == "" {
+		return errors.New("empty handler type")
+	}
+
+	switch h.Type {
+	case "pipe", "set", "grpc":
+		return nil
+	case "tcp", "udp":
+		return h.Socket.Validate()
+	}
+
+	return fmt.Errorf("unknown handler type: %s", h.Type)
+}
+
+func (s *HandlerSocket) Validate() error {
+	if s == nil {
+		return errors.New("tcp and udp handlers need a valid socket")
+	}
+	if len(s.Host) == 0 {
+		return errors.New("socket host undefined")
+	}
+	if s.Port == 0 {
+		return errors.New("socket port undefined")
+	}
 	return nil
 }
 

--- a/types/validators.go
+++ b/types/validators.go
@@ -22,24 +22,6 @@ var StrictNameRegex = regexp.MustCompile(`\A[a-z0-9\_\.\-]+\z`)
 // entity:foo)
 var SubscriptionNameRegex = regexp.MustCompile(`\A[\w\.\-]+\:?[\w\.\-]+\z`)
 
-func validateHandlerType(t string) error {
-	if t == "" {
-		return errors.New("must not be empty")
-	}
-
-	switch t {
-	case
-		"pipe",
-		"tcp",
-		"udp",
-		"transport",
-		"set":
-		return nil
-	}
-
-	return errors.New("is unknown")
-}
-
 // ValidateName validates the name of an element so it's not empty and it does
 // not contains specical characters. Compatible with Sensu 1.0.
 func ValidateName(name string) error {

--- a/types/validators_test.go
+++ b/types/validators_test.go
@@ -6,16 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateHandlerType(t *testing.T) {
-	assert.Error(t, validateHandlerType(""))
-	assert.Error(t, validateHandlerType("foo"))
-	assert.NoError(t, validateHandlerType("pipe"))
-	assert.NoError(t, validateHandlerType("tcp"))
-	assert.NoError(t, validateHandlerType("udp"))
-	assert.NoError(t, validateHandlerType("transport"))
-	assert.NoError(t, validateHandlerType("set"))
-}
-
 func TestValidateName(t *testing.T) {
 	assert.Error(t, ValidateName(""))
 	assert.Error(t, ValidateName("foo bar"))


### PR DESCRIPTION
This commit fixes several issues around handler validation.

* Add grpc as a recognized handler type.
* Remove transport as a recognized handler type.
* Ensure tcp and udp handlers have valid sockets.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1452