### PR TITLE
[Web UI] Update material-ui dependency to latest RC

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@10xjs/date-input-controller": "^0.1.5",
     "@10xjs/form": "^0.1.5",
+    "@material-ui/core": "^1.0.0-rc.1",
+    "@material-ui/icons": "^1.0.0-rc.0",
     "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.2.8",
     "apollo-link": "^1.2.2",
@@ -86,8 +88,6 @@
     "koa-connect": "^2.0.1",
     "koa-webpack": "^3.0.2",
     "lodash": "^4.17.0",
-    "material-ui": "^1.0.0-beta.36",
-    "material-ui-icons": "^1.0.0-beta.36",
     "object-assign": "^4.1.1",
     "prettier": "^1.12.1",
     "promise": "^8.0.1",

--- a/dashboard/src/colors/appleGreen.js
+++ b/dashboard/src/colors/appleGreen.js
@@ -1,4 +1,4 @@
-import { darken, lighten } from "material-ui/styles/colorManipulator";
+import { darken, lighten } from "@material-ui/core/styles/colorManipulator";
 
 const appleGreenColor = "#82C023";
 const appleGreen = {

--- a/dashboard/src/colors/index.js
+++ b/dashboard/src/colors/index.js
@@ -1,4 +1,4 @@
-import * as muiColors from "material-ui/colors";
+import * as muiColors from "@material-ui/core/colors";
 import salmon from "./salmon";
 import appleGreen from "./appleGreen";
 import slateBlue from "./slateBlue";

--- a/dashboard/src/colors/magenta.js
+++ b/dashboard/src/colors/magenta.js
@@ -1,4 +1,4 @@
-import { darken, lighten } from "material-ui/styles/colorManipulator";
+import { darken, lighten } from "@material-ui/core/styles/colorManipulator";
 
 // TODO: Don't use lighten / darken
 const magentaColor = "#d86cc5";

--- a/dashboard/src/colors/salmon.js
+++ b/dashboard/src/colors/salmon.js
@@ -1,4 +1,4 @@
-import { darken, lighten } from "material-ui/styles/colorManipulator";
+import { darken, lighten } from "@material-ui/core/styles/colorManipulator";
 
 // TODO: Don't use lighten / darken
 const salmonColor = "#FA8072";

--- a/dashboard/src/colors/slateBlue.js
+++ b/dashboard/src/colors/slateBlue.js
@@ -1,4 +1,4 @@
-import { darken, lighten } from "material-ui/styles/colorManipulator";
+import { darken, lighten } from "@material-ui/core/styles/colorManipulator";
 
 // TODO: Don't use lighten / darken
 const slateBlueColor = "#717CE5";

--- a/dashboard/src/components/AppBar.js
+++ b/dashboard/src/components/AppBar.js
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import MUIAppBar from "material-ui/AppBar";
-import MaterialToolbar from "material-ui/Toolbar";
-import Typography from "material-ui/Typography";
-import IconButton from "material-ui/IconButton";
-import { withStyles } from "material-ui/styles";
-import MenuIcon from "material-ui-icons/Menu";
+import MUIAppBar from "@material-ui/core/AppBar";
+import MaterialToolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+import IconButton from "@material-ui/core/IconButton";
+import { withStyles } from "@material-ui/core/styles";
+import MenuIcon from "@material-ui/icons/Menu";
 import EnvironmentLabel from "/components/EnvironmentLabel";
 import Wordmark from "/icons/SensuWordmark";
 

--- a/dashboard/src/components/AppContent.js
+++ b/dashboard/src/components/AppContent.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/AppFrame.js
+++ b/dashboard/src/components/AppFrame.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import gql from "graphql-tag";
 import { Route } from "react-router-dom";
 

--- a/dashboard/src/components/AppRoot.js
+++ b/dashboard/src/components/AppRoot.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { compose } from "recompose";
 import { Provider } from "react-redux";
 import { ApolloProvider } from "react-apollo";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import { Switch, Route, withRouter } from "react-router-dom";
 
 import AppThemeProvider from "/components/AppThemeProvider";

--- a/dashboard/src/components/AppSearch.js
+++ b/dashboard/src/components/AppSearch.js
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import compose from "recompose/compose";
 import pure from "recompose/pure";
-import withWidth, { isWidthUp } from "material-ui/utils/withWidth";
-import SearchIcon from "material-ui-icons/Search";
-import { fade } from "material-ui/styles/colorManipulator";
-import { withStyles } from "material-ui/styles";
+import withWidth, { isWidthUp } from "@material-ui/core/withWidth";
+import SearchIcon from "@material-ui/icons/Search";
+import { fade } from "@material-ui/core/styles/colorManipulator";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   wrapper: {

--- a/dashboard/src/components/ButtonSet/ButtonSet.js
+++ b/dashboard/src/components/ButtonSet/ButtonSet.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/CardHighlight/CardHighlight.js
+++ b/dashboard/src/components/CardHighlight/CardHighlight.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/CheckList.js
+++ b/dashboard/src/components/CheckList.js
@@ -3,13 +3,12 @@ import PropTypes from "prop-types";
 import map from "lodash/map";
 import gql from "graphql-tag";
 
-import Table, {
-  TableBody,
-  TableHead,
-  TableCell,
-  TableRow,
-} from "material-ui/Table";
-import Checkbox from "material-ui/Checkbox";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableHead from "@material-ui/core/TableHead";
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
+import Checkbox from "@material-ui/core/Checkbox";
 import Row from "/components/CheckRow";
 
 import Loader from "/components/util/Loader";

--- a/dashboard/src/components/CheckRow.js
+++ b/dashboard/src/components/CheckRow.js
@@ -2,8 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
-import { TableRow, TableCell } from "material-ui/Table";
-import Checkbox from "material-ui/Checkbox";
+import TableRow from "@material-ui/core/TableRow";
+import TableCell from "@material-ui/core/TableCell";
+import Checkbox from "@material-ui/core/Checkbox";
 
 class CheckRow extends React.Component {
   static fragments = {

--- a/dashboard/src/components/CheckStatusIcon/CheckStatusIcon.js
+++ b/dashboard/src/components/CheckStatusIcon/CheckStatusIcon.js
@@ -2,11 +2,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import { withStyles } from "material-ui/styles";
-import OKIcon from "material-ui-icons/CheckCircle";
-import WarnIcon from "material-ui-icons/Warning";
-import ErrIcon from "material-ui-icons/Error";
-import UnknownIcon from "material-ui-icons/Help";
+import { withStyles } from "@material-ui/core/styles";
+import OKIcon from "@material-ui/icons/CheckCircle";
+import WarnIcon from "@material-ui/icons/Warning";
+import ErrIcon from "@material-ui/icons/Error";
+import UnknownIcon from "@material-ui/icons/Help";
 
 import { statusCodeToId } from "/utils/checkStatus";
 import OKIconSm from "/icons/SmallCheck";

--- a/dashboard/src/components/Code.js
+++ b/dashboard/src/components/Code.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/Content/Content.js
+++ b/dashboard/src/components/Content/Content.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/DetailedListItem/DetailedListItem.js
+++ b/dashboard/src/components/DetailedListItem/DetailedListItem.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/DetailedListItem/DetailedListItemSubtitle.js
+++ b/dashboard/src/components/DetailedListItem/DetailedListItemSubtitle.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/DetailedListItem/DetailedListItemTitle.js
+++ b/dashboard/src/components/DetailedListItem/DetailedListItemTitle.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/Dictionary/Dictionary.js
+++ b/dashboard/src/components/Dictionary/Dictionary.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = {
   root: {

--- a/dashboard/src/components/Dictionary/DictionaryKey.js
+++ b/dashboard/src/components/Dictionary/DictionaryKey.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/Dictionary/DictionaryValue.js
+++ b/dashboard/src/components/Dictionary/DictionaryValue.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/Drawer.js
+++ b/dashboard/src/components/Drawer.js
@@ -5,18 +5,18 @@ import gql from "graphql-tag";
 import { withApollo } from "react-apollo";
 import { compose } from "recompose";
 
-import MaterialDrawer from "material-ui/Drawer";
-import List from "material-ui/List";
-import Divider from "material-ui/Divider";
-import { withStyles } from "material-ui/styles";
+import MaterialDrawer from "@material-ui/core/Drawer";
+import List from "@material-ui/core/List";
+import Divider from "@material-ui/core/Divider";
+import { withStyles } from "@material-ui/core/styles";
 
-import EntityIcon from "material-ui-icons/DesktopMac";
-import CheckIcon from "material-ui-icons/AssignmentTurnedIn";
-import EventIcon from "material-ui-icons/Notifications";
-import FeedbackIcon from "material-ui-icons/Feedback";
-import LogoutIcon from "material-ui-icons/ExitToApp";
-import IconButton from "material-ui/IconButton";
-import MenuIcon from "material-ui-icons/Menu";
+import EntityIcon from "@material-ui/icons/DesktopMac";
+import CheckIcon from "@material-ui/icons/AssignmentTurnedIn";
+import EventIcon from "@material-ui/icons/Notifications";
+import FeedbackIcon from "@material-ui/icons/Feedback";
+import LogoutIcon from "@material-ui/icons/ExitToApp";
+import IconButton from "@material-ui/core/IconButton";
+import MenuIcon from "@material-ui/icons/Menu";
 
 import WandIcon from "/icons/Wand";
 import Wordmark from "/icons/SensuWordmark";

--- a/dashboard/src/components/DrawerButton.js
+++ b/dashboard/src/components/DrawerButton.js
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { ListItem, ListItemIcon, ListItemText } from "material-ui/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
 
 class DrawerButton extends React.Component {
   static propTypes = {

--- a/dashboard/src/components/EnvironmentLabel/EnvironmentLabelBase.js
+++ b/dashboard/src/components/EnvironmentLabel/EnvironmentLabelBase.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import Typography from "material-ui/Typography";
-import { withStyles } from "material-ui/styles";
+import Typography from "@material-ui/core/Typography";
+import { withStyles } from "@material-ui/core/styles";
 
 import { EnvironmentIconBase as Icon } from "/components/EnvironmentIcon";
 

--- a/dashboard/src/components/EventsContainer.js
+++ b/dashboard/src/components/EventsContainer.js
@@ -7,12 +7,12 @@ import { every, filter, reduce, capitalize } from "lodash";
 import { compose } from "lodash/fp";
 import { map, join } from "ramda";
 import gql from "graphql-tag";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Typography from "material-ui/Typography";
-import { MenuItem } from "material-ui/Menu";
-import { ListItemText } from "material-ui/List";
-import Checkbox from "material-ui/Checkbox";
+import Typography from "@material-ui/core/Typography";
+import MenuItem from "@material-ui/core/MenuItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import Checkbox from "@material-ui/core/Checkbox";
 
 import EventsListItem from "/components/EventsListItem";
 import resolveEvent from "/mutations/resolveEvent";

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -71,7 +71,7 @@ class EventListItem extends React.Component {
 
   resolve = () => {
     const { client, event } = this.props;
-    resolveEvent(client, event.id);
+    resolveEvent(client, event);
   };
 
   renderMenu = ({ open, onClose, anchorEl }) => {

--- a/dashboard/src/components/EventsListItem.js
+++ b/dashboard/src/components/EventsListItem.js
@@ -3,9 +3,10 @@ import PropTypes from "prop-types";
 import { compose } from "recompose";
 import gql from "graphql-tag";
 import { withApollo } from "react-apollo";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
-import Menu, { MenuItem } from "material-ui/Menu";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
 
 import resolveEvent from "/mutations/resolveEvent";
 import RelativeDate from "/components/RelativeDate";

--- a/dashboard/src/components/ExteriorWrapper.js
+++ b/dashboard/src/components/ExteriorWrapper.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import ThemeProvider from "/components/ThemeProvider";
 
 class ExteriorWrapper extends React.Component {

--- a/dashboard/src/components/InlineLink/InlineLink.js
+++ b/dashboard/src/components/InlineLink/InlineLink.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import { NavLink } from "react-router-dom";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = () => ({
   root: {

--- a/dashboard/src/components/Monospaced/Monospaced.js
+++ b/dashboard/src/components/Monospaced/Monospaced.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import { emphasize } from "material-ui/styles/colorManipulator";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import { emphasize } from "@material-ui/core/styles/colorManipulator";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/NamespaceSelector.js
+++ b/dashboard/src/components/NamespaceSelector.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import { Route } from "react-router-dom";
 
 import gql from "graphql-tag";
-import { withStyles } from "material-ui/styles";
-import Button from "material-ui/ButtonBase";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/ButtonBase";
 
 import NamespaceSelectorBuilder from "/components/NamespaceSelectorBuilder";
 import NamespaceSelectorMenu from "/components/NamespaceSelectorMenu";

--- a/dashboard/src/components/NamespaceSelectorBuilder.js
+++ b/dashboard/src/components/NamespaceSelectorBuilder.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Typography from "material-ui/Typography";
-import ArrowIcon from "material-ui-icons/ArrowDropDown";
+import Typography from "@material-ui/core/Typography";
+import ArrowIcon from "@material-ui/icons/ArrowDropDown";
 
 const styles = theme => ({
   label: {

--- a/dashboard/src/components/NamespaceSelectorMenu.js
+++ b/dashboard/src/components/NamespaceSelectorMenu.js
@@ -2,11 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import partition from "lodash/partition";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import { Link } from "react-router-dom";
-import Menu, { MenuItem } from "material-ui/Menu";
-import { ListItemIcon, ListItemText } from "material-ui/List";
-import Divider from "material-ui/Divider";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import Divider from "@material-ui/core/Divider";
 import OrganizationIcon from "/components/OrganizationIcon";
 import EnvironmentSymbol from "/components/EnvironmentSymbol";
 
@@ -69,8 +71,9 @@ class NamespaceSelectorMenu extends React.Component {
             <Link
               to={`/${currentOrganization.name}/${environment.name}`}
               onClick={onClick}
+              key={environment.name}
             >
-              <MenuItem key={environment.name}>
+              <MenuItem>
                 <ListItemIcon>
                   <div className={classes.envIcon}>
                     <EnvironmentSymbol environment={environment} size={12} />
@@ -85,9 +88,10 @@ class NamespaceSelectorMenu extends React.Component {
           organization.environments.map(environment => (
             <Link
               to={`/${organization.name}/${environment.name}`}
+              key={`${organization.name}${environment.name}`}
               onClick={onClick}
             >
-              <MenuItem key={`${organization.name}${environment.name}`}>
+              <MenuItem>
                 <ListItemIcon>
                   <OrganizationIcon organization={organization} size={24}>
                     <EnvironmentSymbol

--- a/dashboard/src/components/NamespaceSelectorMenu.js
+++ b/dashboard/src/components/NamespaceSelectorMenu.js
@@ -88,7 +88,7 @@ class NamespaceSelectorMenu extends React.Component {
           organization.environments.map(environment => (
             <Link
               to={`/${organization.name}/${environment.name}`}
-              key={`${organization.name}${environment.name}`}
+              key={`${organization.name}/${environment.name}`}
               onClick={onClick}
             >
               <MenuItem>

--- a/dashboard/src/components/OrganizationIcon/OrganizationIconBase.js
+++ b/dashboard/src/components/OrganizationIcon/OrganizationIconBase.js
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import DonutSmall from "material-ui-icons/DonutSmall";
-import Explore from "material-ui-icons/Explore";
-import Visibility from "material-ui-icons/Visibility";
-import Emoticon from "material-ui-icons/InsertEmoticon";
+import DonutSmall from "@material-ui/icons/DonutSmall";
+import Explore from "@material-ui/icons/Explore";
+import Visibility from "@material-ui/icons/Visibility";
+import Emoticon from "@material-ui/icons/InsertEmoticon";
 import Hot from "/icons/Hot";
 import Donut from "/icons/Donut";
 import Briefcase from "/icons/Briefcase";

--- a/dashboard/src/components/PlaceholderCard.js
+++ b/dashboard/src/components/PlaceholderCard.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
-import Card from "material-ui/Card";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
 
 const styles = () => ({
   root: {

--- a/dashboard/src/components/Preferences.js
+++ b/dashboard/src/components/Preferences.js
@@ -2,21 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { compose } from "lodash/fp";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Modal from "material-ui/Modal";
-import Paper from "material-ui/Paper";
-import List, {
-  ListItem,
-  ListItemIcon,
-  ListItemSecondaryAction,
-  ListItemText,
-  ListSubheader,
-} from "material-ui/List";
-import Menu, { MenuItem } from "material-ui/Menu";
-import Switch from "material-ui/Switch";
-import BulbIcon from "material-ui-icons/LightbulbOutline";
-import EyeIcon from "material-ui-icons/RemoveRedEye";
+import Modal from "@material-ui/core/Modal";
+import Paper from "@material-ui/core/Paper";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import MenuItem from "@material-ui/core/MenuItem";
+import Menu from "@material-ui/core/Menu";
+import Switch from "@material-ui/core/Switch";
+import BulbIcon from "@material-ui/icons/LightbulbOutline";
+import EyeIcon from "@material-ui/icons/RemoveRedEye";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/QuickNav.js
+++ b/dashboard/src/components/QuickNav.js
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 
-import { withStyles } from "material-ui/styles";
-import EventIcon from "material-ui-icons/Notifications";
-import EntityIcon from "material-ui-icons/DesktopMac";
-import CheckIcon from "material-ui-icons/AssignmentTurnedIn";
+import { withStyles } from "@material-ui/core/styles";
+import EventIcon from "@material-ui/icons/Notifications";
+import EntityIcon from "@material-ui/icons/DesktopMac";
+import CheckIcon from "@material-ui/icons/AssignmentTurnedIn";
 
 import QuickNavButton from "/components/QuickNavButton";
 

--- a/dashboard/src/components/QuickNavButton.js
+++ b/dashboard/src/components/QuickNavButton.js
@@ -1,10 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import { NavLink } from "react-router-dom";
 
-import Typography from "material-ui/Typography";
-import IconButton from "material-ui/IconButton";
+import Typography from "@material-ui/core/Typography";
+import IconButton from "@material-ui/core/IconButton";
 
 const styles = theme => ({
   menuText: {

--- a/dashboard/src/components/ResetStyles.js
+++ b/dashboard/src/components/ResetStyles.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 import reset from "/reset.css";
 

--- a/dashboard/src/components/SearchBox.js
+++ b/dashboard/src/components/SearchBox.js
@@ -2,10 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import { withStyles } from "material-ui/styles";
-import Paper from "material-ui/Paper";
-import Typography from "material-ui/Typography";
-import Icon from "material-ui-icons/FilterList";
+import { withStyles } from "@material-ui/core/styles";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Icon from "@material-ui/icons/FilterList";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/StatusListItem.js
+++ b/dashboard/src/components/StatusListItem.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-import Button from "material-ui/ButtonBase";
-import Checkbox from "material-ui/Checkbox";
-import Disclosure from "material-ui-icons/MoreVert";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/ButtonBase";
+import Checkbox from "@material-ui/core/Checkbox";
+import Disclosure from "@material-ui/icons/MoreVert";
 
 import CheckStatusIcon from "/components/CheckStatusIcon";
 import { TableListItem } from "/components/TableList";

--- a/dashboard/src/components/TableList/TableList.js
+++ b/dashboard/src/components/TableList/TableList.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   [theme.breakpoints.up("sm")]: {

--- a/dashboard/src/components/TableList/TableListBody.js
+++ b/dashboard/src/components/TableList/TableListBody.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/TableList/TableListButton.js
+++ b/dashboard/src/components/TableList/TableListButton.js
@@ -2,8 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import { withStyles } from "material-ui/styles";
-import Button from "material-ui/ButtonBase";
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/ButtonBase";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/TableList/TableListEmptyState.js
+++ b/dashboard/src/components/TableList/TableListEmptyState.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/TableList/TableListHeader.js
+++ b/dashboard/src/components/TableList/TableListHeader.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => {
   const toolbar = theme.mixins.toolbar;

--- a/dashboard/src/components/TableList/TableListItem.js
+++ b/dashboard/src/components/TableList/TableListItem.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/components/TableList/TableListSelect.js
+++ b/dashboard/src/components/TableList/TableListSelect.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import warning from "warning";
 
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
-import Menu from "material-ui/Menu";
-import DropdownArrow from "material-ui-icons/ArrowDropDown";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Menu from "@material-ui/core/Menu";
+import DropdownArrow from "@material-ui/icons/ArrowDropDown";
 import Button from "./TableListButton";
 
 const styles = {

--- a/dashboard/src/components/TagOrb.js
+++ b/dashboard/src/components/TagOrb.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { emphasize } from "material-ui/styles/colorManipulator";
-import { withStyles } from "material-ui/styles";
+import { emphasize } from "@material-ui/core/styles/colorManipulator";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = () => ({
   root: {

--- a/dashboard/src/components/ThemeProvider.js
+++ b/dashboard/src/components/ThemeProvider.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { MuiThemeProvider } from "material-ui/styles";
+import { MuiThemeProvider } from "@material-ui/core/styles";
 import * as themes from "/themes";
 
 class ThemeProvider extends React.Component {

--- a/dashboard/src/components/ThemeStyles.js
+++ b/dashboard/src/components/ThemeStyles.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 const styles = theme => ({
   "@global": {

--- a/dashboard/src/components/partials/EntitiesList/EntitiesListHeader.js
+++ b/dashboard/src/components/partials/EntitiesList/EntitiesListHeader.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import Checkbox from "material-ui/Checkbox";
-import { withStyles } from "material-ui/styles";
+import Checkbox from "@material-ui/core/Checkbox";
+import { withStyles } from "@material-ui/core/styles";
 
 import { TableListHeader } from "/components/TableList";
 

--- a/dashboard/src/components/partials/EntitiesList/EntitiesListItem.js
+++ b/dashboard/src/components/partials/EntitiesList/EntitiesListItem.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
-import Typography from "material-ui/Typography";
+import Typography from "@material-ui/core/Typography";
 
 import RelativeDate from "/components/RelativeDate";
 import StatusListItem from "/components/StatusListItem";

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsContainer.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsContainer.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Grid from "material-ui/Grid";
+import Grid from "@material-ui/core/Grid";
 import Content from "/components/Content";
 import RelatedEntitiesCard from "/components/partials/RelatedEntitiesCard";
 import EntityDetailsEvents from "./EntityDetailsEvents";
@@ -34,7 +34,7 @@ class EntityDetailsContainer extends React.PureComponent {
     const { entity } = this.props;
     return (
       <Content>
-        <Grid container>
+        <Grid container spacing={16}>
           <Grid item xs={12}>
             <EntityDetailsInformation entity={entity} />
           </Grid>

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsEvents.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsEvents.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Card, { CardContent } from "material-ui/Card";
-import Typography from "material-ui/Typography";
-import List from "material-ui/List";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import List from "@material-ui/core/List";
 import RelativeDate from "/components/RelativeDate";
 import StatusIcon from "/components/CheckStatusIcon";
 import InlineLink from "/components/InlineLink";

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import { withStyles } from "material-ui/styles";
-import Card, { CardContent } from "material-ui/Card";
-import Divider from "material-ui/Divider";
-import Grid from "material-ui/Grid";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Divider from "@material-ui/core/Divider";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
 import { statusCodeToId } from "/utils/checkStatus";
 import CardHighlight from "/components/CardHighlight";
 import Dictionary, {

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -1,10 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Card, { CardContent } from "material-ui/Card";
-import Divider from "material-ui/Divider";
-import Typography from "material-ui/Typography";
-import Grid from "material-ui/Grid";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Divider from "@material-ui/core/Divider";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
 import { statusCodeToId } from "/utils/checkStatus";
 import Dictionary, {
   DictionaryKey,

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Grid from "material-ui/Grid";
+import Grid from "@material-ui/core/Grid";
 
 import Loader from "/components/util/Loader";
 
@@ -92,7 +92,7 @@ class EventDetailsContainer extends React.PureComponent {
               </ButtonSet>
             </Content>
             <Content>
-              <Grid container>
+              <Grid container spacing={16}>
                 <Grid item xs={12}>
                   <CheckResult check={event.check} entity={event.entity} />
                 </Grid>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsDeleteAction.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsDeleteAction.js
@@ -2,13 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import { withRouter } from "react-router-dom";
-import Button from "material-ui/Button";
-import Typography from "material-ui/Typography";
-import Dialog, {
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-} from "material-ui/Dialog";
+import Button from "@material-ui/core/Button";
+import Typography from "@material-ui/core/Typography";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
 import ButtonSet from "/components/ButtonSet";
 import deleteEvent from "/mutations/deleteEvent";
 

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsResolveAction.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsResolveAction.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Button from "material-ui/Button";
+import Button from "@material-ui/core/Button";
 import resolveEvent from "/mutations/resolveEvent";
 
 class EventDetailsResolveAction extends React.PureComponent {

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Card, { CardContent } from "material-ui/Card";
-import Typography from "material-ui/Typography";
-import Divider from "material-ui/Divider";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import Divider from "@material-ui/core/Divider";
 import Dictionary, {
   DictionaryKey,
   DictionaryValue,

--- a/dashboard/src/components/partials/RelatedEntitiesCard/RelatedEntitiesCard.js
+++ b/dashboard/src/components/partials/RelatedEntitiesCard/RelatedEntitiesCard.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import Card, { CardContent } from "material-ui/Card";
-import Typography from "material-ui/Typography";
-import List from "material-ui/List";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import List from "@material-ui/core/List";
 import RelativeDate from "/components/RelativeDate";
 import StatusIcon from "/components/CheckStatusIcon";
 import InlineLink from "/components/InlineLink";

--- a/dashboard/src/components/partials/SilenceEntryDialog.js
+++ b/dashboard/src/components/partials/SilenceEntryDialog.js
@@ -1,15 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Button from "material-ui/Button";
-import Dialog, {
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  withMobileDialog,
-} from "material-ui/Dialog";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import withMobileDialog from "@material-ui/core/withMobileDialog";
 
 import Loader from "/components/util/Loader";
 

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormCheckPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormCheckPanel.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Field } from "@10xjs/form";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Typography from "material-ui/Typography";
-import TextField from "material-ui/TextField";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
 
 import Panel from "./SilenceEntryFormPanel";
 

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormExpirationPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormExpirationPanel.js
@@ -3,11 +3,12 @@ import PropTypes from "prop-types";
 import { compose } from "recompose";
 import { withField } from "@10xjs/form";
 
-import { FormControl, FormControlLabel } from "material-ui/Form";
-import TextField from "material-ui/TextField";
-import Switch from "material-ui/Switch";
-import { InputAdornment } from "material-ui/Input";
-import Typography from "material-ui/Typography";
+import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import TextField from "@material-ui/core/TextField";
+import Switch from "@material-ui/core/Switch";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import Typography from "@material-ui/core/Typography";
 
 import Panel from "./SilenceEntryFormPanel";
 

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormPanel.js
@@ -1,16 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-
-import Grid from "material-ui/Grid";
-
-import ExpansionPanel, {
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-} from "material-ui/ExpansionPanel";
-import Typography from "material-ui/Typography";
-
-import ExpandMoreIcon from "material-ui-icons/ExpandMore";
+import { withStyles } from "@material-ui/core/styles";
+import Grid from "@material-ui/core/Grid";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import Typography from "@material-ui/core/Typography";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
 const StyledExpansionPanelSummary = withStyles(() => ({
   content: { maxWidth: "100%" },

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormReasonPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormReasonPanel.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { Field } from "@10xjs/form";
 
-import Typography from "material-ui/Typography";
-import TextField from "material-ui/TextField";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
 
 import Panel from "./SilenceEntryFormPanel";
 

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormSchedulePanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormSchedulePanel.js
@@ -1,13 +1,14 @@
 import React from "react";
 import { Field } from "@10xjs/form";
 import DateInputController from "@10xjs/date-input-controller";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import { FormControl, FormControlLabel } from "material-ui/Form";
-import Switch from "material-ui/Switch";
-import Typography from "material-ui/Typography";
-import Select from "material-ui/Select";
-import { InputLabel } from "material-ui/Input";
+import FormControl from "@material-ui/core/FormControl";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Switch from "@material-ui/core/Switch";
+import Typography from "@material-ui/core/Typography";
+import Select from "@material-ui/core/Select";
+import InputLabel from "@material-ui/core/InputLabel";
 
 import {
   getMonthName,

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormSubscriptionPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormSubscriptionPanel.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { Field } from "@10xjs/form";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
-import Typography from "material-ui/Typography";
-import TextField from "material-ui/TextField";
+import Typography from "@material-ui/core/Typography";
+import TextField from "@material-ui/core/TextField";
 
 import Code from "/components/Code";
 

--- a/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormTargetsPanel.js
+++ b/dashboard/src/components/partials/SilenceEntryForm/SilenceEntryFormTargetsPanel.js
@@ -1,12 +1,11 @@
 import React from "react";
 import { Field } from "@10xjs/form";
 
-import Table, {
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-} from "material-ui/Table";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
 
 import Panel from "./SilenceEntryFormPanel";
 

--- a/dashboard/src/components/partials/StatusMenu.js
+++ b/dashboard/src/components/partials/StatusMenu.js
@@ -1,8 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { MenuItem } from "material-ui/Menu";
-import { ListItemText, ListItemIcon } from "material-ui/List";
+import MenuItem from "@material-ui/core/MenuItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
 
 import CheckStatusIcon from "/components/CheckStatusIcon";
 import { TableListSelect } from "/components/TableList";

--- a/dashboard/src/components/util/Loader.js
+++ b/dashboard/src/components/util/Loader.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import ResizeObserver from "react-resize-observer";
 import { Motion, spring, presets } from "react-motion";
 import classnames from "classnames";

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -2,8 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
-import Paper from "material-ui/Paper";
-import Button from "material-ui/Button";
+import Paper from "@material-ui/core/Paper";
+import Button from "@material-ui/core/Button";
 
 import AppContent from "/components/AppContent";
 import CheckList from "/components/CheckList";

--- a/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
@@ -2,8 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
 
 import Content from "/components/Content";
 import AppContent from "/components/AppContent";

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import { Query } from "react-apollo";
 import gql from "graphql-tag";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
-import Button from "material-ui/Button";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
 
 import AppContent from "/components/AppContent";
 import EventsContainer from "/components/EventsContainer";

--- a/dashboard/src/components/views/LoginView.js
+++ b/dashboard/src/components/views/LoginView.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 import { compose } from "recompose";
 import { withApollo } from "react-apollo";
 
-import Paper from "material-ui/Paper";
-import Button from "material-ui/Button";
-import TextField from "material-ui/TextField";
-import Typography from "material-ui/Typography";
+import Paper from "@material-ui/core/Paper";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
 
 import { when } from "/utils/promise";
 import { UnauthorizedError } from "/errors/FetchError";

--- a/dashboard/src/components/views/NotFoundView.js
+++ b/dashboard/src/components/views/NotFoundView.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-import Typography from "material-ui/Typography";
-import Grid from "material-ui/Grid";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
 
 const styles = theme => ({
   root: {

--- a/dashboard/src/icons/Briefcase.js
+++ b/dashboard/src/icons/Briefcase.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/Donut.js
+++ b/dashboard/src/icons/Donut.js
@@ -1,5 +1,5 @@
 import React from "react";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.PureComponent {
   render() {

--- a/dashboard/src/icons/ErrorHollow.js
+++ b/dashboard/src/icons/ErrorHollow.js
@@ -1,5 +1,5 @@
 import React from "react";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.PureComponent {
   render() {

--- a/dashboard/src/icons/Espresso.js
+++ b/dashboard/src/icons/Espresso.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/HalfHeart.js
+++ b/dashboard/src/icons/HalfHeart.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { pure } from "recompose";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/Heart.js
+++ b/dashboard/src/icons/Heart.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/HeartMug.js
+++ b/dashboard/src/icons/HeartMug.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/Hot.js
+++ b/dashboard/src/icons/Hot.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-import SvgIcon from "material-ui/SvgIcon";
+import { withStyles } from "@material-ui/core/styles";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 const styles = {
   root: {

--- a/dashboard/src/icons/Poly.js
+++ b/dashboard/src/icons/Poly.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.Component {
   render() {

--- a/dashboard/src/icons/SensuLogoGraphic.js
+++ b/dashboard/src/icons/SensuLogoGraphic.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 import { pure } from "recompose";
 
 class Icon extends React.Component {

--- a/dashboard/src/icons/SensuWordmark.js
+++ b/dashboard/src/icons/SensuWordmark.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { compose, pure } from "recompose";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 import classnames from "classnames";
-import { withStyles } from "material-ui/styles";
+import { withStyles } from "@material-ui/core/styles";
 
 class Icon extends React.Component {
   static propTypes = {

--- a/dashboard/src/icons/SmallCheck.js
+++ b/dashboard/src/icons/SmallCheck.js
@@ -1,5 +1,5 @@
 import React from "react";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.PureComponent {
   render() {

--- a/dashboard/src/icons/Wand.js
+++ b/dashboard/src/icons/Wand.js
@@ -1,6 +1,6 @@
 import React from "react";
 import pure from "recompose/pure";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 const Icon = props => (
   <SvgIcon {...props}>

--- a/dashboard/src/icons/WarnHollow.js
+++ b/dashboard/src/icons/WarnHollow.js
@@ -1,5 +1,5 @@
 import React from "react";
-import SvgIcon from "material-ui/SvgIcon";
+import SvgIcon from "@material-ui/core/SvgIcon";
 
 class Icon extends React.PureComponent {
   render() {

--- a/dashboard/src/themes/createTheme.js
+++ b/dashboard/src/themes/createTheme.js
@@ -1,7 +1,7 @@
 import deepmerge from "deepmerge";
-import createMuiTheme from "material-ui/styles/createMuiTheme";
-import createPalette from "material-ui/styles/createPalette";
-import createTypography from "material-ui/styles/createTypography";
+import createMuiTheme from "@material-ui/core/styles/createMuiTheme";
+import createPalette from "@material-ui/core/styles/createPalette";
+import createTypography from "@material-ui/core/styles/createTypography";
 
 import defaults from "./defaults";
 

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -110,6 +110,44 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@material-ui/core@^1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-1.0.0-rc.1.tgz#71a0b98c5698a4631114678eaec2d28b7d04c369"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.42"
+    "@types/jss" "^9.5.3"
+    "@types/react-transition-group" "^2.0.8"
+    brcast "^3.0.1"
+    classnames "^2.2.5"
+    deepmerge "^2.0.1"
+    dom-helpers "^3.2.1"
+    hoist-non-react-statics "^2.5.0"
+    jss "^9.3.3"
+    jss-camel-case "^6.0.0"
+    jss-default-unit "^8.0.2"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-vendor-prefixer "^7.0.0"
+    keycode "^2.1.9"
+    lodash "^4.2.0"
+    normalize-scroll-left "^0.1.2"
+    prop-types "^15.6.0"
+    react-event-listener "^0.5.1"
+    react-jss "^8.1.0"
+    react-popper "^0.10.0"
+    react-scrollbar-size "^2.0.2"
+    react-transition-group "^2.2.1"
+    recompose "^0.26.0 || ^0.27.0"
+    scroll "^2.0.3"
+    warning "^3.0.0"
+
+"@material-ui/icons@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-1.0.0-rc.0.tgz#1c836832183d509eaac9df42aa31dbbe4dd337cb"
+  dependencies:
+    recompose "^0.26.0 || ^0.27.0"
+
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -118,7 +156,7 @@
   version "0.12.6"
   resolved "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz#3d619198585fcabe5f4e1adfb5cf5f3388c66c13"
 
-"@types/jss@^9.3.0":
+"@types/jss@^9.5.3":
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.3.tgz#0c106de3fe0b324cd4173fac7dab26c12cda624e"
   dependencies:
@@ -4979,45 +5017,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-material-ui-icons@^1.0.0-beta.36:
-  version "1.0.0-beta.36"
-  resolved "https://registry.yarnpkg.com/material-ui-icons/-/material-ui-icons-1.0.0-beta.36.tgz#86390a61f4c83f718eaba77ccce575834f2cf2a8"
-  dependencies:
-    recompose "^0.26.0"
-
-material-ui@^1.0.0-beta.36:
-  version "1.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.47.tgz#5deb97dc3e694299992d3c3cacb44051f8bc2166"
-  dependencies:
-    "@babel/runtime" "^7.0.0-beta.42"
-    "@types/jss" "^9.3.0"
-    "@types/react-transition-group" "^2.0.8"
-    brcast "^3.0.1"
-    classnames "^2.2.5"
-    deepmerge "^2.0.1"
-    dom-helpers "^3.2.1"
-    hoist-non-react-statics "^2.5.0"
-    jss "^9.3.3"
-    jss-camel-case "^6.0.0"
-    jss-default-unit "^8.0.2"
-    jss-global "^3.0.0"
-    jss-nested "^6.0.1"
-    jss-props-sort "^6.0.0"
-    jss-vendor-prefixer "^7.0.0"
-    keycode "^2.1.9"
-    lodash "^4.2.0"
-    normalize-scroll-left "^0.1.2"
-    prop-types "^15.6.0"
-    react-event-listener "^0.5.1"
-    react-jss "^8.1.0"
-    react-lifecycles-compat "^3.0.0"
-    react-popper "^0.10.0"
-    react-scrollbar-size "^2.0.2"
-    react-transition-group "^2.2.1"
-    recompose "^0.26.0 || ^0.27.0"
-    scroll "^2.0.3"
-    warning "^3.0.0"
-
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
@@ -6135,7 +6134,7 @@ react-jss@^8.1.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -6289,15 +6288,6 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
-
-recompose@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
-  dependencies:
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    symbol-observable "^1.0.4"
 
 "recompose@^0.26.0 || ^0.27.0", recompose@^0.27.0:
   version "0.27.0"


### PR DESCRIPTION
## What is this change?

The dependency was previously updated along with our recent build changes but none of the breaking changes were not addressed, this lead to some (relatively minor) issues.

https://github.com/mui-org/material-ui/releases
https://github.com/mui-org/material-ui/compare/v1.0.0-beta.37...v1.0.0-rc.1

## Why is this change necessary?

Content is borked.

## Does your change need a Changelog entry?

Unlikely

## Do you need clarification on anything?

nada

## Were there any complications while making this change?

`material-ui` moved to `@material-ui/core`.

mui-org/material-ui#11310
mui-org/material-ui#11330