### PR TITLE
[Web UI] Add ESLint rule 'curly'

### DIFF
--- a/dashboard/.eslintrc.yml
+++ b/dashboard/.eslintrc.yml
@@ -17,6 +17,11 @@ settings:
   import/resolver:
     babel-module:
 rules:
+  # Single line conditionals are more difficult to set breakpoints on.
+  curly:
+    - error
+    - all
+
   # While I personally prefer stateless functional components, since not every
   # component can be one, I'd rather be consistent and extend React.Component.
   react/prefer-es6-class: 2

--- a/dashboard/src/apollo/authLink.js
+++ b/dashboard/src/apollo/authLink.js
@@ -44,7 +44,9 @@ const authLink = ({ getClient }) =>
           .catch(observer.error.bind(observer));
 
         return () => {
-          if (sub) sub.unsubscribe();
+          if (sub) {
+            sub.unsubscribe();
+          }
         };
       }),
   );

--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -28,7 +28,9 @@ const createClient = () => {
 
   let client = null;
   const getClient = () => {
-    if (!client) throw new Error("apollo client is not initialized");
+    if (!client) {
+      throw new Error("apollo client is not initialized");
+    }
     return client;
   };
 

--- a/dashboard/src/apollo/schema/combinedTypes.macro.js
+++ b/dashboard/src/apollo/schema/combinedTypes.macro.js
@@ -32,7 +32,9 @@ export default () => {
     `,
   );
   const result = execute(schema, queryAST);
-  if (result.errors) throw result.errors;
+  if (result.errors) {
+    throw result.errors;
+  }
 
   // https://github.com/apollographql/apollo-client/blob/2701b0acb89711864bde28341cb5cfcf909d2caf/packages/apollo-cache-inmemory/src/fragmentMatcher.ts#L149-L155
   const filteredTypes = result.data.__schema.types.filter(

--- a/dashboard/src/components/RelativeDate/RelativeDate.js
+++ b/dashboard/src/components/RelativeDate/RelativeDate.js
@@ -54,7 +54,9 @@ class RelativeDate extends React.PureComponent {
     const formatter = new IntlRelativeFormat("en", { style });
 
     let relativeDate = formatter.format(dateValue, unit);
-    if (capitalize) relativeDate = capitalizeStr(relativeDate);
+    if (capitalize) {
+      relativeDate = capitalizeStr(relativeDate);
+    }
     return (
       <time dateTime={dateTime} {...props}>
         {relativeDate}

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsDeleteAction.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsDeleteAction.js
@@ -67,7 +67,9 @@ class EventDetailsDeleteAction extends React.PureComponent {
       event: { id, ns },
       history,
     } = this.props;
-    if (this.state.locked) return;
+    if (this.state.locked) {
+      return;
+    }
 
     // Cleanup
     this.closeDialog();

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsResolveAction.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsResolveAction.js
@@ -44,7 +44,9 @@ class EventDetailsResolveAction extends React.PureComponent {
       client,
       event: { id },
     } = this.props;
-    if (this.state.locked) return;
+    if (this.state.locked) {
+      return;
+    }
 
     this.resolveStart();
     resolveEvent(client, { id }).then(

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -40,7 +40,9 @@ class ChecksContent extends React.Component {
     return (
       <Query query={ChecksContent.query} variables={variables}>
         {({ data: { environment } = {}, loading, aborted, refetch }) => {
-          if (!environment && !loading && !aborted) return <NotFoundView />;
+          if (!environment && !loading && !aborted) {
+            return <NotFoundView />;
+          }
 
           return (
             <AppContent>

--- a/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
@@ -63,7 +63,9 @@ class EntitiesContent extends React.PureComponent {
     return (
       <Query query={EntitiesContent.query} variables={this.props.match.params}>
         {({ data: { environment } = {}, loading, aborted, refetch }) => {
-          if (!environment && !loading && !aborted) return <NotFoundView />;
+          if (!environment && !loading && !aborted) {
+            return <NotFoundView />;
+          }
 
           return (
             <AppContent>

--- a/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
@@ -36,7 +36,9 @@ class EntityDetailsContent extends React.PureComponent {
         variables={{ ...params, ns }}
       >
         {({ data: { entity } = {}, loading, aborted }) => {
-          if (!loading && !entity && !aborted) return <NotFoundView />;
+          if (!loading && !entity && !aborted) {
+            return <NotFoundView />;
+          }
 
           return (
             <AppContent>

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -115,7 +115,9 @@ class EventsContent extends React.Component {
         variables={{ ...match.params, filter: query.get("filter") }}
       >
         {({ data: { environment } = {}, loading, aborted, refetch }) => {
-          if (!environment && !loading && !aborted) return <NotFoundView />;
+          if (!environment && !loading && !aborted) {
+            return <NotFoundView />;
+          }
 
           return (
             <AppContent>

--- a/dashboard/src/utils/checkStatus.js
+++ b/dashboard/src/utils/checkStatus.js
@@ -10,8 +10,12 @@ const unknown = "unknown";
 // > 2 == unknown
 // eslint-disable-next-line import/prefer-default-export
 export function statusCodeToId(st) {
-  if (st === 0) return success;
-  else if (st === 1) return warning;
-  else if (st === 2) return critical;
+  if (st === 0) {
+    return success;
+  } else if (st === 1) {
+    return warning;
+  } else if (st === 2) {
+    return critical;
+  }
   return unknown;
 }

--- a/dashboard/src/utils/consecutivePairs.js
+++ b/dashboard/src/utils/consecutivePairs.js
@@ -1,6 +1,8 @@
 function consecutivePairs([f, s, ...rest], acc = []) {
   const next = [...acc, [f, s]];
-  if (rest.length < 2) return next;
+  if (rest.length < 2) {
+    return next;
+  }
   return consecutivePairs(rest, next);
 }
 

--- a/dashboard/src/utils/dispatcher.js
+++ b/dashboard/src/utils/dispatcher.js
@@ -13,7 +13,9 @@ const createDispatcher = () => {
   };
 
   const subscribe = listener => {
-    if (listeners.indexOf(listener) !== -1) return () => {};
+    if (listeners.indexOf(listener) !== -1) {
+      return () => {};
+    }
     listeners.push(listener);
 
     return () => unsubscribe(listener);


### PR DESCRIPTION
## What is this change?

Add rule to disallow omission of curly braces.

> JavaScript allows the omission of curly braces when a block contains
only one statement. However, it is considered by many to be best
practice to never omit curly braces around blocks, even when they are
optional, because it can lead to bugs and reduces code clarity.

https://eslint.org/docs/rules/curly

Also, omission of curly braces makes it [more difficult to set breakpoints](https://github.com/sensu/sensu-go/pull/1606#discussion_r191593693).


## Why is this change necessary?

I'd always rather the linter be the source of pedantry and not PR reviews.

## Does your change need a Changelog entry?

`null`

## Do you need clarification on anything?

`undefined`

## Were there any complications while making this change?

`0`