### PR TITLE
Renew AppVeyor API token

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,5 +59,5 @@ deploy:
     secure: e3aSzq/Y9btOgFMXc3rfGwjPLj/LnxyG8KY6czcrywgQXEm+9X74fvGFE0B9Km/j
   draft: false
   prerelease: true
-  on:
-    appveyor_repo_tag: true
+  # on:
+  #   appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -59,5 +59,5 @@ deploy:
     secure: e3aSzq/Y9btOgFMXc3rfGwjPLj/LnxyG8KY6czcrywgQXEm+9X74fvGFE0B9Km/j
   draft: false
   prerelease: true
-  # on:
-  #   appveyor_repo_tag: true
+  on:
+    appveyor_repo_tag: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ environment:
       MSI_BUILDER: true
       TIME_OUT_MINS: 30
       APPVEYOR_API_TOKEN:
-        secure: rkeQYUjyfquA6N33QIUU46tWQMgnxZfHvn1Y6WiZm6o=
+        secure: 9DEZNCLW186SbfhAzXCPXh8TfOFysY56bW32dSpTWlQ=
     - GOARCH: amd64
       TEST_SUITE: unit
     - GOARCH: 386

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ lockfiles to not be cleaned up.
 - Fixed a bug where the CLI default for round robin checks was not appearing.
 - Missing custom attributes in govaluate expressions no longer result in
 an error being logged. Instead, a debug message is logged.
+- Update AppVeyor API token to enable GitHub deployments.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/build.ps1
+++ b/build.ps1
@@ -252,7 +252,7 @@ function wait_for_appveyor_jobs {
 
     if (!$success) {throw "Test jobs were not finished in $env:TIME_OUT_MINS minutes"}
 
-    echo "Test jobs are finished"
+    if ($success) {throw "Test jobs are finished"}
 }
 
 function build_package([string]$package, [string]$arch)

--- a/build.ps1
+++ b/build.ps1
@@ -251,8 +251,6 @@ function wait_for_appveyor_jobs {
     }
 
     if (!$success) {throw "Test jobs were not finished in $env:TIME_OUT_MINS minutes"}
-
-    if ($success) {throw "Test jobs are finished"}
 }
 
 function build_package([string]$package, [string]$arch)
@@ -338,7 +336,6 @@ ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
         build_package "agent" "x64"
         build_package "agent" "x86"
     }
-    wait_for_appveyor_jobs
 }
 Else {
     install_deps

--- a/build.ps1
+++ b/build.ps1
@@ -251,6 +251,8 @@ function wait_for_appveyor_jobs {
     }
 
     if (!$success) {throw "Test jobs were not finished in $env:TIME_OUT_MINS minutes"}
+
+    echo "Test jobs are finished"
 }
 
 function build_package([string]$package, [string]$arch)
@@ -336,6 +338,7 @@ ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
         build_package "agent" "x64"
         build_package "agent" "x86"
     }
+    wait_for_appveyor_jobs
 }
 Else {
     install_deps


### PR DESCRIPTION
## What is this change?

It updates the AppVeyor API token, used by the `wait_for_appveyor_jobs` script.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/1496.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not required!