### PR TITLE
Fix table formatting for 'sensuctl extension list'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ an error being logged. Instead, a debug message is logged.
 would never fail.
 - Fixed a goroutine leak in the ring.
 - Fixed `sensuctl completion` help for bash and zsh.
+- Display the name of extensions with table formatting in sensuctl.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed `sensuctl completion` help for bash and zsh.
+- Display the name of extensions with table formatting in sensuctl.
 
 ## [2.0.0-beta.2] - 2018-06-28
 
@@ -98,7 +99,6 @@ an error being logged. Instead, a debug message is logged.
 would never fail.
 - Fixed a goroutine leak in the ring.
 - Fixed `sensuctl completion` help for bash and zsh.
-- Display the name of extensions with table formatting in sensuctl.
 
 ### Removed
 - Removed Linux/386 & Windows/386 e2e jobs on Travis CI & AppVeyor

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -51,17 +51,17 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				asset, _ := data.(types.Asset)
-				return asset.Name
+				extension, _ := data.(types.Extension)
+				return extension.Name
 			},
 		},
 		{
 			Title: "URL",
 			CellTransformer: func(data interface{}) string {
-				asset, _ := data.(types.Asset)
-				u, err := url.Parse(asset.URL)
+				extension, _ := data.(types.Extension)
+				u, err := url.Parse(extension.URL)
 				if err != nil {
-					return ""
+					return extension.URL
 				}
 
 				_, file := path.Split(u.EscapedPath())


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It makes sure the name of extensions are properly displayed when showing all extensions.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1757

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!