### PR TITLE
Add dockerfile for rhel-atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ commands, which is compatible with `sensuctl create`.
 - Added the `sensuctl config view` subcommand.
 - Added extension service configuration to staging resources.
 - Added some documentation around extensions.
+- Added Dockerfile.rhel to build RHEL containers.
 
 ### Changed
 - Upgraded gometalinter to v2.

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,7 +12,8 @@ LABEL name="sensu/sensu-go-rhel" \
       run="docker run -d --name sensu-backend sensu/sensu-go-rhel" \
       io.k8s.description="Sensu" \
       io.k8s.display-name="Sensu" \
-      io.openshift.expose-services="8081:http,8080:http,3000:http,2379:http"
+      io.openshift.expose-services="8081:http,8080:http,3000:http,2379:http" \
+      io.openshift.tags="sensu,monitoring,observability"
 
 
 VOLUME /var/lib/sensu

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/rhel-atomic
+MAINTAINER Sensu, Inc. Engineering <engineering@sensu.io>
+
+LABEL name="sensu/sensu-go-rhel" \
+      maintainer="engineering@sensu.io" \
+      vendor="Sensu, Inc." \
+      version="2.0" \
+      release="1" \
+      summary="Sensu 2.0 - Full-stack monitoring" \
+      description="Sensu is an event pipeline and monitoring system for everything from the server closet to the serverless application." \
+      url="https://sensu.io/" \
+      run="docker run -d --name sensu-backend sensu/sensu-go-rhel" \
+      io.k8s.description="Sensu" \
+      io.k8s.display-name="Sensu" \
+      io.openshift.expose-services="8081:http,8080:http,3000:http,2379:http"
+
+
+VOLUME /var/lib/sensu
+
+EXPOSE 2379 2380 8080 8081 3000
+
+RUN curl -o /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && \
+    chmod +x /usr/bin/dumb-init && \
+    ln -sf /opt/sensu/bin/sensu-entrypoint.sh /usr/local/bin/sensu-agent && \
+    ln -sf /opt/sensu/bin/sensu-entrypoint.sh /usr/local/bin/sensu-backend && \
+    ln -sf /opt/sensu/bin/sensuctl /usr/local/bin/sensuctl
+
+COPY target/linux-amd64/ /opt/sensu/bin/
+COPY docker-scripts/ /opt/sensu/bin/
+
+CMD ["sensu-backend"]


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Adds a dockerfile for RHEL (rhel-atomic).


## Why is this change necessary?

We're going to start shipping RHEL containers for the RedHat container registry.