### PR TITLE
Add circleci configuration

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -1,0 +1,25 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.10
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/sensu/sensu-go
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: ./build.sh


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Adds basic circleci configuration to get project setup on circleci.

## Why is this change necessary?

Setting up a paid account and need to invite team members. This satisfies their project setup checklist.