### PR TITLE
Export GetWatcherAction function for use by sensu-enterprise-go

### DIFF
--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -10,7 +10,9 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-func getWatcherAction(event *clientv3.Event) store.WatchActionType {
+// GetWatcherAction maps an etcd Event to the corresponding WatchActionType.
+// This function is exported for use by sensu-enterprise-go's etcd watchers.
+func GetWatcherAction(event *clientv3.Event) store.WatchActionType {
 	switch event.Type {
 	case mvccpb.PUT:
 		if event.IsCreate() {
@@ -44,7 +46,7 @@ func (s *Store) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEve
 					checkConfig *types.CheckConfig
 				)
 
-				action = getWatcherAction(event)
+				action = GetWatcherAction(event)
 				if action == store.WatchUnknown {
 					logger.Error("unknown etcd watch action: ", event.Type.String())
 				}
@@ -96,7 +98,7 @@ func (s *Store) GetAssetWatcher(ctx context.Context) <-chan store.WatchEventAsse
 
 		for watchResponse := range watcherChan {
 			for _, event := range watchResponse.Events {
-				action = getWatcherAction(event)
+				action = GetWatcherAction(event)
 				if action == store.WatchUnknown {
 					logger.Error("unknown etcd watch action: ", event.Type.String())
 				}
@@ -139,7 +141,7 @@ func (s *Store) GetHookConfigWatcher(ctx context.Context) <-chan store.WatchEven
 
 		for watchResponse := range watcherChan {
 			for _, event := range watchResponse.Events {
-				action = getWatcherAction(event)
+				action = GetWatcherAction(event)
 				if action == store.WatchUnknown {
 					logger.Error("unknown etcd watch action: ", event.Type.String())
 				}


### PR DESCRIPTION
Signed-off-by: Terrance Kennedy <terrancerkennedy@gmail.com>

## What is this change?

Export GetWatcherAction function for use by sensu-enterprise-go.


## Why is this change necessary?

We're going to have etcd watchers defined in both repos, and should avoid code duplication.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

I'm good.


## Were there any complications while making this change?

None

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This is a source level change