### PR TITLE
Add unit test coverage for check routers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added unit test coverage for check routers.
+
 ### Changed
 - The Backend struct has been refactored to allow easier customization for the
 enterprise edition.

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -190,7 +190,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store, getter t
 			middlewares.LimitRequest{},
 		),
 		routers.NewAssetRouter(store),
-		routers.NewChecksRouter(store, getter),
+		routers.NewChecksRouter(actions.NewCheckController(store, getter)),
 		routers.NewEntitiesRouter(store),
 		routers.NewEnvironmentsRouter(actions.NewEnvironmentController(store)),
 		routers.NewEventFiltersRouter(store),

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -1,26 +1,38 @@
 package routers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/sensu/sensu-go/backend/apid/actions"
-	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
+// CheckController represents the controller needs of the ChecksRouter.
+type CheckController interface {
+	Create(context.Context, types.CheckConfig) error
+	CreateOrReplace(context.Context, types.CheckConfig) error
+	Update(context.Context, types.CheckConfig) error
+	Query(context.Context) ([]*types.CheckConfig, error)
+	Find(context.Context, string) (*types.CheckConfig, error)
+	Destroy(context.Context, string) error
+	AddCheckHook(context.Context, string, types.HookList) error
+	RemoveCheckHook(context.Context, string, string, string) error
+	QueueAdhocRequest(context.Context, string, *types.AdhocRequest) error
+}
+
 // ChecksRouter handles requests for /checks
 type ChecksRouter struct {
-	controller actions.CheckController
+	controller CheckController
 }
 
 // NewChecksRouter instantiates new router for controlling check resources
-func NewChecksRouter(store store.Store, getter types.QueueGetter) *ChecksRouter {
+func NewChecksRouter(ctrl CheckController) *ChecksRouter {
 	return &ChecksRouter{
-		controller: actions.NewCheckController(store, getter),
+		controller: ctrl,
 	}
 }
 

--- a/backend/apid/routers/checks_test.go
+++ b/backend/apid/routers/checks_test.go
@@ -2,11 +2,14 @@ package routers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/testing/mockqueue"
 	"github.com/sensu/sensu-go/testing/mockstore"
@@ -15,8 +18,223 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestHttpApiEventsGet(t *testing.T) {
+type mockCheckController struct {
+	mock.Mock
+}
 
+func (m *mockCheckController) Create(ctx context.Context, check types.CheckConfig) error {
+	return m.Called(ctx, check).Error(0)
+}
+
+func (m *mockCheckController) CreateOrReplace(ctx context.Context, check types.CheckConfig) error {
+	return m.Called(ctx, check).Error(0)
+}
+
+func (m *mockCheckController) Update(ctx context.Context, check types.CheckConfig) error {
+	return m.Called(ctx, check).Error(0)
+}
+
+func (m *mockCheckController) Query(ctx context.Context) ([]*types.CheckConfig, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*types.CheckConfig), args.Error(1)
+}
+
+func (m *mockCheckController) Find(ctx context.Context, check string) (*types.CheckConfig, error) {
+	args := m.Called(ctx, check)
+	return args.Get(0).(*types.CheckConfig), args.Error(1)
+}
+
+func (m *mockCheckController) Destroy(ctx context.Context, check string) error {
+	return m.Called(ctx, check).Error(0)
+}
+
+func (m *mockCheckController) AddCheckHook(ctx context.Context, check string, hook types.HookList) error {
+	return m.Called(ctx, check, hook).Error(0)
+}
+
+func (m *mockCheckController) RemoveCheckHook(ctx context.Context, check string, hookType string, hookName string) error {
+	return m.Called(ctx, check, hookType, hookName).Error(0)
+}
+
+func (m *mockCheckController) QueueAdhocRequest(ctx context.Context, check string, req *types.AdhocRequest) error {
+	return m.Called(ctx, check, req).Error(0)
+}
+
+func newCheckTest(t *testing.T) (*mockCheckController, *httptest.Server) {
+	controller := &mockCheckController{}
+	checkRouter := NewChecksRouter(controller)
+	router := mux.NewRouter()
+	checkRouter.Mount(router)
+
+	return controller, httptest.NewServer(router)
+}
+
+func TestPostCheck(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	check := types.FixtureCheckConfig("check1")
+	controller.On("Create", mock.Anything, mock.AnythingOfType("types.CheckConfig")).Return(nil)
+	b, _ := json.Marshal(check)
+	body := bytes.NewReader(b)
+	endpoint := "/checks"
+	req := newRequest(t, http.MethodPost, server.URL+endpoint, body)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	controller.AssertCalled(t,
+		"Create",
+		mock.Anything,
+		mock.AnythingOfType("CheckConfig"))
+}
+
+func TestPutCheck(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	controller.On("CreateOrReplace", mock.Anything, mock.AnythingOfType("types.CheckConfig")).Return(nil)
+	b, _ := json.Marshal(types.FixtureCheckConfig("check1"))
+	body := bytes.NewReader(b)
+	endpoint := "/checks/check1"
+	req := newRequest(t, http.MethodPut, server.URL+endpoint, body)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	controller.AssertCalled(t, "CreateOrReplace", mock.Anything, mock.AnythingOfType("types.CheckConfig"))
+}
+
+func TestGetCheck(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	fixture := types.FixtureCheckConfig("check1")
+	controller.On("Find", mock.Anything, "check1").Return(fixture, nil)
+	endpoint := "/checks/check1"
+	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestDeleteCheck(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	controller.On("Destroy", mock.Anything, "check1").Return(nil)
+	endpoint := "/checks/check1"
+	req := newRequest(t, http.MethodDelete, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestGetAllChecks(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	fixtures := []*types.CheckConfig{types.FixtureCheckConfig("check1")}
+	controller.On("Query", mock.Anything).Return(fixtures, nil)
+	endpoint := "/checks"
+	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestPutCheckHook(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	fixture := types.FixtureHookList("hook1")
+	controller.On("AddCheckHook", mock.Anything, mock.Anything, mock.AnythingOfType("types.HookList")).Return(nil)
+	b, _ := json.Marshal(fixture)
+	body := bytes.NewReader(b)
+	endpoint := "/checks/check1/hooks/non-zero"
+	req := newRequest(t, http.MethodPut, server.URL+endpoint, body)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	controller.AssertCalled(t, "AddCheckHook", mock.Anything, mock.Anything, mock.AnythingOfType("types.HookList"))
+}
+
+func TestDeleteCheckHook(t *testing.T) {
+	controller, server := newCheckTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	controller.On("RemoveCheckHook", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	endpoint := "/checks/check1/hooks/non-zero/hook/hook1"
+	req := newRequest(t, http.MethodDelete, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	controller.AssertCalled(t, "RemoveCheckHook", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHttpApiChecksAdhocRequest(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds unit test coverage for check routes.

## Why is this change necessary?

Closes #1802 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.