### PR TITLE
Don't allow unknown fields when creating resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ prior to assuming the existence of said check.
 - Add logging around the Sensu event pipeline.
 - Migrated the InfluxDB handler from the sensu-go repository to
 github.com/nikkiki/sensu-influxdb-handler
+- Don't allow unknown fields in types that do not support custom attributes
+when creating resources with `sensuctl create`.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -37,7 +38,9 @@ func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	if wrapper.Value == nil {
 		return fmt.Errorf("no spec provided")
 	}
-	if err := json.Unmarshal(*wrapper.Value, &resource); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(*wrapper.Value))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&resource); err != nil {
 		return err
 	}
 	w.Value = resource

--- a/types/wrapper_test.go
+++ b/types/wrapper_test.go
@@ -1,0 +1,98 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+var null = json.RawMessage("null")
+
+type generic map[string]*json.RawMessage
+
+func (g generic) URIPath() string {
+	return ""
+}
+
+func (g generic) Validate() error {
+	return nil
+}
+
+func addExtendedAttrToWrapped(t *testing.T, wrapped Wrapper) []byte {
+	t.Helper()
+
+	b := mustMarshal(t, wrapped.Value)
+	generic := make(generic)
+	if err := json.Unmarshal(b, &generic); err != nil {
+		t.Fatal(err)
+	}
+	generic["unknown"] = &null
+
+	return mustMarshal(t, Wrapper{Type: wrapped.Type, Value: generic})
+}
+
+func mustMarshal(t *testing.T, value interface{}) []byte {
+	t.Helper()
+
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return b
+}
+
+func TestUnmarshalBody(t *testing.T) {
+	var (
+		wrappedAsset = Wrapper{Type: "Asset", Value: FixtureAsset("bar")}
+		wrappedCheck = Wrapper{Type: "Check", Value: FixtureCheck("barbaz")}
+	)
+
+	wrappedAssetB := mustMarshal(t, wrappedAsset)
+	wrappedCheckB := mustMarshal(t, wrappedCheck)
+
+	badWrappedAssetB := addExtendedAttrToWrapped(t, wrappedAsset)
+	goodWrappedCheckB := addExtendedAttrToWrapped(t, wrappedCheck)
+
+	tests := []struct {
+		Name   string
+		Body   []byte
+		Value  interface{}
+		ExpErr bool
+	}{
+		{
+			Name:  "wrapped regular type, no extras",
+			Body:  wrappedAssetB,
+			Value: &wrappedAsset,
+		},
+		{
+			Name:  "wrapped extended attributes type, no extras",
+			Body:  wrappedCheckB,
+			Value: &wrappedCheck,
+		},
+		{
+			Name:   "wrapped type with extras",
+			Body:   badWrappedAssetB,
+			Value:  &wrappedAsset,
+			ExpErr: true,
+		},
+		{
+			Name:  "wrapped extended attributes type, with extras",
+			Body:  goodWrappedCheckB,
+			Value: &wrappedCheck,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := json.Unmarshal(test.Body, test.Value)
+			if err != nil && !test.ExpErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ExpErr {
+				t.Fatal("expected an error")
+				fmt.Println(string(test.Body))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit disallows unknown fields in types that do not support
extended attributes, when the types are created with the
`sensuctl create` command. Types that do support extended
attributes will function as before when created with this command.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1480 