### PR TITLE
Add validation for Asset SHA512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ commands
 - Fix a bug where environments could not be created with sensuctl create
 - StatsD listener on Windows is functional
 - Fixed `sensuctl create -f` for `Role`
+- Added validation for asset SHA512 checksum, requiring that it be at least 128
+characters and therefore fixing a bug in sensuctl
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/cli/commands/asset/create_test.go
+++ b/cli/commands/asset/create_test.go
@@ -44,7 +44,7 @@ func TestCreateCommandRunEClosureWithAllFlags(t *testing.T) {
 
 	cmd := CreateCommand(cli)
 	require.NoError(t, cmd.Flags().Set("url", "http://lol"))
-	require.NoError(t, cmd.Flags().Set("sha512", "12345qwerty"))
+	require.NoError(t, cmd.Flags().Set("sha512", "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17"))
 	out, err := test.RunCmd(cmd, []string{"ruby22"})
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestCreateCommandRunEClosureWithServerErr(t *testing.T) {
 	client.On("CreateAsset", mock.AnythingOfType("*types.Asset")).Return(errors.New("whoops"))
 
 	cmd := CreateCommand(cli)
-	require.NoError(t, cmd.Flags().Set("sha512", "12345qwerty"))
+	require.NoError(t, cmd.Flags().Set("sha512", "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17"))
 	require.NoError(t, cmd.Flags().Set("url", "http://lol"))
 	out, err := test.RunCmd(cmd, []string{"ruby22"})
 
@@ -86,7 +86,7 @@ func TestConfigureAsset(t *testing.T) {
 	flags := &pflag.FlagSet{}
 	flags.StringSlice("metadata", []string{}, "")
 	flags.StringSlice("filter", []string{}, "")
-	flags.String("sha512", "12345qwerty", "")
+	flags.String("sha512", "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17", "")
 	flags.String("url", "http://lol", "")
 
 	// Too many args

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -80,10 +80,10 @@ func printToTable(results interface{}, writer io.Writer) {
 			CellTransformer: func(data interface{}) string {
 				asset, _ := data.(types.Asset)
 
-				if len(asset.Sha512) >= 7 {
+				if len(asset.Sha512) >= 128 {
 					return string(asset.Sha512[0:7])
 				}
-				return ""
+				return "invalid"
 			},
 		},
 	})

--- a/testing/e2e/asset_store_test.go
+++ b/testing/e2e/asset_store_test.go
@@ -37,7 +37,7 @@ func TestAssetStore(t *testing.T) {
 		Name:         "asset1",
 		Organization: "default",
 		URL:          "http:foo.com",
-		Sha512:       "12345678",
+		Sha512:       "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
 	}
 	output, err := sensuctl.run("asset", "create", asset.Name,
 		"--organization", asset.Organization,

--- a/types/asset.go
+++ b/types/asset.go
@@ -32,6 +32,10 @@ func (a *Asset) Validate() error {
 		return errors.New("SHA-512 checksum cannot be empty")
 	}
 
+	if len(a.Sha512) < 128 {
+		return errors.New("SHA-512 checksum must be at least 128 characters")
+	}
+
 	if a.URL == "" {
 		return errors.New("URL cannot be empty")
 	}

--- a/types/asset_test.go
+++ b/types/asset_test.go
@@ -58,4 +58,14 @@ func TestValidator(t *testing.T) {
 	asset = FixtureAsset("name")
 	asset.Filters = []string{`entity.OS in ("macos", "linux")`}
 	assert.NoError(asset.Validate())
+
+	// Given asset without a Sha512 it should not pass
+	asset = FixtureAsset("name")
+	asset.Sha512 = ""
+	assert.Error(asset.Validate())
+
+	// Given asset with an invalid Sha512 it should not pass
+	asset = FixtureAsset("name")
+	asset.Sha512 = "nope"
+	assert.Error(asset.Validate())
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds validation for asset SHA512 checksum, requiring that it be at least 128 characters and therefore fixing a bug in sensuctl.

## Why is this change necessary?

Closes #1467 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.