### PR TITLE
Return an error from configure on invalid env/org.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ when creating resources with `sensuctl create`.
 - Provided additional context to metric event logs.
 - Updated goversion in the appveyor configuration for minor releases.
 - Use a default hostname if one cannot be retrieved.
+- Return an error from `sensuctl configure` when the configured organization
+or environment does not exist.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/cli/client/environment.go
+++ b/cli/client/environment.go
@@ -83,7 +83,7 @@ func (client *RestClient) FetchEnvironment(envName string) (*types.Environment, 
 	}
 
 	if res.StatusCode() >= 400 {
-		return env, fmt.Errorf("%v", res.String())
+		return env, fmt.Errorf("error getting environment: %v", res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &env)

--- a/cli/client/organization.go
+++ b/cli/client/organization.go
@@ -91,7 +91,7 @@ func (client *RestClient) FetchOrganization(orgName string) (*types.Organization
 	}
 
 	if res.StatusCode() >= 400 {
-		return org, fmt.Errorf("%v", res.String())
+		return org, fmt.Errorf("error getting organization: %v", res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &org)

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -89,14 +89,6 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				)
 			}
 
-			if err = cli.Config.SaveEnvironment(answers.Environment); err != nil {
-				fmt.Fprintln(cmd.OutOrStderr())
-				return fmt.Errorf(
-					"unable to write new configuration file with error: %s",
-					err,
-				)
-			}
-
 			// Write CLI preferences to disk
 			if err = cli.Config.SaveFormat(answers.Format); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
@@ -106,7 +98,23 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				)
 			}
 
+			if _, err := cli.Client.FetchOrganization(answers.Organization); err != nil {
+				return err
+			}
+
 			if err = cli.Config.SaveOrganization(answers.Organization); err != nil {
+				fmt.Fprintln(cmd.OutOrStderr())
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
+			if _, err := cli.Client.FetchEnvironment(answers.Environment); err != nil {
+				return err
+			}
+
+			if err = cli.Config.SaveEnvironment(answers.Environment); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(
 					"unable to write new configuration file with error: %s",


### PR DESCRIPTION
The commit modifies the behaviour of sensuctl configure, so that
if a user attempts to configure an organization or environment that
does not exist, an error will be returned.

Previously, sensuctl would allow an organization or environment
to be configured even if they did not exist.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #1515