### PR TITLE
Fix format strings for --format help flag in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 generated correctly.
 - Display the name of extensions with table formatting in sensuctl.
 - Check TTL now works with round robin checks.
+- Format string for --format flag help now shows actual arguments.
 
 ## [2.0.0-beta.2] - 2018-06-28
 

--- a/cli/commands/helpers/flags.go
+++ b/cli/commands/helpers/flags.go
@@ -16,7 +16,16 @@ var commaWhitespaceRegex *regexp.Regexp
 // configuration the user's configured default format is used as the flag's
 // default value.
 func AddFormatFlag(flagSet *pflag.FlagSet) {
-	flagSet.String("format", config.DefaultFormat, `format of data returned ("json"|config.FormatTabular)`)
+	flagSet.String(
+		"format",
+		config.DefaultFormat,
+		fmt.Sprintf(
+			`format of data returned ("%s"|"%s"|"%s")`,
+			config.FormatJSON,
+			config.FormatWrappedJSON,
+			config.FormatTabular,
+		),
+	)
 }
 
 // AddAllOrganization adds the '--all-organizations' flag to the given command


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

Fixes the help string for the --format sensuctl flag.


## Why is this change necessary?

closes #1785 
