### PR TITLE
Docker changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ or environment does not exist.
 - The profile environment & organization values are used by default when
 creating a resource with sensuctl.
 - Migrated docker image to sensu Docker Hub organization from sensuapp.
+- Use the sensu/sensu image instead of sensu/sensu-go in Docker Hub.
 
 ### Fixed
 - Prevent panic when verifying if a metric event is silenced.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 MAINTAINER Sensu, Inc. Engineering <engineering@sensu.io>
 
-LABEL name="sensu/sensu-go" \
+LABEL name="sensu/sensu" \
       maintainer="engineering@sensu.io" \
       vendor="Sensu, Inc." \
       version="2.0" \
@@ -9,7 +9,7 @@ LABEL name="sensu/sensu-go" \
       summary="Sensu 2.0 - Full-stack monitoring" \
       description="Sensu is an event pipeline and monitoring system for everything from the server closet to the serverless application." \
       url="https://sensu.io/" \
-      run="docker run -d --name sensu-backend sensu/sensu-go" \
+      run="docker run -d --name sensu-backend sensu/sensu" \
       io.k8s.description="Sensu" \
       io.k8s.display-name="Sensu" \
       io.openshift.expose-services="8081:http,8080:http,3000:http,2379:http" \

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/rhel-atomic
 MAINTAINER Sensu, Inc. Engineering <engineering@sensu.io>
 
-LABEL name="sensu/sensu-go-rhel" \
+LABEL name="sensu/sensu-rhel" \
       maintainer="engineering@sensu.io" \
       vendor="Sensu, Inc." \
       version="2.0" \
@@ -9,7 +9,7 @@ LABEL name="sensu/sensu-go-rhel" \
       summary="Sensu 2.0 - Full-stack monitoring" \
       description="Sensu is an event pipeline and monitoring system for everything from the server closet to the serverless application." \
       url="https://sensu.io/" \
-      run="docker run -d --name sensu-backend sensu/sensu-go-rhel" \
+      run="docker run -d --name sensu-backend sensu/sensu-rhel" \
       io.k8s.description="Sensu" \
       io.k8s.display-name="Sensu" \
       io.openshift.expose-services="8081:http,8080:http,3000:http,2379:http" \

--- a/build.sh
+++ b/build.sh
@@ -277,7 +277,7 @@ docker_build() {
     done
 
     # build the docker image with master tag
-    docker build --label build.sha=${build_sha} -t sensu/sensu-go:master .
+    docker build --label build.sha=${build_sha} -t sensu/sensu:master .
 }
 
 docker_push() {
@@ -290,18 +290,23 @@ docker_push() {
 
     # push master - tags and pushes latest master docker build only
     if [ "$release" == "master" ]; then
-        docker push sensu/sensu-go:master
+        docker push sensu/sensu:master
+        exit 0
+    fi
+
+    if [ "$release" == "nightly" ]; then
+        docker push sensu/sensu:nightly
         exit 0
     fi
 
     # if versioned release push to 'latest' tag
     if [ "$release" == "versioned" ]; then
-        docker tag sensu/sensu-go:master sensu/sensu-go:latest
-        docker push sensu/sensu-go:latest
+        docker tag sensu/sensu:master sensu/sensu:latest
+        docker push sensu/sensu:latest
     fi
 
     # push current revision
-    docker tag sensu/sensu-go:master $version_iteration
+    docker tag sensu/sensu:master $version_iteration
     docker push $version_iteration
     docker tag $version_iteration $version
     docker push $version

--- a/build.sh
+++ b/build.sh
@@ -282,8 +282,8 @@ docker_build() {
 
 docker_push() {
     local release=$1
-    local version=$(echo sensu/sensu-go:$($VERSION_CMD -v)-$($VERSION_CMD -t))
-    local version_iteration=$(echo sensu/sensu-go:$($VERSION_CMD -v)-$($VERSION_CMD -t).$($VERSION_CMD -i))
+    local version=$(echo sensu/sensu:$($VERSION_CMD -v))
+    local version_iteration=$(echo sensu/sensu:$($VERSION_CMD -v).$($VERSION_CMD -i))
 
     # ensure we are authenticated
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   sensu-backend1:
-    image: sensu/sensu-go:master
+    image: sensu/sensu:master
     command: sensu-backend start --listen-client-urls http://0.0.0.0:2379
     hostname: backend1
     restart: always
@@ -11,7 +11,7 @@ services:
       - "8080:8080"
       - "8081:8081"
   sensu-agent1:
-    image: sensu/sensu-go:master
+    image: sensu/sensu:master
     command: sensu-agent start --backend-url ws://sensu-backend1:8081 --subscriptions test
     hostname: agent1
     restart: always


### PR DESCRIPTION
## What is this change?

This changes how we tag nightly images to be "sensu/sensu:nightly" and removes the build type from all docker tags (no more 2.0.0-alpha-alpha.1). It also moves us over the sensu/sensu from sensu/sensu-go.


## Why is this change necessary?

We'll be flipping to 2.0 being The Sensu eventually, and I'd rather start as early as possible with a small change like the docker image.

There will be a corresponding docs change.