### PR TITLE
Add enterprise feature flag to sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added unit test coverage for check routers.
+- Added an enterprise feature flag in sensuctl.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization for the

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateAccessToken returns a new access token given userid and password
-func (client *RestClient) CreateAccessToken(url, userid, password string) (*types.Tokens, error) {
+func (client *RestClient) CreateAccessToken(url, userid, password string) (*types.Tokens, string, error) {
 	// Make sure any existing auth token doesn't get injected instead
 	client.ClearAuthToken()
 	defer client.Reset()
@@ -17,22 +17,24 @@ func (client *RestClient) CreateAccessToken(url, userid, password string) (*type
 	// Execute
 	res, err := client.R().SetBasicAuth(userid, password).Get(url + "/auth")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if res.StatusCode() == 401 {
-		return nil, errors.New(string(res.Body()))
+		return nil, "", errors.New(string(res.Body()))
 	} else if res.StatusCode() >= 400 {
 		// TODO: (JK) we may want to expose a bit more of the error here
-		return nil, errors.New("Received an unexpected response from the API")
+		return nil, "", errors.New("Received an unexpected response from the API")
 	}
 
 	var tokens types.Tokens
 	if err = json.Unmarshal(res.Body(), &tokens); err != nil {
-		return nil, errors.New("Unable to unmarshal response from server")
+		return nil, "", errors.New("Unable to unmarshal response from server")
 	}
 
-	return &tokens, err
+	edition := res.Header().Get("Sensu-Edition")
+
+	return &tokens, edition, err
 }
 
 // Logout performs a logout of the configured user

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -32,7 +32,7 @@ func (client *RestClient) CreateAccessToken(url, userid, password string) (*type
 		return nil, "", errors.New("Unable to unmarshal response from server")
 	}
 
-	edition := res.Header().Get("Sensu-Edition")
+	edition := res.Header().Get(types.EditionHeader)
 
 	return &tokens, edition, err
 }

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -17,6 +17,7 @@ func TestCreateAccessToken(t *testing.T) {
 		assert.NotEmpty(t, r.Header["Authorization"])
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Sensu-Edition", types.CoreEdition)
 		_, _ = w.Write([]byte(`{"access_token": "foo", "expires_at": 123456789, "refresh_token": "bar"}`))
 	}
 	server := httptest.NewServer(http.HandlerFunc(testHandler))
@@ -29,9 +30,10 @@ func TestCreateAccessToken(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	token, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	token, edition, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.NoError(t, err)
 	assert.NotNil(t, token)
+	assert.Equal(t, types.CoreEdition, edition)
 }
 
 func TestCreateAccessTokenForbidden(t *testing.T) {
@@ -48,7 +50,7 @@ func TestCreateAccessTokenForbidden(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	_, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	_, _, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.Error(t, err)
 }
 

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -17,7 +17,7 @@ func TestCreateAccessToken(t *testing.T) {
 		assert.NotEmpty(t, r.Header["Authorization"])
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Sensu-Edition", types.CoreEdition)
+		w.Header().Set(types.EditionHeader, types.CoreEdition)
 		_, _ = w.Write([]byte(`{"access_token": "foo", "expires_at": 123456789, "refresh_token": "bar"}`))
 	}
 	server := httptest.NewServer(http.HandlerFunc(testHandler))

--- a/cli/client/config/basic/basic.go
+++ b/cli/client/config/basic/basic.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -30,7 +30,8 @@ type Config struct {
 
 // Cluster contains the Sensu cluster access information
 type Cluster struct {
-	APIUrl string `json:"api-url"`
+	APIUrl  string `json:"api-url"`
+	Edition string `json:"edition"`
 	*types.Tokens
 }
 

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -10,6 +10,14 @@ func (c *Config) APIUrl() string {
 	return c.Cluster.APIUrl
 }
 
+// Edition returns the active cluster edition. Defaults to core
+func (c *Config) Edition() string {
+	if c.Cluster.Edition == "" {
+		return config.DefaultEdition
+	}
+	return c.Cluster.Edition
+}
+
 // Environment returns the user's active environment
 func (c *Config) Environment() string {
 	if c.Profile.Environment == "" {
@@ -24,6 +32,12 @@ func (c *Config) Format() string {
 		return config.DefaultFormat
 	}
 	return c.Profile.Format
+}
+
+// IsEnterprise indicates whether or not the configured cluster is running an
+// enterprise edition (EE)
+func (c *Config) IsEnterprise() bool {
+	return types.EnterpriseEdition == c.Edition()
 }
 
 // Organization returns the user's active organization

--- a/cli/client/config/basic/reader_test.go
+++ b/cli/client/config/basic/reader_test.go
@@ -13,6 +13,19 @@ func TestAPIUrl(t *testing.T) {
 	assert.Equal(t, conf.Cluster.APIUrl, conf.APIUrl())
 }
 
+func TestFormat(t *testing.T) {
+	conf := &Config{Profile: Profile{Format: "json"}}
+	assert.Equal(t, conf.Profile.Format, conf.Format())
+}
+
+func TestEdition(t *testing.T) {
+	conf := &Config{Cluster: Cluster{Edition: types.CoreEdition}}
+	assert.Equal(t, types.CoreEdition, conf.Edition())
+
+	conf.Cluster.Edition = ""
+	assert.Equal(t, types.CoreEdition, conf.Edition())
+}
+
 func TestEnvironment(t *testing.T) {
 	conf := &Config{Profile: Profile{Environment: "dev"}}
 	assert.Equal(t, conf.Profile.Environment, conf.Environment())
@@ -23,14 +36,20 @@ func TestEnvironmentDefault(t *testing.T) {
 	assert.Equal(t, config.DefaultEnvironment, conf.Environment())
 }
 
-func TestFormat(t *testing.T) {
-	conf := &Config{Profile: Profile{Format: "json"}}
-	assert.Equal(t, conf.Profile.Format, conf.Format())
-}
-
 func TestFormatDefault(t *testing.T) {
 	conf := &Config{}
 	assert.Equal(t, config.DefaultFormat, conf.Format())
+}
+
+func TestIsEnterprise(t *testing.T) {
+	conf := &Config{Cluster: Cluster{Edition: types.CoreEdition}}
+	assert.False(t, conf.IsEnterprise())
+
+	conf.Cluster.Edition = ""
+	assert.False(t, conf.IsEnterprise())
+
+	conf.Cluster.Edition = types.EnterpriseEdition
+	assert.True(t, conf.IsEnterprise())
 }
 
 func TestOrganization(t *testing.T) {

--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -16,6 +16,13 @@ func (c *Config) SaveAPIUrl(url string) error {
 	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }
 
+// SaveEdition saves the Sensu edition to a configuration file
+func (c *Config) SaveEdition(edition string) error {
+	c.Cluster.Edition = edition
+
+	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
+}
+
 // SaveEnvironment saves the user's default environment to a configuration file
 func (c *Config) SaveEnvironment(env string) error {
 	c.Profile.Environment = env

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	// DefaultEdition represents the default Sensu edition
+	DefaultEdition = types.CoreEdition
 	// DefaultEnvironment represents the default environment
 	DefaultEnvironment = "default"
 	// DefaultFormat represents the default format output when displaying objects
@@ -28,8 +30,10 @@ type Config interface {
 // Read contains all methods related to reading configuration
 type Read interface {
 	APIUrl() string
-	Format() string
+	Edition() string
 	Environment() string
+	Format() string
+	IsEnterprise() bool
 	Organization() string
 	Tokens() *types.Tokens
 }
@@ -37,8 +41,9 @@ type Read interface {
 // Write contains all methods related to setting and writting configuration
 type Write interface {
 	SaveAPIUrl(string) error
-	SaveFormat(string) error
+	SaveEdition(string) error
 	SaveEnvironment(string) error
+	SaveFormat(string) error
 	SaveOrganization(string) error
 	SaveTokens(*types.Tokens) error
 }

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -32,7 +32,7 @@ type GenericClient interface {
 
 // AuthenticationAPIClient client methods for authenticating
 type AuthenticationAPIClient interface {
-	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, error)
+	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, string, error)
 	Logout(token string) error
 	RefreshAccessToken(refreshToken string) (*types.Tokens, error)
 }

--- a/cli/client/testing/mock_authentication_client.go
+++ b/cli/client/testing/mock_authentication_client.go
@@ -3,9 +3,9 @@ package testing
 import "github.com/sensu/sensu-go/types"
 
 // CreateAccessToken for use with mock lib
-func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, error) {
+func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, string, error) {
 	args := c.Called(url, u, p)
-	return args.Get(0).(*types.Tokens), args.Error(1)
+	return args.Get(0).(*types.Tokens), args.String(1), args.Error(2)
 }
 
 // Logout for use with mock lib

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -19,6 +19,12 @@ func (m *MockConfig) APIUrl() string {
 	return args.String(0)
 }
 
+// Edition mocks the cluster edition
+func (m *MockConfig) Edition() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Environment mocks the environment config
 func (m *MockConfig) Environment() string {
 	args := m.Called()
@@ -31,6 +37,12 @@ func (m *MockConfig) Format() string {
 	return args.String(0)
 }
 
+// Edition mocks the cluster edition
+func (m *MockConfig) IsEnterprise() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 // Organization mocks the organization config
 func (m *MockConfig) Organization() string {
 	args := m.Called()
@@ -40,6 +52,12 @@ func (m *MockConfig) Organization() string {
 // SaveAPIUrl mocks saving the API URL
 func (m *MockConfig) SaveAPIUrl(url string) error {
 	args := m.Called(url)
+	return args.Error(0)
+}
+
+// SaveEdition mocks saving the environment
+func (m *MockConfig) SaveEdition(edition string) error {
+	args := m.Called(edition)
 	return args.Error(0)
 }
 

--- a/cli/cmd/cobra.go
+++ b/cli/cmd/cobra.go
@@ -2,16 +2,23 @@ package main
 
 import (
 	"github.com/docker/docker/pkg/term"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	cobra.AddTemplateFunc("hasOperationalSubCommands", hasOperationalSubCommands)
+	cobra.AddTemplateFunc("hasEnterpriseSubCommands", hasEnterpriseSubCommands)
 	cobra.AddTemplateFunc("hasManagementSubCommands", hasManagementSubCommands)
-	cobra.AddTemplateFunc("operationalSubCommands", operationalSubCommands)
+	cobra.AddTemplateFunc("hasOperationalSubCommands", hasOperationalSubCommands)
+	cobra.AddTemplateFunc("enterpriseSubCommands", enterpriseSubCommands)
 	cobra.AddTemplateFunc("managementSubCommands", managementSubCommands)
+	cobra.AddTemplateFunc("operationalSubCommands", operationalSubCommands)
 	cobra.AddTemplateFunc("wrappedInheritedFlagUsages", wrappedInheritedFlagUsages)
 	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
+}
+
+func hasEnterpriseSubCommands(cmd *cobra.Command) bool {
+	return len(enterpriseSubCommands(cmd)) > 0
 }
 
 func hasOperationalSubCommands(cmd *cobra.Command) bool {
@@ -20,6 +27,22 @@ func hasOperationalSubCommands(cmd *cobra.Command) bool {
 
 func hasManagementSubCommands(cmd *cobra.Command) bool {
 	return len(managementSubCommands(cmd)) > 0
+}
+
+func enterpriseSubCommands(cmd *cobra.Command) []*cobra.Command {
+	cmds := []*cobra.Command{}
+	for _, sub := range cmd.Commands() {
+		if sub.IsAvailableCommand() && sub.HasSubCommands() {
+			// Verify if the command has an annotation that contains the edition
+			if edition, ok := sub.Annotations["edition"]; ok {
+				// Only add commands explicitly marked as being enterprise
+				if edition == types.EnterpriseEdition {
+					cmds = append(cmds, sub)
+				}
+			}
+		}
+	}
+	return cmds
 }
 
 func operationalSubCommands(cmd *cobra.Command) []*cobra.Command {
@@ -36,6 +59,13 @@ func managementSubCommands(cmd *cobra.Command) []*cobra.Command {
 	cmds := []*cobra.Command{}
 	for _, sub := range cmd.Commands() {
 		if sub.IsAvailableCommand() && sub.HasSubCommands() {
+			// Verify if the command has an annotation that contains the edition
+			if edition, ok := sub.Annotations["edition"]; ok {
+				// Ignore commands explicitly marked as being enterprise
+				if edition == types.EnterpriseEdition {
+					continue
+				}
+			}
 			cmds = append(cmds, sub)
 		}
 	}

--- a/cli/cmd/start.go
+++ b/cli/cmd/start.go
@@ -107,7 +107,17 @@ Management Commands:
 {{- end}}
 {{- end}}
 
+{{- if hasEnterpriseSubCommands . }}
+
+Enterprise Commands:
+
+{{- range enterpriseSubCommands . }}
+  {{rpad .Name .NamePadding }} {{.Short}}
+{{- end}}
+{{- end}}
+
 {{- if .HasSubCommands }}
+
 
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/config"
 	"github.com/sensu/sensu-go/cli/commands/configure"
 	"github.com/sensu/sensu-go/cli/commands/create"
+	"github.com/sensu/sensu-go/cli/commands/enterprise/licensing"
 	"github.com/sensu/sensu-go/cli/commands/entity"
 	"github.com/sensu/sensu-go/cli/commands/environment"
 	"github.com/sensu/sensu-go/cli/commands/event"
@@ -48,6 +49,9 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		silenced.HelpCommand(cli),
 		create.CreateCommand(cli),
 		extension.HelpCommand(cli),
+
+		// Enterprise commands
+		licensing.HelpCommand(cli),
 	)
 
 	for _, cmd := range rootCmd.Commands() {

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/cli"
 	config "github.com/sensu/sensu-go/cli/client/config"
 	hooks "github.com/sensu/sensu-go/cli/commands/hooks"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,7 +70,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Authenticate
-			tokens, err := cli.Client.CreateAccessToken(
+			tokens, edition, err := cli.Client.CreateAccessToken(
 				answers.URL, answers.Username, answers.Password,
 			)
 			if err != nil {
@@ -82,6 +83,18 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 
 			// Write new credentials to disk
 			if err = cli.Config.SaveTokens(tokens); err != nil {
+				fmt.Fprintln(cmd.OutOrStderr())
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
+			// Write Sensu edition to disk
+			if edition == "" {
+				edition = types.CoreEdition
+			}
+			if err = cli.Config.SaveEdition(edition); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(
 					"unable to write new configuration file with error: %s",

--- a/cli/commands/enterprise/LICENSE
+++ b/cli/commands/enterprise/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cli/commands/enterprise/licensing/LICENSE
+++ b/cli/commands/enterprise/licensing/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cli/commands/enterprise/licensing/help.go
+++ b/cli/commands/enterprise/licensing/help.go
@@ -1,0 +1,23 @@
+package licensing
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new parent
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "license",
+		Short:       "Manage enterprise license",
+		Hidden:      !cli.Config.IsEnterprise(),
+		Annotations: map[string]string{"edition": types.EnterpriseEdition},
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		InfoCommand(cli),
+	)
+	return cmd
+}

--- a/cli/commands/enterprise/licensing/info.go
+++ b/cli/commands/enterprise/licensing/info.go
@@ -1,0 +1,23 @@
+package licensing
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// InfoCommand defines the license info subcommand
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info",
+		Short:        "show detailed license information",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+
+	return cmd
+}

--- a/cli/commands/user/change_password.go
+++ b/cli/commands/user/change_password.go
@@ -134,7 +134,7 @@ func verifyExistingPassword(cli *cli.SensuCli, flags *pflag.FlagSet, isInteracti
 	}
 
 	// Attempt to authenticate
-	if _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
+	if _, _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
 		return errBadCurrentPassword
 	}
 

--- a/types/edition.go
+++ b/types/edition.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	// CoreEdition represents the Sensu Core Edition (CE)
+	CoreEdition = "core"
+
+	// EnterpriseEdition represents the Sensu Enterprise Edition (EE)
+	EnterpriseEdition = "enterprise"
+)

--- a/types/edition.go
+++ b/types/edition.go
@@ -4,6 +4,9 @@ const (
 	// CoreEdition represents the Sensu Core Edition (CE)
 	CoreEdition = "core"
 
+	// EditionHeader represents the HTTP header containing the edition value
+	EditionHeader = "Sensu-Edition"
+
 	// EnterpriseEdition represents the Sensu Enterprise Edition (EE)
 	EnterpriseEdition = "enterprise"
 )


### PR DESCRIPTION
## What is this change?

It basically adds a configuration value in the cluster config that indicates the Sensu edition, which can be either `core` or `enterprise`, and that acts as a feature flag. This value is configured whenever the user runs `sensuctl configure` and if it's not configured, we use `core` as the default value. 

More specifically:
- We annotate the enterprise commands to mark them as enterprise
- We also mark these commands as hidden unless we have an enterprise cluster
  - A hidden command can still be used, which is okay I believe because the Core API will not implement enterprise routes
- If we have an enterprise cluster, the help usage will display the specific enterprise commands:

```
$ sensuctl -h
sensuctl controls Sensu instances

Usage:	sensuctl COMMAND

Flags:
[...]

Commands:
[...]

Management Commands:
[...]

Enterprise Commands:
  license      Manage enterprise license
```


## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/42

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
