### PR TITLE
Check execution test failures

### DIFF
--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -71,7 +71,7 @@ func TestExecuteCheck(t *testing.T) {
 	event := &types.Event{}
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotZero(event.Timestamp)
-	assert.EqualValues(int32(0), event.Check.Status)
+	assert.Equal(uint32(0), event.Check.Status)
 	assert.False(event.HasMetrics())
 
 	falsePath := testutil.CommandPath(filepath.Join(toolsDir, "false"))
@@ -84,7 +84,7 @@ func TestExecuteCheck(t *testing.T) {
 	event = &types.Event{}
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotZero(event.Timestamp)
-	assert.EqualValues(int32(1), event.Check.Status)
+	assert.Equal(uint32(1), event.Check.Status)
 	assert.NotZero(event.Check.Issued)
 
 	sleepPath := testutil.CommandPath(filepath.Join(toolsDir, "sleep"), "5")
@@ -98,7 +98,7 @@ func TestExecuteCheck(t *testing.T) {
 	event = &types.Event{}
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotZero(event.Timestamp)
-	assert.EqualValues(int32(2), event.Check.Status)
+	assert.Equal(uint32(2), event.Check.Status)
 
 	checkConfig.Command = truePath
 	checkConfig.OutputMetricHandlers = nil

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -118,7 +119,8 @@ func TestExecuteCheck(t *testing.T) {
 	assert.NoError(err)
 	err = ioutil.WriteFile(f.Name(), []byte(metrics), 0644)
 	assert.NoError(err)
-	defer f.Close()
+	f.Close()
+	defer os.Remove(f.Name())
 	checkConfig.OutputMetricFormat = types.GraphiteOutputMetricFormat
 	catPath := testutil.CommandPath(filepath.Join(toolsDir, "cat"), f.Name())
 	checkConfig.Command = catPath


### PR DESCRIPTION
## What is this change?

While this won't fix the master build, this will at least prevent a race condition with file flushing and give us a more accurate test against the check types in the test.

I don't really think this requires a changelog entry.