### PR TITLE
Organization must be created before environment

### DIFF
--- a/testing/config/resources.json
+++ b/testing/config/resources.json
@@ -476,14 +476,6 @@
   }
 }
 {
-  "type": "Environment",
-  "spec": {
-    "description": "",
-    "name": "dev",
-    "organization": "ops"
-  }
-}
-{
   "type": "Extension",
   "spec": {
     "name": "foo",
@@ -496,6 +488,14 @@
   "spec": {
     "description": "",
     "name": "ops"
+  }
+}
+{
+  "type": "Environment",
+  "spec": {
+    "description": "",
+    "name": "dev",
+    "organization": "ops"
   }
 }
 {

--- a/testing/config/staging-agent-0.yml.example
+++ b/testing/config/staging-agent-0.yml.example
@@ -34,7 +34,7 @@ subscriptions: "metrics,misc"
 # statsd configuration
 ##
 #statsd-disable: false
-#statsd-event-handlers: ""
+statsd-event-handlers: "cat"
 #statsd-flush-interval: 10
 #statsd-metrics-host: "127.0.0.1"
 #statsd-metrics-port: 8125


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Moves test organization before environment.

## Why is this change necessary?

In order for `sensuctl create -f` to work for the test resources, the organization must be created before called upon by the environment.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.