### PR TITLE
Add the wrapped-json format to sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ prior to assuming the existence of said check.
 - Additional logging around handlers
 - Accept additional time formats in sensuctl
 - Entities can now be created via sensuctl.
+- Added the format `wrapped-json` to sensuctl `configure`, `list` and `info`
+commands, which is compatible with `sensuctl create`.
 
 ### Changed
 - Add logging around the Sensu event pipeline.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -3,10 +3,10 @@ package cli
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/client/config/basic"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "github.com/sensu/sensu-go/types"
+import (
+	"github.com/sensu/sensu-go/types"
+)
 
 const (
 	// DefaultEnvironment represents the default environment
@@ -9,6 +11,12 @@ const (
 	DefaultFormat = "tabular"
 	// DefaultOrganization represents the default organization
 	DefaultOrganization = "default"
+	// FormatTabular represents the string for tabular format
+	FormatTabular = "tabular"
+	// FormatJSON represents the string for JSON format
+	FormatJSON = "json"
+	// FormatWrappedJSON represents the string for wrapped JSON format
+	FormatWrappedJSON = "wrapped-json"
 )
 
 // Config represents an abstracted configuration

--- a/cli/commands/asset/info.go
+++ b/cli/commands/asset/info.go
@@ -2,6 +2,7 @@ package asset
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -32,15 +33,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printAssetToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -49,7 +44,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printAssetToList(r *types.Asset, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	r, ok := v.(*types.Asset)
+	if !ok {
+		return fmt.Errorf("%t is not an Asset", v)
+	}
 	var metadata []string
 	for k, v := range r.Metadata {
 		metadata = append(metadata, k+"="+v)

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -38,7 +38,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/check/info.go
+++ b/cli/commands/check/info.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -34,15 +35,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printCheckToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -51,7 +46,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printCheckToList(r *types.CheckConfig, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	r, ok := v.(*types.CheckConfig)
+	if !ok {
+		return fmt.Errorf("%t is not a CheckConfig", v)
+	}
 	cfg := &list.Config{
 		Title: r.Name,
 		Rows: []*list.Row{

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -38,7 +38,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -192,7 +192,7 @@ func askForDefaultFormat(c config.Config) *survey.Question {
 		Name: "format",
 		Prompt: &survey.Select{
 			Message: "Preferred output format:",
-			Options: []string{"none", "json"},
+			Options: []string{"none", config.FormatJSON, config.FormatWrappedJSON},
 			Default: format,
 		},
 	}

--- a/cli/commands/entity/info.go
+++ b/cli/commands/entity/info.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -34,15 +35,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printEntityToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -51,7 +46,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printEntityToList(r *types.Entity, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	r, ok := v.(*types.Entity)
+	if !ok {
+		return fmt.Errorf("%t is not an Entity", v)
+	}
 	cfg := &list.Config{
 		Title: r.ID,
 		Rows: []*list.Row{

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -37,7 +37,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/environment/list.go
+++ b/cli/commands/environment/list.go
@@ -35,7 +35,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/event/info.go
+++ b/cli/commands/event/info.go
@@ -36,15 +36,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(event, cmd.OutOrStdout())
-			}
-			return printEntityToList(event, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, event, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -53,7 +47,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printEntityToList(event *types.Event, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	event, ok := v.(*types.Event)
+	if !ok {
+		return fmt.Errorf("%t is not an Event", v)
+	}
 	statusHistory := []string{}
 	for _, entry := range event.Check.History {
 		statusHistory = append(statusHistory, fmt.Sprint(entry.Status))

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -38,7 +38,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -16,14 +16,16 @@ import (
 )
 
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "list extensions",
-		RunE:  runList(cli.Client, cli.Config.Organization(), cli.Config.Format()),
+		RunE:  runList(cli.Config.Format(), cli.Client, cli.Config.Organization(), cli.Config.Format()),
 	}
+	helpers.AddFormatFlag(cmd.Flags())
+	return cmd
 }
 
-func runList(client client.APIClient, org, format string) func(*cobra.Command, []string) error {
+func runList(config string, client client.APIClient, org, format string) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			_ = cmd.Help()
@@ -34,7 +36,12 @@ func runList(client client.APIClient, org, format string) func(*cobra.Command, [
 			return err
 		}
 
-		return helpers.Print(cmd, format, printToTable, extensions)
+		// Print the results based on the user preferences
+		resources := []types.Resource{}
+		for i := range extensions {
+			resources = append(resources, &extensions[i])
+		}
+		return helpers.Print(cmd, config, printToTable, resources, extensions)
 	}
 }
 

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -36,7 +36,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/handler/info.go
+++ b/cli/commands/handler/info.go
@@ -35,15 +35,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printCheckToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -52,7 +46,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printCheckToList(handler *types.Handler, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	handler, ok := v.(*types.Handler)
+	if !ok {
+		return fmt.Errorf("%t is not a Handler", v)
+	}
 	// Determine what will be executed based on the type
 	var execute string
 	switch handler.Type {

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -38,7 +38,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/helpers/flags.go
+++ b/cli/commands/helpers/flags.go
@@ -16,7 +16,7 @@ var commaWhitespaceRegex *regexp.Regexp
 // configuration the user's configured default format is used as the flag's
 // default value.
 func AddFormatFlag(flagSet *pflag.FlagSet) {
-	flagSet.String("format", config.DefaultFormat, `format of data returned ("json"|"tabular")`)
+	flagSet.String("format", config.DefaultFormat, `format of data returned ("json"|config.FormatTabular)`)
 }
 
 // AddAllOrganization adds the '--all-organizations' flag to the given command

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 
 	"github.com/sensu/sensu-go/cli/client/config"
@@ -32,18 +31,12 @@ func PrintJSON(r interface{}, io io.Writer) error {
 	return err
 }
 
-// PrintWrappedJSON takes a record(s) and an io.Writer, converts the record to
+// PrintWrappedJSON takes a record(s) and Resource, converts the record to
 // human-readable JSON (pretty-prints), wraps that JSON using types.Wrapper, and
 // then prints the result to the given writer. Unescapes any &, <, or >
 // characters it finds.
-func PrintWrappedJSON(r types.Resource, io io.Writer) error {
-	v := reflect.ValueOf(r)
-	i := reflect.Indirect(v)
-	t := i.Type()
-	w := types.Wrapper{
-		Type:  t.Name(),
-		Value: r,
-	}
+func PrintWrappedJSON(r types.Resource, wr io.Writer) error {
+	w := types.WrapResource(r)
 
 	buf := new(bytes.Buffer)
 	encoder := json.NewEncoder(buf)
@@ -55,14 +48,14 @@ func PrintWrappedJSON(r types.Resource, io io.Writer) error {
 	}
 
 	s := htmlReplacer.Replace(buf.String())
-	_, err := fmt.Fprint(io, s)
+	_, err := fmt.Fprint(wr, s)
 	return err
 }
 
-// PrintWrappedJSONList takes a record(s) and an io.Writer, converts the record to
-// human-readable JSON (pretty-prints), wraps that JSON using types.Wrapper, and
-// then prints the result to the given writer. Unescapes any &, <, or >
-// characters it finds.
+// PrintWrappedJSONList takes a resource list and an io.Writer, converts the
+// record to human-readable JSON (pretty-prints), wraps that JSON using
+// types.Wrapper, and then prints the result to the given writer. Unescapes
+// any &, <, or > characters it finds.
 func PrintWrappedJSONList(r []types.Resource, io io.Writer) error {
 	for _, res := range r {
 		err := PrintWrappedJSON(res, io)

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -5,7 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
+
+	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/types"
 )
 
 var htmlReplacer = strings.NewReplacer(`\u0026`, "&", `\u003c`, "<", `\u003e`, ">")
@@ -26,4 +30,65 @@ func PrintJSON(r interface{}, io io.Writer) error {
 	s := htmlReplacer.Replace(buf.String())
 	_, err := fmt.Fprintln(io, s)
 	return err
+}
+
+// PrintWrappedJSON takes a record(s) and an io.Writer, converts the record to
+// human-readable JSON (pretty-prints), wraps that JSON using types.Wrapper, and
+// then prints the result to the given writer. Unescapes any &, <, or >
+// characters it finds.
+func PrintWrappedJSON(r types.Resource, io io.Writer) error {
+	v := reflect.ValueOf(r)
+	i := reflect.Indirect(v)
+	t := i.Type()
+	w := types.Wrapper{
+		Type:  t.Name(),
+		Value: r,
+	}
+
+	buf := new(bytes.Buffer)
+	encoder := json.NewEncoder(buf)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(w); err != nil {
+		return err
+	}
+
+	s := htmlReplacer.Replace(buf.String())
+	_, err := fmt.Fprint(io, s)
+	return err
+}
+
+// PrintWrappedJSONList takes a record(s) and an io.Writer, converts the record to
+// human-readable JSON (pretty-prints), wraps that JSON using types.Wrapper, and
+// then prints the result to the given writer. Unescapes any &, <, or >
+// characters it finds.
+func PrintWrappedJSONList(r []types.Resource, io io.Writer) error {
+	for _, res := range r {
+		err := PrintWrappedJSON(res, io)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PrintFormatted prints the provided interface in the specified format.
+// flag overrides the cli config format if set
+func PrintFormatted(flag string, format string, v interface{}, w io.Writer, printToList func(interface{}, io.Writer) error) error {
+	if flag != "" {
+		format = flag
+	}
+	switch format {
+	case config.FormatJSON:
+		return PrintJSON(v, w)
+	case config.FormatWrappedJSON:
+		r, ok := v.(types.Resource)
+		if !ok {
+			return fmt.Errorf("%t is not a Resource", v)
+		}
+		return PrintWrappedJSON(r, w)
+	default:
+		return printToList(v, w)
+	}
 }

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -2,9 +2,14 @@ package helpers
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
+	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/cli/elements/list"
+	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,4 +26,112 @@ func TestPrintJSON(t *testing.T) {
 	writer := io.Writer(buf)
 	require.NoError(t, PrintJSON(testInput, writer))
 	assert.Equal("{\n  \"commandAnd\": \"echo bar && exit 1\",\n  \"commandLessThan\": \"echo foo >> output.txt\"\n}\n\n", buf.String())
+}
+
+func TestPrintWrappedJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	check := types.FixtureCheckConfig("check")
+	check.Command = "echo foo >> output.txt"
+
+	w := types.Wrapper{
+		Type:  "CheckConfig",
+		Value: check,
+	}
+	output, err := json.Marshal(w)
+	assert.NoError(err)
+
+	buf := new(bytes.Buffer)
+	writer := io.Writer(buf)
+	require.NoError(t, PrintWrappedJSON(check, writer))
+	assert.JSONEq(string(output), buf.String())
+}
+
+func TestPrintWrappedJSONList(t *testing.T) {
+	assert := assert.New(t)
+
+	check1 := types.FixtureCheckConfig("check1")
+	check2 := types.FixtureCheckConfig("check2")
+
+	w1 := types.Wrapper{
+		Type:  "CheckConfig",
+		Value: check1,
+	}
+	w2 := types.Wrapper{
+		Type:  "CheckConfig",
+		Value: check2,
+	}
+	output1, err := json.Marshal(w1)
+	assert.NoError(err)
+	output2, err := json.Marshal(w2)
+	assert.NoError(err)
+
+	buf := new(bytes.Buffer)
+	writer := io.Writer(buf)
+
+	require.NoError(t, PrintWrappedJSONList([]types.Resource{check1, check2}, writer))
+	// trim \n and white space for equal comparison
+	output3 := strings.Replace(buf.String(), "\n", "", -1)
+	output3 = strings.Replace(output3, " ", "", -1)
+	assert.Equal(string(output1)+string(output2), output3)
+}
+
+func TestPrintFormatted(t *testing.T) {
+	assert := assert.New(t)
+
+	check := types.FixtureCheckConfig("check")
+
+	w := types.Wrapper{
+		Type:  "CheckConfig",
+		Value: check,
+	}
+
+	// test wrapped-json format
+	output, err := json.Marshal(w)
+	assert.NoError(err)
+
+	buf := new(bytes.Buffer)
+	writer := io.Writer(buf)
+
+	require.NoError(t, PrintFormatted("", config.FormatWrappedJSON, check, writer, printToList))
+	assert.JSONEq(string(output), buf.String())
+
+	// test json format
+	output, err = json.Marshal(check)
+	assert.NoError(err)
+
+	buf = new(bytes.Buffer)
+	writer = io.Writer(buf)
+
+	require.NoError(t, PrintFormatted("", config.FormatJSON, check, writer, printToList))
+	assert.JSONEq(string(output), buf.String())
+
+	// test tabular format
+	buf = new(bytes.Buffer)
+	writer = io.Writer(buf)
+
+	require.NoError(t, PrintFormatted("", config.FormatTabular, check, writer, printToList))
+	assert.Equal("=== \n", buf.String()) // empty table
+
+	// test default format
+	buf = new(bytes.Buffer)
+	writer = io.Writer(buf)
+
+	require.NoError(t, PrintFormatted("none", config.DefaultFormat, check, writer, printToList))
+	assert.Equal("=== \n", buf.String()) // empty table
+
+	// test flag override (json format)
+	output, err = json.Marshal(check)
+	assert.NoError(err)
+
+	buf = new(bytes.Buffer)
+	writer = io.Writer(buf)
+
+	require.NoError(t, PrintFormatted(config.FormatJSON, config.FormatWrappedJSON, check, writer, printToList))
+	assert.JSONEq(string(output), buf.String())
+}
+
+func printToList(v interface{}, writer io.Writer) error {
+	cfg := &list.Config{}
+	return list.Print(writer, cfg)
 }

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -67,10 +67,10 @@ func TestPrintWrappedJSONList(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	require.NoError(t, PrintWrappedJSONList([]types.Resource{check1, check2}, buf))
-	// trim \n and white space for equal comparison
-	output3 := strings.Replace(buf.String(), "\n", "", -1)
-	output3 = strings.Replace(output3, " ", "", -1)
-	assert.Equal(string(output1)+string(output2), output3)
+	// compare each string individually
+	output3 := strings.Split(buf.String(), "}\n{")
+	assert.JSONEq(string(output1), output3[0]+"}")
+	assert.JSONEq(string(output2), "{"+output3[1])
 }
 
 func TestPrintFormatted(t *testing.T) {

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -23,8 +23,7 @@ func TestPrintJSON(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	writer := io.Writer(buf)
-	require.NoError(t, PrintJSON(testInput, writer))
+	require.NoError(t, PrintJSON(testInput, buf))
 	assert.Equal("{\n  \"commandAnd\": \"echo bar && exit 1\",\n  \"commandLessThan\": \"echo foo >> output.txt\"\n}\n\n", buf.String())
 }
 
@@ -42,8 +41,7 @@ func TestPrintWrappedJSON(t *testing.T) {
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
-	writer := io.Writer(buf)
-	require.NoError(t, PrintWrappedJSON(check, writer))
+	require.NoError(t, PrintWrappedJSON(check, buf))
 	assert.JSONEq(string(output), buf.String())
 }
 
@@ -67,9 +65,8 @@ func TestPrintWrappedJSONList(t *testing.T) {
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
-	writer := io.Writer(buf)
 
-	require.NoError(t, PrintWrappedJSONList([]types.Resource{check1, check2}, writer))
+	require.NoError(t, PrintWrappedJSONList([]types.Resource{check1, check2}, buf))
 	// trim \n and white space for equal comparison
 	output3 := strings.Replace(buf.String(), "\n", "", -1)
 	output3 = strings.Replace(output3, " ", "", -1)
@@ -91,9 +88,8 @@ func TestPrintFormatted(t *testing.T) {
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
-	writer := io.Writer(buf)
 
-	require.NoError(t, PrintFormatted("", config.FormatWrappedJSON, check, writer, printToList))
+	require.NoError(t, PrintFormatted("", config.FormatWrappedJSON, check, buf, printToList))
 	assert.JSONEq(string(output), buf.String())
 
 	// test json format
@@ -101,23 +97,20 @@ func TestPrintFormatted(t *testing.T) {
 	assert.NoError(err)
 
 	buf = new(bytes.Buffer)
-	writer = io.Writer(buf)
 
-	require.NoError(t, PrintFormatted("", config.FormatJSON, check, writer, printToList))
+	require.NoError(t, PrintFormatted("", config.FormatJSON, check, buf, printToList))
 	assert.JSONEq(string(output), buf.String())
 
 	// test tabular format
 	buf = new(bytes.Buffer)
-	writer = io.Writer(buf)
 
-	require.NoError(t, PrintFormatted("", config.FormatTabular, check, writer, printToList))
+	require.NoError(t, PrintFormatted("", config.FormatTabular, check, buf, printToList))
 	assert.Equal("=== \n", buf.String()) // empty table
 
 	// test default format
 	buf = new(bytes.Buffer)
-	writer = io.Writer(buf)
 
-	require.NoError(t, PrintFormatted("none", config.DefaultFormat, check, writer, printToList))
+	require.NoError(t, PrintFormatted("none", config.DefaultFormat, check, buf, printToList))
 	assert.Equal("=== \n", buf.String()) // empty table
 
 	// test flag override (json format)
@@ -125,9 +118,8 @@ func TestPrintFormatted(t *testing.T) {
 	assert.NoError(err)
 
 	buf = new(bytes.Buffer)
-	writer = io.Writer(buf)
 
-	require.NoError(t, PrintFormatted(config.FormatJSON, config.FormatWrappedJSON, check, writer, printToList))
+	require.NoError(t, PrintFormatted(config.FormatJSON, config.FormatWrappedJSON, check, buf, printToList))
 	assert.JSONEq(string(output), buf.String())
 }
 

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -3,24 +3,30 @@ package helpers
 import (
 	"io"
 
+	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
 type printTableFunc func(interface{}, io.Writer)
 
 // Print displays
-func Print(cmd *cobra.Command, format string, printTable printTableFunc, objects interface{}) error {
+func Print(cmd *cobra.Command, format string, printTable printTableFunc, objects []types.Resource, v interface{}) error {
 	if f := GetChangedStringValueFlag(flags.Format, cmd.Flags()); f != "" {
 		format = f
 	}
-
-	if format == "json" {
+	switch format {
+	case config.FormatJSON:
 		if err := PrintJSON(objects, cmd.OutOrStdout()); err != nil {
 			return err
 		}
-	} else {
-		printTable(objects, cmd.OutOrStdout())
+	case config.FormatWrappedJSON:
+		if err := PrintWrappedJSONList(objects, cmd.OutOrStdout()); err != nil {
+			return err
+		}
+	default:
+		printTable(v, cmd.OutOrStdout())
 	}
 
 	return nil

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -18,7 +18,7 @@ func Print(cmd *cobra.Command, format string, printTable printTableFunc, objects
 	}
 	switch format {
 	case config.FormatJSON:
-		if err := PrintJSON(objects, cmd.OutOrStdout()); err != nil {
+		if err := PrintJSON(v, cmd.OutOrStdout()); err != nil {
 			return err
 		}
 	case config.FormatWrappedJSON:

--- a/cli/commands/hook/info.go
+++ b/cli/commands/hook/info.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 
@@ -33,15 +34,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printHookToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -50,7 +45,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printHookToList(r *types.HookConfig, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	r, ok := v.(*types.HookConfig)
+	if !ok {
+		return fmt.Errorf("%t is not a HookConfig", v)
+	}
 	cfg := &list.Config{
 		Title: r.Name,
 		Rows: []*list.Row{

--- a/cli/commands/hook/list.go
+++ b/cli/commands/hook/list.go
@@ -36,7 +36,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -37,7 +37,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/organization/list.go
+++ b/cli/commands/organization/list.go
@@ -29,7 +29,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -29,7 +29,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printRolesToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 
@@ -38,7 +42,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
-func printRolesToTable(results interface{}, writer io.Writer) {
+func printToTable(results interface{}, writer io.Writer) {
 	table := table.New([]*table.Column{
 		{
 			Title:       "Name",

--- a/cli/commands/silenced/info.go
+++ b/cli/commands/silenced/info.go
@@ -35,15 +35,9 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Determine the format to use to output the data
-			var format string
-			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
-				format = cli.Config.Format()
-			}
-
-			if format == "json" {
-				return helpers.PrintJSON(r, cmd.OutOrStdout())
-			}
-			return printToList(r, cmd.OutOrStdout())
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
 		},
 	}
 
@@ -64,7 +58,11 @@ func expireTime(beginTS, expireSeconds int64) time.Duration {
 	return time.Duration(expireSeconds) * time.Second
 }
 
-func printToList(r *types.Silenced, writer io.Writer) error {
+func printToList(v interface{}, writer io.Writer) error {
+	r, ok := v.(*types.Silenced)
+	if !ok {
+		return fmt.Errorf("%t is not a Silenced", v)
+	}
 	cfg := &list.Config{
 		Title: r.ID,
 		Rows: []*list.Row{

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -47,7 +47,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -31,11 +31,8 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
-			for i := range results {
-				resources = append(resources, &results[i])
-			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			// User is not a Resource (does not implement URIPath()) so wrapped-json format is not supported
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, []types.Resource{}, results)
 		},
 	}
 

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -31,7 +31,11 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Print the results based on the user preferences
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, results)
+			resources := []types.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
 		},
 	}
 

--- a/testing/e2e/sensuctl_create_test.go
+++ b/testing/e2e/sensuctl_create_test.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSensuctlCreate(t *testing.T) {
+	t.Parallel()
+
+	// Start the backend
+	backend, cleanup := newBackend(t)
+	defer cleanup()
+
+	// Initializes sensuctl
+	sensuctl, cleanup := newSensuCtl(backend.HTTPURL, "default", "default", "admin", "P@ssw0rd!")
+	defer cleanup()
+
+	// Create a check named check1
+	check := types.FixtureCheckConfig("check1")
+	output, err := sensuctl.run("check", "create", "check1",
+		"--command", check.Command,
+		"--interval", strconv.FormatUint(uint64(check.Interval), 10),
+		"--organization", check.Organization,
+		"--environment", check.Environment,
+		"--subscriptions", strings.Join(check.Subscriptions, ","),
+	)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, output)
+
+	// Ensure the check has been created
+	output, err = sensuctl.run("check", "info", "check1")
+	assert.NoError(t, err)
+	c := types.CheckConfig{}
+	assert.NoError(t, json.Unmarshal(output, &c))
+	assert.Equal(t, check.Name, c.Name)
+
+	// Print the list of checks in wrapped-json format
+	output, err = sensuctl.run("check", "list", "--format", "wrapped-json")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, output)
+
+	// Write the wrapped-json list to a temp file called checks.json
+	file, cleanup := writeTempFile(t, output, "checks.json")
+	defer cleanup()
+
+	// Delete the check using sensuctl
+	_, err = sensuctl.run("check", "delete", "check1", "--skip-confirm")
+	assert.NoError(t, err)
+
+	// Ensure the check has been removed
+	output, err = sensuctl.run("check", "list")
+	assert.NoError(t, err)
+	checks := []types.CheckConfig{}
+	assert.NoError(t, json.Unmarshal(output, &checks))
+	assert.Equal(t, 0, len(checks))
+
+	// Use sensuctl create to read the wrapped-json from the file
+	_, err = sensuctl.run("create", "-f", file)
+	assert.NoError(t, err)
+
+	// Ensure the check has been created again
+	output, err = sensuctl.run("check", "list", "--format", "json")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, output)
+	checks = []types.CheckConfig{}
+	assert.NoError(t, json.Unmarshal(output, &checks))
+	assert.Equal(t, 1, len(checks))
+	assert.Equal(t, "check1", checks[0].Name)
+}

--- a/types/check.go
+++ b/types/check.go
@@ -407,6 +407,11 @@ func (c *Check) URIPath() string {
 	return fmt.Sprintf("/checks/%s", url.PathEscape(c.Name))
 }
 
+// URIPath returns the path component of a CheckConfig URI.
+func (c *CheckConfig) URIPath() string {
+	return fmt.Sprintf("/checks/%s", url.PathEscape(c.Name))
+}
+
 //
 // Sorting
 

--- a/types/extension.go
+++ b/types/extension.go
@@ -1,6 +1,10 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"net/url"
+)
 
 // Validate validates the extension.
 func (e *Extension) Validate() error {
@@ -14,6 +18,11 @@ func (e *Extension) Validate() error {
 		return errors.New("empty Organization")
 	}
 	return nil
+}
+
+// URIPath returns the path component of an Extension URI.
+func (e *Extension) URIPath() string {
+	return fmt.Sprintf("/extensions/%s", url.PathEscape(e.Name))
 }
 
 // FixtureExtension given a name returns a valid extension for use in tests

--- a/types/hook.go
+++ b/types/hook.go
@@ -60,6 +60,11 @@ func (c *HookConfig) Validate() error {
 	return nil
 }
 
+// URIPath returns the path component of a HookConfig URI.
+func (c *HookConfig) URIPath() string {
+	return fmt.Sprintf("/hooks/%s", url.PathEscape(c.Name))
+}
+
 // Validate returns an error if the check hook does not pass validation tests.
 func (h *HookList) Validate() error {
 	if h.Type == "" {

--- a/types/user.go
+++ b/types/user.go
@@ -3,7 +3,6 @@ package types
 import (
 	"errors"
 	fmt "fmt"
-	"net/url"
 )
 
 // FixtureUser returns a testing fixture for an Entity object.
@@ -22,11 +21,6 @@ func (u *User) Validate() error {
 	}
 
 	return nil
-}
-
-// URIPath returns the path component of a User URI.
-func (u *User) URIPath() string {
-	return fmt.Sprintf("/rbac/users/%s", url.PathEscape(u.Username))
 }
 
 // ValidatePassword returns an error if the entity is invalid.

--- a/types/user.go
+++ b/types/user.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	fmt "fmt"
+	"net/url"
 )
 
 // FixtureUser returns a testing fixture for an Entity object.
@@ -21,6 +22,11 @@ func (u *User) Validate() error {
 	}
 
 	return nil
+}
+
+// URIPath returns the path component of a User URI.
+func (u *User) URIPath() string {
+	return fmt.Sprintf("/rbac/users/%s", url.PathEscape(u.Username))
 }
 
 // ValidatePassword returns an error if the entity is invalid.

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 // Wrapper is a generic wrapper, with a type field for distinguishing its
@@ -45,4 +46,13 @@ func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	}
 	w.Value = resource
 	return nil
+}
+
+// WrapResource uses reflection on a Resource to wrap it in a Wrapper
+func WrapResource(r Resource) Wrapper {
+	name := reflect.Indirect(reflect.ValueOf(r)).Type().Name()
+	return Wrapper{
+		Type:  name,
+		Value: r,
+	}
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the format `wrapped-json` to sensuctl `configure`, `list` and `info`commands, which is compatible with `sensuctl create`.

## Why is this change necessary?

Closes #1221.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Yes, refactoring was required. And reflection is hard.