### PR TITLE
[Web UI] Standardize "sign in" and "sign out" copy

### DIFF
--- a/dashboard/src/components/AppRoot.js
+++ b/dashboard/src/components/AppRoot.js
@@ -16,7 +16,7 @@ import UnauthenticatedRoute from "/components/util/UnauthenticatedRoute";
 import DefaultRedirect from "/components/util/DefaultRedirect";
 
 import EnvironmentView from "/components/views/EnvironmentView";
-import LoginView from "/components/views/LoginView";
+import SignInView from "/components/views/SignInView";
 import NotFoundView from "/components/views/NotFoundView";
 
 class AppRoot extends React.PureComponent {
@@ -38,8 +38,8 @@ class AppRoot extends React.PureComponent {
               <Route exact path="/" component={DefaultRedirect} />
               <UnauthenticatedRoute
                 exact
-                path="/login"
-                component={LoginView}
+                path="/signin"
+                component={SignInView}
                 fallbackComponent={DefaultRedirect}
               />
               <AuthenticatedRoute

--- a/dashboard/src/components/util/DefaultRedirect.js
+++ b/dashboard/src/components/util/DefaultRedirect.js
@@ -15,7 +15,7 @@ class DefaultRedirect extends React.PureComponent {
     // TODO: Store and retrieve last viewed environment.
     const lastEnvironment = "/default/default";
 
-    const nextPath = data.auth.accessToken ? lastEnvironment : "/login";
+    const nextPath = data.auth.accessToken ? lastEnvironment : "/signin";
 
     return <Redirect to={nextPath} />;
   }

--- a/dashboard/src/components/views/SignInView.js
+++ b/dashboard/src/components/views/SignInView.js
@@ -17,7 +17,7 @@ import createTokens from "/mutations/createTokens";
 import Logo from "/icons/SensuLogoGraphic";
 import Wordmark from "/icons/SensuWordmark";
 
-class LoginView extends React.Component {
+class SignInView extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     client: PropTypes.object.isRequired,
@@ -27,7 +27,7 @@ class LoginView extends React.Component {
     "@global html": {
       background: theme.palette.background.main,
     },
-    loginCard: {
+    signInCard: {
       margin: "0 auto",
       padding: 48,
       maxWidth: 450,
@@ -112,7 +112,7 @@ class LoginView extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Paper className={classes.loginCard}>
+        <Paper className={classes.signInCard}>
           <Logo className={classes.icon} />
           <Wordmark className={classes.wordmark} />
           <div className={classes.headline}>
@@ -158,7 +158,7 @@ class LoginView extends React.Component {
                 disabled={disabled}
                 className={classes.button}
               >
-                Log in
+                Sign in
               </Button>
             </div>
           </form>
@@ -168,4 +168,4 @@ class LoginView extends React.Component {
   }
 }
 
-export default compose(withApollo, withStyles(LoginView.styles))(LoginView);
+export default compose(withApollo, withStyles(SignInView.styles))(SignInView);


### PR DESCRIPTION
## What is this change?

The app currently has a mix of "login" and "sign out". Replace references to "login" with "sign in"

Research shows that "sign in" and "sign out" are a good choice. (https://ux.stackexchange.com/questions/1080/using-sign-in-vs-using-log-in#answer-1084)

## Why is this change necessary?

Because consistency.

## Does your change need a Changelog entry?

no

## Do you need clarification on anything?

no

## Were there any complications while making this change?

no