### PR TITLE
Address staging env feedback from QA testing

### DIFF
--- a/testing/config/resources.json
+++ b/testing/config/resources.json
@@ -302,7 +302,7 @@
 {
   "type": "CheckConfig",
   "spec": {
-    "command": "echo passing round robin && exit 0",
+    "command": "echo passing round robin 0 && exit 0",
     "environment": "default",
     "handlers": [
       "filtered-cat"
@@ -310,12 +310,12 @@
     "high_flap_threshold": 0,
     "interval": 60,
     "low_flap_threshold": 0,
-    "name": "passing-round-robin",
+    "name": "passing-round-robin-0",
     "organization": "default",
     "publish": true,
     "runtime_assets": [],
     "subscriptions": [
-      "schedules"
+      "round-robin"
     ],
     "proxy_entity_id": "",
     "check_hooks": [
@@ -330,6 +330,66 @@
         ]
       }
     ],
+    "stdin": false,
+    "subdue": null,
+    "cron": "",
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": true,
+    "output_metric_format": "",
+    "output_metric_handlers": []
+  }
+}
+{
+  "type": "CheckConfig",
+  "spec": {
+    "command": "echo passing round robin 1 && exit 0",
+    "environment": "default",
+    "handlers": [
+      "filtered-cat"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "name": "passing-round-robin-1",
+    "organization": "default",
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "round-robin"
+    ],
+    "proxy_entity_id": "",
+    "check_hooks": [],
+    "stdin": false,
+    "subdue": null,
+    "cron": "",
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": true,
+    "output_metric_format": "",
+    "output_metric_handlers": []
+  }
+}
+{
+  "type": "CheckConfig",
+  "spec": {
+    "command": "echo passing round robin 2 && exit 0",
+    "environment": "default",
+    "handlers": [
+      "filtered-cat"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "name": "passing-round-robin-2",
+    "organization": "default",
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "round-robin"
+    ],
+    "proxy_entity_id": "",
+    "check_hooks": [],
     "stdin": false,
     "subdue": null,
     "cron": "",

--- a/testing/config/staging-agent-0.yml.example
+++ b/testing/config/staging-agent-0.yml.example
@@ -5,7 +5,7 @@
 id: "staging-agent-0"
 #organization: "default"
 #environment: "default"
-subscriptions: "metrics,misc"
+subscriptions: "metrics,misc,round-robin"
 # UPDATE BACKEND URL
 #backend-url:
 #  - "ws://127.0.0.1:8081"

--- a/testing/config/staging-agent-1.yml.example
+++ b/testing/config/staging-agent-1.yml.example
@@ -5,7 +5,7 @@
 id: "staging-agent-1"
 #organization: "default"
 #environment: "default"
-subscriptions: "schedules,rbac"
+subscriptions: "schedules,rbac,round-robin"
 # UPDATE BACKEND URL
 #backend-url:
 #  - "ws://127.0.0.1:8081"

--- a/testing/config/staging-agent-2.yml.example
+++ b/testing/config/staging-agent-2.yml.example
@@ -5,7 +5,7 @@
 id: "staging-agent-2"
 organization: "ops"
 environment: "dev"
-subscriptions: "rbac"
+subscriptions: "rbac,round-robin"
 # UPDATE BACKEND URL
 #backend-url:
 #  - "ws://127.0.0.1:8081"

--- a/testing/config/staging-backend.yml.example
+++ b/testing/config/staging-backend.yml.example
@@ -45,6 +45,6 @@ state-dir: "/var/lib/sensu"
 # other
 ##
 #config-file: ""
-#debug: false
+debug: true
 #deregistration-handler: ""
 log-level: "debug"


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

- Add `--debug` flag to sensu-backend config file for pprof
- Add 2 more round-robin checks (all entities subscribe to “round-robin”)

## Why is this change necessary?

Addresses initial feedback from QA testing on the staging env resources.

## Does your change need a Changelog entry?

Nah, it's kind of an ongoing process.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.