### PR TITLE
Fix the URIPath method of Event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ commands
 - Fix a bug where environments could not be created with sensuctl create
 - StatsD listener on Windows is functional
 - Fixed `sensuctl create -f` for `Role`
+- Fixed `sensuctl create -f` for `Event`
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/types/event.go
+++ b/types/event.go
@@ -240,5 +240,5 @@ func (e *Event) URIPath() string {
 	if !e.HasCheck() {
 		return ""
 	}
-	return fmt.Sprintf("/%s/%s", url.PathEscape(e.Entity.ID), url.PathEscape(e.Check.Name))
+	return fmt.Sprintf("/events/%s/%s", url.PathEscape(e.Entity.ID), url.PathEscape(e.Check.Name))
 }


### PR DESCRIPTION
This allows events to be created with sensuctl create.

Signed-off-by: Eric Chlebek <eric@sensu.io>

Closes #1548 