### PR TITLE
Set proxy entity IDs for round-robin checks

### DIFF
--- a/testing/config/resources.json
+++ b/testing/config/resources.json
@@ -317,7 +317,7 @@
     "subscriptions": [
       "round-robin"
     ],
-    "proxy_entity_id": "",
+    "proxy_entity_id": "proxy-round-robin-0",
     "check_hooks": [
       {
         "0": [
@@ -358,7 +358,7 @@
     "subscriptions": [
       "round-robin"
     ],
-    "proxy_entity_id": "",
+    "proxy_entity_id": "proxy-round-robin-1",
     "check_hooks": [],
     "stdin": false,
     "subdue": null,
@@ -388,7 +388,7 @@
     "subscriptions": [
       "round-robin"
     ],
-    "proxy_entity_id": "",
+    "proxy_entity_id": "proxy-round-robin-2",
     "check_hooks": [],
     "stdin": false,
     "subdue": null,


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Ensures check robin checks are reporting under a specific proxy entity ID.

## Why is this change necessary?

QA in staging

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
