### PR TITLE
[Web UI] Reduce lodash's footprint on the bundle

### DIFF
--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -177,7 +177,7 @@ export default () => {
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin({
         inject: true,
-        template: require.resolve("src/static/index.html"),
+        template: path.resolve(root, "src/static/index.html"),
         minify: isProduction && {
           removeComments: true,
           collapseWhitespace: true,

--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -135,6 +135,10 @@ export default () => {
                 name: "static/media/[name].[hash:8].[ext]",
               },
             },
+            {
+              test: /\.html$/,
+              loader: require.resolve("raw-loader"),
+            },
           ],
         },
       ],
@@ -173,7 +177,7 @@ export default () => {
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin({
         inject: true,
-        template: "!!raw-loader!./src/static/index.html",
+        template: require.resolve("src/static/index.html"),
         minify: isProduction && {
           removeComments: true,
           collapseWhitespace: true,

--- a/dashboard/config/webpack.config.js
+++ b/dashboard/config/webpack.config.js
@@ -143,17 +143,20 @@ export default () => {
       new StatsWriterPlugin({
         filename: "../stats.json",
         fields: [
-          "version",
-          "hash",
-          "time",
-          "builtAt",
-          "assetsByChunkName",
           "assets",
-          "filteredAssets",
-          "entrypoints",
-          "modules",
-          "filteredModules",
+          "assetsByChunkName",
+          "builtAt",
           "children",
+          "chunks",
+          "entrypoints",
+          "errors",
+          "filteredAssets",
+          "filteredModules",
+          "hash",
+          "modules",
+          "time",
+          "version",
+          "warnings",
         ],
       }),
       new CleanPlugin([outputPath, path.resolve(outputPath, "../stats.json")], {
@@ -170,7 +173,7 @@ export default () => {
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin({
         inject: true,
-        template: path.resolve(root, "src/static/index.html"),
+        template: "!!raw-loader!./src/static/index.html",
         minify: isProduction && {
           removeComments: true,
           collapseWhitespace: true,

--- a/dashboard/src/components/CheckList.js
+++ b/dashboard/src/components/CheckList.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import map from "lodash/map";
 import gql from "graphql-tag";
 
 import Table from "@material-ui/core/Table";
@@ -62,7 +61,7 @@ class CheckList extends React.Component {
             </TableRow>
           </TableHead>
           <TableBody style={{ minHeight: 200 }}>
-            {map(checks, node => <Row key={node.id} check={node} />)}
+            {checks.map(node => <Row key={node.id} check={node} />)}
           </TableBody>
         </Table>
       </Loader>

--- a/dashboard/src/components/EventsContainer.js
+++ b/dashboard/src/components/EventsContainer.js
@@ -276,7 +276,7 @@ class EventsContainer extends React.Component {
                   </Button>
                 )}
               </ConfirmDelete>
-              <Button onClick={this.silenceSelectedEvents(params)}>
+              <Button onClick={() => this.silenceSelectedEvents(params)}>
                 <Typography variant="button">Silence</Typography>
               </Button>
               <Button onClick={this._handleBulkResolve}>

--- a/dashboard/src/components/EventsContainer.js
+++ b/dashboard/src/components/EventsContainer.js
@@ -2,12 +2,11 @@ import React from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 import gql from "graphql-tag";
-
+import { compose } from "recompose";
 import { Route } from "react-router-dom";
 import { withApollo } from "react-apollo";
-import { reduce, capitalize } from "lodash";
-import { compose } from "lodash/fp";
 import { withStyles } from "@material-ui/core/styles";
+import capitalize from "lodash/capitalize";
 import MenuItem from "@material-ui/core/MenuItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Checkbox from "@material-ui/core/Checkbox";
@@ -149,8 +148,7 @@ class EventsContainer extends React.Component {
     // if every state is false or undefined, switch the header
     const newState = events.length === 0;
     this.setState({
-      rowState: reduce(
-        keys,
+      rowState: keys.reduce(
         (acc, key) => ({ ...acc, [key]: newState }),
         this.state.rowState,
       ),

--- a/dashboard/src/components/Preferences.js
+++ b/dashboard/src/components/Preferences.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { compose } from "lodash/fp";
+import { compose } from "recompose";
 import { withStyles } from "@material-ui/core/styles";
 
 import Modal from "@material-ui/core/Modal";

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsDeleteAction.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsDeleteAction.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
-import { compose } from "lodash/fp";
+import { compose } from "recompose";
 import { withApollo } from "react-apollo";
 import { withRouter } from "react-router-dom";
 import Button from "@material-ui/core/Button";

--- a/dashboard/src/store/createStore.js
+++ b/dashboard/src/store/createStore.js
@@ -1,5 +1,5 @@
 import { createStore as create, applyMiddleware } from "redux";
-import { compose } from "lodash/fp";
+import { compose } from "recompose";
 import { devToolsEnhancer } from "redux-devtools-extension/logOnlyInProduction";
 
 import thunkMiddleware from "redux-thunk";

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -657,6 +657,10 @@ ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -2585,6 +2589,13 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.1:
     d "1"
     es5-ext "~0.10.14"
 
+es6-templates@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
+  dependencies:
+    recast "~0.11.12"
+    through "~2.3.6"
+
 escape-html@~1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2782,7 +2793,7 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-esprima@^3.1.3:
+esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -2965,6 +2976,10 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fastparse@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
 faye-websocket@~0.11.0:
   version "0.11.1"
@@ -3593,9 +3608,31 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-loader@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.5.tgz#6356dbeb0c49756d8ebd5ca327f16ff06ab5faea"
+  dependencies:
+    es6-templates "^0.2.3"
+    fastparse "^1.1.1"
+    html-minifier "^3.5.8"
+    loader-utils "^1.1.0"
+    object-assign "^4.1.1"
+
 html-minifier@^3.2.3:
   version "3.5.15"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.15.tgz#f869848d4543cbfd84f26d5514a2a87cbf9a05e0"
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.1.x"
+    commander "2.15.x"
+    he "1.1.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.3.x"
+
+html-minifier@^3.5.8:
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.16.tgz#39f5aabaf78bdfc057fe67334226efd7f3851175"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
@@ -5992,7 +6029,7 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.8:
+private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -6379,6 +6416,15 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
+
+recast@~0.11.12:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -6974,7 +7020,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -7331,7 +7377,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -657,10 +657,6 @@ ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -2589,13 +2585,6 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.1:
     d "1"
     es5-ext "~0.10.14"
 
-es6-templates@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
-  dependencies:
-    recast "~0.11.12"
-    through "~2.3.6"
-
 escape-html@~1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2793,7 +2782,7 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-esprima@^3.1.3, esprima@~3.1.0:
+esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -2976,10 +2965,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-fastparse@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
 faye-websocket@~0.11.0:
   version "0.11.1"
@@ -3608,31 +3593,9 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-html-loader@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.5.tgz#6356dbeb0c49756d8ebd5ca327f16ff06ab5faea"
-  dependencies:
-    es6-templates "^0.2.3"
-    fastparse "^1.1.1"
-    html-minifier "^3.5.8"
-    loader-utils "^1.1.0"
-    object-assign "^4.1.1"
-
 html-minifier@^3.2.3:
   version "3.5.15"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.15.tgz#f869848d4543cbfd84f26d5514a2a87cbf9a05e0"
-  dependencies:
-    camel-case "3.0.x"
-    clean-css "4.1.x"
-    commander "2.15.x"
-    he "1.1.x"
-    param-case "2.1.x"
-    relateurl "0.2.x"
-    uglify-js "3.3.x"
-
-html-minifier@^3.5.8:
-  version "3.5.16"
-  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.16.tgz#39f5aabaf78bdfc057fe67334226efd7f3851175"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
@@ -6029,7 +5992,7 @@ pretty-format@^22.4.3:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-private@^0.1.6, private@^0.1.8, private@~0.1.5:
+private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -6416,15 +6379,6 @@ realpath-native@^1.0.0:
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.0.tgz#7885721a83b43bd5327609f0ddecb2482305fdf0"
   dependencies:
     util.promisify "^1.0.0"
-
-recast@~0.11.12:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -7020,7 +6974,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -7377,7 +7331,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6, through@~2.3.6:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
## What is this change?

Reduce lodash's footprint on the bundle by no longer using `html-webpack-plugin`'s default loader (see: [this comment](https://github.com/jantimon/html-webpack-plugin/issues/681#issuecomment-351471890) for context) and by removing needless instances from src.

## Why is this change necessary?

Reduces uncompressed bundle size by ~500KBs.

**previously**

![screen shot 2018-06-01 at 10 36 28 am](https://user-images.githubusercontent.com/194892/40854891-b440f570-6587-11e8-9fc1-af9c6435a0cc.png)

**after changes**

![screen shot 2018-06-01 at 10 15 11 am](https://user-images.githubusercontent.com/194892/40854732-37b3ad5e-6587-11e8-8757-fa6015b93700.png)

## Does your change need a Changelog entry?

unlikely.

## Do you need clarification on anything?

`null`

## Were there any complications while making this change?

`null`