### PR TITLE
Refactor/monitor

### DIFF
--- a/backend/monitor/logger.go
+++ b/backend/monitor/logger.go
@@ -1,0 +1,7 @@
+package monitor
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "monitor",
+})

--- a/backend/monitor/monitors.go
+++ b/backend/monitor/monitors.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -27,22 +28,39 @@ type EtcdGetter struct {
 	Client *clientv3.Client
 }
 
-// MonitorUpdateHandler provides an event update handler.
-type MonitorUpdateHandler interface {
-	HandleUpdate(e *types.Event) error
+// Service is the monitors interface.
+type Service interface {
+	// GetMonitor starts a new monitor.
+	GetMonitor(ctx context.Context, name string, entity *types.Entity, event *types.Event, ttl int64) error
 }
 
-// MonitorFailureHandler provides a failure handler.
+// Factory takes an entity and returns a Monitor interface so the
+// monitor can be mocked.
+type Factory func(*clientv3.Client, UpdateHandler, FailureHandler) Service
+
+// MonitorFailureHandler provides a failure handler. TODO: rename this to
+// FailureHandler when we remove the other monitor code.
 type MonitorFailureHandler interface {
 	HandleFailure(entity *types.Entity, event *types.Event) error
 }
 
-// Monitors is a monitor based on a leased key in etcd. Monitor leases can be
-// extended, and a watcher on the key will run a handler when the lease expires
-// and the key is deleted.
-type Monitors struct {
-	FailureHandler MonitorFailureHandler
-	UpdateHandler  MonitorUpdateHandler
+type ErrorHandler interface {
+	HandleError(error)
+}
+
+// ErrorHandler provides a handler for errors from WatchMon.
+type ErrorHandlerFunc func(error)
+
+func (e ErrorHandlerFunc) HandleError(err error) {
+	return e(err)
+}
+
+// EtcdService is an etcd backed monitor service monitor based on a leased key.
+// Monitor leases can be extended, and a watcher on the key will run a handler
+// when the lease expires and the key is deleted.
+type EtcdService struct {
+	failureHandler MonitorFailureHandler
+	errorHandler   ErrorHandler
 	client         *clientv3.Client
 }
 
@@ -52,47 +70,27 @@ type monitor struct {
 	key     string
 	leaseID clientv3.LeaseID
 	ttl     int64
-	value   string
 }
 
 // NewMonitor returns a new monitor.
-func NewMonitor(client *clientv3.Client) *Monitors {
-	return &Monitors{
-		client: client,
+func NewService(client *clientv3.Client, failureHandler MonitorFailureHandler, errorHandler ErrorHandler) *EtcdService {
+	return &EtcdService{
+		client:         client,
+		failureHandler: failurehandler,
+		errorHandler:   errorHandler,
 	}
 }
 
-// WatchMon takes a monitor key and watches for a deletion op. If a delete event
-// is witnessed, it calls the provided HandleFailure func.
-func (m *Monitors) WatchMon(ctx context.Context, mon *monitor) error {
-	var err error
-	// call a goroutine, on delete call HandleFailure
-	go func() {
-		responseChan := m.client.Watch(ctx, mon.key)
-		for wresp := range responseChan {
-			for _, ev := range wresp.Events {
-				if ev.Type == mvccpb.DELETE {
-					err = m.HandleFailure(mon.entity, mon.event)
-					return
-				}
-
-			}
-		}
-	}()
-	return err
-}
-
-// HandleFailure...
-func (m *Monitors) HandleFailure(entity *types.Entity, event *types.Event) error {
-	err := m.FailureHandler.HandleFailure(entity, event)
-	return err
+// HandleFailure handles the failing monitor.
+func (m *EtcdService) HandleFailure(entity *types.Entity, event *types.Event) error {
+	return m.FailureHandler.HandleFailure(entity, event)
 }
 
 // GetMonitor checks for the presense of a monitor for a given entity or check.
 // if no monitor exists, one is created. If a monitor exists, its ttl is
-// extended. If the monitor's ttl has changed, it extended with a new lease.
-func (m *Monitors) GetMonitor(ctx context.Context, name string, entity *types.Entity, event *types.Event, ttl int64) error {
-	key := monitorKeyBuilder.WithContext(ctx).Build(name)
+// extended. If the monitor's ttl has changed, create a new lease.
+func (m *EtcdService) GetMonitor(ctx context.Context, name string, entity *types.Entity, event *types.Event, ttl int64) error {
+	key := monitorKeyBuilder.Build(name)
 	// try to get the monitor from the store
 	mon, err := m.getMonitor(ctx, key)
 	if err != nil {
@@ -118,22 +116,17 @@ func (m *Monitors) GetMonitor(ctx context.Context, name string, entity *types.En
 		return err
 	}
 
-	//create a monitor value
-	value := "type of event or entity or check etc that we're storing"
-
 	mon = &monitor{
 		entity:  entity,
 		event:   event,
 		key:     key,
 		leaseID: leaseID,
 		ttl:     ttl,
-		value:   value,
 	}
-	// put key to etcd and start the watcher - if a watcher already exists,
-	// don't start it (figure out how to cancel a goroutine that's already
-	// running? or maybe do this another way)
+
+	// put key and start the watcher
 	cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
-	req := clientv3.OpPut(mon.key, mon.value, clientv3.WithLease(mon.leaseID))
+	req := clientv3.OpPut(mon.key, fmt.Sprintf("%d", mon.ttl), clientv3.WithLease(mon.leaseID))
 	res, err := m.client.Txn(ctx).If(cmp).Then(req).Commit()
 	if err != nil {
 		return err
@@ -142,26 +135,52 @@ func (m *Monitors) GetMonitor(ctx context.Context, name string, entity *types.En
 	if !res.Succeeded {
 		return fmt.Errorf("could not create monitor for %s", key)
 	}
-	// start watcher here
-	err = m.WatchMon(ctx, mon)
+	// start watcher here only if monitor didn't previously exist
+	err = m.watchMon(ctx, mon)
 	return err
 }
 
-func (m *Monitors) getMonitor(ctx context.Context, id string) (*monitor, error) {
+func (m *EtcdService) getMonitor(ctx context.Context, key string) (*monitor, error) {
 	// try to get the key from the store
-	response, err := m.client.Get(ctx, id)
+	response, err := m.client.Get(ctx, key)
 	if err != nil {
 		return nil, err
 	}
 	// if it exists, return it as a monitor
 	if len(response.Kvs) > 0 {
 		mon := response.Kvs[0]
+		// if there is no lease, this will be 0 (NoLease constant in etcd)
 		leaseID := clientv3.LeaseID(mon.Lease)
 		return &monitor{
 			key:     string(mon.Key),
 			leaseID: leaseID,
+			ttl:     strconv.Atoi(mon.value),
 		}, nil
 	}
 	// otherwise, return nil
 	return nil, nil
+}
+
+// watchMon takes a monitor key and watches for a deletion op. If a delete event
+// is witnessed, it calls the provided HandleFailure func.
+func (m *EtcdService) watchMon(ctx context.Context, mon *monitor) {
+	go func() {
+		responseChan := m.client.Watch(ctx, mon.key)
+		for wresp := range responseChan {
+			for _, ev := range wresp.Events {
+				if ev.Type == mvccpb.DELETE {
+					err := m.HandleFailure(mon.entity, mon.event)
+					if err != nil {
+						m.HandleError(err)
+					}
+				}
+				// if there is a PUT on the key, the lease has been extended,
+				// and we want to kill this watcher as another one will be
+				// started.
+				if ev.Type == mvccpb.PUT {
+					return
+				}
+			}
+		}
+	}()
 }

--- a/backend/monitor/monitors.go
+++ b/backend/monitor/monitors.go
@@ -1,0 +1,72 @@
+package monitor
+
+import (
+	"sync"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// create leased key under monitors prefix:
+//	- /sensu.io/monitors/org/env/<entity or round robin check>
+// update leased key
+// get ttl of current monitor (check for existence of key)
+// watch monitor for deletion event, alert on that entity
+
+var (
+	monitorPathPrefix = "monitors"
+	monitorKeyBuilder = store.NewKeyBuilder(monitorPathPrefix)
+)
+
+// EtcdGetter is an Etcd implementation of Getter.
+type EtcdGetter struct {
+	*clientv3.Client
+}
+
+// Monitors is a monitor based on a leased key in etcd. Monitor leases can be
+// extended, and a watcher on the key will run a handler when the lease expires
+// and the key is deleted.
+type Monitors struct {
+	client *clientv3.Client
+	mu     *sync.Mutex
+}
+
+type monitor struct {
+	check  *types.Check
+	entity *types.Entity
+	event  *types.Event
+}
+
+// NewMonitors return new monitors.
+func NewMonitors(client *clientv3.Client) *Monitors {
+	return &Monitors{
+		client: client,
+	}
+}
+
+// GetMonitor returns a monitor. If a monitor is current, it is returned; if no
+// monitor exists, it is created.
+func (m *Monitors) GetMonitor(name string, ttl int) error {
+
+	return nil
+}
+
+// UpdateMonitor extends the lease on a monitor.
+func (m *Monitors) UpdateMonitor(name string, ttl int) error {
+	return nil
+}
+
+// CheckMonitor checks for the existence of a monitor. It returns the ttl
+// remaining if the monitor exists, otherwise it returns zero.
+func (m *Monitors) CheckMonitor(name string) error {
+	// might not need this func.
+	return nil
+}
+
+// WatchMon takes a monitor key and watches for a deletion op. If a delete event
+// is witnessed, it calls the provided HandleFailure func.
+func (m *Monitors) WatchMon(name string) error {
+
+	return nil
+}

--- a/backend/monitor/monitors.go
+++ b/backend/monitor/monitors.go
@@ -1,9 +1,11 @@
 package monitor
 
 import (
-	"sync"
+	"context"
+	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
@@ -13,60 +15,153 @@ import (
 // update leased key
 // get ttl of current monitor (check for existence of key)
 // watch monitor for deletion event, alert on that entity
+// also might need a mechanism for deleting a monitor (ie deregistration)
 
 var (
 	monitorPathPrefix = "monitors"
 	monitorKeyBuilder = store.NewKeyBuilder(monitorPathPrefix)
 )
 
-// EtcdGetter is an Etcd implementation of Getter.
+// EtcdGetter provides access to the etcd client.
 type EtcdGetter struct {
-	*clientv3.Client
+	Client *clientv3.Client
+}
+
+// MonitorUpdateHandler provides an event update handler.
+type MonitorUpdateHandler interface {
+	HandleUpdate(e *types.Event) error
+}
+
+// MonitorFailureHandler provides a failure handler.
+type MonitorFailureHandler interface {
+	HandleFailure(entity *types.Entity, event *types.Event) error
 }
 
 // Monitors is a monitor based on a leased key in etcd. Monitor leases can be
 // extended, and a watcher on the key will run a handler when the lease expires
 // and the key is deleted.
 type Monitors struct {
-	client *clientv3.Client
-	mu     *sync.Mutex
+	FailureHandler MonitorFailureHandler
+	UpdateHandler  MonitorUpdateHandler
+	client         *clientv3.Client
 }
 
 type monitor struct {
-	check  *types.Check
-	entity *types.Entity
-	event  *types.Event
+	entity  *types.Entity
+	event   *types.Event
+	key     string
+	leaseID clientv3.LeaseID
+	ttl     int64
+	value   string
 }
 
-// NewMonitors return new monitors.
-func NewMonitors(client *clientv3.Client) *Monitors {
+// NewMonitor returns a new monitor.
+func NewMonitor(client *clientv3.Client) *Monitors {
 	return &Monitors{
 		client: client,
 	}
 }
 
-// GetMonitor returns a monitor. If a monitor is current, it is returned; if no
-// monitor exists, it is created.
-func (m *Monitors) GetMonitor(name string, ttl int) error {
-
-	return nil
-}
-
-// UpdateMonitor extends the lease on a monitor.
-func (m *Monitors) UpdateMonitor(name string, ttl int) error {
-	return nil
-}
-
-// CheckMonitor checks for the existence of a monitor. It returns the ttl
-// remaining if the monitor exists, otherwise it returns zero.
-func (m *Monitors) CheckMonitor(name string) error {
-	// might not need this func.
-	return nil
-}
-
 // WatchMon takes a monitor key and watches for a deletion op. If a delete event
 // is witnessed, it calls the provided HandleFailure func.
-func (m *Monitors) WatchMon(name string) error {
+func (m *Monitors) WatchMon(ctx context.Context, mon *monitor) error {
+	var err error
+	// call a goroutine, on delete call HandleFailure
+	go func() {
+		responseChan := m.client.Watch(ctx, mon.key)
+		for wresp := range responseChan {
+			for _, ev := range wresp.Events {
+				if ev.Type == mvccpb.DELETE {
+					err = m.HandleFailure(mon.entity, mon.event)
+					return
+				}
 
-	return nil
+			}
+		}
+	}()
+	return err
+}
+
+// HandleFailure...
+func (m *Monitors) HandleFailure(entity *types.Entity, event *types.Event) error {
+	err := m.FailureHandler.HandleFailure(entity, event)
+	return err
+}
+
+// GetMonitor checks for the presense of a monitor for a given entity or check.
+// if no monitor exists, one is created. If a monitor exists, its ttl is
+// extended. If the monitor's ttl has changed, it extended with a new lease.
+func (m *Monitors) GetMonitor(ctx context.Context, name string, entity *types.Entity, event *types.Event, ttl int64) error {
+	key := monitorKeyBuilder.WithContext(ctx).Build(name)
+	// try to get the monitor from the store
+	mon, err := m.getMonitor(ctx, key)
+	if err != nil {
+		return err
+	}
+	// if it exists and the ttl matches the original ttl of the lease, extend its
+	// lease with keep-alive.
+	if mon != nil && mon.ttl == ttl {
+		_, kaerr := m.client.KeepAliveOnce(ctx, mon.leaseID)
+		if kaerr != nil {
+			return kaerr
+		}
+
+		return nil
+	}
+
+	// If the ttls do not match or the monitor doesn't exist, create a new lease
+	// and do a put on the key with that lease.
+	leaseID := clientv3.LeaseID(ttl)
+
+	lease, err := m.client.Grant(ctx, ttl)
+	if err != nil {
+		return err
+	}
+
+	//create a monitor value
+	value := "type of event or entity or check etc that we're storing"
+
+	mon = &monitor{
+		entity:  entity,
+		event:   event,
+		key:     key,
+		leaseID: leaseID,
+		ttl:     ttl,
+		value:   value,
+	}
+	// put key to etcd and start the watcher - if a watcher already exists,
+	// don't start it (figure out how to cancel a goroutine that's already
+	// running? or maybe do this another way)
+	cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
+	req := clientv3.OpPut(mon.key, mon.value, clientv3.WithLease(mon.leaseID))
+	res, err := m.client.Txn(ctx).If(cmp).Then(req).Commit()
+	if err != nil {
+		return err
+	}
+
+	if !res.Succeeded {
+		return fmt.Errorf("could not create monitor for %s", key)
+	}
+	// start watcher here
+	err = m.WatchMon(ctx, mon)
+	return err
+}
+
+func (m *Monitors) getMonitor(ctx context.Context, id string) (*monitor, error) {
+	// try to get the key from the store
+	response, err := m.client.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	// if it exists, return it as a monitor
+	if len(response.Kvs) > 0 {
+		mon := response.Kvs[0]
+		leaseID := clientv3.LeaseID(mon.Lease)
+		return &monitor{
+			key:     string(mon.Key),
+			leaseID: leaseID,
+		}, nil
+	}
+	// otherwise, return nil
+	return nil, nil
 }

--- a/backend/monitor/monitors.go
+++ b/backend/monitor/monitors.go
@@ -18,13 +18,13 @@ var (
 
 // Service is the monitors interface.
 type Service interface {
-	// RefreshMonitor starts a new monitor.
+	// RefreshMonitor starts a new monitor or resets an existing monitor.
 	RefreshMonitor(ctx context.Context, name string, entity *types.Entity, event *types.Event, ttl int64) error
 }
 
-// Factory takes an entity and returns a Monitor interface so the
-// monitor can be mocked.
-type Factory func(*clientv3.Client, UpdateHandler, FailureHandler) Service
+// Factory takes an etcd client, failure handler, and error handler and returns
+// a monitor service.
+type Factory func(*clientv3.Client, MonitorFailureHandler, ErrorHandler) Service
 
 // MonitorFailureHandler provides a failure handler. TODO: rename this to
 // FailureHandler when we remove the other monitor code.
@@ -32,11 +32,12 @@ type MonitorFailureHandler interface {
 	HandleFailure(entity *types.Entity, event *types.Event) error
 }
 
+// ErrorHandler is the error handler func interface.
 type ErrorHandler interface {
 	HandleError(error)
 }
 
-// ErrorHandler provides a handler for errors from WatchMon.
+// ErrorHandlerFunc implements ErrorHandler
 type ErrorHandlerFunc func(error)
 
 func (e ErrorHandlerFunc) HandleError(err error) {

--- a/backend/monitor/monitors.go
+++ b/backend/monitor/monitors.go
@@ -114,17 +114,12 @@ func (m *EtcdService) GetMonitor(ctx context.Context, name string, entity *types
 	}
 
 	// put key and start the watcher
-	cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
-	req := clientv3.OpPut(mon.key, fmt.Sprintf("%d", mon.ttl), clientv3.WithLease(mon.leaseID))
-	res, err := m.client.Txn(ctx).If(cmp).Then(req).Commit()
+	res, err := m.client.Put(ctx, key, fmt.Sprintf("%d", mon.ttl), clientv3.WithLease(lease.ID))
 	if err != nil {
-		fmt.Println("etcd transaction error:", err)
 		return err
 	}
 
-	if !res.Succeeded {
-		return fmt.Errorf("could not create monitor for %s", key)
-	}
+	fmt.Println("transaction response in monitors:", res)
 
 	failureFunc := func() {
 		logger.Infof("monitor timed out, for %s, handling failure", key)

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -29,6 +29,10 @@ func TestGetMonitors(t *testing.T) {
 
 }
 
+func TestGetMonitors(t *testing.T) {
+
+}
+
 func TestMonitorsHandleUpdate(t *testing.T) {
 
 	passEntity := types.FixtureEntity("entity")

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -1,0 +1,72 @@
+package monitor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type testMonitorsHandler struct{}
+
+// create update and failure handlers for use with the monitor
+func (handler *testMonitorsHandler) HandleUpdate(event *types.Event) error {
+	if event.Entity.ID == "entity" {
+		return nil
+	}
+	return errors.New("test update handler error")
+}
+
+func (handler *testMonitorsHandler) HandleFailure(entity *types.Entity, event *types.Event) error {
+	if entity.ID == "entity" {
+		return nil
+	}
+	return errors.New("test failure handler error")
+}
+
+func TestGetMonitors(t *testing.T) {
+
+}
+
+func TestMonitorsHandleUpdate(t *testing.T) {
+
+	passEntity := types.FixtureEntity("entity")
+	failEntity := types.FixtureEntity("fail")
+	testCases := []struct {
+		name        string
+		entity      *types.Entity
+		event       *types.Event
+		handler     *testHandler
+		expectedErr error
+	}{
+		{
+			name:   "test no error",
+			entity: passEntity,
+			event: &types.Event{
+				Entity: passEntity,
+			},
+			handler:     &testHandler{},
+			expectedErr: nil,
+		},
+		{
+			name:   "test with error",
+			entity: failEntity,
+			event: &types.Event{
+				Entity: failEntity,
+			},
+			handler:     &testHandler{},
+			expectedErr: errors.New("test update handler error"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			monitor := NewMonitors()
+
+			assert.EqualValues(tc.expectedErr, monitor.HandleUpdate(tc.event))
+		})
+	}
+
+}

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -1,23 +1,21 @@
 package monitor
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testMonitorsHandler struct{}
 
-// create update and failure handlers for use with the monitor
-func (handler *testMonitorsHandler) HandleUpdate(event *types.Event) error {
-	if event.Entity.ID == "entity" {
-		return nil
-	}
-	return errors.New("test update handler error")
-}
-
+// create failure and error handlers for use with the monitor
 func (handler *testMonitorsHandler) HandleFailure(entity *types.Entity, event *types.Event) error {
 	if entity.ID == "entity" {
 		return nil
@@ -25,23 +23,24 @@ func (handler *testMonitorsHandler) HandleFailure(entity *types.Entity, event *t
 	return errors.New("test failure handler error")
 }
 
-func TestGetMonitors(t *testing.T) {
-
-}
-
-func TestGetMonitors(t *testing.T) {
-
+func (handler *testMonitorsHandler) HandleError(err error) {
+	fmt.Println("error handled")
 }
 
 func TestMonitorsHandleUpdate(t *testing.T) {
-
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+	client, err := e.NewClient()
+	defer client.Close()
+	require.NoError(t, err)
 	passEntity := types.FixtureEntity("entity")
 	failEntity := types.FixtureEntity("fail")
+
 	testCases := []struct {
 		name        string
 		entity      *types.Entity
 		event       *types.Event
-		handler     *testHandler
+		handler     *testMonitorsHandler
 		expectedErr error
 	}{
 		{
@@ -50,7 +49,7 @@ func TestMonitorsHandleUpdate(t *testing.T) {
 			event: &types.Event{
 				Entity: passEntity,
 			},
-			handler:     &testHandler{},
+			handler:     &testMonitorsHandler{},
 			expectedErr: nil,
 		},
 		{
@@ -59,18 +58,64 @@ func TestMonitorsHandleUpdate(t *testing.T) {
 			event: &types.Event{
 				Entity: failEntity,
 			},
-			handler:     &testHandler{},
-			expectedErr: errors.New("test update handler error"),
+			handler:     &testMonitorsHandler{},
+			expectedErr: errors.New("test failure handler error"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			monitor := NewMonitors()
+			monitorService := NewService(client, tc.handler, tc.handler)
 
-			assert.EqualValues(tc.expectedErr, monitor.HandleUpdate(tc.event))
+			assert.EqualValues(tc.expectedErr, monitorService.failureHandler.HandleFailure(tc.entity, tc.event))
 		})
 	}
 
+}
+
+func TestWatchMonDelete(t *testing.T) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+	client, err := e.NewClient()
+	defer client.Close()
+	require.NoError(t, err)
+
+	var failWait sync.WaitGroup
+
+	testFailureHandler := func() {
+		failWait.Done()
+	}
+
+	key := "monitortest"
+	_, err = client.Put(context.Background(), key, "test value")
+	require.NoError(t, err)
+	watchMon(context.Background(), client, key, testFailureHandler, nil)
+	failWait.Add(1)
+	_, err = client.Delete(context.Background(), key)
+	require.NoError(t, err)
+	failWait.Wait()
+}
+
+func TestWatchMonPut(t *testing.T) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+	client, err := e.NewClient()
+	defer client.Close()
+	require.NoError(t, err)
+
+	var shutdownWait sync.WaitGroup
+
+	testShutdownHandler := func() {
+		shutdownWait.Done()
+	}
+
+	key := "monitortest"
+	_, err = client.Put(context.Background(), key, "test value")
+	require.NoError(t, err)
+	watchMon(context.Background(), client, key, nil, testShutdownHandler)
+	shutdownWait.Add(1)
+	_, err = client.Put(context.Background(), key, "test value")
+	require.NoError(t, err)
+	shutdownWait.Wait()
 }

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -37,32 +37,33 @@ func putKeyWithLease(cli *clientv3.Client, key string, ttl int64) error {
 	return err
 }
 
-func TestGetMonitorNew(t *testing.T) {
+// TestRefreshMonitorNew
+func TestRefreshMonitorNew(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	monitorName := "testGetMonitorNew"
+	monitorName := "testRefreshMonitorNew"
 	testEntity := types.FixtureEntity("entity")
 	testEvent := types.FixtureEvent(testEntity.ID, "testCheck")
 
 	handler := &testMonitorsHandler{}
 	monitorService := NewService(client, handler, handler)
-	err = monitorService.GetMonitor(context.Background(), monitorName, testEntity, testEvent, 15)
+	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 15)
 	require.NoError(t, err)
 
 }
 
-func TestGetMonitorExisting(t *testing.T) {
+func TestRefreshMonitorExisting(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	monitorName := "testGetMonitorExisting"
+	monitorName := "testRefreshMonitorExisting"
 	monitorPath := monitorKeyBuilder.Build(monitorName)
 	testEntity := types.FixtureEntity("entity")
 	testEvent := types.FixtureEvent(testEntity.ID, "testCheck")
@@ -73,18 +74,18 @@ func TestGetMonitorExisting(t *testing.T) {
 	err = putKeyWithLease(client, monitorPath, 15)
 	require.NoError(t, err)
 
-	err = monitorService.GetMonitor(context.Background(), monitorName, testEntity, testEvent, 15)
+	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 15)
 	require.NoError(t, err)
 }
 
-func TestGetMonitorNewTTL(t *testing.T) {
+func TestRefreshMonitorNewTTL(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	monitorName := "testGetMonitorNewTTL"
+	monitorName := "testRefreshMonitorNewTTL"
 	monitorPath := monitorKeyBuilder.Build(monitorName)
 	testEntity := types.FixtureEntity("entity")
 	testEvent := types.FixtureEvent(testEntity.ID, "testCheck")
@@ -98,11 +99,11 @@ func TestGetMonitorNewTTL(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println("put response in test:", response)
 
-	err = monitorService.GetMonitor(context.Background(), monitorName, testEntity, testEvent, 20)
+	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 20)
 	require.NoError(t, err)
 }
 
-func TestLittleGetMonitorNone(t *testing.T) {
+func TestGetMonitorNone(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
@@ -111,12 +112,12 @@ func TestLittleGetMonitorNone(t *testing.T) {
 
 	handler := &testMonitorsHandler{}
 	monitorService := NewService(client, handler, handler)
-	mon, err := monitorService.getMonitor(context.Background(), "testLittleGetMonitorNone")
+	mon, err := monitorService.getMonitor(context.Background(), "testGetMonitorNone")
 	require.NoError(t, err)
 	assert.Nil(t, mon)
 }
 
-func TestLittleGetMonitorExisting(t *testing.T) {
+func TestGetMonitorExisting(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
@@ -125,7 +126,7 @@ func TestLittleGetMonitorExisting(t *testing.T) {
 
 	handler := &testMonitorsHandler{}
 	testMon := &monitor{
-		key:     "testLittleGetMonitorExisting",
+		key:     "testGetMonitorExisting",
 		leaseID: 0,
 		ttl:     0,
 	}
@@ -138,6 +139,8 @@ func TestLittleGetMonitorExisting(t *testing.T) {
 	assert.EqualValues(t, testMon.key, mon.key)
 }
 
+// TestWatchMonDelete uses a wait group to monitor the state of watchMon. The
+// test passes if the failure handler is called, which closes the wait group.
 func TestWatchMonDelete(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
@@ -161,6 +164,8 @@ func TestWatchMonDelete(t *testing.T) {
 	failWait.Wait()
 }
 
+// TestWatchMonPut uses a wait group to monitor the state of watchMon. The
+// test passes if the failure handler is called, which closes the wait group.
 func TestWatchMonPut(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -95,7 +95,7 @@ func TestRefreshMonitorNewTTL(t *testing.T) {
 
 	err = putKeyWithLease(client, monitorPath, 15)
 	require.NoError(t, err)
-	_, err := client.Get(context.Background(), monitorPath)
+	_, err = client.Get(context.Background(), monitorPath)
 	require.NoError(t, err)
 
 	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 20)

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -95,7 +95,7 @@ func TestRefreshMonitorNewTTL(t *testing.T) {
 
 	err = putKeyWithLease(client, monitorPath, 15)
 	require.NoError(t, err)
-	response, err := client.Get(context.Background(), monitorPath)
+	_, err := client.Get(context.Background(), monitorPath)
 	require.NoError(t, err)
 
 	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 20)

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -97,7 +97,6 @@ func TestRefreshMonitorNewTTL(t *testing.T) {
 	require.NoError(t, err)
 	response, err := client.Get(context.Background(), monitorPath)
 	require.NoError(t, err)
-	fmt.Println("put response in test:", response)
 
 	err = monitorService.RefreshMonitor(context.Background(), monitorName, testEntity, testEvent, 20)
 	require.NoError(t, err)

--- a/backend/monitor/monitors_test.go
+++ b/backend/monitor/monitors_test.go
@@ -1,3 +1,5 @@
+// +build integration,!race
+
 package monitor
 
 import (
@@ -39,8 +41,8 @@ func TestGetMonitorNew(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	monitorName := "testGetMonitorNew"
 	testEntity := types.FixtureEntity("entity")
@@ -57,8 +59,8 @@ func TestGetMonitorExisting(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	monitorName := "testGetMonitorExisting"
 	monitorPath := monitorKeyBuilder.Build(monitorName)
@@ -79,8 +81,8 @@ func TestGetMonitorNewTTL(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	monitorName := "testGetMonitorNewTTL"
 	monitorPath := monitorKeyBuilder.Build(monitorName)
@@ -104,8 +106,8 @@ func TestLittleGetMonitorNone(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	handler := &testMonitorsHandler{}
 	monitorService := NewService(client, handler, handler)
@@ -118,8 +120,8 @@ func TestLittleGetMonitorExisting(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	handler := &testMonitorsHandler{}
 	testMon := &monitor{
@@ -140,8 +142,8 @@ func TestWatchMonDelete(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	var failWait sync.WaitGroup
 
@@ -163,8 +165,8 @@ func TestWatchMonPut(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 	client, err := e.NewClient()
-	defer client.Close()
 	require.NoError(t, err)
+	defer client.Close()
 
 	var shutdownWait sync.WaitGroup
 


### PR DESCRIPTION
## What is this change?

Adds an etcd backed monitor implementation.

## Why is this change necessary?

Closes #1674 

## Does your change need a Changelog entry?

Maybe not yet? This code is not yet integrated and doesn't change any system  behavior. Happy to add one if necessary, or can update the changelog when integrated.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

This refactor exists alongside the current implementation, and shares some naming. Due to that, there are a few long names for functions or variables that exist in both files that should be changed when we factor out the in-memory monitor.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!