### PR TITLE
Make sure GOOS=linux and GOARCH=amd64 for version cmd.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed `sensuctl completion` help for bash and zsh.
+- Fixed a bug in build.sh where versions for Windows and Mac OS were not
+generated correctly.
 
 ## [2.0.0-beta.2] - 2018-06-28
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cmd=${1:-"all"}
 
 RACE=""
 
-VERSION_CMD="go run ./version/cmd/version/version.go"
+VERSION_CMD="GOOS=linux GOARCH=amd64 go run ./version/cmd/version/version.go"
 
 HANDLERS=(slack)
 


### PR DESCRIPTION
The commit forces the version command to run with GOOS=linux and
GOARCH=amd64. The version command was failing to run properly when
cross-compiling to Mac OS and Windows, since the environment
variables were causing the binary produced to not be executable
on Travis CI.

Closes #1759

Signed-off-by: Eric Chlebek <eric@sensu.io>