### PR TITLE
Issue 1730, part 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run: ./build.sh deps
       - run: ./build.sh lint
-      - run: ./build.sh build_tools
       - run: ./build.sh build
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,22 @@
 # Golang CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
+
 version: 2
+
+sensu_go_build_env: &sensu_go_build_env
+  #### TEMPLATE_NOTE: go expects specific checkout path representing url
+  #### expecting it in the form of
+  ####   /go/src/github.com/circleci/go-tool
+  ####   /go/src/bitbucket.org/circleci/go-tool
+  working_directory: /go/src/github.com/sensu/sensu-go
+  docker:
+    - image: circleci/golang:1.10
 
 jobs:
   build:
-    docker:
-      # specify the version
-      - image: circleci/golang:1.10
+    <<: *sensu_go_build_env
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/sensu/sensu-go
     steps:
       - checkout
 
@@ -26,13 +24,34 @@ jobs:
       - run: ./build.sh deps
       - run: ./build.sh lint
       - run: ./build.sh build_tools
-      - run: ./build.sh unit
-      - run: ./build.sh integration
       - run: ./build.sh build
 
-    # Only build build-related branches (to test CI/CD changes) and master
-    # for now.
-    branches:
-      only:
-        - /build\/.+/
-        - /^master$/
+      - persist_to_workspace:
+          root: /go/src/github.com/
+          paths:
+            - sensu
+
+  test:
+    <<: *sensu_go_build_env
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: /go/src/github.com
+      - run: ./build.sh unit
+      - run: ./build.sh integration
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+          # Only build build-related branches (to test CI/CD changes) and
+          # master for now.
+          filters:
+            branches:
+              only:
+                - /build\/.+/
+                - /^master$/


### PR DESCRIPTION
## What is this change?

Separate out CircleCI build+test jobs

## Why is this change necessary?

There are a number of reasons this is beneficial, but the main one is to get some data around which failures are build failures and which failures are test failures. Recent job failures on CircleCI have been mostly unit tests failures, but since it's one item, it's hard to tell that. This should help sort that out.

There are also a number of other benefits to splitting these two things out:
- Builds can be published, distinct from whether or not the tests pass; this can be useful for...
- ... If the unit tests fail on Circle, but work for the developer, the developer can pull down the artifacts from Circle and look at them
- As tests take longer to run, get quicker feedback about build status
- This setup also allows us to parallelize tests in the future, should we want to do that.