### PR TITLE
Add round-robin scheduling to sensuctl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Performed an audit of events and checks. Added `event.HasCheck()` nil checks
 prior to assuming the existence of said check.
+- Added the ability to set round robin scheduling in sensuctl
 
 ### Changed
 - Add logging around the Sensu event pipeline

--- a/cli/commands/check/create.go
+++ b/cli/commands/check/create.go
@@ -97,6 +97,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd.Flags().String("low-flap-threshold", "", "flap detection low threshold (percent state change) for the check")
 	cmd.Flags().String("output-metric-handlers", "", "comma separated list of handlers to set on output check metrics")
 	cmd.Flags().String("output-metric-format", "", "the output metric format to be used to parse check output for metric extraction")
+	cmd.Flags().Bool("round-robin", false, "enable round-robin scheduling")
 
 	helpers.AddInteractiveFlag(cmd.Flags())
 	return cmd

--- a/cli/commands/check/help.go
+++ b/cli/commands/check/help.go
@@ -62,6 +62,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		subcommands.SetTimeoutCommand(cli),
 		subcommands.SetOutputMetricHandlersCommand(cli),
 		subcommands.SetOutputMetricFormatCommand(cli),
+		subcommands.SetRoundRobinCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/check/subcommands/set_round_robin.go
+++ b/cli/commands/check/subcommands/set_round_robin.go
@@ -1,0 +1,50 @@
+package subcommands
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// SetRoundRobinCommand updates the round-robin of a check
+func SetRoundRobinCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "set-round-robin [NAME] [VALUE]",
+		Short:        "set round robin to true or false",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			checkName := args[0]
+			value := args[1]
+
+			check, err := cli.Client.FetchCheck(checkName)
+			if err != nil {
+				return err
+			}
+			roundRobin, err := strconv.ParseBool(value)
+			check.RoundRobin = roundRobin
+
+			if err != nil {
+				return err
+			}
+			if err := check.Validate(); err != nil {
+				return err
+			}
+			if err := cli.Client.UpdateCheck(check); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Updated")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/check/subcommands/set_round_robin_test.go
+++ b/cli/commands/check/subcommands/set_round_robin_test.go
@@ -1,0 +1,62 @@
+package subcommands
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSetRoundRobinCommand(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		args           []string
+		fetchResponse  error
+		updateResponse error
+		expectedOutput string
+		expectError    bool
+	}{
+		{"no args", []string{}, nil, nil, "Usage", true},
+		{"fetch error", []string{"checky", "foo"}, fmt.Errorf("error"), nil, "", true},
+		{"update error", []string{"checky", "bar"}, nil, fmt.Errorf("error"), "", true},
+		{"invalid input", []string{"checky", "yes"}, nil, nil, "", true},
+		{"valid input", []string{"checky", "true"}, nil, nil, "Updated", false},
+	}
+
+	for _, tc := range testCases {
+		var name string
+		if len(tc.args) > 0 {
+			name = tc.args[0]
+		}
+
+		t.Run(tc.testName, func(t *testing.T) {
+			check := types.FixtureCheckConfig("checky")
+			cli := test.NewMockCLI()
+
+			client := cli.Client.(*client.MockClient)
+			client.On(
+				"FetchCheck",
+				name,
+			).Return(check, tc.fetchResponse)
+
+			client.On(
+				"UpdateCheck",
+				mock.Anything,
+			).Return(tc.updateResponse)
+
+			cmd := SetRoundRobinCommand(cli)
+			out, err := test.RunCmd(cmd, tc.args)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Regexp(t, tc.expectedOutput, out)
+		})
+	}
+}


### PR DESCRIPTION
This commit adds the ability to set and update round-robin
scheduling in sensuctl.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1465 