### PR TITLE
Upgrade gometalinter to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ commands, which is compatible with `sensuctl create`.
 - Added check token substitution integration test.
 
 ### Changed
+- Upgraded gometalinter to v2.
 - Add logging around the Sensu event pipeline.
 - Split out the docker commands in build script so that building images and
   pushing can be done separately.

--- a/build.ps1
+++ b/build.ps1
@@ -35,7 +35,7 @@ function install_deps
 {
     echo "Installing deps..."
     go get github.com/axw/gocov/gocov
-    go get gopkg.in/alecthomas/gometalinter.v1
+    go get gopkg.in/alecthomas/gometalinter.v2
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
     go get github.com/kisielk/errcheck
@@ -184,7 +184,7 @@ function linter_commands
 {
     echo "Running linter..."
 
-    gometalinter.v1 --vendor --disable-all --enable=vet --linter='vet:go tool vet -composites=false {paths}:PATH:LINE:MESSAGE' --enable=golint --enable=ineffassign --enable=goconst --tests ./...
+    gometalinter.v2 --vendor --disable-all --enable=vet --linter='vet:go tool vet -composites=false {paths}:PATH:LINE:MESSAGE' --enable=golint --enable=ineffassign --enable=goconst --tests ./...
     If ($LASTEXITCODE -ne 0) {
         echo "Linting failed..."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,7 @@ esac
 install_deps () {
     echo "Installing deps..."
     go get github.com/axw/gocov/gocov
-    go get gopkg.in/alecthomas/gometalinter.v1
+    go get gopkg.in/alecthomas/gometalinter.v2
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
     go get honnef.co/go/tools/cmd/megacheck
@@ -179,7 +179,7 @@ build_command () {
 linter_commands () {
     echo "Running linter..."
 
-    gometalinter.v1 --vendor --disable-all --enable=vet --enable=ineffassign --enable=goconst --tests ./...
+    gometalinter.v2 --vendor --disable-all --enable=vet --enable=ineffassign --enable=goconst --tests ./...
     if [ $? -ne 0 ]; then
         echo "Linting failed..."
         exit 1


### PR DESCRIPTION
Signed-off-by: Terrance Kennedy <terrancerkennedy@gmail.com>

## What is this change?

Upgrade gometalinter to v2.


## Why is this change necessary?

I upgraded gometalinter in sensu-enterprise-go after submitting a patch for v1 and learning that it is no longer supported.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

The `install_deps` function inside build.sh installs gocov and golint, but neither appear to be used anywhere else in the build system. Can they be removed?


## Were there any complications while making this change?

The gometalinter command's invocation did not need to be changed, making this an easy PR.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs required!
