### PR TITLE
[Web UI] Fix prettier package script

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,7 @@
     "postinstall": "yarn run precompile",
     "prestart": "yarn precompile",
     "pretest": "yarn precompile",
-    "prettier": "npx prettier --write **/*.js",
+    "prettier": "npx prettier --write '**/*.js'",
     "start": "node scripts serve",
     "build": "node scripts build",
     "analyze": "npx webpack-bundle-analyzer stats.json -s gzip",


### PR DESCRIPTION
## What is this change?

Ensure all `.js` files in the `dashboard` dir are targeted and formatted by the `prettier` script.

This needs to be the same as the files targeted by `eslint`.

## Why is this change necessary?

For some reason the glob doesn't match correctly unless it is quoted.

## Does your change need a Changelog entry?

nah

## Do you need clarification on anything?

nope

## Were there any complications while making this change?

naw