### PR TITLE
Address staging env resources to include more use-cases

### DIFF
--- a/testing/config/resources.json
+++ b/testing/config/resources.json
@@ -32,9 +32,7 @@
   "spec": {
     "command": "echo $(hostname)'.cpu:41|c' | nc -u -w1 127.0.0.1 8125",
     "environment": "default",
-    "handlers": [
-      "cat"
-    ],
+    "handlers": [],
     "high_flap_threshold": 0,
     "interval": 10,
     "low_flap_threshold": 0,
@@ -131,7 +129,7 @@
     "command": "echo silenced",
     "environment": "default",
     "handlers": [
-      "cat"
+      "silenced-cat"
     ],
     "high_flap_threshold": 0,
     "interval": 10,
@@ -157,6 +155,33 @@
 {
   "type": "CheckConfig",
   "spec": {
+    "command": "echo ttl",
+    "environment": "default",
+    "handlers": [],
+    "high_flap_threshold": 0,
+    "interval": 60,
+    "low_flap_threshold": 0,
+    "name": "ttl-check",
+    "organization": "default",
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "misc"
+    ],
+    "proxy_entity_id": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 90,
+    "timeout": 30,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": []
+  }
+}
+{
+  "type": "CheckConfig",
+  "spec": {
     "command": "echo not published",
     "environment": "default",
     "handlers": [
@@ -165,7 +190,7 @@
     "high_flap_threshold": 0,
     "interval": 10,
     "low_flap_threshold": 0,
-    "name": "silenced-check",
+    "name": "unpublished-check",
     "organization": "default",
     "publish": false,
     "runtime_assets": [],
@@ -209,8 +234,8 @@
       "entity_attributes": [
         "entity.Class == \"proxy\""
       ],
-      "splay": false,
-      "splay_coverage": 0
+      "splay": true,
+      "splay_coverage": 90
     },
     "round_robin": false,
     "output_metric_format": "",
@@ -220,10 +245,40 @@
 {
   "type": "CheckConfig",
   "spec": {
+    "command": "echo hello tcp",
+    "environment": "default",
+    "handlers": [
+      "tcp-handler"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 10,
+    "low_flap_threshold": 0,
+    "name": "tcp-handled-check",
+    "organization": "default",
+    "publish": true,
+    "runtime_assets": [],
+    "subscriptions": [
+      "misc"
+    ],
+    "proxy_entity_id": "",
+    "check_hooks": null,
+    "stdin": false,
+    "subdue": null,
+    "ttl": 0,
+    "timeout": 0,
+    "round_robin": false,
+    "output_metric_format": "",
+    "output_metric_handlers": [],
+    "env_vars": null
+  }
+}
+{
+  "type": "CheckConfig",
+  "spec": {
     "command": "echo failing cron && exit 1",
     "environment": "default",
     "handlers": [
-      "filtered-cat"
+      "incident-filtered-cat"
     ],
     "high_flap_threshold": 0,
     "interval": 0,
@@ -264,7 +319,7 @@
     "command": "echo passing interval && exit 0",
     "environment": "default",
     "handlers": [
-      "filtered-cat"
+      "passing-filtered-cat"
     ],
     "high_flap_threshold": 0,
     "interval": 60,
@@ -305,7 +360,7 @@
     "command": "echo passing round robin 0 && exit 0",
     "environment": "default",
     "handlers": [
-      "filtered-cat"
+      "handler-set"
     ],
     "high_flap_threshold": 0,
     "interval": 60,
@@ -346,7 +401,7 @@
     "command": "echo passing round robin 1 && exit 0",
     "environment": "default",
     "handlers": [
-      "filtered-cat"
+      "handler-set"
     ],
     "high_flap_threshold": 0,
     "interval": 60,
@@ -376,7 +431,7 @@
     "command": "echo passing round robin 2 && exit 0",
     "environment": "default",
     "handlers": [
-      "filtered-cat"
+      "handler-set"
     ],
     "high_flap_threshold": 0,
     "interval": 60,
@@ -494,14 +549,79 @@
 {
   "type": "Handler",
   "spec": {
-    "name": "filtered-cat",
+    "name": "incident-filtered-cat",
     "type": "pipe",
     "command": "cat",
     "timeout": 0,
     "handlers": [],
     "filters": [
-      "handle-failing-only"
+      "is_incident"
     ],
+    "env_vars": [],
+    "environment": "default",
+    "organization": "default"
+  }
+}
+{
+  "type": "Handler",
+  "spec": {
+    "name": "passing-filtered-cat",
+    "type": "pipe",
+    "command": "cat",
+    "timeout": 0,
+    "handlers": [],
+    "filters": [
+      "handle-passing-only"
+    ],
+    "env_vars": [],
+    "environment": "default",
+    "organization": "default"
+  }
+}
+{
+  "type": "Handler",
+  "spec": {
+    "name": "handler-set",
+    "type": "set",
+    "timeout": 0,
+    "handlers": [
+      "incident-filtered-cat",
+      "passing-filtered-cat"
+    ],
+    "filters": [],
+    "env_vars": [],
+    "environment": "default",
+    "organization": "default"
+  }
+}
+{
+  "type": "Handler",
+  "spec": {
+    "name": "silenced-cat",
+    "type": "pipe",
+    "command": "cat",
+    "timeout": 0,
+    "handlers": [],
+    "filters": [
+      "not_silenced"
+    ],
+    "env_vars": [],
+    "environment": "default",
+    "organization": "default"
+  }
+}
+{
+  "type": "Handler",
+  "spec": {
+    "name": "tcp-handler",
+    "type": "tcp",
+    "timeout": 0,
+    "socket": {
+      "host": "127.0.0.1",
+      "port": 3333
+    },
+    "handlers": [],
+    "filters": [],
     "env_vars": [],
     "environment": "default",
     "organization": "default"
@@ -510,10 +630,10 @@
 {
   "type": "EventFilter",
   "spec": {
-    "name": "handle-failing-only",
+    "name": "handle-passing-only",
     "action": "allow",
     "statements": [
-      "event.Check.Status == 1"
+      "event.Check.Status == 0"
     ],
     "environment": "default",
     "organization": "default"
@@ -589,7 +709,7 @@
   "type": "Handler",
   "spec": {
     "name": "filter-extension",
-    "type": "pipe",
+    "type": "grpc",
     "timeout": 0,
     "handlers": [],
     "filters": [
@@ -604,7 +724,7 @@
   "type": "Handler",
   "spec": {
     "name": "mutate-extension",
-    "type": "pipe",
+    "type": "grpc",
     "mutator": "handle-extension",
     "timeout": 0,
     "handlers": [],

--- a/testing/tcphandler/LICENSE
+++ b/testing/tcphandler/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/testing/tcphandler/main.go
+++ b/testing/tcphandler/main.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
 )
 
 var (
-	port = flag.Int("port", 3333, "port to run extension server on")
+	port = flag.Int("port", 3333, "port to run tcp server on")
 	conn = flag.String("type", "tcp", "type of connection to establish (ex. tcp)")
 )
 
@@ -18,7 +17,6 @@ func main() {
 	l, err := net.Listen(*conn, fmt.Sprintf("127.0.0.1:%d", *port))
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 	defer l.Close()
 	log.Print(fmt.Sprintf("Listening on %s 127.0.0.1:%d", *conn, *port))
@@ -26,18 +24,18 @@ func main() {
 		conn, err := l.Accept()
 		if err != nil {
 			log.Fatal(err)
-			os.Exit(1)
 		}
 		go handleRequest(conn)
 	}
 }
 
 func handleRequest(conn net.Conn) {
+	defer conn.Close()
 	buf := make([]byte, 4096)
 	_, err := conn.Read(buf)
 	if err != nil {
 		log.Print("Error reading: ", err.Error())
+		return
 	}
 	log.Print(string(buf))
-	conn.Close()
 }

--- a/testing/tcphandler/main.go
+++ b/testing/tcphandler/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+var (
+	port = flag.Int("port", 3333, "port to run extension server on")
+	conn = flag.String("type", "tcp", "type of connection to establish (ex. tcp)")
+)
+
+func main() {
+	flag.Parse()
+	l, err := net.Listen(*conn, fmt.Sprintf("127.0.0.1:%d", *port))
+	if err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+	defer l.Close()
+	log.Print(fmt.Sprintf("Listening on %s 127.0.0.1:%d", *conn, *port))
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+		go handleRequest(conn)
+	}
+}
+
+func handleRequest(conn net.Conn) {
+	buf := make([]byte, 4096)
+	_, err := conn.Read(buf)
+	if err != nil {
+		log.Print("Error reading: ", err.Error())
+	}
+	log.Print(string(buf))
+	conn.Close()
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Addresses the following in the staging env resources:
- Configure splay & splay_coverage for “proxy-check” check
- We need a check that uses TTL
- TCP/UDP handlers
- Handler set
- Replace “handle-failing-only” filter with built-in “is_incident” filter
- Two checks are using the “silenced-check” name, so the first definition is overriden.
- Create a “silenced-cat” handler, using the “not_silenced” filter so silenced events are not handled, and modify the “silenced-check” to use that handler
- Remove “cat” handler from “feed-statsd” check. This handler is unnecessary, it is handled by the statsd-metrics-handler
- Extension handlers should be of type “grpc” not “pipe”

## Why is this change necessary?

To cover more use cases and features in test.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Manual staging instructions have been updated for the tcp handler.