### PR TITLE
[Web UI] Create wrapped <Query> component

### DIFF
--- a/dashboard/src/components/AppWrapper.js
+++ b/dashboard/src/components/AppWrapper.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Query } from "react-apollo";
 import gql from "graphql-tag";
 
+import Query from "/components/util/Query";
 import AppFrame from "/components/AppFrame";
 
 class AppWrapper extends React.Component {
@@ -36,19 +36,15 @@ class AppWrapper extends React.Component {
           environment: this.props.environment,
         }}
       >
-        {({ data: { viewer, environment } = {}, loading, error }) => {
-          if (error) throw error;
-
-          return (
-            <AppFrame
-              loading={loading}
-              viewer={viewer}
-              environment={environment}
-            >
-              {this.props.children}
-            </AppFrame>
-          );
-        }}
+        {({ data: { viewer, environment } = {}, loading, aborted }) => (
+          <AppFrame
+            loading={loading || aborted}
+            viewer={viewer}
+            environment={environment}
+          >
+            {this.props.children}
+          </AppFrame>
+        )}
       </Query>
     );
   }

--- a/dashboard/src/components/util/Query.js
+++ b/dashboard/src/components/util/Query.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { ApolloError } from "apollo-client";
+import { Query as BaseQuery } from "react-apollo";
+
+import QueryAbortedError from "/errors/QueryAbortedError";
+
+class Query extends React.PureComponent {
+  static propTypes = {
+    onError: PropTypes.func.isRequired,
+    children: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    onError(error) {
+      throw error;
+    },
+  };
+
+  componentDidMount() {
+    const { onError } = this.props;
+    this.querySubscription = this.queryRef.current.queryObservable.subscribe({
+      next(result) {
+        if (result.errors && result.errors.length > 0) {
+          throw new ApolloError({ graphQLErrors: result.errors });
+        }
+      },
+      error(error) {
+        if (!(error.networkError instanceof QueryAbortedError)) {
+          onError(error);
+        }
+      },
+    });
+  }
+
+  componentWillUnmount() {
+    if (this.querySubscription) {
+      this.querySubscription.unsubscribe();
+    }
+  }
+
+  queryRef = React.createRef();
+
+  render() {
+    const { onError, children, ...props } = this.props;
+
+    return (
+      <BaseQuery ref={this.queryRef} {...props}>
+        {queryResult => {
+          const { error, ...rest } = queryResult;
+          if (error && error.networkError instanceof QueryAbortedError) {
+            return children({ aborted: true, ...rest });
+          }
+          return children({ aborted: false, ...queryResult });
+        }}
+      </BaseQuery>
+    );
+  }
+}
+
+export default Query;

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Query } from "react-apollo";
 import gql from "graphql-tag";
 import Paper from "@material-ui/core/Paper";
 import Button from "@material-ui/core/Button";
+
+import Query from "/components/util/Query";
 
 import AppContent from "/components/AppContent";
 import CheckList from "/components/CheckList";
@@ -38,11 +39,8 @@ class ChecksContent extends React.Component {
 
     return (
       <Query query={ChecksContent.query} variables={variables}>
-        {({ data: { environment } = {}, loading, error, refetch }) => {
-          // TODO: Connect this error handler to display a blocking error alert
-          if (error) throw error;
-
-          if (!environment && !loading) return <NotFoundView />;
+        {({ data: { environment } = {}, loading, aborted, refetch }) => {
+          if (!environment && !loading && !aborted) return <NotFoundView />;
 
           return (
             <AppContent>
@@ -50,7 +48,7 @@ class ChecksContent extends React.Component {
               <Paper>
                 <CheckList
                   environment={environment}
-                  loading={loading}
+                  loading={loading || aborted}
                   refetch={refetch}
                 />
               </Paper>

--- a/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
@@ -1,9 +1,10 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Query } from "react-apollo";
 import gql from "graphql-tag";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
+
+import Query from "/components/util/Query";
 
 import Content from "/components/Content";
 import AppContent from "/components/AppContent";
@@ -61,11 +62,8 @@ class EntitiesContent extends React.PureComponent {
   render() {
     return (
       <Query query={EntitiesContent.query} variables={this.props.match.params}>
-        {({ data: { environment } = {}, loading, error, refetch }) => {
-          // TODO: Connect this error handler to display a blocking error alert
-          if (error) throw error;
-
-          if (!environment && !loading) return <NotFoundView />;
+        {({ data: { environment } = {}, loading, aborted, refetch }) => {
+          if (!environment && !loading && !aborted) return <NotFoundView />;
 
           return (
             <AppContent>
@@ -73,7 +71,7 @@ class EntitiesContent extends React.PureComponent {
                 <Title>Entities</Title>
               </Headline>
               <EntitiesList
-                loading={loading}
+                loading={loading || aborted}
                 environment={environment}
                 refetch={refetch}
               />

--- a/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import { Query } from "react-apollo";
 
+import Query from "/components/util/Query";
 import Loader from "/components/util/Loader";
 
 import AppContent from "/components/AppContent";
@@ -35,12 +35,12 @@ class EntityDetailsContent extends React.PureComponent {
         fetchPolicy="cache-and-network"
         variables={{ ...params, ns }}
       >
-        {({ data: { entity } = {}, loading }) => {
-          if (!loading && !entity) return <NotFoundView />;
+        {({ data: { entity } = {}, loading, aborted }) => {
+          if (!loading && !entity && !aborted) return <NotFoundView />;
 
           return (
             <AppContent>
-              <Loader loading={loading} passthrough>
+              <Loader loading={loading || aborted} passthrough>
                 {entity && <EntityDetailsContainer entity={entity} />}
               </Loader>
             </AppContent>

--- a/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
@@ -1,7 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import { Query } from "react-apollo";
+
+import Query from "/components/util/Query";
+
 import AppContent from "/components/AppContent";
 import NotFoundView from "/components/views/NotFoundView";
 import Container from "/components/partials/EventDetailsContainer";
@@ -39,11 +41,18 @@ class EventDetailsContent extends React.PureComponent {
         fetchPolicy="cache-and-network"
         variables={{ ...match.params, ns }}
       >
-        {({ client, data: { event } = {}, loading }) => {
-          if (!loading && (!event || event.deleted)) return <NotFoundView />;
+        {({ client, data: { event } = {}, loading, aborted }) => {
+          if (!loading && !aborted && (!event || event.deleted)) {
+            return <NotFoundView />;
+          }
+
           return (
             <AppContent>
-              <Container client={client} event={event} loading={loading} />
+              <Container
+                client={client}
+                event={event}
+                loading={loading || aborted}
+              />
             </AppContent>
           );
         }}

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -1,11 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
-import { Query } from "react-apollo";
 import gql from "graphql-tag";
+
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
+
+import Query from "/components/util/Query";
 
 import AppContent from "/components/AppContent";
 import EventsContainer from "/components/EventsContainer";
@@ -112,10 +114,8 @@ class EventsContent extends React.Component {
         fetchPolicy="cache-and-network"
         variables={{ ...match.params, filter: query.get("filter") }}
       >
-        {({ data: { environment } = {}, loading, error, refetch }) => {
-          if (error) throw error;
-
-          if (!environment && !loading) return <NotFoundView />;
+        {({ data: { environment } = {}, loading, aborted, refetch }) => {
+          if (!environment && !loading && !aborted) return <NotFoundView />;
 
           return (
             <AppContent>
@@ -142,7 +142,7 @@ class EventsContent extends React.Component {
                 className={classes.container}
                 onQueryChange={this.changeQuery}
                 environment={environment}
-                loading={loading}
+                loading={loading || aborted}
               />
             </AppContent>
           );

--- a/dashboard/src/errors/QueryAbortedError.js
+++ b/dashboard/src/errors/QueryAbortedError.js
@@ -1,0 +1,10 @@
+import ExtendableError from "es6-error";
+
+class QueryAbortedError extends ExtendableError {
+  constructor(error) {
+    super(error.name);
+    this.original = error;
+  }
+}
+
+export default QueryAbortedError;


### PR DESCRIPTION
## What is this change?

This component enhances the original `<Query>` component from `react-apollo` giving us a few extra features. OOB it is compatible with the original component interface.

## Why is this change necessary?

This new component gives us an `onError` callback for handling errors within the original request continuation. By default `<Query>` will now globally reject errors not handled within `onError`, fixing the issue of `<Query>` silencing errors.

A new `QueryAbortedError` class allows us to "abort" a GraphQL query request without triggering a failure state. The aborted status is returned to the consumer as an `aborted` boolean among the query render callback props. Once a query has been aborted, it can be be manually restarted with the `refetch` render prop.

## Do you need clarification on anything?

no

## Were there any complications while making this change?

**Why not use `apollo-link-error` to handle errors as part of the request continuation?** Handling errors at the apollo-client level is not a great approach. It does not allow the consumer of `<Query>` to handle errors representing a failure to delegate control to the consumer.
