### PR TITLE
Fix a bug where checks created with `sensuctl create` would never fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ lockfiles to not be cleaned up.
 an error being logged. Instead, a debug message is logged.
 - Update AppVeyor API token to enable GitHub deployments.
 - Allow creation of metric events via backend API.
+- Fixed a bug where in some circumstances checks created with sensuctl create
+would never fail.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/types/check.go
+++ b/types/check.go
@@ -58,7 +58,6 @@ func NewCheck(c *CheckConfig) *Check {
 		Publish:              c.Publish,
 		RuntimeAssets:        c.RuntimeAssets,
 		Subscriptions:        c.Subscriptions,
-		ExtendedAttributes:   c.ExtendedAttributes,
 		ProxyEntityID:        c.ProxyEntityID,
 		CheckHooks:           c.CheckHooks,
 		Stdin:                c.Stdin,
@@ -72,6 +71,9 @@ func NewCheck(c *CheckConfig) *Check {
 		OutputMetricHandlers: c.OutputMetricHandlers,
 		EnvVars:              c.EnvVars,
 	}
+	dummyCheck := &Check{}
+	_ = dynamic.Unmarshal(c.ExtendedAttributes, dummyCheck)
+	check.ExtendedAttributes = dummyCheck.ExtendedAttributes
 	return check
 }
 

--- a/types/check.go
+++ b/types/check.go
@@ -71,9 +71,12 @@ func NewCheck(c *CheckConfig) *Check {
 		OutputMetricHandlers: c.OutputMetricHandlers,
 		EnvVars:              c.EnvVars,
 	}
-	dummyCheck := &Check{}
-	_ = dynamic.Unmarshal(c.ExtendedAttributes, dummyCheck)
-	check.ExtendedAttributes = dummyCheck.ExtendedAttributes
+	// Unmarshal extended attributes into a different Check value, so that
+	// we don't accidentally corrupt any of the default values for Check.
+	// See https://github.com/sensu/sensu-go/issues/1732 for more information.
+	tmpCheck := Check{}
+	_ = dynamic.Unmarshal(c.ExtendedAttributes, &tmpCheck)
+	check.ExtendedAttributes = tmpCheck.ExtendedAttributes
 	return check
 }
 

--- a/types/check_test.go
+++ b/types/check_test.go
@@ -341,3 +341,10 @@ func TestIsSubdued(t *testing.T) {
 		})
 	}
 }
+
+func TestAliasedExtendedAttributeBehaviour_GH1732(t *testing.T) {
+	config := FixtureCheckConfig("foo")
+	config.SetExtendedAttributes([]byte(`{"status":5}`))
+	check := NewCheck(config)
+	require.Equal(t, uint32(0), check.Status)
+}

--- a/types/dynamic/encoding_test.go
+++ b/types/dynamic/encoding_test.go
@@ -194,3 +194,15 @@ func TestMarshalUnmarshalEmbedded(t *testing.T) {
 
 	require.Equal(t, test, &result)
 }
+
+func TestEncodeNoDuplicateFields(t *testing.T) {
+	p := &Problematic{
+		Foo:   "foo",
+		Attrs: []byte(`{"Foo": "bar"}`),
+	}
+	b, err := Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, `{"Bar":null,"Foo":"foo"}`, string(b))
+}


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in the dynamic marshaler that could lead to JSON objects being written out with duplicate object names. Through a series of unfortunate events, this was causing checks created with `sensuctl create` (vs `sensuctl check create`) to never fail.

## Why is this change necessary?

This is a critical bug and after merging this PR we should do a release.

## Were there any complications while making this change?

This took a while to debug. If a user created a check with the `Check` type instead of `CheckConfig`, the `Status` field of a Check would become a custom attribute, as the message would be unmarshaled into a `CheckConfig` on the other side.

This resulted in the extended attributes being blindly copied over to the Check when the agent created a Check from the CheckConfig, and shadowing the Status of the Check. As a result, the Check could never fail.

Closes #1732