### PR TITLE
Fix a goroutine leak in Ring.Next.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ an error being logged. Instead, a debug message is logged.
 - Allow creation of metric events via backend API.
 - Fixed a bug where in some circumstances checks created with sensuctl create
 would never fail.
+- Fixed a goroutine leak in the ring.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor


### PR DESCRIPTION
Next creates a goroutine that watches an etcd key for deletes.
After Next returns, the goroutine is supposed to be shut down, but
isn't, because the context it is using to determine cancellation is
the wrong one.

This commit refactors the watcher into a separate function, and
passes the correct context into it.

Closes #1746

Signed-off-by: Eric Chlebek <eric@sensu.io>