### PR TITLE
Use default hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ github.com/nikkiki/sensu-influxdb-handler
 - Don't allow unknown fields in types that do not support custom attributes
 when creating resources with `sensuctl create`.
 - Provided additional context to metric event logs.
+- Use a default hostname if one cannot be retrieved.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -31,6 +31,7 @@ func TestSendLoop(t *testing.T) {
 		assert.NoError(t, json.Unmarshal(msg.Payload, event))
 		assert.NotNil(t, event.Entity)
 		assert.Equal(t, "agent", event.Entity.Class)
+		assert.NotEmpty(t, event.Entity.System)
 		assert.NotEmpty(t, event.Entity.System.Hostname)
 		done <- struct{}{}
 	}))

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -32,7 +32,6 @@ func TestSendLoop(t *testing.T) {
 		assert.NotNil(t, event.Entity)
 		assert.Equal(t, "agent", event.Entity.Class)
 		assert.NotEmpty(t, event.Entity.System)
-		assert.NotEmpty(t, event.Entity.System.Hostname)
 		done <- struct{}{}
 	}))
 	defer ts.Close()

--- a/system/system.go
+++ b/system/system.go
@@ -11,6 +11,8 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
+const defaultHostname = "Hostname-Not-Found"
+
 // Info describes the local system, hostname, OS, platform, platform
 // family, platform version, and network interfaces.
 func Info() (types.System, error) {
@@ -27,6 +29,10 @@ func Info() (types.System, error) {
 		Platform:        info.Platform,
 		PlatformFamily:  info.PlatformFamily,
 		PlatformVersion: info.PlatformVersion,
+	}
+
+	if system.Hostname == "" {
+		system.Hostname = defaultHostname
 	}
 
 	network, err := NetworkInfo()

--- a/system/system.go
+++ b/system/system.go
@@ -11,7 +11,7 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
-const defaultHostname = "Hostname-Not-Found"
+const defaultHostname = "unidentified-hostname"
 
 // Info describes the local system, hostname, OS, platform, platform
 // family, platform version, and network interfaces.

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestInfo(t *testing.T) {
-	info, _ := Info()
+	info, err := Info()
+	assert.NoError(t, err)
 	assert.NotEmpty(t, info.Arch)
 	assert.NotEmpty(t, info.Hostname)
 	assert.NotEmpty(t, info.OS)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Use a default hostname if one cannot be retrieved from the system.

## Why is this change necessary?

Closes #1636 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.