### PR TITLE
Remove linux/386 & windows/386 CI jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,6 @@ environment:
       TEST_SUITE: integration
     - GOARCH: amd64
       TEST_SUITE: integration
-    - GOARCH: 386
-      TEST_SUITE: e2e
     - GOARCH: amd64
       TEST_SUITE: e2e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ env:
   - GOARCH=amd64 TEST_SUITE=unit GOGC=off
   - GOARCH=386 TEST_SUITE=integration GOGC=off
   - GOARCH=amd64 TEST_SUITE=integration GOGC=off
-  - GOARCH=386 TEST_SUITE=e2e GOGC=off
   - GOARCH=amd64 TEST_SUITE=e2e GOGC=off
   - TEST_SUITE=dashboard-ci GOGC=off
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ characters and therefore fixing a bug in sensuctl
 - Fixed a bug where only a single resource could be created with
 `sensuctl create` at a time.
 
+### Removed
+- Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor
+
 ## [2.0.0-beta.1] - 2018-05-07
 ### Added
 - Add Ubuntu 18.04 repository


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Removes the linux/386 windows/386 e2e jobs from CI.

## Why is this change necessary?

We are not planning on supporting Sensu Backend on linux/386 or windows/386. As a result, the e2e tests for those platforms do not provide us any value.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!