### PR TITLE
[Web UI] Prevent cascading errors when token refresh fails

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,7 +26,7 @@
     "@10xjs/form": "^0.1.5",
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
-    "apollo-link": "^1.2.1",
+    "apollo-link": "^1.2.2",
     "apollo-link-context": "^1.0.7",
     "apollo-link-http": "^1.5.3",
     "apollo-link-state": "^0.4.1",

--- a/dashboard/src/apollo/authLink.js
+++ b/dashboard/src/apollo/authLink.js
@@ -1,30 +1,52 @@
-import { setContext } from "apollo-link-context";
+import { ApolloLink, Observable } from "apollo-link";
 
-import handle from "/exceptionHandler";
+import { when } from "/utils/promise";
+import { UnauthorizedError } from "/errors/FetchError";
 
 import refreshTokens from "/mutations/refreshTokens";
+import invalidateTokens from "/mutations/invalidateTokens";
 
 const EXPIRY_THRESHOLD_MS = 13 * 60 * 1000;
 
 const authLink = ({ getClient }) =>
-  setContext(async () => {
-    try {
-      const notBefore = new Date(Date.now() + EXPIRY_THRESHOLD_MS);
+  new ApolloLink(
+    (operation, forward) =>
+      new Observable(observer => {
+        let sub;
+        refreshTokens(getClient(), {
+          notBefore: new Date(Date.now() + EXPIRY_THRESHOLD_MS).toISOString(),
+        })
+          .then(
+            ({ data }) => {
+              operation.setContext({
+                headers: {
+                  Authorization: `Bearer ${
+                    data.refreshTokens.auth.accessToken
+                  }`,
+                },
+              });
+              sub = forward(operation).subscribe(observer);
+            },
+            when(UnauthorizedError, error => {
+              // Remove the current stored tokens if the token refresh attempt
+              // fails. This will redirect the user back to the login screen.
+              // We could potentially introduce a less disruptive behavior here,
+              // maybe show a modal allowing the user to re-enter credentials
+              // without loosing the current app state.
+              invalidateTokens(getClient());
 
-      // TODO: Prevent parallel auth token requests
-      const { data } = await refreshTokens(getClient(), {
-        notBefore: notBefore.toISOString(),
-      });
+              // re-throw the UnauthorizedError instance to ensure later error
+              // handling (likely a <Query> instance) can deal with it
+              // appropriately.
+              throw error;
+            }),
+          )
+          .catch(observer.error.bind(observer));
 
-      return {
-        headers: {
-          Authorization: `Bearer ${data.refreshTokens.auth.accessToken}`,
-        },
-      };
-    } catch (error) {
-      handle(error);
-      return {};
-    }
-  });
+        return () => {
+          if (sub) sub.unsubscribe();
+        };
+      }),
+  );
 
 export default authLink;

--- a/dashboard/src/errors/FetchError.js
+++ b/dashboard/src/errors/FetchError.js
@@ -8,7 +8,7 @@ export default class FetchError extends ExtendableError {
       throw new TypeError("Can't initiate an abstract class.");
     }
 
-    this.status = status;
+    this.statusCode = status;
     this.url = url;
     this.response = response;
     this.original = error;

--- a/dashboard/src/utils/authAPI.js
+++ b/dashboard/src/utils/authAPI.js
@@ -1,5 +1,6 @@
 import { parseUNIX } from "/utils/date";
 import doFetch from "/utils/fetch";
+import { memoize } from "/utils/promise";
 
 const parseTokenResponse = body => ({
   accessToken: body.access_token,
@@ -7,59 +8,70 @@ const parseTokenResponse = body => ({
   expiresAt: parseUNIX(body.expires_at).toISOString(),
 });
 
-export const createTokens = async ({ username, password }) => {
-  const path = "/auth";
-  const config = {
-    method: "GET",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Basic ${window.btoa(`${username}:${password}`)}`,
-    },
-  };
+export const createTokens = memoize(
+  async ({ username, password }) => {
+    const path = "/auth";
+    const config = {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Basic ${window.btoa(`${username}:${password}`)}`,
+      },
+    };
 
-  const response = await doFetch(path, config);
-  return parseTokenResponse(await response.json());
-};
+    const response = await doFetch(path, config);
+    return parseTokenResponse(await response.json());
+  },
+  ({ username, password }) => JSON.stringify({ username, password }),
+);
 
 export default createTokens;
 
-export const refreshTokens = async ({ accessToken, refreshToken }) => {
-  const path = "/auth/token";
-  const config = {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify({
-      refresh_token: refreshToken,
-    }),
-  };
+export const refreshTokens = memoize(
+  async ({ accessToken, refreshToken }) => {
+    const path = "/auth/token";
+    const config = {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+      }),
+    };
 
-  const response = await doFetch(path, config);
-  return parseTokenResponse(await response.json());
-};
+    const response = await doFetch(path, config);
+    return parseTokenResponse(await response.json());
+  },
+  ({ accessToken, refreshToken }) =>
+    JSON.stringify({ accessToken, refreshToken }),
+);
 
-export const invalidateTokens = async ({ accessToken, refreshToken }) => {
-  const path = "/auth/logout";
-  const config = {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify({
-      refresh_token: refreshToken,
-    }),
-  };
+export const invalidateTokens = memoize(
+  async ({ accessToken, refreshToken }) => {
+    const path = "/auth/logout";
+    const config = {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+      }),
+    };
 
-  await doFetch(path, config);
+    await doFetch(path, config);
 
-  return {
-    accessToken: null,
-    refreshToken: null,
-    expiresAt: null,
-  };
-};
+    return {
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+    };
+  },
+  ({ accessToken, refreshToken }) =>
+    JSON.stringify({ accessToken, refreshToken }),
+);

--- a/dashboard/src/utils/promise.js
+++ b/dashboard/src/utils/promise.js
@@ -32,3 +32,33 @@ export const when = (...args) => {
     throw error;
   };
 };
+
+// TODO: Ensure WeakMap is polyfilled
+const cache = new WeakMap();
+
+export const memoize = (promiseCreator, keyCreator) => (...args) => {
+  let map = cache.get(promiseCreator);
+  const key = keyCreator(...args);
+
+  if (!map) {
+    map = new Map();
+    cache.set(promiseCreator, map);
+  } else if (map.has(key)) {
+    return map.get(key);
+  }
+
+  const promise = promiseCreator(...args).then(
+    result => {
+      map.delete(key);
+      return result;
+    },
+    error => {
+      map.delete(key);
+      throw error;
+    },
+  );
+
+  map.set(key, promise);
+
+  return promise;
+};

--- a/dashboard/src/utils/promise.test.js
+++ b/dashboard/src/utils/promise.test.js
@@ -1,0 +1,101 @@
+import { when, memoize } from "./promise";
+
+describe("promise utils", () => {
+  describe("when", () => {
+    it("should throw received error", () => {
+      expect(() => {
+        when()(new Error());
+      }).toThrow(Error);
+    });
+
+    it("should call first matching handler for error type", () => {
+      const handler = jest.fn();
+      const otherHandler = jest.fn();
+      const error = new Error();
+      when(TypeError, otherHandler, Error, handler, Error, otherHandler)(error);
+
+      expect(handler.mock.calls).toHaveLength(1);
+      expect(handler.mock.calls[0][0]).toBe(error);
+    });
+
+    it("should support arrays of types", () => {
+      const handler = jest.fn();
+      const otherHandler = jest.fn();
+      const error = new Error();
+
+      when(
+        TypeError,
+        otherHandler,
+        [TypeError, Error],
+        handler,
+        Error,
+        otherHandler,
+      )(error);
+
+      expect(handler.mock.calls).toHaveLength(1);
+      expect(handler.mock.calls[0][0]).toBe(error);
+    });
+  });
+
+  describe("memoize", () => {
+    let creator;
+    let key;
+
+    beforeEach(() => {
+      creator = jest.fn(val => Promise.resolve(val));
+      key = jest.fn(val => val);
+    });
+
+    it("should call the wrapped functions with provided args ", async () => {
+      await memoize(creator, key)("arg1", "arg2");
+
+      expect(creator.mock.calls).toHaveLength(1);
+      expect(creator.mock.calls[0]).toEqual(["arg1", "arg2"]);
+
+      expect(key.mock.calls).toHaveLength(1);
+      expect(key.mock.calls[0]).toEqual(["arg1", "arg2"]);
+    });
+
+    it("should return the result of the promise creator", async () => {
+      const data = {};
+      expect(await memoize(creator, key)(data)).toBe(data);
+    });
+
+    it("should return the cached promise instance for a matching key", async () => {
+      const wrapped = memoize(creator, key);
+
+      wrapped("a");
+      await wrapped("a");
+
+      expect(creator.mock.calls).toHaveLength(1);
+    });
+
+    it("should return a new promise without a cache key match", async () => {
+      const wrapped = memoize(creator, key);
+
+      wrapped("a");
+      await wrapped("b");
+
+      expect(creator.mock.calls).toHaveLength(2);
+    });
+
+    it("should clear cache for key when promise resolves", async () => {
+      const wrapped = memoize(creator, key);
+
+      await wrapped("a");
+      await wrapped("a");
+
+      expect(creator.mock.calls).toHaveLength(2);
+    });
+
+    it("should clear cache for key when promise rejects", async () => {
+      creator = jest.fn(val => Promise.reject(val));
+      const wrapped = memoize(creator, key);
+
+      await wrapped("a").catch(() => {});
+      await wrapped("a").catch(() => {});
+
+      expect(creator.mock.calls).toHaveLength(2);
+    });
+  });
+});

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -443,7 +443,7 @@ apollo-link-state@^0.4.1:
     apollo-utilities "^1.0.8"
     graphql-anywhere "^4.1.0-alpha.0"
 
-apollo-link@^1.0.0, apollo-link@^1.2.1, apollo-link@^1.2.2:
+apollo-link@^1.0.0, apollo-link@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.2.tgz#54c84199b18ac1af8d63553a68ca389c05217a03"
   dependencies:


### PR DESCRIPTION
## What is this change?

This prevents the app from crashing, and instead kicks the user back to the login screen when token refresh fails.

This change also disallows multiple parallel requests to the auth API with the same data. If a token refresh request is fired while an identical one is in-flight, the `refreshTokens` function will resolve the current pending fetch for both requests.
    
## Why is this change necessary?

In the event that an auth token refresh fails while processing a mutation or query, abort the operation with the failed token request error. There is no sense in continuing to attempt the operation if authentication has failed. This prevents a cascade of additional failed attempts with the API.

When a token refresh is required, there are likely to be multiple pending queries that have just been fired. Each of these will trigger an auth token refresh in 
`authLink`. Memoizing the auth API functions prevents parallel identical auth API requests at a low level in a way that doesn't concern the consuming logic.

## Does your change need a Changelog entry?

no

## Do you need clarification on anything?

no

## Were there any complications while making this change?

The behavior of kicking the user back to the login screen is quite disruptive if they are mid-session. It would be more ideal to show a modal allowing the user to re-enter credentials without leaving the current page. This is something to think about as we develop the product further.