### PR TITLE
Use constants instead of hardcoded strings for all rules, all orgs, all envs #1285

### DIFF
--- a/backend/apid/middlewares/environment_test.go
+++ b/backend/apid/middlewares/environment_test.go
@@ -92,8 +92,8 @@ func TestValidateWildcard(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", server.URL, nil)
 	query := req.URL.Query()
-	query.Add("env", "*")
-	query.Add("org", "*")
+	query.Add("env", types.EnvironmentTypeAll)
+	query.Add("org", types.OrganizationTypeAll)
 	req.URL.RawQuery = query.Encode()
 
 	res, err := http.DefaultClient.Do(req)

--- a/backend/authorization/authorization.go
+++ b/backend/authorization/authorization.go
@@ -21,13 +21,11 @@ func matchesRuleType(rule types.Rule, resource string) bool {
 }
 
 func matchesRuleEnvironment(rule types.Rule, environment string) bool {
-	return rule.Environment == environment || rule.Environment == "*"
+	return rule.Environment == environment || rule.Environment == types.EnvironmentTypeAll
 }
 
-// TODO (JK): this function may end up becoming more complex if
-// we decide to use "*" as more than a way of saying "all organizations"
 func matchesRuleOrganization(rule types.Rule, organization string) bool {
-	return rule.Organization == organization || rule.Organization == "*"
+	return rule.Organization == organization || rule.Organization == types.OrganizationTypeAll
 }
 
 // CanAccessResource will verify whether or not a user has permission to perform

--- a/backend/authorization/organizations.go
+++ b/backend/authorization/organizations.go
@@ -27,7 +27,7 @@ func (p *OrganizationPolicy) Context() Context {
 // WithContext returns new policy populated with rules & organization.
 func (p OrganizationPolicy) WithContext(ctx context.Context) OrganizationPolicy { // nolint
 	p.context = ExtractValueFromContext(ctx)
-	p.context.Organization = "*"
+	p.context.Organization = types.OrganizationTypeAll
 
 	return p
 }

--- a/backend/authorization/roles.go
+++ b/backend/authorization/roles.go
@@ -27,7 +27,7 @@ func (p *RolePolicy) Context() Context {
 // WithContext returns new policy populated with rules & organization.
 func (p RolePolicy) WithContext(ctx context.Context) RolePolicy { // nolint
 	p.context = ExtractValueFromContext(ctx)
-	p.context.Organization = "*"
+	p.context.Organization = types.OrganizationTypeAll
 
 	return p
 }

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -86,8 +86,8 @@ func setupAdminRole(store store.Store) error {
 			Name: "admin",
 			Rules: []types.Rule{{
 				Type:         types.RuleTypeAll,
-				Environment:  "*",
-				Organization: "*",
+				Environment:  types.EnvironmentTypeAll,
+				Organization: types.OrganizationTypeAll,
 				Permissions:  types.RuleAllPerms,
 			}},
 		},
@@ -101,8 +101,8 @@ func setupReadOnlyRole(store store.Store) error {
 			Name: "read-only",
 			Rules: []types.Rule{{
 				Type:         types.RuleTypeAll,
-				Environment:  "*",
-				Organization: "*",
+				Environment:  types.EnvironmentTypeAll,
+				Organization: types.OrganizationTypeAll,
 				Permissions:  []string{types.RulePermRead},
 			}},
 		},

--- a/backend/store/etcd/environment_store.go
+++ b/backend/store/etcd/environment_store.go
@@ -91,8 +91,8 @@ func (s *Store) GetEnvironment(ctx context.Context, org, env string) (*types.Env
 
 // GetEnvironments returns all Environments.
 func (s *Store) GetEnvironments(ctx context.Context, org string) ([]*types.Environment, error) {
-	// Support "*" as a wildcard
-	if org == "*" {
+	// Support "*" as a wildcard (defined by constant types.OrganizationTypeAll)
+	if org == types.OrganizationTypeAll {
 		org = ""
 	}
 

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -66,7 +66,7 @@ func (s *Store) GetEvents(ctx context.Context) ([]*types.Event, error) {
 
 	// Support "*" as a wildcard for filtering environments
 	var env string
-	if env = types.ContextEnvironment(ctx); env == "*" {
+	if env = types.ContextEnvironment(ctx); env == types.EnvironmentTypeAll {
 		env = ""
 	}
 

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -36,8 +36,8 @@ func TestEventStorage(t *testing.T) {
 		assert.EqualValues(t, event, events[0])
 
 		// Get all events with wildcards
-		ctx = context.WithValue(ctx, types.OrganizationKey, "*")
-		ctx = context.WithValue(ctx, types.EnvironmentKey, "*")
+		ctx = context.WithValue(ctx, types.OrganizationKey, types.OrganizationTypeAll)
+		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentTypeAll)
 		events, err = store.GetEvents(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(events))
@@ -50,7 +50,7 @@ func TestEventStorage(t *testing.T) {
 
 		// Get all events from an unexisting org
 		ctx = context.WithValue(ctx, types.OrganizationKey, "acme")
-		ctx = context.WithValue(ctx, types.EnvironmentKey, "*")
+		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentKeyAll)
 		events, err = store.GetEvents(ctx)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(events))

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -50,7 +50,7 @@ func TestEventStorage(t *testing.T) {
 
 		// Get all events from an unexisting org
 		ctx = context.WithValue(ctx, types.OrganizationKey, "acme")
-		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentKeyAll)
+		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentTypeAll)
 		events, err = store.GetEvents(ctx)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(events))

--- a/backend/store/etcd/helpers.go
+++ b/backend/store/etcd/helpers.go
@@ -20,10 +20,10 @@ type getObjectsPath func(context.Context, string) string
 func query(ctx context.Context, store *Store, fn getObjectsPath) (*clientv3.GetResponse, error) {
 	// Support "*" as a wildcard
 	var org, env string
-	if org = types.ContextOrganization(ctx); org == "*" {
+	if org = types.ContextOrganization(ctx); org == types.OrganizationTypeAll {
 		org = ""
 	}
-	if env = types.ContextEnvironment(ctx); env == "*" {
+	if env = types.ContextEnvironment(ctx); env == types.EnvironmentTypeAll {
 		env = ""
 	}
 

--- a/backend/store/etcd/helpers_test.go
+++ b/backend/store/etcd/helpers_test.go
@@ -56,7 +56,7 @@ func TestQuery(t *testing.T) {
 		assert.Len(t, resp.Kvs, 1)
 
 		// Mock a context to query across every single organization
-		ctx = context.WithValue(ctx, types.OrganizationKey, "*")
+		ctx = context.WithValue(ctx, types.OrganizationKey, types.OrganizationTypeAll)
 
 		// We now have two result given our "wildcard" org
 		resp, err = query(ctx, etcd, getCheckConfigsPath)
@@ -65,7 +65,7 @@ func TestQuery(t *testing.T) {
 
 		// Mock a context to query across every single environment of the acme org
 		ctx = context.WithValue(ctx, types.OrganizationKey, "acme")
-		ctx = context.WithValue(ctx, types.EnvironmentKey, "*")
+		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentTypeAll)
 
 		// We now have two result given our "wildcard" env
 		resp, err = query(ctx, etcd, getCheckConfigsPath)
@@ -73,8 +73,8 @@ func TestQuery(t *testing.T) {
 		assert.Len(t, resp.Kvs, 2)
 
 		// Mock a context to query across every single organization and environment
-		ctx = context.WithValue(ctx, types.OrganizationKey, "*")
-		ctx = context.WithValue(ctx, types.EnvironmentKey, "*")
+		ctx = context.WithValue(ctx, types.OrganizationKey, types.OrganizationTypeAll)
+		ctx = context.WithValue(ctx, types.EnvironmentKey, types.EnvironmentTypeAll)
 
 		// We now have two result given our "wildcard" org
 		resp, err = query(ctx, etcd, getCheckConfigsPath)

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -28,7 +28,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch assets from API

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -28,7 +28,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch checks from the API

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -27,7 +27,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch handlers from API

--- a/cli/commands/environment/list.go
+++ b/cli/commands/environment/list.go
@@ -25,7 +25,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch orgs from API

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -28,7 +28,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch events from API

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -26,7 +26,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch filters from the API

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -28,7 +28,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch handlers from API

--- a/cli/commands/hook/list.go
+++ b/cli/commands/hook/list.go
@@ -26,7 +26,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch hooks from the API

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -27,7 +27,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			org := cli.Config.Organization()
 			if ok, _ := cmd.Flags().GetBool(flags.AllOrgs); ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 
 			// Fetch mutators from the API

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -30,7 +30,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			if ok, err := flg.GetBool(flags.AllOrgs); err != nil {
 				return err
 			} else if ok {
-				org = "*"
+				org = types.OrganizationTypeAll
 			}
 			// Fetch silenceds from the API
 			sub, err := flg.GetString("subscription")

--- a/types/environment.go
+++ b/types/environment.go
@@ -6,6 +6,11 @@ import (
 	"net/url"
 )
 
+const (
+	// EnvironmentTypeAll matches all actions
+	EnvironmentTypeAll = "*"
+)
+
 // Validate returns an error if the environment does not pass validation tests.
 func (e *Environment) Validate() error {
 	if err := ValidateName(e.Name); err != nil {

--- a/types/organization.go
+++ b/types/organization.go
@@ -5,6 +5,11 @@ import (
 	"net/url"
 )
 
+const (
+	// OrganizationTypeAll matches all actions
+	OrganizationTypeAll = "*"
+)
+
 // Validate returns an error if the organization does not pass validation tests
 func (o *Organization) Validate() error {
 	if err := ValidateName(o.Name); err != nil {

--- a/types/rbac_test.go
+++ b/types/rbac_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"sensu-go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func TestRuleValidate(t *testing.T) {
 	assert.NoError(t, r.Validate())
 
 	// Wildcard org
-	r.Organization = "*"
+	r.Organization = types.OrganizationTypeAll
 	assert.NoError(t, r.Validate())
 }
 

--- a/types/rbac_test.go
+++ b/types/rbac_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/types/rbac_test.go
+++ b/types/rbac_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"sensu-go/types"
+	"types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/types/rbac_test.go
+++ b/types/rbac_test.go
@@ -47,7 +47,7 @@ func TestRuleValidate(t *testing.T) {
 	assert.NoError(t, r.Validate())
 
 	// Wildcard org
-	r.Organization = types.OrganizationTypeAll
+	r.Organization = OrganizationTypeAll
 	assert.NoError(t, r.Validate())
 }
 


### PR DESCRIPTION
## What is this change?

First pass at implementing the change outlined in #1285 by defining necessary constants and using them throughout the code where seemed appropriate.

## Why is this change necessary?

Constants are better than literals, there might be some risk of issues around text encoding.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

I am a first-time contributor to Sensu, and super open to any input on how I should engage as a contributor or if I need to sign a contributor agreement!

## Were there any complications while making this change?

Nah, it was my first golang work, and I felt pretty comfy, just needed to find the right time and mood to lock it all together, had thought about this for weeks.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Would happily update documentation that folks should use these constants instead of literal splat, and would welcome input and guidance on that!

@mercul3s 