### PR TITLE
Support check execution via sensuctl with RBAC

### DIFF
--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -81,7 +81,11 @@ func (client *RestClient) ExecuteCheck(req *types.AdhocRequest) error {
 	}
 
 	checkPath := fmt.Sprintf("/checks/%s/execute", url.PathEscape(req.Name))
-	res, err := client.R().SetBody(bytes).Post(checkPath)
+	res, err := client.R().
+		SetQueryParam("env", client.config.Environment()).
+		SetQueryParam("org", client.config.Organization()).
+		SetBody(bytes).
+		Post(checkPath)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds support for `--environment` & `--organization` flags in `sensuctl check execute` subcommand, and otherwise use the configured env & org in the user profile.

This is a quick fix, until we revisit https://github.com/sensu/sensu-go/issues/1008.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1646.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!