### PR TITLE
Improve TestExecuteCheck

### DIFF
--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -117,7 +118,7 @@ func TestExecuteCheck(t *testing.T) {
 	metrics := "metric.foo 1 123456789\nmetric.bar 2 987654321"
 	f, err := ioutil.TempFile("", "metric")
 	assert.NoError(err)
-	err = ioutil.WriteFile(f.Name(), []byte(metrics), 0644)
+	_, err = fmt.Fprintln(f, metrics)
 	assert.NoError(err)
 	f.Close()
 	defer os.Remove(f.Name())
@@ -133,7 +134,10 @@ func TestExecuteCheck(t *testing.T) {
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotZero(event.Timestamp)
 	assert.True(event.HasMetrics())
-	assert.Equal(2, len(event.Metrics.Points))
+	if len(event.Metrics.Points) != 2 {
+		fmt.Println(event)
+	}
+	require.Equal(t, 2, len(event.Metrics.Points))
 	metric0 := event.Metrics.Points[0]
 	assert.Equal(float64(1), metric0.Value)
 	assert.Equal("metric.foo", metric0.Name)

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -119,7 +119,7 @@ func TestExecuteCheck(t *testing.T) {
 	f, err := ioutil.TempFile("", "metric")
 	assert.NoError(err)
 	_, err = fmt.Fprintln(f, metrics)
-	assert.NoError(err)
+	require.NoError(t, err)
 	f.Close()
 	defer os.Remove(f.Name())
 	checkConfig.OutputMetricFormat = types.GraphiteOutputMetricFormat
@@ -134,10 +134,7 @@ func TestExecuteCheck(t *testing.T) {
 	assert.NoError(json.Unmarshal(msg.Payload, event))
 	assert.NotZero(event.Timestamp)
 	assert.True(event.HasMetrics())
-	if len(event.Metrics.Points) != 2 {
-		fmt.Println(event)
-	}
-	require.Equal(t, 2, len(event.Metrics.Points))
+	require.Equal(t, 2, len(event.Metrics.Points), string(msg.Payload))
 	metric0 := event.Metrics.Points[0]
 	assert.Equal(float64(1), metric0.Value)
 	assert.Equal("metric.foo", metric0.Name)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Improves TestExecuteCheck, add debug print statement in the event future failures happen, avoid panic by using `require`.

## Why is this change necessary?

Closes #1825 

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

🤞 Hoping the behavior is the same on windows.