### PR TITLE
Add API support for cluster management.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added unit test coverage for check routers.
+- Added API support for cluster management.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization for the

--- a/backend/apid/actions/cluster.go
+++ b/backend/apid/actions/cluster.go
@@ -1,0 +1,54 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/authorization"
+)
+
+// ClusterController is a thin wrapper around clientv3.Cluster. It exists
+// only for the purposes of access control.
+type ClusterController struct {
+	cluster clientv3.Cluster
+	policy  authorization.ClusterPolicy
+}
+
+func NewClusterController(cluster clientv3.Cluster) ClusterController {
+	return ClusterController{
+		cluster: cluster,
+		policy:  authorization.ClusterPolicy{},
+	}
+}
+
+func (c ClusterController) MemberList(ctx context.Context) (*clientv3.MemberListResponse, error) {
+	abilities := c.policy.WithContext(ctx)
+	if !abilities.HasPermission() {
+		return nil, NewErrorf(PermissionDenied)
+	}
+	return c.cluster.MemberList(ctx)
+}
+
+func (c ClusterController) MemberAdd(ctx context.Context, addrs []string) (*clientv3.MemberAddResponse, error) {
+	abilities := c.policy.WithContext(ctx)
+	if !abilities.HasPermission() {
+		return nil, NewErrorf(PermissionDenied)
+	}
+	return c.cluster.MemberAdd(ctx, addrs)
+}
+
+func (c ClusterController) MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
+	abilities := c.policy.WithContext(ctx)
+	if !abilities.HasPermission() {
+		return nil, NewErrorf(PermissionDenied)
+	}
+	return c.cluster.MemberRemove(ctx, id)
+}
+
+func (c ClusterController) MemberUpdate(ctx context.Context, id uint64, addrs []string) (*clientv3.MemberUpdateResponse, error) {
+	abilities := c.policy.WithContext(ctx)
+	if !abilities.HasPermission() {
+		return nil, NewErrorf(PermissionDenied)
+	}
+	return c.cluster.MemberUpdate(ctx, id, addrs)
+}

--- a/backend/apid/actions/cluster_test.go
+++ b/backend/apid/actions/cluster_test.go
@@ -1,0 +1,127 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/testing/testutil"
+	"github.com/sensu/sensu-go/types"
+	"golang.org/x/net/context"
+)
+
+type mockCluster struct {
+}
+
+func (mockCluster) MemberList(context.Context) (*clientv3.MemberListResponse, error) {
+	return new(clientv3.MemberListResponse), nil
+}
+
+func (mockCluster) MemberAdd(context.Context, []string) (*clientv3.MemberAddResponse, error) {
+	return new(clientv3.MemberAddResponse), nil
+}
+
+func (mockCluster) MemberRemove(context.Context, uint64) (*clientv3.MemberRemoveResponse, error) {
+	return new(clientv3.MemberRemoveResponse), nil
+}
+
+func (mockCluster) MemberUpdate(context.Context, uint64, []string) (*clientv3.MemberUpdateResponse, error) {
+	return new(clientv3.MemberUpdateResponse), nil
+}
+
+var _ clientv3.Cluster = mockCluster{}
+
+func TestMemberListNoPerm(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	_, err := ctrl.MemberList(context.TODO())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	e := err.(Error)
+	if got, want := e.Code, PermissionDenied; got != want {
+		t.Errorf("bad error code: got %v, want %v", got, want)
+	}
+}
+
+func TestMemberAddNoPerm(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	_, err := ctrl.MemberAdd(context.TODO(), []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	e := err.(Error)
+	if got, want := e.Code, PermissionDenied; got != want {
+		t.Errorf("bad error code: got %v, want %v", got, want)
+	}
+}
+
+func TestMemberRemoveNoPerm(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	_, err := ctrl.MemberRemove(context.TODO(), 1234)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	e := err.(Error)
+	if got, want := e.Code, PermissionDenied; got != want {
+		t.Errorf("bad error code: got %v, want %v", got, want)
+	}
+}
+
+func TestMemberUpdateNoPerm(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	_, err := ctrl.MemberUpdate(context.TODO(), 1234, []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	e := err.(Error)
+	if got, want := e.Code, PermissionDenied; got != want {
+		t.Errorf("bad error code: got %v, want %v", got, want)
+	}
+}
+
+func TestMemberList(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	ctx := testutil.NewContext(
+		testutil.ContextWithRules(
+			types.FixtureRuleWithPerms(types.RuleTypeCluster, types.RuleTypeAll)))
+
+	_, err := ctrl.MemberList(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMemberAdd(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	ctx := testutil.NewContext(
+		testutil.ContextWithRules(
+			types.FixtureRuleWithPerms(types.RuleTypeCluster, types.RuleTypeAll)))
+
+	_, err := ctrl.MemberAdd(ctx, []string{"foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMemberUpdate(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	ctx := testutil.NewContext(
+		testutil.ContextWithRules(
+			types.FixtureRuleWithPerms(types.RuleTypeCluster, types.RuleTypeAll)))
+
+	_, err := ctrl.MemberUpdate(ctx, 1234, []string{"foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMemberRemove(t *testing.T) {
+	ctrl := NewClusterController(mockCluster{})
+	ctx := testutil.NewContext(
+		testutil.ContextWithRules(
+			types.FixtureRuleWithPerms(types.RuleTypeCluster, types.RuleTypeAll)))
+
+	_, err := ctrl.MemberRemove(ctx, 1234)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/apid/routers/cluster.go
+++ b/backend/apid/routers/cluster.go
@@ -1,0 +1,124 @@
+package routers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/mux"
+)
+
+// ClusterController represents the controller needs of the ClusterRouter.
+type ClusterController interface {
+	// MemberList lists the current cluster membership.
+	MemberList(ctx context.Context) (*clientv3.MemberListResponse, error)
+
+	// MemberAdd adds a new member into the cluster.
+	MemberAdd(ctx context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error)
+
+	// MemberRemove removes an existing member from the cluster.
+	MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error)
+
+	// MemberUpdate updates the peer addresses of the member.
+	MemberUpdate(ctx context.Context, id uint64, peerAddrs []string) (*clientv3.MemberUpdateResponse, error)
+}
+
+// ClusterRouter handles requests for /cluster
+type ClusterRouter struct {
+	controller ClusterController
+}
+
+// NewClusterRouter creates a new ClusterRouter.
+func NewClusterRouter(ctrl ClusterController) *ClusterRouter {
+	return &ClusterRouter{
+		controller: ctrl,
+	}
+}
+
+// Mount mounts the ClusterRouter to a parent Router.
+func (r *ClusterRouter) Mount(parent *mux.Router) {
+	parent.HandleFunc("/cluster/members", r.list).Methods(http.MethodGet)
+	parent.HandleFunc("/cluster/members", r.memberAdd).Methods(http.MethodPost)
+	parent.HandleFunc("/cluster/members/{id}", r.memberRemove).Methods(http.MethodDelete)
+	parent.HandleFunc("/cluster/members/{id}", r.memberUpdate).Methods(http.MethodPut)
+}
+
+func parseID(req *http.Request) (uint64, error) {
+	params := mux.Vars(req)
+	id, err := strconv.Atoi(params["id"])
+	if err != nil {
+		return 0, err
+	}
+	if id < 0 {
+		return 0, errors.New("member IDs must be positive integers")
+	}
+	return uint64(id), nil
+}
+
+func parsePeerAddrs(req *http.Request) ([]string, error) {
+	peerAddrsValue := req.FormValue("peer-addrs")
+	if len(peerAddrsValue) == 0 {
+		return nil, errors.New("missing peer-addrs form value")
+	}
+	return strings.Split(peerAddrsValue, ","), nil
+}
+
+func (r *ClusterRouter) list(w http.ResponseWriter, req *http.Request) {
+	resp, err := r.controller.MemberList(req.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (r *ClusterRouter) memberAdd(w http.ResponseWriter, req *http.Request) {
+	peerAddrs, err := parsePeerAddrs(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := r.controller.MemberAdd(req.Context(), peerAddrs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (r *ClusterRouter) memberRemove(w http.ResponseWriter, req *http.Request) {
+	id, err := parseID(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := r.controller.MemberRemove(req.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (r *ClusterRouter) memberUpdate(w http.ResponseWriter, req *http.Request) {
+	id, err := parseID(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	peerAddrs, err := parsePeerAddrs(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := r.controller.MemberUpdate(req.Context(), id, peerAddrs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/backend/apid/routers/cluster_test.go
+++ b/backend/apid/routers/cluster_test.go
@@ -1,0 +1,238 @@
+package routers
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockClusterController struct {
+	mock.Mock
+}
+
+func (m *mockClusterController) MemberList(ctx context.Context) (*clientv3.MemberListResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*clientv3.MemberListResponse), args.Error(1)
+}
+
+func (m *mockClusterController) MemberAdd(ctx context.Context, peerAddrs []string) (*clientv3.MemberAddResponse, error) {
+	args := m.Called(ctx, peerAddrs)
+	return args.Get(0).(*clientv3.MemberAddResponse), args.Error(1)
+}
+
+func (m *mockClusterController) MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(*clientv3.MemberRemoveResponse), args.Error(1)
+}
+
+func (m *mockClusterController) MemberUpdate(ctx context.Context, id uint64, peerAddrs []string) (*clientv3.MemberUpdateResponse, error) {
+	args := m.Called(ctx, id, peerAddrs)
+	return args.Get(0).(*clientv3.MemberUpdateResponse), args.Error(1)
+}
+
+func newClusterTest(t *testing.T) (*mockClusterController, *httptest.Server) {
+	controller := &mockClusterController{}
+	clusterRouter := NewClusterRouter(controller)
+	router := mux.NewRouter()
+	clusterRouter.Mount(router)
+
+	return controller, httptest.NewServer(router)
+}
+
+func TestClusterRouterMemberList(t *testing.T) {
+	ctrl, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+	ctrl.On("MemberList", mock.Anything).Return(new(clientv3.MemberListResponse), nil)
+
+	endpoint := "/cluster/members"
+	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	ctrl.AssertCalled(t, "MemberList", mock.Anything)
+}
+
+func TestClusterRouterMemberAdd(t *testing.T) {
+	ctrl, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+	ctrl.On("MemberAdd", mock.Anything, mock.Anything).Return(new(clientv3.MemberAddResponse), nil)
+
+	endpoint := "/cluster/members?peer-addrs=127.0.0.1:1234"
+	req := newRequest(t, http.MethodPost, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	ctrl.AssertCalled(t, "MemberAdd", mock.Anything, []string{"127.0.0.1:1234"})
+}
+
+func TestClusterRouterMemberAddBadRequest(t *testing.T) {
+	_, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	endpoint := "/cluster/members?peer-urls=127.0.0.1:1234"
+	req := newRequest(t, http.MethodPost, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status (want 400): %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestClusterRouterMemberRemove(t *testing.T) {
+	ctrl, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+	ctrl.On("MemberRemove", mock.Anything, uint64(1234)).Return(new(clientv3.MemberRemoveResponse), nil)
+
+	endpoint := "/cluster/members/1234"
+	req := newRequest(t, http.MethodDelete, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	ctrl.AssertCalled(t, "MemberRemove", mock.Anything, uint64(1234))
+}
+
+func TestClusterRouterMemberRemoveBadRequestNotANumber(t *testing.T) {
+	_, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	endpoint := "/cluster/members/not-a-number"
+	req := newRequest(t, http.MethodDelete, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status (want 400): %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestClusterRouterMemberRemoveBadRequestNegativeNumber(t *testing.T) {
+	_, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	endpoint := "/cluster/members/-1"
+	req := newRequest(t, http.MethodDelete, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status (want 400): %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestClusterRouterMemberUpdate(t *testing.T) {
+	ctrl, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+	ctrl.On("MemberUpdate", mock.Anything, uint64(1234), []string{"127.0.0.1:1234"}).Return(new(clientv3.MemberUpdateResponse), nil)
+
+	endpoint := "/cluster/members/1234?peer-addrs=127.0.0.1:1234"
+	req := newRequest(t, http.MethodPut, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status: %d (%q)", resp.StatusCode, string(body))
+	}
+
+	ctrl.AssertCalled(t, "MemberUpdate", mock.Anything, uint64(1234), []string{"127.0.0.1:1234"})
+}
+
+func TestClusterRouterMemberUpdateBadRequestID(t *testing.T) {
+	_, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	endpoint := "/cluster/members/not-a-number"
+	req := newRequest(t, http.MethodPut, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status (want 400): %d (%q)", resp.StatusCode, string(body))
+	}
+}
+
+func TestClusterRouterMemberUpdateBadRequestPeerAddrs(t *testing.T) {
+	_, server := newClusterTest(t)
+	defer server.Close()
+
+	client := new(http.Client)
+
+	endpoint := "/cluster/members/1234?foo=bar"
+	req := newRequest(t, http.MethodPut, server.URL+endpoint, nil)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bad status (want 400): %d (%q)", resp.StatusCode, string(body))
+	}
+}

--- a/backend/authorization/cluster.go
+++ b/backend/authorization/cluster.go
@@ -1,0 +1,33 @@
+package authorization
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// ClusterPolicy defines access control for cluster administration.
+type ClusterPolicy struct {
+	context Context
+}
+
+// Resource returns the type of resource for this policy
+func (p *ClusterPolicy) Resource() string {
+	return types.RuleTypeCluster
+}
+
+// Context returns the policy context
+func (p *ClusterPolicy) Context() Context {
+	return p.context
+}
+
+// WithContext adds the ctx values to the ClusterPolicy's context
+func (p ClusterPolicy) WithContext(ctx context.Context) ClusterPolicy {
+	p.context = ExtractValueFromContext(ctx)
+	return p
+}
+
+// Returns true if RuleTypeAll applies
+func (p *ClusterPolicy) HasPermission() bool {
+	return canPerform(p, types.RuleTypeAll)
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/agentd"
 	"github.com/sensu/sensu-go/backend/apid"
 	"github.com/sensu/sensu-go/backend/daemon"
@@ -178,6 +179,7 @@ func Initialize(config *Config) (*Backend, error) {
 		QueueGetter:   queueGetter,
 		TLS:           config.TLS,
 		BackendStatus: b.Status,
+		Cluster:       clientv3.NewCluster(client),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", api.Name(), err.Error())

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -28,6 +28,9 @@ const (
 	// RuleTypeCheck access control for check objects
 	RuleTypeCheck = "checks"
 
+	// RuleTypeCluster access control for cluster management
+	RuleTypeCluster = "cluster"
+
 	// RuleTypeEntity access control for entity objects
 	RuleTypeEntity = "entities"
 


### PR DESCRIPTION
This commit adds API support for cluster management.

The following new routes are supported:

GET    /cluster/members
POST   /cluster/members
PUT    /cluster/members/{id}
DELETE /cluster/members/{id}

Signed-off-by: Eric Chlebek <eric@sensu.io>