### PR TITLE
Make metric event logs more specific with additional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ github.com/nikkiki/sensu-influxdb-handler
   `github.com/sensu/sensu-go/cmd/sensu-backend`
 - Don't allow unknown fields in types that do not support custom attributes
 when creating resources with `sensuctl create`.
+- Provided additional context to metric event logs.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -27,10 +27,10 @@ func EventFields(event *types.Event) map[string]interface{} {
 
 	if event.HasMetrics() {
 		count := len(event.Metrics.Points)
-		fields["metric count"] = count
+		fields["metric_count"] = count
 		if count > 0 {
-			fields["first metric name"] = event.Metrics.Points[0].Name
-			fields["first metric value"] = event.Metrics.Points[0].Value
+			fields["first_metric_name"] = event.Metrics.Points[0].Name
+			fields["first_metric_value"] = event.Metrics.Points[0].Value
 		}
 	}
 

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -23,16 +23,15 @@ func EventFields(event *types.Event) map[string]interface{} {
 	// adding the check name
 	if event.HasCheck() {
 		fields["check"] = event.Check.Name
-	} else if event.HasMetrics() {
-		fields["metric"] = true
 	}
 
 	if event.HasMetrics() {
-		fields["metrics"] = true
-	}
-
-	if event.HasMetrics() {
-		fields["metrics"] = true
+		count := len(event.Metrics.Points)
+		fields["metric count"] = count
+		if count > 0 {
+			fields["first metric name"] = event.Metrics.Points[0].Name
+			fields["first metric value"] = event.Metrics.Points[0].Value
+		}
 	}
 
 	return fields


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Provides additional context to metric event logs included # of metrics and first metric.

## Why is this change necessary?

Metric event logs are vague.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.