### PR TITLE
Add nuance to govaluate error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ non-default organizations or environments are configured.
 - When installing assets, errors no longer cause file descriptors to leak, or
 lockfiles to not be cleaned up.
 - Fixed a bug where the CLI default for round robin checks was not appearing.
+- Missing custom attributes in govaluate expressions no longer result in
+an error being logged. Instead, a debug message is logged.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/agent/assetmanager/asset.go
+++ b/agent/assetmanager/asset.go
@@ -51,7 +51,14 @@ func (d *RuntimeAsset) isRelevantTo(entity types.Entity) (bool, error) {
 	for _, filter := range d.asset.Filters {
 		result, err := eval.EvaluatePredicate(filter, params)
 		if err != nil {
-			return false, err
+			switch err.(type) {
+			case eval.SyntaxError, eval.TypeError:
+				return false, err
+			default:
+				// Other errors during execution are likely due to missing attrs,
+				// simply continue in this case.
+				continue
+			}
 		}
 
 		if !result {

--- a/util/eval/predicate_test.go
+++ b/util/eval/predicate_test.go
@@ -16,6 +16,7 @@ func TestEvaluatePredicate(t *testing.T) {
 		args    args
 		want    bool
 		wantErr bool
+		errType string
 	}{
 		{
 			name: "unparsable expression",
@@ -23,6 +24,7 @@ func TestEvaluatePredicate(t *testing.T) {
 				expression: "1 &&",
 			},
 			wantErr: true,
+			errType: "SyntaxError",
 		},
 		{
 			name: "unevaluable expression",
@@ -37,6 +39,7 @@ func TestEvaluatePredicate(t *testing.T) {
 				expression: "42",
 			},
 			wantErr: true,
+			errType: "TypeError",
 		},
 		{
 			name: "positive result",
@@ -125,6 +128,18 @@ func TestEvaluatePredicate(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Evaluate() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if err != nil && tt.wantErr && tt.errType != "" {
+				switch tt.errType {
+				case "SyntaxError":
+					if _, ok := err.(SyntaxError); !ok {
+						t.Error("want SyntaxError")
+					}
+				case "TypeError":
+					if _, ok := err.(TypeError); !ok {
+						t.Error("want TypeError")
+					}
+				}
 			}
 			if got != tt.want {
 				t.Errorf("Evaluate() = %v, want %v", got, tt.want)


### PR DESCRIPTION
Add two error types to the eval package, which allows users of the
package to distinguish between syntax errors and type errors.

In the asset manager, if errors are not SyntaxErrors or TypeErrors,
then only issue a debug log entry. Otherwise issue an error log
entry. Do the same thing for proxy check entities.

Closes #1512

Signed-off-by: Eric Chlebek <eric@sensu.io>