### PR TITLE
Agent Transport debug log event

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -287,7 +287,7 @@ func (a *Agent) receivePump() {
 
 			logger.WithFields(logrus.Fields{
 				"type":    msg.Type,
-				"message": string(msg.Payload),
+				"payload": string(msg.Payload),
 			}).Info("message received")
 			err := a.handler.Handle(msg.Type, msg.Payload)
 			if err != nil {
@@ -300,7 +300,7 @@ func (a *Agent) receivePump() {
 func (a *Agent) sendMessage(msgType string, payload []byte) {
 	logger.WithFields(logrus.Fields{
 		"type":    msgType,
-		"message": string(payload),
+		"payload": string(payload),
 	}).Debug("sending message")
 	// blocks until message can be enqueued.
 	// TODO(greg): ring buffer?

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -298,6 +298,10 @@ func (a *Agent) receivePump() {
 }
 
 func (a *Agent) sendMessage(msgType string, payload []byte) {
+	logger.WithFields(logrus.Fields{
+		"type":    msgType,
+		"message": string(payload),
+	}).Debug("sending message")
 	// blocks until message can be enqueued.
 	// TODO(greg): ring buffer?
 	msg := &transport.Message{


### PR DESCRIPTION
## What is this change?

Added Agent Transport "sending message" debug log event.

Could be enough to close https://github.com/sensu/sensu-go/issues/1725

For example:

```
{"component":"agent","level":"debug","message":"{\"timestamp\":1529627830,\"entity\":{\"class\":\"agent\",\"deregister\":false,\"deregistration
\":{},\"environment\":\"default\",\"id\":\"portertech.local\",\"keepalive_timeout\":120,\"last_seen\":1529627801,\"organization\":\"default\",\
"redact\":[\"password\",\"passwd\",\"pass\",\"api_key\",\"api_token\",\"access_key\",\"secret_key\",\"private_key\",\"secret\"],\"subscriptions
\":[\"workstation\"],\"system\":{\"hostname\":\"portertech.local\",\"os\":\"darwin\",\"platform\":\"darwin\",\"platform_version\":\"10.13.5\",\
"network\":{\"interfaces\":[{\"name\":\"lo0\",\"addresses\":[\"127.0.0.1/8\",\"::1/128\",\"fe80::1/64\"]},{\"name\":\"gif0\",\"addresses\":null
},{\"name\":\"stf0\",\"addresses\":null},{\"name\":\"XHC1\",\"addresses\":null},{\"name\":\"XHC20\",\"addresses\":null},{\"name\":\"XHC0\",\"ad
dresses\":null},{\"name\":\"en0\",\"mac\":\"78:4f:43:97:38:11\",\"addresses\":[\"fe80::1cb7:992e:8316:3de4/64\",\"10.0.1.11/24\"]},{\"name\":\"
p2p0\",\"mac\":\"0a:4f:43:97:38:11\",\"addresses\":null},{\"name\":\"awdl0\",\"mac\":\"12:0d:05:81:6c:7f\",\"addresses\":[\"fe80::100d:5ff:fe81
:6c7f/64\"]},{\"name\":\"en3\",\"mac\":\"26:00:00:3a:90:01\",\"addresses\":null},{\"name\":\"en1\",\"mac\":\"26:00:00:3a:90:00\",\"addresses\":
null},{\"name\":\"en4\",\"mac\":\"26:00:00:3a:90:05\",\"addresses\":null},{\"name\":\"en2\",\"mac\":\"26:00:00:3a:90:04\",\"addresses\":null},{
\"name\":\"bridge0\",\"mac\":\"26:00:00:3a:90:00\",\"addresses\":null},{\"name\":\"utun0\",\"addresses\":[\"fe80::78f2:1066:aa5c:a29d/64\"]},{\
"name\":\"en5\",\"mac\":\"ac:de:48:00:11:22\",\"addresses\":[\"fe80::aede:48ff:fe00:1122/64\"]}]},\"arch\":\"amd64\"},\"user\":\"agent\"},\"che
ck\":{\"command\":\"check-ping -h google.ca -P 80\",\"environment\":\"default\",\"handlers\":[],\"high_flap_threshold\":0,\"interval\":10,\"low
_flap_threshold\":0,\"name\":\"google\",\"organization\":\"default\",\"publish\":true,\"runtime_assets\":[\"check-plugins\"],\"subscriptions\":
[\"workstation\"],\"proxy_entity_id\":\"\",\"check_hooks\":null,\"stdin\":false,\"subdue\":null,\"ttl\":0,\"timeout\":5,\"round_robin\":false,\
"executed\":1529627830,\"history\":null,\"issued\":1529627830,\"output\":\"error installing dependencies: error creating directory \\\"/var/cac
he/sensu/sensu-agent/4e6f621ebe652d3b0ba5d4dead8ddb2901ea03f846a1cb2e39ddb71b8d0daa83b54742671f179913ed6c350fc32446a22501339f60b8d4e0cdb6ade5ee
77af16/bin\\\": mkdir /var/cache: permission denied\",\"status\":3,\"total_state-change\":0,\"last_ok\":0,\"occurrences\":0,\"occurrences_water
mark\":0,\"output_metric_format\":\"\",\"output_metric_handlers\":[],\"env_vars\":null}}","msg":"sending message","time":"2018-06-21T17:37:10-0
7:00","type":"event"}
```

## Why is this change necessary?

So we can observe what an Agent is sending to the Backend over the websocket Transport. This helps when debugging check execution etc, e.g. how do the extracted metrics look?

## Does your change need a Changelog entry?

Yes?

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No. No.