### PR TITLE
[Web UI]  Create error display modal

### DIFF
--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -92,6 +92,16 @@ export default () => {
           ],
         },
         {
+          enforce: "pre",
+          test: /\.js$/,
+          include: path.resolve(root, "node_modules"),
+          exclude: [path.resolve(root, "node_modules/apollo-client")],
+          loader: require.resolve("source-map-loader"),
+          options: {
+            includeModulePaths: true,
+          },
+        },
+        {
           oneOf: [
             {
               test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],

--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -17,21 +17,13 @@ export default () => {
   const isDevelopment = process.env.NODE_ENV === "development";
   const isProduction = process.env.NODE_ENV === "production";
 
-  let devtool = false;
-
-  if (process.env.GENERATE_SOURCEMAP === "true") {
-    devtool = "source-map";
-  } else if (!isProduction) {
-    devtool = "cheap-module-source-map";
-  }
-
   const outputPath = path.resolve(root, "build");
 
   return {
     bail: true,
     mode: process.env.NODE_ENV,
 
-    devtool,
+    devtool: "source-map",
 
     entry: [path.resolve(root, "src/index.js")],
 
@@ -50,10 +42,9 @@ export default () => {
         ? "static/js/[name].[chunkhash:8].chunk.js"
         : "static/js/[name].chunk.js",
 
-      // Point sourcemap entries to original disk location (format as URL on Windows)
       devtoolModuleFilenameTemplate: ({ absoluteResourcePath }) =>
         path
-          .relative(path.resolve(root, "src"), absoluteResourcePath)
+          .relative(path.resolve(root), absoluteResourcePath)
           .replace(/\\/g, "/"),
     },
 

--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -7,6 +7,7 @@ import eslintFormatter from "react-dev-utils/eslintFormatter";
 import CaseSensitivePathsPlugin from "case-sensitive-paths-webpack-plugin";
 import CleanPlugin from "clean-webpack-plugin";
 import { StatsWriterPlugin } from "webpack-stats-plugin";
+import UglifyJsPlugin from "uglifyjs-webpack-plugin";
 
 export default () => {
   // Make sure any symlinks in the project folder are resolved:
@@ -58,6 +59,17 @@ export default () => {
 
     optimization: {
       splitChunks: { minChunks: 2 },
+      minimizer: [
+        new UglifyJsPlugin({
+          sourceMap: true,
+          uglifyOptions: {
+            // Disable function name minification in order to preserve class
+            // names. This makes tracking down bugs in production builds far
+            // more manageable.
+            keep_fnames: true,
+          },
+        }),
+      ],
     },
 
     resolve: {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,6 +7,10 @@
     "npm": ">= 5.2.0",
     "yarn": ">= 1.5.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sensu/sensu-go/"
+  },
   "scripts": {
     "prettier": "npx prettier --write '**/*.js'",
     "start": "node scripts serve",
@@ -74,6 +78,7 @@
     "glob": "^7.1.2",
     "graphql": "0.13.0",
     "graphql-config": "^2.0.1",
+    "git-rev-sync": "^1.12.0",
     "graphql-tag": "^2.9.2",
     "html-webpack-plugin": "^3.2.0",
     "http-proxy-middleware": "^0.18.0",
@@ -111,6 +116,7 @@
     "redux-thunk": "^2.2.0",
     "regenerator-runtime": "^0.11.1",
     "source-map-loader": "bryanforbes/source-map-loader#module-context",
+    "stacktrace-js": "^2.0.0",
     "sw-precache-webpack-plugin": "^0.11.5",
     "typeface-roboto": "^0.0.54",
     "uglifyjs-webpack-plugin": "^1.2.5",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -112,6 +112,7 @@
     "regenerator-runtime": "^0.11.1",
     "sw-precache-webpack-plugin": "^0.11.5",
     "typeface-roboto": "^0.0.54",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "url-loader": "^1.0.1",
     "url-search-params-polyfill": "^2.0.3",
     "value-loader": "^0.1.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -110,6 +110,7 @@
     "redux-freeze": "^0.1.5",
     "redux-thunk": "^2.2.0",
     "regenerator-runtime": "^0.11.1",
+    "source-map-loader": "bryanforbes/source-map-loader#module-context",
     "sw-precache-webpack-plugin": "^0.11.5",
     "typeface-roboto": "^0.0.54",
     "uglifyjs-webpack-plugin": "^1.2.5",

--- a/dashboard/src/.eslintrc
+++ b/dashboard/src/.eslintrc
@@ -1,4 +1,3 @@
 globals:
   __webpack_public_path__: false
   __non_webpack_require__: false
-

--- a/dashboard/src/buildInfo.macro.js
+++ b/dashboard/src/buildInfo.macro.js
@@ -1,0 +1,18 @@
+const gitRevSync = __non_webpack_require__("git-rev-sync");
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+export default ({ rootContext }) => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(rootContext, "package.json"), "utf8"),
+  );
+  const sourceRevision = gitRevSync.short();
+  const sourceVersion = packageJson.version;
+  const sourceURL = packageJson.repository.url;
+
+  return `module.exports = ${JSON.stringify({
+    sourceRevision,
+    sourceVersion,
+    sourceURL,
+  })}`;
+};

--- a/dashboard/src/components/ErrorRoot.js
+++ b/dashboard/src/components/ErrorRoot.js
@@ -1,0 +1,274 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import StackTrace from "stacktrace-js";
+import ErrorStackParser from "error-stack-parser";
+import { isApolloError } from "apollo-client/errors/ApolloError";
+
+import Dialog from "@material-ui/core/Dialog";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+
+import ErrorIcon from "@material-ui/icons/Error";
+
+import { sourceURL, sourceRevision } from "/buildInfo.macro";
+
+import FetchError from "/errors/FetchError";
+import ReactError from "/errors/ReactError";
+
+const Title = withStyles(theme => ({
+  root: {
+    background: theme.palette.error.main,
+    display: "flex",
+    alignItems: "center",
+    color: theme.palette.error.contrastText,
+  },
+}))(props => <DialogTitle {...props} disableTypography />);
+
+const Icon = withStyles(theme => ({
+  root: {
+    width: 32,
+    height: 32,
+    marginRight: theme.spacing.unit * 2,
+  },
+}))(ErrorIcon);
+
+const Pre = withStyles(() => ({
+  root: {
+    marginTop: 16,
+    lineHeight: 1.5,
+    fontSize: 14,
+    fontFamily: `"SFMono-Regular", Consolas, "Liberation Mono", Menlo,Courier, monospace`,
+  },
+}))(({ classes, ...props }) => <pre {...props} className={classes.root} />);
+
+const formatFrame = ({ functionName, fileName, lineNumber }) => ({
+  functionName,
+  url: /^src\//.test(fileName)
+    ? `${sourceURL}blob/${sourceRevision}/dashboard/${fileName}#L${lineNumber}`
+    : undefined,
+  source: `${fileName}:${lineNumber}`,
+});
+
+const issueLink = ({ name, message, frames, componentStack }) => {
+  const title = `[Web UI] ${name}: ${message}`;
+
+  const body = `
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're looking for help, please see https://sensuapp.org/support for resources --->
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas as to the implementation of the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code or configuration to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context (e.g. links to configuration settings, stack strace or log data) helps us come up with a solution that is most useful in the real world -->
+
+**Web UI Stack Trace:**
+
+${frames
+    .slice(0, 15)
+    .map(
+      ({ functionName, url, source }) =>
+        `at \`${functionName}\` (${url ? `[${source}](${url})` : source})`,
+    )
+    .join("\n")}
+${
+    componentStack instanceof ReactError
+      ? `
+
+
+Component Stack:
+
+${"```"}${componentStack.replace(/^ {4}/gm, "")}
+${"```"}`
+      : ""
+  }
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Sensu version used (sensuctl, sensu-backend, and/or sensu-agent): \`${sourceRevision}\`
+* Installation method (packages, binaries, docker etc.):
+* Operating System and version (e.g. Ubuntu 14.04):`.slice(0);
+
+  const params = `?title=${encodeURIComponent(title)}&body=${encodeURIComponent(
+    body,
+  )}`;
+
+  return `${sourceURL}issues/new${params}`;
+};
+
+const unwrapError = error => {
+  const meta = {};
+
+  if (error instanceof ReactError) {
+    return {
+      componentStack: error.componentStack,
+      ...unwrapError(error.original),
+    };
+  }
+
+  if (isApolloError(error) && error.networkError) {
+    return unwrapError(error.networkError);
+  }
+
+  if (error instanceof FetchError) {
+    if (error.original) {
+      return {
+        url: error.url,
+        statusCode: error.statusCode,
+        ...unwrapError(error.original),
+      };
+    }
+
+    meta.url = error.url;
+    meta.statusCode = error.statusCode;
+  }
+
+  return {
+    ...meta,
+    name: error.name,
+    stack: error.stack,
+    message: error.message,
+  };
+};
+
+class ErrorRoot extends React.PureComponent {
+  static propTypes = {
+    // eslint-disable-next-line react/no-unused-prop-types
+    error: PropTypes.instanceOf(Error).isRequired,
+  };
+
+  state = {};
+
+  static getDerivedStateFromProps(props) {
+    const unwrapped = unwrapError(props.error);
+    return {
+      ...unwrapped,
+      frames: ErrorStackParser.parse(unwrapped)
+        .map(frame => ({
+          ...frame,
+          functionName: `${frame.functionName}`,
+          fileName: frame.fileName.replace(window.location.origin, ""),
+        }))
+        .map(formatFrame),
+    };
+  }
+
+  componentDidMount() {
+    StackTrace.fromError(this.state).then(frames => {
+      this.setState({
+        frames: frames
+          .map((frame, i) => ({
+            ...frame,
+            functionName: this.state.frames[i].functionName,
+            fileName: frame.fileName.replace(window.location.origin, ""),
+          }))
+          .map(formatFrame),
+      });
+    });
+  }
+
+  render() {
+    const {
+      stack,
+      frames,
+      name,
+      message,
+      url,
+      statusCode,
+      componentStack,
+    } = this.state;
+
+    return (
+      <Dialog open>
+        <Title>
+          <Icon />
+          <Typography variant="title" color="inherit">
+            Something went wrong
+          </Typography>
+        </Title>
+        <DialogContent>
+          <Pre>
+            <strong>
+              {name}: {message}
+            </strong>
+            {"\n\n"}
+            Environment:
+            {"\n"}
+            source revision: {sourceRevision}
+            {"\n\n"}
+            Stack Trace:
+            {frames ? (
+              <div>
+                {frames.map((frame, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={index}>
+                    {"   "}at {frame.functionName} ({frame.url ? (
+                      <a href={frame.url} target="_blank">
+                        {frame.source}
+                      </a>
+                    ) : (
+                      frame.source
+                    )})
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div>{stack}</div>
+            )}
+            {componentStack && (
+              <div>
+                {"\n"}
+                Component Stack:
+                {"\n"}
+                {componentStack.replace(/^ {4}/gm, "  ")}
+              </div>
+            )}
+            {url && (
+              <div>
+                {"\n"}
+                Fetch URL:
+                {"\n"}
+                {url.replace(window.location.origin, "")}
+              </div>
+            )}
+            {statusCode !== undefined && (
+              <div>
+                {"\n"}
+                Fetch Status:
+                {"\n"}
+                {statusCode}
+              </div>
+            )}
+            {"\n\n"}
+            <a href={issueLink(this.state)} target="_blank">
+              submit new issue
+            </a>{" "}
+            (populated with current error details)
+          </Pre>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+
+export default ErrorRoot;

--- a/dashboard/src/exceptionHandler.js
+++ b/dashboard/src/exceptionHandler.js
@@ -1,6 +1,8 @@
 import capture from "bugnet";
 import ErrorStackParser from "error-stack-parser";
 
+import renderError from "/renderError";
+
 let a;
 const absolute = path => {
   a = a || document.createElement("a");
@@ -38,7 +40,7 @@ const handle = error => {
     // Ignore vendor script error.
   } else {
     // eslint-disable-next-line no-console
-    console.log("exceptionHandler.js", error);
+    renderError(error);
   }
 };
 

--- a/dashboard/src/renderError.js
+++ b/dashboard/src/renderError.js
@@ -1,0 +1,29 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import ErrorRoot from "/components/ErrorRoot";
+
+let lastError;
+let rootElement;
+
+const getRootElement = () => {
+  if (!rootElement) {
+    rootElement = document.createElement("div");
+    document.body.appendChild(rootElement);
+  }
+
+  return rootElement;
+};
+
+const renderError = error => {
+  if (
+    // Abort rendering if an error is already displayed. This prevents a
+    // potential endless loop when rendering an error encounters an error.
+    !lastError
+  ) {
+    lastError = error;
+    ReactDOM.render(<ErrorRoot error={error} />, getRootElement());
+  }
+};
+
+export default renderError;

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -3238,6 +3238,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-rev-sync@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/git-rev-sync/-/git-rev-sync-1.12.0.tgz#4468406c7e6c3ba4cf4587999e1adb28d9d1af55"
+  dependencies:
+    escape-string-regexp "1.0.5"
+    graceful-fs "4.1.11"
+    shelljs "0.7.7"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -3258,7 +3266,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -3345,7 +3353,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3772,6 +3780,10 @@ inquirer@3.3.0, inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 intl-messageformat-parser@1.4.0:
   version "1.4.0"
@@ -6358,6 +6370,12 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 "recompose@^0.26.0 || ^0.27.0", recompose@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.0.tgz#8230ebd651bf1159097006f79083fe224b1501cf"
@@ -6634,7 +6652,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:
@@ -6827,6 +6845,14 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -6934,6 +6960,10 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+
 source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -7006,13 +7036,34 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+stack-generator@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.2.tgz#3c13d952a596ab9318fec0669d0a1df8b87176c7"
+  dependencies:
+    stackframe "^1.0.4"
+
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
-stackframe@^1.0.3:
+stackframe@^1.0.3, stackframe@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+
+stacktrace-gps@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.0.4"
+
+stacktrace-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
+  dependencies:
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 static-extend@^0.1.1:
   version "0.1.2"

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -7396,7 +7396,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@^1.2.4:
+uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -655,6 +655,10 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async@^0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -4891,6 +4895,14 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
+loader-utils@~1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.0.4.tgz#13f56197f1523a305891248b4c7244540848426c"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -6887,6 +6899,14 @@ source-list-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.0.tgz#aaa47403f7b245a92fbc97ea08f250d6087ed085"
 
+source-map-loader@bryanforbes/source-map-loader#module-context:
+  version "0.2.0"
+  resolved "https://codeload.github.com/bryanforbes/source-map-loader/tar.gz/a2225bd6419fd20d130bba6ded7ff3e219633424"
+  dependencies:
+    async "^0.9.0"
+    loader-utils "~1.0.3"
+    source-map "~0.1.33"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
@@ -6927,6 +6947,12 @@ source-map@^0.4.4:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+source-map@~0.1.33:
+  version "0.1.43"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
+  dependencies:
+    amdefine ">=0.0.4"
 
 spdx-correct@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What is this change?

Display caught errors in a modal showing error stack track and other details. The error modal contents are anonymous, and can be copied for to share as an error report.

![image](https://user-images.githubusercontent.com/1074748/40502155-f25b7d70-5f3e-11e8-9871-cb917bed6819.png)


## Why is this change necessary?

This will be a great benefit to early testers enabling them to accurately report errors.

Closes #1360 

## Does your change need a Changelog entry?

nah

## Do you need clarification on anything?

nope

## Were there any complications while making this change?

no