### PR TITLE
Fix an aliasing bug in ResolveResource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ commands
 - Fixed `sensuctl create -f` for `Event`
 - Added validation for asset SHA512 checksum, requiring that it be at least 128
 characters and therefore fixing a bug in sensuctl
+- Fixed a bug where only a single resource could be created with
+`sensuctl create` at a time.
 
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added

--- a/types/typemap.go
+++ b/types/typemap.go
@@ -2,7 +2,10 @@ package types
 
 // automatically generated file, do not edit!
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 // typeMap is used to dynamically look up data types from strings.
 var typeMap = map[string]interface{}{
@@ -96,9 +99,14 @@ func ResolveResource(name string) (Resource, error) {
 	if !ok {
 		return nil, fmt.Errorf("type could not be found: %q", name)
 	}
-	r, ok := t.(Resource)
-	if !ok {
+	if _, ok := t.(Resource); !ok {
 		return nil, fmt.Errorf("%q is not a Resource", name)
 	}
-	return r, nil
+	return newResource(t), nil
+}
+
+// Make a new Resource to avoid aliasing problems with ResolveResource.
+// don't use this function. no, seriously.
+func newResource(r interface{}) Resource {
+	return reflect.New(reflect.ValueOf(r).Elem().Type()).Interface().(Resource)
 }

--- a/types/typemap.tmpl
+++ b/types/typemap.tmpl
@@ -2,7 +2,10 @@ package types
 
 // automatically generated file, do not edit!
 
-import "fmt"
+import (
+  "fmt"
+  "reflect"
+)
 
 // typeMap is used to dynamically look up data types from strings.
 var typeMap = map[string]interface{}{ {{ range $index, $typename := .TypeNames }}
@@ -18,9 +21,14 @@ func ResolveResource(name string) (Resource, error) {
   if !ok {
     return nil, fmt.Errorf("type could not be found: %q", name)
   }
-  r, ok := t.(Resource)
-  if !ok {
+  if _, ok := t.(Resource); !ok {
     return nil, fmt.Errorf("%q is not a Resource", name)
   }
-  return r, nil
+  return newResource(t), nil
+}
+
+// Make a new Resource to avoid aliasing problems with ResolveResource.
+// don't use this function. no, seriously.
+func newResource(r interface{}) Resource {
+	return reflect.New(reflect.ValueOf(r).Elem().Type()).Interface().(Resource)
 }

--- a/types/typemap_test.go
+++ b/types/typemap_test.go
@@ -1,0 +1,24 @@
+package types
+
+import "testing"
+
+func TestResolveResource_GH1565(t *testing.T) {
+	v1, err := ResolveResource("Check")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := ResolveResource("Check")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c1, c2 := v1.(*Check), v2.(*Check)
+
+	if c1 == c2 {
+		t.Fatal("pointer values should differ")
+	}
+
+	if &c1.Subscriptions == &c2.Subscriptions {
+		t.Fatal("internal pointer values should differ")
+	}
+}


### PR DESCRIPTION
This commit fixes a bug where the same pointer is returned from
ResolveResource every time. This causes havoc with functions that
expect the value coming from ResolveResource to be a new resource
every time.

The effect of this was that unmarshalling tended to simply not work
properly.

This commit uses the reflect package to copy the type from the
type map, providing a new Resource with every invocation.

Signed-off-by: Eric Chlebek <eric@sensu.io>

Closes #1565

WIP, I'll add a test and a changelog entry to this PR on monday.