### PR TITLE
Add support for additional time formats and better handle timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ prior to assuming the existence of said check.
 - Added the ability to set round robin scheduling in sensuctl
 - Added Output field to GRPC handlers
 - Additional logging around handlers
+- Accept additional time formats in sensuctl
 
 ### Changed
 - Add logging around the Sensu event pipeline.

--- a/cli/commands/silenced/interactive.go
+++ b/cli/commands/silenced/interactive.go
@@ -47,7 +47,7 @@ func (o *silencedOpts) Apply(s *types.Silenced) (err error) {
 	if err != nil {
 		return err
 	}
-	s.Begin, err = timeutil.ConvertToUnixUTC(o.Begin)
+	s.Begin, err = timeutil.ConvertToUnix(o.Begin)
 	return err
 }
 
@@ -124,7 +124,7 @@ func (o *silencedOpts) administerQuestionnaire(editing bool) error {
 				Help:    "Start silencing events at this time. Format: Jan 02 2006 3:04PM MST",
 			},
 			Validate: func(val interface{}) error {
-				_, err := timeutil.ConvertToUnixUTC(val.(string))
+				_, err := timeutil.ConvertToUnix(val.(string))
 				return err
 			},
 		},

--- a/cli/commands/timeutil/time.go
+++ b/cli/commands/timeutil/time.go
@@ -1,6 +1,7 @@
 package timeutil
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -8,13 +9,64 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-const dateFormat = "Jan 02 2006 3:04PM"
+const (
+	kitchen24     = "15:04"
+	kitchenOffset = "15:04 -07:00"
+	legacy        = "Jan 02 2006 3:04PM"
+	rfc3339Space  = "2006-01-02 15:04:05 Z07:00"
+)
 
-var kitchenTZRE = regexp.MustCompile(`[0-1]?[0-9]:[0-5][0-9]\s?(AM|PM)( .+)?`)
-var dateFormatTZRE = regexp.MustCompile(`[A-Z][a-z]{2} (0[1-9]|[1-2][0-9]|3[0-1]) [0-9]{4} [0-1]?[0-9]:[0-5][0-9](AM|PM)( .+)?`)
+var (
+	// kitchen12Re represents the time.Kitchen format: 3:04PM
+	kitchen12Re = regexp.MustCompile(`^([0-1]?[0-9]:[0-5][0-9])\s?(AM|PM)( .+)?$`)
 
-// HumanTimestamp takes a timestamp and returns a readable date. If the
-// timestamp equals 0, "N/A" will be returned instead of the epoch date
+	// kitchen24Re represents the the kitchen format but in 24-hour format: 15:04
+	kitchen24Re = regexp.MustCompile(`^([01][0-9]|2[0-3])(:?)([0-5][0-9])( .+)?$`)
+
+	// legacyRe represents the legacy format used in Sensu 2 alpha releases: Jan
+	// 02 2006 3:04PM MST
+	legacyRe = regexp.MustCompile(`([A-Z][a-z]{2}) ` + // Month (i.e. May)
+		`(0[1-9]|[1-2][0-9]|3[0-1]) ` + // Day (i.e. 14)
+		`([0-9]{4}) ` + // Year (i.e. 2018)
+		`([0-1]?[0-9]:[0-5][0-9](?:AM|PM))` + // Hour (i.e. 3:04PM)
+		`( .+)?`) // Timezone (e.g. MST or America/New_York)
+
+	// offsetTz represents a numeric zone offset, e.g. -07:00
+	offsetTz = regexp.MustCompile(`^([+-](?:2[0-3]|[01][0-9]):[0-5][0-9])$`)
+
+	// rfc3339Re represents the time.RFC3339 format
+	rfc3339Re = regexp.MustCompile(`^(\d+)` + // year (i.e. 2018)
+		`-` +
+		`(0[1-9]|1[012])` + // month (i.e. 05)
+		`-` +
+		`(0[1-9]|[12]\d|3[01])` + // day (i.e. 14)
+		`T` +
+		`([01]\d|2[0-3])` + // hour (i.e. 15)
+		`:` +
+		`([0-5]\d)` + // minute (i.e. 04)
+		`:` +
+		`([0-5]\d|60)` + // second (i.e. 05)
+		`(Z|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))$`) // zone (e.g. Z or -07:00)
+
+	// rfc3339SpaceRe represents the time.RFC3339 format but with space delimiters
+	rfc3339SpaceRe = regexp.MustCompile(`^(\d+)` + // year (i.e. 2018)
+		`-` +
+		`(0[1-9]|1[012])` + // month (i.e. 05)
+		`-` +
+		`(0[1-9]|[12]\d|3[01])` + // day (i.e. 14)
+		`\s` +
+		`([01]\d|2[0-3])` + // hour (i.e. 15)
+		`:` +
+		`([0-5]\d)` + // minute (i.e. 04)
+		`:` +
+		`([0-5]\d|60)` + // second (i.e. 05)
+		`\s` +
+		`(Z|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))$`) // zone (e.g. Z or -07:00)
+)
+
+// HumanTimestamp takes a timestamp and returns a readable date using the format
+// string "2006-01-02 15:04:05.999999999 -0700 MST". If the timestamp equals 0,
+// "N/A" will be returned instead of the epoch date
 func HumanTimestamp(timestamp int64) string {
 	if timestamp == 0 {
 		return "N/A"
@@ -26,58 +78,113 @@ func HumanTimestamp(timestamp int64) string {
 // ConvertToUTC takes a TimeWindowRange and converts both the begin time and
 // end time of the window to UTC
 func ConvertToUTC(t *types.TimeWindowTimeRange) error {
-	begin, err := offsetTime(t.Begin, time.Kitchen, kitchenTZRE)
+	begin, err := kitchenToTime(t.Begin)
 	if err != nil {
-		return nil
+		return err
 	}
-	end, err := offsetTime(t.End, time.Kitchen, kitchenTZRE)
+
+	end, err := kitchenToTime(t.End)
 	if err != nil {
-		return nil
+		return err
 	}
-	t.Begin = begin.Format(time.Kitchen)
-	t.End = end.Format(time.Kitchen)
+
+	t.Begin = begin.UTC().Format(time.Kitchen)
+	t.End = end.UTC().Format(time.Kitchen)
 	return nil
 }
 
-// ConvertToUnixUTC takes a string formatted as dateFormat and converts it to
-// UTC in unix epoch form
-func ConvertToUnixUTC(begin string) (int64, error) {
-	if begin == "0" || begin == "now" {
+// ConvertToUnix takes a full date and converts it to a UNIX timestamp
+func ConvertToUnix(value string) (int64, error) {
+	if value == "0" || value == "now" {
 		return time.Now().Unix(), nil
 	}
-	utc, err := offsetTime(begin, dateFormat, dateFormatTZRE)
+
+	t, err := dateToTime(value)
 	if err != nil {
 		return 0, err
 	}
-	return utc.Unix(), nil
+
+	return t.Unix(), nil
 }
 
-func offsetTime(s string, fs string, format *regexp.Regexp) (time.Time, error) {
-	ts, tz, err := extractLocation(s, format)
+// dateToTime takes a full date in an unknown format and tries to detect it
+// using various formats. The time is returned as time.Time or an error if no
+// matching format was found
+func dateToTime(str string) (time.Time, error) {
+	// Try RFC3339 format (2006-01-02T15:04:05-07:00)
+	if match := rfc3339Re.FindString(str); match != "" {
+		return time.Parse(time.RFC3339, match)
+	}
+
+	// Try RFC3339 format with space delimiter (2006-01-02 15:04:05 -07:00)
+	if match := rfc3339SpaceRe.FindString(str); match != "" {
+		return time.Parse(rfc3339Space, match)
+	}
+
+	// Try legacy format (Jan 02 2006 3:04PM UTC)
+	if matches := legacyRe.FindStringSubmatch(str); len(matches) > 0 {
+		// Extract the timezone
+		tz := strings.TrimSpace(matches[5])
+
+		// Reassemble the time, without any timezone
+		t := strings.Join(matches[1:len(matches)-1], " ")
+
+		return parseInLocaton(legacy, t, tz)
+	}
+
+	return time.Time{}, fmt.Errorf("unknown format for provided date %s", str)
+}
+
+// kitchenToTime takes a kitchen time (without a date) in an unknown format and
+// tries to detect it using various formats. The time is returned as time.Time
+// or an error if no matching format was found
+func kitchenToTime(str string) (time.Time, error) {
+	// Try 24-hour kitchen format (15:04)
+	if matches := kitchen24Re.FindStringSubmatch(str); len(matches) > 0 {
+		// Extract the timezone
+		tz := strings.TrimSpace(matches[4])
+
+		// Verify if we have a numerical zone offset (i.e. -07:00)
+		if match := offsetTz.FindString(tz); match != "" {
+			return time.Parse(kitchenOffset, matches[0])
+		}
+
+		// Reassemble the time, without any timezone
+		t := strings.Join(matches[1:len(matches)-1], "")
+
+		return parseInLocaton(kitchen24, t, tz)
+	}
+
+	// Try 12-hour kitchen format (3:04PM)
+	if matches := kitchen12Re.FindStringSubmatch(str); len(matches) > 0 {
+		// Extract the timezone
+		tz := strings.TrimSpace(matches[3])
+
+		// Reassemble the time, without any timezone
+		t := strings.Join(matches[1:len(matches)-1], "")
+
+		return parseInLocaton(time.Kitchen, t, tz)
+	}
+
+	return time.Time{}, fmt.Errorf("unknown format for provided time %s", str)
+}
+
+// extractLocation extracts the location from the time value, using the regex,
+// and returns a standardized time value, along with its location and any error
+// encountered
+func extractLocation(location string) (*time.Location, error) {
+	if location == "" {
+		return time.Local, nil
+	}
+
+	return time.LoadLocation(location)
+}
+
+func parseInLocaton(layout, value, locString string) (time.Time, error) {
+	loc, err := extractLocation(locString)
 	if err != nil {
 		return time.Time{}, err
 	}
-	tm, err := time.ParseInLocation(fs, ts, tz)
-	if err != nil {
-		return time.Time{}, err
-	}
-	_, offset := tm.Zone()
-	tm = tm.Add(-time.Duration(offset) * time.Second)
-	return tm, nil
-}
 
-func extractLocation(s string, format *regexp.Regexp) (string, *time.Location, error) {
-	tz := time.Local
-	beginMatches := format.FindStringSubmatch(s)
-	if len(beginMatches) == 0 {
-		return s, tz, nil
-	}
-	possibleTZ := strings.TrimSpace(beginMatches[len(beginMatches)-1])
-	if len(possibleTZ) == 0 {
-		return s, tz, nil
-	}
-	loc, err := time.LoadLocation(possibleTZ)
-	trimmed := strings.TrimSpace(strings.TrimSuffix(s, possibleTZ))
-	normalized := strings.Replace(strings.Replace(trimmed, " AM", "AM", -1), " PM", "PM", -1)
-	return normalized, loc, err
+	return time.ParseInLocation(layout, value, loc)
 }

--- a/cli/commands/timeutil/time_test.go
+++ b/cli/commands/timeutil/time_test.go
@@ -58,7 +58,7 @@ func TestDateToTime(t *testing.T) {
 }
 
 func TestKitchenToTime(t *testing.T) {
-	baseTime, _ := time.Parse(time.Kitchen, "3:04PM")
+	baseTime, _ := time.ParseInLocation(time.Kitchen, "3:04PM", time.UTC)
 
 	// Our test cases
 	tests := []struct {
@@ -176,9 +176,9 @@ func TestConvertToUnix(t *testing.T) {
 }
 
 func TestConvertToUTC(t *testing.T) {
-	b, _ := time.Parse(time.Kitchen, "3:04PM")
+	b, _ := time.ParseInLocation(time.Kitchen, "3:04PM", time.UTC)
 	begin := b.Format(time.Kitchen)
-	e, _ := time.Parse(time.Kitchen, "4:04PM")
+	e, _ := time.ParseInLocation(time.Kitchen, "4:04PM", time.UTC)
 	end := e.Format(time.Kitchen)
 
 	tests := []struct {

--- a/cli/commands/timeutil/time_test.go
+++ b/cli/commands/timeutil/time_test.go
@@ -1,35 +1,282 @@
 package timeutil
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/sensu/sensu-go/types"
 )
 
-func TestOffsetTime(t *testing.T) {
+func TestDateToTime(t *testing.T) {
+	baseTime, _ := time.Parse(time.RFC3339, "2018-05-10T15:04:00Z")
+
+	// Our test cases
 	tests := []struct {
-		In          string
-		Want        string
-		ExpectedErr bool
-		Format      string
-		Regex       *regexp.Regexp
+		name    string
+		str     string
+		want    time.Time
+		wantErr bool
 	}{
-		{"8:00AM MST", "3:00PM", false, time.Kitchen, kitchenTZRE},
-		{"800AM", "12:00AM", true, time.Kitchen, kitchenTZRE},
-		{"Feb 06 2018 8:00AM MST", "Feb 06 2018 3:00PM", false, dateFormat, dateFormatTZRE},
-		{"Feb 06 2018 8:00AM foo", "Jan 01 0001 12:00AM", true, dateFormat, dateFormatTZRE},
-		{"foo", "Jan 01 0001 12:00AM", true, dateFormat, dateFormatTZRE},
-		{"Feb 06 2018 800AM", "Jan 01 0001 12:00AM", true, dateFormat, dateFormatTZRE},
+		{
+			name: "RFC3339 UTC",
+			str:  "2018-05-10T15:04:00Z",
+			want: baseTime,
+		},
+		{
+			name: "RFC3339 with numeric zone offset",
+			str:  "2018-05-10T07:04:00-08:00",
+			want: baseTime,
+		},
+		{
+			name: "RFC3339 with space delimiter",
+			str:  "2018-05-10 07:04:00 -08:00",
+			want: baseTime,
+		},
+		{
+			name: "legacy UTC",
+			str:  "May 10 2018 3:04PM UTC",
+			want: baseTime,
+		},
+		{
+			name:    "unknown format",
+			str:     "Mon Jan _2 15:04:05 2006",
+			wantErr: true,
+		},
 	}
-	for _, test := range tests {
-		t.Run(test.In, func(t *testing.T) {
-			got, err := offsetTime(test.In, test.Format, test.Regex)
-			if !test.ExpectedErr {
-				require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := dateToTime(tt.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("dateToTime() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			require.Equal(t, test.Want, got.Format(test.Format))
+			if !tt.want.Equal(got) {
+				t.Errorf("dateToTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKitchenToTime(t *testing.T) {
+	baseTime, _ := time.Parse(time.Kitchen, "3:04PM")
+
+	// Our test cases
+	tests := []struct {
+		name    string
+		str     string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "24-hour kitchen UTC",
+			str:  "15:04 UTC",
+			want: baseTime,
+		},
+		{
+			name: "24-hour kitchen with canonical timezone",
+			str:  "07:04 America/Vancouver",
+			want: baseTime,
+		},
+		{
+			name: "24-hour kitchen with numeric zone offset",
+			str:  "07:04 -08:00",
+			want: baseTime,
+		},
+		{
+			name:    "24-hour kitchen with unknown location",
+			str:     "07:04 foo",
+			wantErr: true,
+		},
+		{
+			name: "12-hour kitchen UTC",
+			str:  "3:04PM UTC",
+			want: baseTime,
+		},
+		{
+			name: "12-hour kitchen with canonical timezone",
+			str:  "10:04AM America/Montreal",
+			want: baseTime,
+		},
+		{
+			name:    "12-hour kitchen with unknown location",
+			str:     "10:04AM foo",
+			wantErr: true,
+		},
+		{
+			name:    "unknown format",
+			str:     "15:04:05.000000000",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := kitchenToTime(tt.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("kitchenToTime() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.want.Equal(got) {
+				t.Errorf("kitchenToTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToUnix(t *testing.T) {
+	tests := []struct {
+		name    string
+		str     string
+		now     bool
+		want    int64
+		wantErr bool
+	}{
+		{
+			name: "RFC3339",
+			str:  "2018-05-10T15:04:00Z",
+			want: 1525964640,
+		},
+		{
+			name: "0 value",
+			str:  "0",
+			now:  true,
+		},
+		{
+			name: "now value",
+			str:  "now",
+			now:  true,
+		},
+		{
+			name:    "unknown value",
+			str:     "3:04PM",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertToUnix(tc.str)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ConvertToUnix() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if tc.now {
+				// Remove the last two digits of the unix timestamp when comparing the
+				// current timestamp, in case the test took more than 1 second (i.e.
+				// 1526399179 vs 1526399180)
+				if time.Now().Unix()/100 != got/100 {
+					t.Errorf("ConvertToUnix() = %v, want ~ %v", got, time.Now().Unix())
+					return
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("ConvertToUnix() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertToUTC(t *testing.T) {
+	b, _ := time.Parse(time.Kitchen, "3:04PM")
+	begin := b.Format(time.Kitchen)
+	e, _ := time.Parse(time.Kitchen, "4:04PM")
+	end := e.Format(time.Kitchen)
+
+	tests := []struct {
+		name      string
+		window    *types.TimeWindowTimeRange
+		wantBegin string
+		wantEnd   string
+		wantErr   bool
+	}{
+		{
+			name: "12-hour kitchen UTC",
+			window: &types.TimeWindowTimeRange{
+				Begin: "3:04PM UTC",
+				End:   "4:04PM UTC",
+			},
+			wantBegin: begin,
+			wantEnd:   end,
+		},
+		{
+			name: "12-hour kitchen canonical timezone",
+			window: &types.TimeWindowTimeRange{
+				Begin: "7:04AM America/Vancouver",
+				End:   "8:04AM America/Vancouver",
+			},
+			wantBegin: begin,
+			wantEnd:   end,
+		},
+		{
+			name: "24-hour kitchen numeric timezone",
+			window: &types.TimeWindowTimeRange{
+				Begin: "07:04 -08:00",
+				End:   "08:04 -08:00",
+			},
+			wantBegin: begin,
+			wantEnd:   end,
+		},
+		{
+			name: "invalid begin",
+			window: &types.TimeWindowTimeRange{
+				Begin: "15:04:00.000000000",
+				End:   "08:04 -08:00",
+			},
+			wantBegin: "15:04:00.000000000",
+			wantEnd:   "08:04 -08:00",
+			wantErr:   true,
+		},
+		{
+			name: "invalid end",
+			window: &types.TimeWindowTimeRange{
+				Begin: "07:04 -08:00",
+				End:   "16:04:00.000000000",
+			},
+			wantBegin: "07:04 -08:00",
+			wantEnd:   "16:04:00.000000000",
+			wantErr:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ConvertToUTC(tc.window); (err != nil) != tc.wantErr {
+				t.Errorf("ConvertToUTC() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+
+			if tc.window.Begin != tc.wantBegin {
+				t.Errorf("ConvertToUTC() = %v, want begin %v", tc.window.Begin, tc.wantBegin)
+				return
+			}
+
+			if tc.window.End != tc.wantEnd {
+				t.Errorf("ConvertToUTC() = %v, want end %v", tc.window.End, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestHumanTimestamp(t *testing.T) {
+	tests := []struct {
+		name      string
+		timestamp int64
+		wantNA    bool
+	}{
+		{
+			name:      "valid timestamp",
+			timestamp: 1525964640,
+			wantNA:    false,
+		},
+		{
+			name:      "zero timestamp",
+			timestamp: 0,
+			wantNA:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HumanTimestamp(tc.timestamp); (got == "N/A") != tc.wantNA {
+				t.Errorf("HumanTimestamp() length = %v, wanted N/A? %v", len(got), tc.wantNA)
+			}
 		})
 	}
 }

--- a/subdue.json
+++ b/subdue.json
@@ -1,1 +1,0 @@
-{"days":{"all":[{"begin":"12:00 AM","end":"11:59 PM"},{"begin":"11:00 PM","end":"1:00 AM"}]}}

--- a/subdue.json
+++ b/subdue.json
@@ -1,0 +1,1 @@
+{"days":{"all":[{"begin":"12:00 AM","end":"11:59 PM"},{"begin":"11:00 PM","end":"1:00 AM"}]}}

--- a/testing/e2e/check_subdue_test.go
+++ b/testing/e2e/check_subdue_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const timeWindow = `{"days":{"all":[{"begin":"12:00 AM","end":"11:59 PM"},{"begin":"11:00 PM","end":"1:00 AM"}]}}`
+const timeWindow = `{"days":{"all":[{"begin":"12:00AM UTC","end":"11:59PM UTC"},` +
+	`{"begin":"11:00PM UTC","end":"1:00AM UTC"}]}}`
 
 func TestCheckSubdue(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What is this change?

It adds support for additional time format. So we now support these formats:

- 12-hour kitchen (zone): `3:04PM UTC`
- 24-hour kitchen (zone & offset): `15:04 UTC` or `07:04 -08:00`
- Sensu alpha legacy format (zone): `May 10 2018 3:04PM UTC`
- RFC3339 (offset): `2018-05-10T15:04:00Z`
- RFC3339 with space delimiters (offset): `2018-05-10 07:04:00 -08:00` 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1448

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

The `time` pkg is hard.