### PR TITLE
Add URIPath for Role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ whitespace characters.
 invalid address or is stopped due to any other error.
 - Fix a bug where environments could not be created with sensuctl create
 - StatsD listener on Windows is functional
+- Fixed `sensuctl create -f` for `Role`
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 const (
@@ -132,6 +133,11 @@ func (r *Role) Validate() error {
 	}
 
 	return nil
+}
+
+// URIPath returns the path component of a Role URI.
+func (r *Role) URIPath() string {
+	return fmt.Sprintf("/rbac/roles/%s", url.PathEscape(r.Name))
 }
 
 //


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the `URIPath()` function for `Role` to fix a bug in `sensuctl create -f`.

## Why is this change necessary?

Closes #1522 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.