### PR TITLE
[Web UI] Fix environment switcher links

### DIFF
--- a/dashboard/src/components/Drawer.js
+++ b/dashboard/src/components/Drawer.js
@@ -158,6 +158,7 @@ class Drawer extends React.Component {
                     viewer={viewer}
                     environment={environment}
                     className={classes.namespaceSelector}
+                    onChange={onToggle}
                   />
                 </div>
               </div>

--- a/dashboard/src/components/NamespaceSelector.js
+++ b/dashboard/src/components/NamespaceSelector.js
@@ -21,9 +21,10 @@ const styles = {
 class NamespaceSelector extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    viewer: PropTypes.object,
     environment: PropTypes.object,
     loading: PropTypes.bool,
+    onChange: PropTypes.func.isRequired,
+    viewer: PropTypes.object,
   };
 
   static defaultProps = {
@@ -64,7 +65,14 @@ class NamespaceSelector extends React.Component {
   };
 
   render() {
-    const { loading, environment, viewer, classes, ...props } = this.props;
+    const {
+      classes,
+      environment,
+      loading,
+      onChange,
+      viewer,
+      ...props
+    } = this.props;
     const { anchorEl } = this.state;
 
     return (
@@ -80,12 +88,16 @@ class NamespaceSelector extends React.Component {
               <NamespaceSelectorBuilder environment={environment} />
             </Button>
             <NamespaceSelectorMenu
-              viewer={viewer}
               anchorEl={anchorEl}
+              id="drawer-selector-menu"
+              viewer={viewer}
+              org={params.organization}
               open={Boolean(anchorEl)}
               onClose={this.onClose}
-              id="drawer-selector-menu"
-              org={params.organization}
+              onClick={ev => {
+                this.onClose();
+                onChange(ev);
+              }}
             />
           </div>
         )}

--- a/dashboard/src/components/NamespaceSelectorMenu.js
+++ b/dashboard/src/components/NamespaceSelectorMenu.js
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import partition from "lodash/partition";
-import { map } from "lodash";
-import { withStyles } from "material-ui/styles";
 import gql from "graphql-tag";
-
+import partition from "lodash/partition";
+import { withStyles } from "material-ui/styles";
+import { Link } from "react-router-dom";
 import Menu, { MenuItem } from "material-ui/Menu";
 import { ListItemIcon, ListItemText } from "material-ui/List";
 import Divider from "material-ui/Divider";
@@ -24,8 +23,9 @@ const styles = () => ({
 class NamespaceSelectorMenu extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    viewer: PropTypes.object,
     org: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+    viewer: PropTypes.object,
   };
 
   static defaultProps = {
@@ -51,14 +51,11 @@ class NamespaceSelectorMenu extends React.Component {
   };
 
   render() {
-    const { viewer, classes, org, ...props } = this.props;
+    const { viewer, classes, org, onClick, ...props } = this.props;
 
     if (!viewer) {
       return null;
     }
-
-    const navigateTo = (organization, environment) => () =>
-      window.location.assign(`/${organization}/${environment}/`);
 
     const [[currentOrganization], otherOrganizations] = partition(
       viewer.organizations,
@@ -69,36 +66,43 @@ class NamespaceSelectorMenu extends React.Component {
       <Menu {...props}>
         {currentOrganization &&
           currentOrganization.environments.map(environment => (
-            <MenuItem
-              key={environment.name}
-              onClick={navigateTo(currentOrganization.name, environment.name)}
+            <Link
+              to={`/${currentOrganization.name}/${environment.name}`}
+              onClick={onClick}
             >
-              <ListItemIcon>
-                <div className={classes.envIcon}>
-                  <EnvironmentSymbol environment={environment} size={12} />
-                </div>
-              </ListItemIcon>
-              <ListItemText inset primary={environment.name} />
-            </MenuItem>
+              <MenuItem key={environment.name}>
+                <ListItemIcon>
+                  <div className={classes.envIcon}>
+                    <EnvironmentSymbol environment={environment} size={12} />
+                  </div>
+                </ListItemIcon>
+                <ListItemText inset primary={environment.name} />
+              </MenuItem>
+            </Link>
           ))}
         <Divider />
-        {map(otherOrganizations, (organization, i) => [
+        {otherOrganizations.map((organization, i) => [
           organization.environments.map(environment => (
-            <MenuItem
-              key={environment.name}
-              onClick={navigateTo(organization.name, environment.name)}
+            <Link
+              to={`/${organization.name}/${environment.name}`}
+              onClick={onClick}
             >
-              <ListItemIcon>
-                <OrganizationIcon organization={organization} size={24}>
-                  <EnvironmentSymbol environment={environment} size={24 / 3} />
-                </OrganizationIcon>
-              </ListItemIcon>
-              <ListItemText
-                inset
-                primary={organization.name}
-                secondary={environment.name}
-              />
-            </MenuItem>
+              <MenuItem key={`${organization.name}${environment.name}`}>
+                <ListItemIcon>
+                  <OrganizationIcon organization={organization} size={24}>
+                    <EnvironmentSymbol
+                      environment={environment}
+                      size={24 / 3}
+                    />
+                  </OrganizationIcon>
+                </ListItemIcon>
+                <ListItemText
+                  inset
+                  primary={organization.name}
+                  secondary={environment.name}
+                />
+              </MenuItem>
+            </Link>
           )),
           i + 1 < otherOrganizations.length ? <Divider /> : null,
         ])}


### PR DESCRIPTION
## What is this change?

* Switches to using a link instead of a button; semantically more correct.
* Passes click event up to parent, so that in the case of the drawer, it can close when a new environment is selected.

## Why is this change necessary?

Discovered by @portertech while testing other environments.

## Does your change need a Changelog entry?

unlikely.

## Do you need clarification on anything?

`undefined`

## Were there any complications while making this change?

Resisting a minor refactor of the "NamespaceSelector" component.