### PR TITLE
[Web UI] Fix bug in error modal

### DIFF
--- a/dashboard/src/components/ErrorRoot.js
+++ b/dashboard/src/components/ErrorRoot.js
@@ -92,7 +92,7 @@ ${frames
     )
     .join("\n")}
 ${
-    componentStack instanceof ReactError
+    componentStack
       ? `
 
 


### PR DESCRIPTION
## What is this change?

Tiny bugfix

## Why is this change necessary?

`componentStack` is a string if it exists, not a `ReactError` instance.


## Does your change need a Changelog entry?

no

## Do you need clarification on anything?

no


## Were there any complications while making this change?

no