### PR TITLE
Fix a bug where URIPath for Environment was wrong.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ prior to assuming the existence of said check.
 whitespace characters.
 - Sensu-agent logs an error if the statsd listener is unable to start due to an
 invalid address or is stopped due to any other error.
+- Fix a bug where environments could not be created with sensuctl create
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/types/environment.go
+++ b/types/environment.go
@@ -47,5 +47,5 @@ func (e *Environment) Update(from *Environment, fields ...string) error {
 
 // URIPath returns the path component of a Environment URI.
 func (e *Environment) URIPath() string {
-	return fmt.Sprintf("/%s/environments/%s", url.PathEscape(e.Organization), url.PathEscape(e.Name))
+	return fmt.Sprintf("/rbac/organizations/%s/environments/%s", url.PathEscape(e.Organization), url.PathEscape(e.Name))
 }


### PR DESCRIPTION
This commit fixes a bug where an incorrect path was specified in
the URIPath method for types.Environment, causing the sensuctl
create command to fail.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1521 

I have filed #1525 as a follow-up issue.