### PR TITLE
Pass CI env var to sensu-go-build docker image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -335,8 +335,8 @@ deploy() {
     make clean
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
     docker pull sensuapp/sensu-go-build
-    docker run -it -e SENSU_BUILD_ITERATION=$SENSU_BUILD_ITERATION -v `pwd`:/go/src/github.com/sensu/sensu-go sensuapp/sensu-go-build
-    docker run -it -v `pwd`:/go/src/github.com/sensu/sensu-go -e PACKAGECLOUD_TOKEN="$PACKAGECLOUD_TOKEN" sensuapp/sensu-go-build publish_travis
+    docker run -it -e SENSU_BUILD_ITERATION=$SENSU_BUILD_ITERATION -e CI=$CI -v `pwd`:/go/src/github.com/sensu/sensu-go sensuapp/sensu-go-build
+    docker run -it -v `pwd`:/go/src/github.com/sensu/sensu-go -e PACKAGECLOUD_TOKEN="$PACKAGECLOUD_TOKEN" -e CI=$CI sensuapp/sensu-go-build publish_travis
     docker run -it -v `pwd`:/go/src/github.com/sensu/sensu-go sensuapp/sensu-go-build clean
 
     # Deploy Docker images to the Docker Hub


### PR DESCRIPTION
nightly deploy was breaking due to incorrect version reporting. The `sensu-go-build` docker container was reporting its build type as `dev`.

Fixed by passing the `CI` environment variable into `sensu-go-build` so that it can report the correct build type of `nightly`