### PR TITLE
[Web UI] Clear apollo state cache on logout

### DIFF
--- a/dashboard/src/apollo/resolvers/auth.js
+++ b/dashboard/src/apollo/resolvers/auth.js
@@ -95,6 +95,10 @@ export default {
 
       invalidateTokens: (_, vars, { cache }) => {
         const result = cache.readQuery({ query });
+
+        // Reset all data in the client cache.
+        cache.reset();
+
         return invalidateTokens(result.auth).then(
           handleTokens(cache, "InvalidateTokensMutation"),
         );


### PR DESCRIPTION
## What is this change?

Prevent private data from leaking between auth sessions by clearing apollo client cache when logging out.

## Why is this change necessary?

Closes #1301

## Does your change need a Changelog entry?

no

## Do you need clarification on anything?

naw

## Were there any complications while making this change?

nope