### PR TITLE
Bugfixes to the Backend refactoring

### DIFF
--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -146,7 +146,7 @@ func newStartCommand() *cobra.Command {
 				return fmt.Errorf("missing the following cert flags: %s", emptyFlags)
 			}
 
-			sensuBackend, err := backend.Initialize(cfg)
+			sensuBackend, err := initialize(cfg)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What is this change?

It corrects some changes made during the Backend struct refactoring. More specifically:

- The `Etcd` & `Daemons` fields of `Backend` struct are now exported so they can be manipulated by the EE.
- The `backend/cmd` package uses the `Initialize` function passed to the package and not directly `backend.Initialize`. 

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/39

## Does your change need a Changelog entry?

Nope; these are bugfixes to an unreleased change.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!