### PR TITLE
Remove --org parameter from environment command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ when creating resources with `sensuctl create`.
 - Use a default hostname if one cannot be retrieved.
 - Return an error from `sensuctl configure` when the configured organization
 or environment does not exist.
+- Remove an unnecessary parameter from sensuctl environment create.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/cli/commands/environment/create.go
+++ b/cli/commands/environment/create.go
@@ -64,10 +64,6 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	_ = cmd.Flags().StringP("description", "", "", "Description of environment")
-	// TODO (Simon): We should be able to use --organization instead but
-	// the environment middleware verifies that the env exists in the given org,
-	// even if we are actually create this env
-	_ = cmd.Flags().StringP("org", "", "", "Name of organization")
 
 	helpers.AddInteractiveFlag(cmd.Flags())
 	return cmd


### PR DESCRIPTION
In testing, it was discovered that the --org parameter is actually
not necessary for the environment create command. Users can specify
the --organization parameter instead.

This commit removes the parameter.

Closes #1514

Signed-off-by: Eric Chlebek <eric@sensu.io>