### PR TITLE
Log statsd errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ prior to assuming the existence of said check.
 - Fix handler validation routine
 - Fixed a small bug in the opentsdb transformer so that it trims trailing
 whitespace characters.
+- Sensu-agent logs an error if the statsd listener is unable to start due to an
+invalid address or is stopped due to any other error.
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -489,6 +489,9 @@ func (a *Agent) StartStatsd() {
 	if runtime.GOOS == "windows" {
 		// TODO: https://github.com/sensu/sensu-go/issues/1498
 		conn, err := net.ListenPacket("tcp", a.statsdServer.MetricsAddr)
+		if err != nil {
+			logger.WithError(err).Errorf("error with statsd server on address: %s, statsd listener will not run", a.statsdServer.MetricsAddr)
+		}
 		socketFactory := func() (net.PacketConn, error) {
 			return conn, err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -487,6 +487,7 @@ func (a *Agent) StartStatsd() {
 	// We need to force a TCP connection for Windows. See
 	// https://github.com/sensu/sensu-go/issues/1402
 	if runtime.GOOS == "windows" {
+		// TODO: https://github.com/sensu/sensu-go/issues/1498
 		conn, err := net.ListenPacket("tcp", a.statsdServer.MetricsAddr)
 		socketFactory := func() (net.PacketConn, error) {
 			return conn, err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -382,21 +382,9 @@ func (a *Agent) Run() error {
 	a.header = a.buildTransportHeaderMap()
 	a.header.Set("Authorization", "Basic "+userCredentials)
 
+	// Start the statsd listener only if the agent configuration has it enabled
 	if !a.config.StatsdServer.Disable {
-		logger.Info("starting statsd server on address: ", a.statsdServer.MetricsAddr)
-
-		// We need to force a TCP connection for Windows. See
-		// https://github.com/sensu/sensu-go/issues/1402
-		if runtime.GOOS == "windows" {
-			conn, err := net.ListenPacket("tcp", a.statsdServer.MetricsAddr)
-			socketFactory := func() (net.PacketConn, error) {
-				return conn, err
-			}
-
-			go a.statsdServer.RunWithCustomSocket(a.context, socketFactory)
-		} else {
-			go a.statsdServer.Run(a.context)
-		}
+		a.StartStatsd()
 	}
 
 	conn, err := transport.Connect(a.backendSelector.Select(), a.config.TLS, a.header)
@@ -488,4 +476,46 @@ func (a *Agent) Stop() {
 
 func (a *Agent) addHandler(msgType string, handlerFunc handler.MessageHandlerFunc) {
 	a.handler.AddHandler(msgType, handlerFunc)
+}
+
+// StartStatsd starts up a StatsD listener on the agent, logs an error for any
+// failures.
+func (a *Agent) StartStatsd() {
+	statsdErr := make(chan error, 1)
+	logger.Info("starting statsd server on address: ", a.statsdServer.MetricsAddr)
+
+	// We need to force a TCP connection for Windows. See
+	// https://github.com/sensu/sensu-go/issues/1402
+	if runtime.GOOS == "windows" {
+		conn, err := net.ListenPacket("tcp", a.statsdServer.MetricsAddr)
+		socketFactory := func() (net.PacketConn, error) {
+			return conn, err
+		}
+
+		go func() {
+			defer close(statsdErr)
+			statsdErr <- a.statsdServer.RunWithCustomSocket(a.context, socketFactory)
+			select {
+			case err := <-statsdErr:
+				if err != nil {
+					logger.WithError(err).Errorf("error with statsd server on address: %s, statsd listener will not run", a.statsdServer.MetricsAddr)
+				}
+				return
+			default:
+			}
+		}()
+	} else {
+		go func() {
+			defer close(statsdErr)
+			statsdErr <- a.statsdServer.Run(a.context)
+			select {
+			case err := <-statsdErr:
+				if err != nil {
+					logger.WithError(err).Errorf("error with statsd server on address: %s, statsd listener will not run", a.statsdServer.MetricsAddr)
+				}
+				return
+			default:
+			}
+		}()
+	}
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -491,6 +491,7 @@ func (a *Agent) StartStatsd() {
 		conn, err := net.ListenPacket("tcp", a.statsdServer.MetricsAddr)
 		if err != nil {
 			logger.WithError(err).Errorf("error with statsd server on address: %s, statsd listener will not run", a.statsdServer.MetricsAddr)
+			return
 		}
 		socketFactory := func() (net.PacketConn, error) {
 			return conn, err

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,4 +1,5 @@
-// +build integration
+// +build integration, !windows
+// TODO: https://github.com/sensu/sensu-go/issues/1498
 
 package agent
 


### PR DESCRIPTION
## What is this change?

Sensu-agent logs an error if the statsd listener is unable to start due to an invalid address or is stopped due to any other error.

## Why is this change necessary?

Closes #1473.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Found https://github.com/sensu/sensu-go/issues/1498 and working on it next.