### PR TITLE
Don't reset check occurrences to 1 on check resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ lockfiles to not be cleaned up.
 - Fixed a bug where the CLI default for round robin checks was not appearing.
 - Missing custom attributes in govaluate expressions no longer result in
 an error being logged. Instead, a debug message is logged.
+- Fixed a bug in check occurrences where the behaviour was not in line with
+1.x behaviour. Check occurrences now only update on failing check statuses.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -131,6 +131,7 @@ func TestEventMonitor(t *testing.T) {
 }
 
 func TestCheckOccurrences(t *testing.T) {
+	now := time.Now()
 	testCases := []struct {
 		name                         string
 		status                       uint32
@@ -144,7 +145,7 @@ func TestCheckOccurrences(t *testing.T) {
 			status:      0,
 			occurrences: int64(0),
 			history: []types.CheckHistory{
-				{Status: 0, Executed: time.Now().Unix() - 1},
+				{Status: 0, Executed: now.Unix() - 1},
 			},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
@@ -154,7 +155,7 @@ func TestCheckOccurrences(t *testing.T) {
 			status:      1,
 			occurrences: int64(0),
 			history: []types.CheckHistory{
-				{Status: 1, Executed: time.Now().Unix() - 1},
+				{Status: 1, Executed: now.Unix() - 1},
 			},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
@@ -164,8 +165,8 @@ func TestCheckOccurrences(t *testing.T) {
 			status:      0,
 			occurrences: int64(1),
 			history: []types.CheckHistory{
-				{Status: 1, Executed: time.Now().Unix() - 2},
-				{Status: 0, Executed: time.Now().Unix() - 1},
+				{Status: 1, Executed: now.Unix() - 2},
+				{Status: 0, Executed: now.Unix() - 1},
 			},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
@@ -175,8 +176,8 @@ func TestCheckOccurrences(t *testing.T) {
 			status:      1,
 			occurrences: int64(1),
 			history: []types.CheckHistory{
-				{Status: 1, Executed: time.Now().Unix() - 2},
-				{Status: 1, Executed: time.Now().Unix() - 1},
+				{Status: 1, Executed: now.Unix() - 2},
+				{Status: 1, Executed: now.Unix() - 1},
 			},
 			expectedOccurrences:          2,
 			expectedOccurrencesWatermark: 2,
@@ -186,11 +187,25 @@ func TestCheckOccurrences(t *testing.T) {
 			status:      1,
 			occurrences: int64(1),
 			history: []types.CheckHistory{
-				{Status: 2, Executed: time.Now().Unix() - 2},
-				{Status: 1, Executed: time.Now().Unix() - 1},
+				{Status: 2, Executed: now.Unix() - 2},
+				{Status: 1, Executed: now.Unix() - 1},
 			},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
+		},
+		{
+			name:        "GH-1624 occurrences property should not reset to 1 on resolve",
+			status:      0,
+			occurrences: 5,
+			history: []types.CheckHistory{
+				{Status: 2, Executed: now.Unix() - 6},
+				{Status: 2, Executed: now.Unix() - 5},
+				{Status: 2, Executed: now.Unix() - 4},
+				{Status: 2, Executed: now.Unix() - 3},
+				{Status: 2, Executed: now.Unix() - 2},
+			},
+			expectedOccurrences:          5,
+			expectedOccurrencesWatermark: 5,
 		},
 	}
 


### PR DESCRIPTION
Check occurrences are the number of times a check has had the same
status, in the case where checks are failing.

When checks are resolved, the occurrences field will stop
receiving updates. Occurrences only apply to failing status codes.

This is somewhat unintuitive, but it makes 2.x compatible with 1.x
in this respect.

Closes #1624

Signed-off-by: Eric Chlebek <eric@sensu.io>