### PR TITLE
Entity/create cli

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,8 +40,6 @@ install:
   - go version
   - go env
   - mkdir %GOPATH%\bin
-  - appveyor DownloadFile https://github.com/golang/dep/releases/download/v0.4.1/dep-windows-amd64.exe
-  - move dep-windows-amd64.exe %GOPATH%\bin\dep.exe
   - ps: .\build.ps1 deps
   - ps: .\build.ps1 build_tools
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,9 +8,6 @@ image:
   - Visual Studio 2015
   # - Visual Studio 2017
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 environment:
   GOPATH: c:\gopath
   GOVERSION: 1.10
@@ -56,9 +53,6 @@ build_script:
 
 before_deploy:
   - ps: .\build.ps1 wait_for_appveyor_jobs
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 deploy:
   provider: GitHub

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,9 @@ image:
   - Visual Studio 2015
   # - Visual Studio 2017
 
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 environment:
   GOPATH: c:\gopath
   GOVERSION: 1.10
@@ -53,6 +56,9 @@ build_script:
 
 before_deploy:
   - ps: .\build.ps1 wait_for_appveyor_jobs
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 deploy:
   provider: GitHub

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ cache:
 before_install:
   - echo -e "machine github.com\n login $GITHUB_TOKEN" >> ~/.netrc
   - ulimit -s 1082768
-  - chmod +x $GOPATH/bin/dep
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ cache:
 before_install:
   - echo -e "machine github.com\n login $GITHUB_TOKEN" >> ~/.netrc
   - ulimit -s 1082768
-  - curl -L -s https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
   - export PATH="$HOME/.yarn/bin:$PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ prior to assuming the existence of said check.
 - Added Output field to GRPC handlers
 - Additional logging around handlers
 - Accept additional time formats in sensuctl
+- Entities can now be created via sensuctl.
 
 ### Changed
 - Add logging around the Sensu event pipeline.

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -29,6 +29,7 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 	routes.get(r.find)
 	routes.del(r.destroy)
 	routes.post(r.create)
+	routes.put(r.createOrReplace)
 }
 
 func (r *EntitiesRouter) destroy(req *http.Request) (interface{}, error) {
@@ -63,4 +64,13 @@ func (r *EntitiesRouter) create(req *http.Request) (interface{}, error) {
 	}
 	err := r.controller.Create(req.Context(), entity)
 	return entity, err
+}
+
+func (r *EntitiesRouter) createOrReplace(req *http.Request) (interface{}, error) {
+	entity := types.Entity{}
+	if err := unmarshalBody(req, &entity); err != nil {
+		return nil, err
+	}
+
+	return entity, r.controller.CreateOrReplace(req.Context(), entity)
 }

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -64,3 +64,22 @@ func (client *RestClient) UpdateEntity(entity *types.Entity) (err error) {
 
 	return nil
 }
+
+// CreateEntity creates a new entity
+func (client *RestClient) CreateEntity(entity *types.Entity) (err error) {
+	bytes, err := json.Marshal(entity)
+	if err != nil {
+		return err
+	}
+
+	res, err := client.R().SetBody(bytes).Post("/entities")
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return unmarshalError(res)
+	}
+
+	return nil
+}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -60,6 +60,7 @@ type CheckAPIClient interface {
 
 // EntityAPIClient client methods for entities
 type EntityAPIClient interface {
+	CreateEntity(entity *types.Entity) error
 	DeleteEntity(entity *types.Entity) error
 	FetchEntity(ID string) (*types.Entity, error)
 	ListEntities(string) ([]types.Entity, error)

--- a/cli/client/testing/mock_entity_client.go
+++ b/cli/client/testing/mock_entity_client.go
@@ -25,3 +25,9 @@ func (c *MockClient) UpdateEntity(entity *types.Entity) error {
 	args := c.Called(entity)
 	return args.Error(0)
 }
+
+// CreateEntity for use with mock lib
+func (c *MockClient) CreateEntity(entity *types.Entity) error {
+	args := c.Called(entity)
+	return args.Error(0)
+}

--- a/cli/commands/entity/create.go
+++ b/cli/commands/entity/create.go
@@ -34,7 +34,6 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			opts := newEntityOpts()
 
 			if len(args) > 0 {
-				fmt.Println("entity id is", args[0])
 				opts.ID = args[0]
 			}
 

--- a/cli/commands/entity/create.go
+++ b/cli/commands/entity/create.go
@@ -1,0 +1,75 @@
+package entity
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// CreateCommand allows a user to create a new entity
+func CreateCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create [ID]",
+		Short:        "create a new entity",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+			if !isInteractive {
+				// Mark flags are required for bash-completions
+				_ = cmd.MarkFlagRequired("id")
+				_ = cmd.MarkFlagRequired("class")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+			opts := newEntityOpts()
+
+			if len(args) > 0 {
+				fmt.Println("entity id is", args[0])
+				opts.ID = args[0]
+			}
+
+			opts.Org = cli.Config.Organization()
+			opts.Env = cli.Config.Environment()
+
+			if isInteractive {
+				if err := opts.administerQuestionnaire(); err != nil {
+					return err
+				}
+			}
+			opts.withFlags(cmd.Flags())
+
+			// Apply given arguments to entity
+			entity := types.Entity{}
+			opts.copy(&entity)
+
+			if err := entity.Validate(); err != nil {
+				if !isInteractive {
+					_ = cmd.Help()
+				}
+				return err
+			}
+
+			if err := cli.Client.CreateEntity(&entity); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "OK")
+			return nil
+		},
+	}
+
+	_ = cmd.Flags().StringP("class", "c", "", "entity class, either proxy or agent")
+	_ = cmd.Flags().StringP("subscriptions", "s", "", "comma separated list of subscriptions")
+	return cmd
+
+}

--- a/cli/commands/entity/create_test.go
+++ b/cli/commands/entity/create_test.go
@@ -1,0 +1,51 @@
+package entity
+
+import (
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("create", cmd.Use)
+	assert.Regexp("entity", cmd.Short)
+}
+
+func TestCreateCommandRunEClosureWithoutAllFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("subscriptions", ""))
+	out, err := test.RunCmd(cmd, []string{"test-entity"})
+	require.Error(t, err)
+	assert.Regexp("Usage", out) // usage should print out
+}
+
+func TestCreateCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateEntity", mock.AnythingOfType("*types.Entity")).Return(nil)
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("class", "agent"))
+	require.NoError(t, cmd.Flags().Set("subscriptions", "test"))
+	out, err := test.RunCmd(cmd, []string{"test-handler"})
+
+	assert.Regexp("OK", out)
+	assert.Nil(err)
+
+}

--- a/cli/commands/entity/create_test.go
+++ b/cli/commands/entity/create_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"errors"
 	"testing"
 
 	client "github.com/sensu/sensu-go/cli/client/testing"
@@ -48,4 +49,21 @@ func TestCreateCommandRunEClosureWithFlags(t *testing.T) {
 	assert.Regexp("OK", out)
 	assert.Nil(err)
 
+}
+
+func TestCreateCommandRunEClosureWithAPIErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateEntity", mock.AnythingOfType("*types.Entity")).Return(errors.New("whoops"))
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("class", "agent"))
+	require.NoError(t, cmd.Flags().Set("subscriptions", "test"))
+	out, err := test.RunCmd(cmd, []string{"test-handler"})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("whoops", err.Error())
 }

--- a/cli/commands/entity/help.go
+++ b/cli/commands/entity/help.go
@@ -14,6 +14,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 
 	// Add sub-commands
 	cmd.AddCommand(
+		CreateCommand(cli),
 		DeleteCommand(cli),
 		ListCommand(cli),
 		InfoCommand(cli),

--- a/cli/commands/entity/interactive.go
+++ b/cli/commands/entity/interactive.go
@@ -6,17 +6,27 @@ import (
 	"github.com/AlecAivazis/survey"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/pflag"
 )
 
-type opts struct {
+type entityOpts struct {
+	ID            string `survey:"id"`
+	Class         string `survey:"class"`
 	Subscriptions string `survey:"subscriptions"`
+	Org           string
+	Env           string
 }
 
-func newOpts() *opts {
-	return &opts{}
+func newEntityOpts() *entityOpts {
+	return &entityOpts{}
 }
 
-func (opts *opts) administerQuestionnaire() error {
+func (opts *entityOpts) withFlags(flags *pflag.FlagSet) {
+	opts.Class, _ = flags.GetString("class")
+	opts.Subscriptions, _ = flags.GetString("subscriptions")
+}
+
+func (opts *entityOpts) administerQuestionnaire() error {
 	qs := []*survey.Question{
 		{
 			Name: "subscriptions",
@@ -32,10 +42,14 @@ func (opts *opts) administerQuestionnaire() error {
 	return survey.Ask(qs, opts)
 }
 
-func (opts *opts) copy(entity *types.Entity) {
+func (opts *entityOpts) copy(entity *types.Entity) {
+	entity.ID = opts.ID
+	entity.Class = opts.Class
 	entity.Subscriptions = helpers.SafeSplitCSV(opts.Subscriptions)
+	entity.Environment = opts.Env
+	entity.Organization = opts.Org
 }
 
-func (opts *opts) withEntity(entity *types.Entity) {
+func (opts *entityOpts) withEntity(entity *types.Entity) {
 	opts.Subscriptions = strings.Join(entity.Subscriptions, ",")
 }

--- a/cli/commands/entity/interactive.go
+++ b/cli/commands/entity/interactive.go
@@ -51,5 +51,9 @@ func (opts *entityOpts) copy(entity *types.Entity) {
 }
 
 func (opts *entityOpts) withEntity(entity *types.Entity) {
+	opts.ID = entity.ID
+	opts.Class = entity.Class
 	opts.Subscriptions = strings.Join(entity.Subscriptions, ",")
+	opts.Env = entity.Environment
+	opts.Org = entity.Organization
 }

--- a/cli/commands/entity/update.go
+++ b/cli/commands/entity/update.go
@@ -29,7 +29,7 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Administer questionnaire
-			opts := newOpts()
+			opts := newEntityOpts()
 			opts.withEntity(entity)
 			if err := opts.administerQuestionnaire(); err != nil {
 				return err


### PR DESCRIPTION
## What is this change?

Adds entity creation and update support to the CLI.

## Why is this change necessary?

Closes #1479 and closes #1461 

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

Our docs state that an entity `class` should be either `proxy` or `agent`, yet it isn't restricted as entity uses the ValidateName method on class. This means that a user can set `class` to be values other than `proxy` or `agent` through the CLI and API. I think this might be ok, but wanted to call it out in case we should restrict it to just those two types.

## Were there any complications while making this change?

I updated `opts` to `entityOpts` to be more consistent with the naming in the cli package.