### PR TITLE
Wipe all artifacts when clean task is invoked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,9 @@ default: all
 all: linux
 
 clean:
-	git clean -dXf .
+	rm -rf out/
+	rm -rf target/
+	git clean -dXf dashboard
 
 ##
 # Operating system targets

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,7 @@ default: all
 all: linux
 
 clean:
-	rm -rf out/
-	rm -rf dashboard/node_modules/
-	rm -rf target/
+	git clean -dXf .
 
 ##
 # Operating system targets


### PR DESCRIPTION
## What is this change?

I suspect that nightly builds are failing because the packaging phase is
being run with a different user. By wiping /all/ artifacts before
continuing we ensure that the next step never writes / deletes a file
they do not have access to.

## Why is this change necessary?

Docker images for nightlies fail to deploy.

## Does your change need a Changelog entry?

maybe?

## Do you need clarification on anything?

nada

## Were there any complications while making this change?

Using Docker for /all the things/ would probably avoid this problem in the first place.