### PR TITLE
Properly tag and push the Docker nightly image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ generated correctly.
 - Fixed TLS issue that occurred when dashboard communicated with API.
 - Check TTL now works with round robin checks.
 - Format string for --format flag help now shows actual arguments.
+- Push the sensu/sensu:nightly docker image to the Docker Hub.
 
 ### Removed
 - Removed check subdue e2e test.

--- a/build.sh
+++ b/build.sh
@@ -295,6 +295,7 @@ docker_push() {
     fi
 
     if [ "$release" == "nightly" ]; then
+        docker tag sensu/sensu:master sensu/sensu:nightly
         docker push sensu/sensu:nightly
         exit 0
     fi


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes the nightly build by properly tagging and pushing the `sensu/sensu:nightly` Docker image.

## Why is this change necessary?

So the nightly build stops failing.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Non!

## Were there any complications while making this change?

Non!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Non!