### PR TITLE
Add example configurations for staging backend and agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ prior to assuming the existence of said check.
 - Added the format `wrapped-json` to sensuctl `configure`, `list` and `info`
 commands, which is compatible with `sensuctl create`.
 - Added debug event log with all event data.
+- Added yml.example configurations for staging backend and agents.
 
 ### Changed
 - Add logging around the Sensu event pipeline.

--- a/testing/config/staging-agent-0.yml.example
+++ b/testing/config/staging-agent-0.yml.example
@@ -1,0 +1,53 @@
+---
+##
+# agent configuration
+##
+id: "staging-agent-0"
+#organization: "default"
+#environment: "default"
+subscriptions: "metrics,misc"
+# UPDATE BACKEND URL
+#backend-url:
+#  - "ws://127.0.0.1:8081"
+
+##
+# authentication configuration
+##
+#user: "agent"
+#password: "P@ssw0rd!"
+
+##
+# api configuration
+##
+#api-host: "127.0.0.1"
+#api-port: 3031
+#disable-api: false
+
+##
+# socket configuration
+##
+#disable-sockets: false
+#socket-host: "127.0.0.1"
+#socket-port: 3030
+
+##
+# statsd configuration
+##
+#statsd-disable: false
+#statsd-event-handlers: ""
+#statsd-flush-interval: 10
+#statsd-metrics-host: "127.0.0.1"
+#statsd-metrics-port: 8125
+
+##
+# other
+##
+#cache-dir: "/var/cache/sensu/sensu-agent"
+#config-file: ""
+#deregister: false
+#deregistration-handler: ""
+#keepalive-timeout: 120
+#keepalive-interval: 20
+#custom-attributes: ""
+log-level: "debug"
+#redact: ""

--- a/testing/config/staging-agent-1.yml.example
+++ b/testing/config/staging-agent-1.yml.example
@@ -1,0 +1,53 @@
+---
+##
+# agent configuration
+##
+id: "staging-agent-1"
+#organization: "default"
+#environment: "default"
+subscriptions: "schedules,rbac"
+# UPDATE BACKEND URL
+#backend-url:
+#  - "ws://127.0.0.1:8081"
+
+##
+# authentication configuration
+##
+#user: "agent"
+#password: "P@ssw0rd!"
+
+##
+# api configuration
+##
+#api-host: "127.0.0.1"
+#api-port: 3031
+#disable-api: false
+
+##
+# socket configuration
+##
+#disable-sockets: false
+#socket-host: "127.0.0.1"
+#socket-port: 3030
+
+##
+# statsd configuration
+##
+#statsd-disable: false
+#statsd-event-handlers: ""
+#statsd-flush-interval: 10
+#statsd-metrics-host: "127.0.0.1"
+#statsd-metrics-port: 8125
+
+##
+# other
+##
+#cache-dir: "/var/cache/sensu/sensu-agent"
+#config-file: ""
+#deregister: false
+#deregistration-handler: ""
+#keepalive-timeout: 120
+#keepalive-interval: 20
+#custom-attributes: ""
+log-level: "debug"
+#redact: ""

--- a/testing/config/staging-agent-2.yml.example
+++ b/testing/config/staging-agent-2.yml.example
@@ -1,0 +1,53 @@
+---
+##
+# agent configuration
+##
+id: "staging-agent-2"
+organization: "ops"
+environment: "dev"
+subscriptions: "rbac"
+# UPDATE BACKEND URL
+#backend-url:
+#  - "ws://127.0.0.1:8081"
+
+##
+# authentication configuration
+##
+#user: "agent"
+#password: "P@ssw0rd!"
+
+##
+# api configuration
+##
+#api-host: "127.0.0.1"
+#api-port: 3031
+#disable-api: false
+
+##
+# socket configuration
+##
+#disable-sockets: false
+#socket-host: "127.0.0.1"
+#socket-port: 3030
+
+##
+# statsd configuration
+##
+#statsd-disable: false
+#statsd-event-handlers: ""
+#statsd-flush-interval: 10
+#statsd-metrics-host: "127.0.0.1"
+#statsd-metrics-port: 8125
+
+##
+# other
+##
+#cache-dir: "/var/cache/sensu/sensu-agent"
+#config-file: ""
+#deregister: true
+#deregistration-handler: ""
+#keepalive-timeout: 120
+#keepalive-interval: 20
+custom-attributes: "{\"ec2_access_key\": \"P@ssw0rd\",\"secret\": \"P@ssw0rd\"}"
+log-level: "debug"
+redact: "ec2_access_key"

--- a/testing/config/staging-backend.yml.example
+++ b/testing/config/staging-backend.yml.example
@@ -1,0 +1,50 @@
+---
+##
+# general configuration
+##
+state-dir: "/var/lib/sensu"
+
+##
+# agent configuration
+##
+#agent-host: "[::]" # listen on all IPv4 and IPv6 addresses
+#agent-port: 8081
+
+##
+# api configuration
+##
+#api-host: "[::]" # listen on all IPv4 and IPv6 addresses
+#api-port: 8080
+
+##
+# ssl configuration
+##
+#cert-file: "/path/to/ssl/cert.pem"
+#key-file: "/path/to/ssl/key.pem"
+#trusted-ca-file: "/path/to/trusted-certificate-authorities.pem"
+#insecure-skip-tls-verify: false
+
+##
+# store configuration
+##
+#listen-client-urls: ""
+#listen-peer-urls: ""
+#initial-cluster: ""
+#initial-advertise-peer-urls: ""
+#initial-cluster-state: ""
+#initial-cluster-token: ""
+#name: ""
+
+##
+# dashboard configuration
+##
+#dashboard-host: "[::]" # listen on all IPv4 and IPv6 addresses
+#dashboard-port: 3000
+
+##
+# other
+##
+#config-file: ""
+#debug: false
+#deregistration-handler: ""
+log-level: "debug"


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds example configurations for agents and backend to `testing/config` for use in the staging environment.

## Why is this change necessary?

Closes #1671 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.