### PR TITLE
Fix a spurious warning in sensuctl create.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ the organization they reside in.
 - Fixed a bug with the IN operator in query statements.
 - Boolean fields with a value of `false` now appear in json format (removed
 `omitempty` from protobufs).
+- The sensuctl create command no longer prints a spurious warning when
+non-default organizations or environments are configured.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -26,6 +26,20 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	return cmd
 }
 
+// returns true iff --organization or --environment are specified to be
+// anything other than "default"
+func namespaceFlagsSet(cmd *cobra.Command) bool {
+	org, err := cmd.Flags().GetString("organization")
+	if err == nil && org != config.DefaultOrganization {
+		return true
+	}
+	env, err := cmd.Flags().GetString("environment")
+	if err == nil && env != config.DefaultEnvironment {
+		return true
+	}
+	return false
+}
+
 func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var in io.Reader
@@ -33,9 +47,8 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			_ = cmd.Help()
 			return errors.New("invalid argument(s) received")
 		}
-		if cli.Config.Organization() != config.DefaultOrganization ||
-			cli.Config.Environment() != config.DefaultEnvironment {
-			cli.Logger.Warn("--organization and --environment flags have no effect for this command")
+		if namespaceFlagsSet(cmd) {
+			cli.Logger.Warn("namespace flags have no effect for create command")
 		}
 		fp, err := cmd.Flags().GetString("file")
 		if err != nil {


### PR DESCRIPTION
The create command should print a warning if --environment or
--organization are specified, but should not print a warning if the
sensuctl client is configured to use a non-default namespace.

The intent of the warning is to let people know that namespace
flags are not consulted when creating resources with the create
command.

Closes #1651

Signed-off-by: Eric Chlebek <eric@sensu.io>