### PR TITLE
Restart the check watcher when the watch chan closes.

### DIFF
--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -84,7 +84,12 @@ func (c *CheckWatcher) startWatcher() {
 	watchChan := c.store.GetCheckConfigWatcher(c.ctx)
 	for {
 		select {
-		case watchEvent := <-watchChan:
+		case watchEvent, ok := <-watchChan:
+			if !ok {
+				// The watchChan has closed. Restart the watcher.
+				watchChan = c.store.GetCheckConfigWatcher(c.ctx)
+				continue
+			}
 			c.handleWatchEvent(watchEvent)
 		case <-c.ctx.Done():
 			c.mu.Lock()


### PR DESCRIPTION
I'm hoping this will resolve the panic that occurs in the check
watcher integration test.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Somewhat speculative change here, as I'm not sure if the channel closing is actually causing this problem. However, I can't see another reason that there would be a nil dereference, and it's hard to reproduce, so I think this is a decent safety valve in any event.

Closes #1640