### PR TITLE
Export apid router and resource routes

### DIFF
--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -48,7 +48,7 @@ func (r *AssetsRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *AssetsRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.Asset{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func (r *AssetsRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *AssetsRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	var asset types.Asset
-	if err := unmarshalBody(req, &asset); err != nil {
+	if err := UnmarshalBody(req, &asset); err != nil {
 		return nil, err
 	}
 	err := r.controller.CreateOrReplace(req.Context(), asset)

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -24,11 +24,11 @@ func NewAssetRouter(store store.AssetStore) *AssetsRouter {
 
 // Mount the AssetsRouter to a parent Router
 func (r *AssetsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/assets"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/assets"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *AssetsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -70,7 +70,7 @@ func (r *ChecksRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.CheckConfig{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (r *ChecksRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	cfg := types.CheckConfig{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func (r *ChecksRouter) destroy(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) addCheckHook(req *http.Request) (interface{}, error) {
 	cfg := types.HookList{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (r *ChecksRouter) removeCheckHook(req *http.Request) (interface{}, error) {
 
 func (r *ChecksRouter) adhocRequest(w http.ResponseWriter, req *http.Request) {
 	adhocReq := types.AdhocRequest{}
-	if err := unmarshalBody(req, &adhocReq); err != nil {
+	if err := UnmarshalBody(req, &adhocReq); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -38,16 +38,16 @@ func NewChecksRouter(ctrl CheckController) *ChecksRouter {
 
 // Mount the ChecksRouter to a parent Router
 func (r *ChecksRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/checks"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/checks"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 
 	// Custom
-	routes.path("{id}/hooks/{type}", r.addCheckHook).Methods(http.MethodPut)
-	routes.path("{id}/hooks/{type}/hook/{hook}", r.removeCheckHook).Methods(http.MethodDelete)
+	routes.Path("{id}/hooks/{type}", r.addCheckHook).Methods(http.MethodPut)
+	routes.Path("{id}/hooks/{type}/hook/{hook}", r.removeCheckHook).Methods(http.MethodDelete)
 
 	// handlefunc returns a custom status and response
 	parent.HandleFunc("/checks/{id}/execute", r.adhocRequest).Methods(http.MethodPost)

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -24,12 +24,12 @@ func NewEntitiesRouter(store store.EntityStore) *EntitiesRouter {
 
 // Mount the EntitiesRouter to a parent Router
 func (r *EntitiesRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/entities"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.del(r.destroy)
-	routes.post(r.create)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/entities"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Del(r.destroy)
+	routes.Post(r.create)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *EntitiesRouter) destroy(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -59,7 +59,7 @@ func (r *EntitiesRouter) list(req *http.Request) (interface{}, error) {
 
 func (r *EntitiesRouter) create(req *http.Request) (interface{}, error) {
 	entity := types.Entity{}
-	if err := unmarshalBody(req, &entity); err != nil {
+	if err := UnmarshalBody(req, &entity); err != nil {
 		return nil, err
 	}
 	err := r.controller.Create(req.Context(), entity)
@@ -68,7 +68,7 @@ func (r *EntitiesRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *EntitiesRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	entity := types.Entity{}
-	if err := unmarshalBody(req, &entity); err != nil {
+	if err := UnmarshalBody(req, &entity); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/environments.go
+++ b/backend/apid/routers/environments.go
@@ -33,12 +33,12 @@ func NewEnvironmentsRouter(ctrl EnvironmentController) *EnvironmentsRouter {
 
 // Mount the EnvironmentsRouter to a parent Router
 func (r *EnvironmentsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/rbac/organizations"}
-	routes.path("{organization}/environments", r.list).Methods(http.MethodGet)
-	routes.path("{organization}/environments/{environment}", r.find).Methods(http.MethodGet)
-	routes.path("{organization}/environments", r.create).Methods(http.MethodPost)
-	routes.path("{organization}/environments/{environment}", r.createOrReplace).Methods(http.MethodPut)
-	routes.path("{organization}/environments/{environment}", r.destroy).Methods(http.MethodDelete)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/rbac/organizations"}
+	routes.Path("{organization}/environments", r.list).Methods(http.MethodGet)
+	routes.Path("{organization}/environments/{environment}", r.find).Methods(http.MethodGet)
+	routes.Path("{organization}/environments", r.create).Methods(http.MethodPost)
+	routes.Path("{organization}/environments/{environment}", r.createOrReplace).Methods(http.MethodPut)
+	routes.Path("{organization}/environments/{environment}", r.destroy).Methods(http.MethodDelete)
 }
 
 func (r *EnvironmentsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/environments.go
+++ b/backend/apid/routers/environments.go
@@ -67,7 +67,7 @@ func (r *EnvironmentsRouter) find(req *http.Request) (interface{}, error) {
 func (r *EnvironmentsRouter) create(req *http.Request) (interface{}, error) {
 	env := types.Environment{}
 	var err error
-	if err = unmarshalBody(req, &env); err != nil {
+	if err = UnmarshalBody(req, &env); err != nil {
 		return nil, err
 	}
 	vars := mux.Vars(req)
@@ -85,7 +85,7 @@ func (r *EnvironmentsRouter) create(req *http.Request) (interface{}, error) {
 func (r *EnvironmentsRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	env := types.Environment{}
 	var err error
-	if err = unmarshalBody(req, &env); err != nil {
+	if err = UnmarshalBody(req, &env); err != nil {
 		return nil, err
 	}
 	vars := mux.Vars(req)

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -63,7 +63,7 @@ func (r *EventsRouter) destroy(req *http.Request) (interface{}, error) {
 
 func (r *EventsRouter) create(req *http.Request) (interface{}, error) {
 	event := types.Event{}
-	if err := unmarshalBody(req, &event); err != nil {
+	if err := UnmarshalBody(req, &event); err != nil {
 		return nil, err
 	}
 
@@ -73,7 +73,7 @@ func (r *EventsRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *EventsRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	event := types.Event{}
-	if err := unmarshalBody(req, &event); err != nil {
+	if err := UnmarshalBody(req, &event); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -25,13 +25,13 @@ func NewEventsRouter(store store.EventStore, bus messaging.MessageBus) *EventsRo
 
 // Mount the EventsRouter to a parent Router
 func (r *EventsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/events"}
-	routes.getAll(r.list)
-	routes.path("{entity}", r.listByEntity).Methods(http.MethodGet)
-	routes.path("{entity}/{check}", r.find).Methods(http.MethodGet)
-	routes.path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
-	routes.path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
-	routes.post(r.create)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/events"}
+	routes.GetAll(r.list)
+	routes.Path("{entity}", r.listByEntity).Methods(http.MethodGet)
+	routes.Path("{entity}/{check}", r.find).Methods(http.MethodGet)
+	routes.Path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
+	routes.Path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
+	routes.Post(r.create)
 }
 
 func (r *EventsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/extensions.go
+++ b/backend/apid/routers/extensions.go
@@ -24,11 +24,11 @@ func NewExtensionsRouter(store store.ExtensionRegistry) *ExtensionsRouter {
 
 // Mount the ExtensionsRouter to a parent Router
 func (r *ExtensionsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/extensions"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.put(r.register)
-	routes.del(r.deregister)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/extensions"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Put(r.register)
+	routes.Del(r.deregister)
 }
 
 func (r *ExtensionsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/extensions.go
+++ b/backend/apid/routers/extensions.go
@@ -48,7 +48,7 @@ func (r *ExtensionsRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *ExtensionsRouter) register(req *http.Request) (interface{}, error) {
 	var extension types.Extension
-	if err := unmarshalBody(req, &extension); err != nil {
+	if err := UnmarshalBody(req, &extension); err != nil {
 		return nil, err
 	}
 	err := r.controller.Register(req.Context(), extension)

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -47,7 +47,7 @@ func (r *EventFiltersRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *EventFiltersRouter) create(req *http.Request) (interface{}, error) {
 	filter := types.EventFilter{}
-	if err := unmarshalBody(req, &filter); err != nil {
+	if err := UnmarshalBody(req, &filter); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +57,7 @@ func (r *EventFiltersRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *EventFiltersRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	filter := types.EventFilter{}
-	if err := unmarshalBody(req, &filter); err != nil {
+	if err := UnmarshalBody(req, &filter); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -24,12 +24,12 @@ func NewEventFiltersRouter(store store.EventFilterStore) *EventFiltersRouter {
 
 // Mount the EventFiltersRouter to a parent Router
 func (r *EventFiltersRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/filters"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/filters"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *EventFiltersRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -34,7 +34,7 @@ func (r *HandlersRouter) Mount(parent *mux.Router) {
 
 func (r *HandlersRouter) create(req *http.Request) (interface{}, error) {
 	handler := types.Handler{}
-	if err := unmarshalBody(req, &handler); err != nil {
+	if err := UnmarshalBody(req, &handler); err != nil {
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func (r *HandlersRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *HandlersRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	handler := types.Handler{}
-	if err := unmarshalBody(req, &handler); err != nil {
+	if err := UnmarshalBody(req, &handler); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -24,12 +24,12 @@ func NewHandlersRouter(store store.HandlerStore) *HandlersRouter {
 
 // Mount the HandlersRouter to a parent Router
 func (r *HandlersRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/handlers"}
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/handlers"}
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *HandlersRouter) create(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -24,12 +24,12 @@ func NewHooksRouter(store store.HookConfigStore) *HooksRouter {
 
 // Mount the HooksRouter to a parent Router
 func (r *HooksRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/hooks"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/hooks"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *HooksRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -49,7 +49,7 @@ func (r *HooksRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *HooksRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.HookConfig{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (r *HooksRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *HooksRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	cfg := types.HookConfig{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -47,7 +47,7 @@ func (r *MutatorsRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *MutatorsRouter) create(req *http.Request) (interface{}, error) {
 	mut := types.Mutator{}
-	if err := unmarshalBody(req, &mut); err != nil {
+	if err := UnmarshalBody(req, &mut); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +57,7 @@ func (r *MutatorsRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *MutatorsRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	mutator := types.Mutator{}
-	if err := unmarshalBody(req, &mutator); err != nil {
+	if err := UnmarshalBody(req, &mutator); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -24,12 +24,12 @@ func NewMutatorsRouter(store store.MutatorStore) *MutatorsRouter {
 
 // Mount the MutatorsRouter to a parent Router
 func (r *MutatorsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/mutators"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/mutators"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *MutatorsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/organizations.go
+++ b/backend/apid/routers/organizations.go
@@ -32,12 +32,12 @@ func NewOrganizationsRouter(ctrl OrganizationsController) *OrganizationsRouter {
 
 // Mount the OrganizationsRouter to a parent Router
 func (r *OrganizationsRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/rbac/organizations"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/rbac/organizations"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 }
 
 func (r *OrganizationsRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/organizations.go
+++ b/backend/apid/routers/organizations.go
@@ -57,7 +57,7 @@ func (r *OrganizationsRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *OrganizationsRouter) create(req *http.Request) (interface{}, error) {
 	org := types.Organization{}
-	if err := unmarshalBody(req, &org); err != nil {
+	if err := UnmarshalBody(req, &org); err != nil {
 		return nil, err
 	}
 
@@ -67,7 +67,7 @@ func (r *OrganizationsRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *OrganizationsRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	org := types.Organization{}
-	if err := unmarshalBody(req, &org); err != nil {
+	if err := UnmarshalBody(req, &org); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -24,16 +24,16 @@ func NewRolesRouter(store store.RBACStore) *RolesRouter {
 
 // Mount the RolesRouter to a parent Router
 func (r *RolesRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/rbac/roles"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/rbac/roles"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 
 	// Custom
-	routes.path("{id}/rules/{type}", r.addRule).Methods(http.MethodPut)
-	routes.path("{id}/rules/{type}", r.rmRule).Methods(http.MethodDelete)
+	routes.Path("{id}/rules/{type}", r.addRule).Methods(http.MethodPut)
+	routes.Path("{id}/rules/{type}", r.rmRule).Methods(http.MethodDelete)
 }
 
 func (r *RolesRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -53,7 +53,7 @@ func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *RolesRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.Role{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -63,7 +63,7 @@ func (r *RolesRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *RolesRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	cfg := types.Role{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func (r *RolesRouter) destroy(req *http.Request) (interface{}, error) {
 
 func (r *RolesRouter) addRule(req *http.Request) (interface{}, error) {
 	cfg := types.Rule{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -133,51 +133,58 @@ func actionHandler(action actionHandlerFunc) http.HandlerFunc {
 type actionHandlerFunc func(r *http.Request) (interface{}, error)
 
 //
-// resourceRoute mounts resources in a convetional RESTful manner.
+// ResourceRoute mounts resources in a convetional RESTful manner.
 //
-//   routes := resourceRoute{pathPrefix: "checks", router: ...}
-//   routes.getAll(myIndexAction) // given action is mounted at GET /checks
-//   routes.get(myShowAction)     // given action is mounted at GET /checks/:id
-//   routes.put(myCreateAction)   // given action is mounted at PUT /checks/:id
-//   routes.patch(myUpdateAction) // given action is mounted at PATCH /checks/:id
-//   routes.post(myCreateAction)  // given action is mounted at POST /checks
-//   routes.del(myCreateAction)   // given action is mounted at DELETE /checks/:id
-//   routes.path("{id}/publish", publishAction).Methods(http.MethodDelete) // when you need something customer
+//   routes := ResourceRoute{PathPrefix: "checks", Router: ...}
+//   routes.GetAll(myIndexAction) // given action is mounted at GET /checks
+//   routes.Get(myShowAction)     // given action is mounted at GET /checks/:id
+//   routes.Put(myCreateAction)   // given action is mounted at PUT /checks/:id
+//   routes.Patch(myUpdateAction) // given action is mounted at PATCH /checks/:id
+//   routes.Post(myCreateAction)  // given action is mounted at POST /checks
+//   routes.Del(myCreateAction)   // given action is mounted at DELETE /checks/:id
+//   routes.Path("{id}/publish", publishAction).Methods(http.MethodDelete) // when you need something customer
 //
-type resourceRoute struct {
-	router     *mux.Router
-	pathPrefix string
+type ResourceRoute struct {
+	Router     *mux.Router
+	PathPrefix string
 }
 
-func (r *resourceRoute) getAll(fn actionHandlerFunc) *mux.Route {
-	return r.path("", fn).Methods(http.MethodGet)
+// GetAll reads all
+func (r *ResourceRoute) GetAll(fn actionHandlerFunc) *mux.Route {
+	return r.Path("", fn).Methods(http.MethodGet)
 }
 
-func (r *resourceRoute) get(fn actionHandlerFunc) *mux.Route {
-	return r.path("{id}", fn).Methods(http.MethodGet)
+// Get reads
+func (r *ResourceRoute) Get(fn actionHandlerFunc) *mux.Route {
+	return r.Path("{id}", fn).Methods(http.MethodGet)
 }
 
-func (r *resourceRoute) post(fn actionHandlerFunc) *mux.Route {
-	return r.path("", fn).Methods(http.MethodPost)
+// Post creates
+func (r *ResourceRoute) Post(fn actionHandlerFunc) *mux.Route {
+	return r.Path("", fn).Methods(http.MethodPost)
 }
 
 // TODO: uncomment this and use it once controller update fits
 // http patch semantics.
-//func (r *resourceRoute) patch(fn actionHandlerFunc) *mux.Route {
+// Patch updates/modifies
+//func (r *ResourceRoute) Patch(fn actionHandlerFunc) *mux.Route {
 //	return r.path("{id}", fn).Methods(http.MethodPatch)
 //}
 
-func (r *resourceRoute) put(fn actionHandlerFunc) *mux.Route {
-	return r.path("{id}", fn).Methods(http.MethodPut)
+// Put updates/replaces
+func (r *ResourceRoute) Put(fn actionHandlerFunc) *mux.Route {
+	return r.Path("{id}", fn).Methods(http.MethodPut)
 }
 
-func (r *resourceRoute) del(fn actionHandlerFunc) *mux.Route {
-	return r.path("{id}", fn).Methods(http.MethodDelete)
+// Del deletes
+func (r *ResourceRoute) Del(fn actionHandlerFunc) *mux.Route {
+	return r.Path("{id}", fn).Methods(http.MethodDelete)
 }
 
-func (r *resourceRoute) path(p string, fn actionHandlerFunc) *mux.Route {
-	fullPath := path.Join(r.pathPrefix, p)
-	return handleAction(r.router, fullPath, fn)
+// Path adds custom path
+func (r *ResourceRoute) Path(p string, fn actionHandlerFunc) *mux.Route {
+	fullPath := path.Join(r.PathPrefix, p)
+	return handleAction(r.Router, fullPath, fn)
 }
 
 func handleAction(router *mux.Router, path string, fn actionHandlerFunc) *mux.Route {

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -191,7 +191,7 @@ func handleAction(router *mux.Router, path string, fn actionHandlerFunc) *mux.Ro
 	return router.HandleFunc(path, actionHandler(fn))
 }
 
-func unmarshalBody(req *http.Request, record interface{}) error {
+func UnmarshalBody(req *http.Request, record interface{}) error {
 	err := json.NewDecoder(req.Body).Decode(&record)
 	if err != nil {
 		logger.WithError(err).Error("unable to read request body")

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -52,7 +52,7 @@ func (r *SilencedRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *SilencedRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.Silenced{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func (r *SilencedRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *SilencedRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	cfg := types.Silenced{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -24,16 +24,16 @@ func NewSilencedRouter(store store.Store) *SilencedRouter {
 
 // Mount the SilencedRouter to a parent Router
 func (r *SilencedRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/silenced"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/silenced"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 
 	// Custom
-	routes.path("subscriptions/{subscription}", r.list).Methods(http.MethodGet)
-	routes.path("checks/{check}", r.list).Methods(http.MethodGet)
+	routes.Path("subscriptions/{subscription}", r.list).Methods(http.MethodGet)
+	routes.Path("checks/{check}", r.list).Methods(http.MethodGet)
 }
 
 func (r *SilencedRouter) list(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -66,7 +66,7 @@ func (r *UsersRouter) find(req *http.Request) (interface{}, error) {
 
 func (r *UsersRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.User{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +79,7 @@ func (r *UsersRouter) create(req *http.Request) (interface{}, error) {
 
 func (r *UsersRouter) createOrReplace(req *http.Request) (interface{}, error) {
 	cfg := types.User{}
-	if err := unmarshalBody(req, &cfg); err != nil {
+	if err := UnmarshalBody(req, &cfg); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func (r *UsersRouter) reinstate(req *http.Request) (interface{}, error) {
 
 func (r *UsersRouter) updatePassword(req *http.Request) (interface{}, error) {
 	params := map[string]string{}
-	if err := unmarshalBody(req, &params); err != nil {
+	if err := UnmarshalBody(req, &params); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -24,20 +24,20 @@ func NewUsersRouter(store store.Store) *UsersRouter {
 
 // Mount the UsersRouter to a parent Router
 func (r *UsersRouter) Mount(parent *mux.Router) {
-	routes := resourceRoute{router: parent, pathPrefix: "/rbac/users"}
-	routes.getAll(r.list)
-	routes.get(r.find)
-	routes.post(r.create)
-	routes.del(r.destroy)
-	routes.put(r.createOrReplace)
+	routes := ResourceRoute{Router: parent, PathPrefix: "/rbac/users"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
 
 	// Custom
-	routes.path("{id}/reinstate", r.reinstate).Methods(http.MethodPut)
-	routes.path("{id}/roles/{role}", r.addRole).Methods(http.MethodPut)
-	routes.path("{id}/roles/{role}", r.removeRole).Methods(http.MethodDelete)
+	routes.Path("{id}/reinstate", r.reinstate).Methods(http.MethodPut)
+	routes.Path("{id}/roles/{role}", r.addRole).Methods(http.MethodPut)
+	routes.Path("{id}/roles/{role}", r.removeRole).Methods(http.MethodDelete)
 
 	// TODO: Remove?
-	routes.path("{id}/password", r.updatePassword).Methods(http.MethodPut)
+	routes.Path("{id}/password", r.updatePassword).Methods(http.MethodPut)
 }
 
 func (r *UsersRouter) list(req *http.Request) (interface{}, error) {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Exports apid router and resource routes.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/40

## Does your change need a Changelog entry?

Probably okay without it.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.