### PR TITLE
[Web UI] Display a modal when authentication fails

### DIFF
--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -47,6 +47,7 @@ const createClient = () => {
     gql`
       query SyncAuthQuery {
         auth @client {
+          invalid
           accessToken
           refreshToken
           expiresAt

--- a/dashboard/src/apollo/schema/client.graphql
+++ b/dashboard/src/apollo/schema/client.graphql
@@ -15,6 +15,12 @@ extend type Mutation {
 }
 
 type Auth {
+  """
+  Indicates that the current access token has been rejected by the API and
+  cannot be automatically refreshed. The user must re-authenticate to continue.
+  """
+  invalid: Boolean!
+
   "Token used to access the system."
   accessToken: String
 

--- a/dashboard/src/apollo/schema/combined.graphql
+++ b/dashboard/src/apollo/schema/combined.graphql
@@ -42,6 +42,12 @@ type Asset implements Node {
 }
 
 type Auth {
+  """
+  Indicates that the current access token has been rejected by the API and
+  cannot be automatically refreshed. The user must re-authenticate to continue.
+  """
+  invalid: Boolean!
+
   """Token used to access the system."""
   accessToken: String
 

--- a/dashboard/src/components/AppRoot.js
+++ b/dashboard/src/components/AppRoot.js
@@ -12,12 +12,14 @@ import ThemeStyles from "/components/ThemeStyles";
 
 import AuthenticatedRoute from "/components/util/AuthenticatedRoute";
 import UnauthenticatedRoute from "/components/util/UnauthenticatedRoute";
-
+import AuthInvalidRoute from "/components/util/AuthInvalidRoute";
 import DefaultRedirect from "/components/util/DefaultRedirect";
 
 import EnvironmentView from "/components/views/EnvironmentView";
 import SignInView from "/components/views/SignInView";
 import NotFoundView from "/components/views/NotFoundView";
+
+import AuthInvalidDialog from "/components/partials/AuthInvalidDialog";
 
 class AppRoot extends React.PureComponent {
   static propTypes = {
@@ -48,6 +50,10 @@ class AppRoot extends React.PureComponent {
                 fallbackComponent={DefaultRedirect}
               />
               <Route component={NotFoundView} />
+            </Switch>
+            <Switch>
+              <UnauthenticatedRoute exact path="/signin" />
+              <AuthInvalidRoute component={AuthInvalidDialog} />
             </Switch>
             <ResetStyles />
             <ThemeStyles />

--- a/dashboard/src/components/partials/AuthInvalidDialog.js
+++ b/dashboard/src/components/partials/AuthInvalidDialog.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { compose } from "recompose";
+import { withApollo } from "react-apollo";
+
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import withMobileDialog from "@material-ui/core/withMobileDialog";
+
+import invalidateTokens from "/mutations/invalidateTokens";
+
+class AuthInvalidDialog extends React.PureComponent {
+  static propTypes = {
+    // fullScreen prop is controlled by the `withMobileDialog` enhancer.
+    fullScreen: PropTypes.bool.isRequired,
+    client: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { fullScreen, client } = this.props;
+
+    return (
+      <Dialog open fullScreen={fullScreen}>
+        <DialogTitle>Session Expired</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Your session has expired. Please sign in to continue.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              invalidateTokens(client);
+            }}
+            color="primary"
+          >
+            Sign In
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+}
+
+export default compose(withMobileDialog({ breakpoint: "xs" }), withApollo)(
+  AuthInvalidDialog,
+);

--- a/dashboard/src/components/util/AuthInvalidRoute.js
+++ b/dashboard/src/components/util/AuthInvalidRoute.js
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { graphql } from "react-apollo";
+import gql from "graphql-tag";
+
+import ConditionalRoute from "/components/util/ConditionalRoute";
+
+class AuthInvalidRoute extends React.PureComponent {
+  static propTypes = {
+    ...ConditionalRoute.propTypes,
+    data: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { data, ...props } = this.props;
+
+    return <ConditionalRoute {...props} active={data.auth.invalid} />;
+  }
+}
+
+export default graphql(gql`
+  query AuthInvalidRouteQuery {
+    auth @client {
+      invalid
+    }
+  }
+`)(AuthInvalidRoute);


### PR DESCRIPTION
## What is this change?

In the event that automatic session refresh fails, show the user a message instead of redirecting directly to the sign in page.

![image](https://user-images.githubusercontent.com/1074748/40745786-4689c12c-640d-11e8-94e3-ca1bbf539593.png)


## Why is this change necessary?

This provides a nicer experience than forcefully redirecting to the sign-in page and gives us a platform for further enhancements such as a login form modal.

## Does your change need a Changelog entry?

no

## Do you need clarification on anything?

nah

## Were there any complications while making this change?

naw