### PR TITLE
Add check for testing execution timeout in staging

### DIFF
--- a/testing/config/resources.json
+++ b/testing/config/resources.json
@@ -429,6 +429,33 @@
   }
 }
 {
+  "type": "CheckConfig",
+  "spec": {
+    "command": "sleep 5 && exit 0",
+    "environment": "default",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "name": "execution-timeout",
+    "organization": "default",
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "misc"
+    ],
+    "proxy_entity_id": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 2,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": []
+  }
+}
+{
   "type": "HookConfig",
   "spec": {
     "name": "passing",


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds a check in our staging environment to test the timeout execution mechanism.

## Why is this change necessary?

QA in staging

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
