### PR TITLE
Introduce Sensu edition detection in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added unit test coverage for check routers.
 - Added API support for cluster management.
 - Added sensuctl cluster member-list command.
+- Added Sensu edition detection in sensuctl.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization in

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -17,6 +17,7 @@ func TestCreateAccessToken(t *testing.T) {
 		assert.NotEmpty(t, r.Header["Authorization"])
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(types.EditionHeader, types.CoreEdition)
 		_, _ = w.Write([]byte(`{"access_token": "foo", "expires_at": 123456789, "refresh_token": "bar"}`))
 	}
 	server := httptest.NewServer(http.HandlerFunc(testHandler))
@@ -29,9 +30,10 @@ func TestCreateAccessToken(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	token, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	token, edition, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.NoError(t, err)
 	assert.NotNil(t, token)
+	assert.Equal(t, types.CoreEdition, edition)
 }
 
 func TestCreateAccessTokenForbidden(t *testing.T) {
@@ -48,7 +50,7 @@ func TestCreateAccessTokenForbidden(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	_, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	_, _, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.Error(t, err)
 }
 

--- a/cli/client/config/basic/basic.go
+++ b/cli/client/config/basic/basic.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -30,7 +30,8 @@ type Config struct {
 
 // Cluster contains the Sensu cluster access information
 type Cluster struct {
-	APIUrl string `json:"api-url"`
+	APIUrl  string `json:"api-url"`
+	Edition string `json:"edition"`
 	*types.Tokens
 }
 

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -10,6 +10,14 @@ func (c *Config) APIUrl() string {
 	return c.Cluster.APIUrl
 }
 
+// Edition returns the active cluster edition. Defaults to core
+func (c *Config) Edition() string {
+	if c.Cluster.Edition == "" {
+		return config.DefaultEdition
+	}
+	return c.Cluster.Edition
+}
+
 // Environment returns the user's active environment
 func (c *Config) Environment() string {
 	if c.Profile.Environment == "" {

--- a/cli/client/config/basic/reader_test.go
+++ b/cli/client/config/basic/reader_test.go
@@ -13,6 +13,14 @@ func TestAPIUrl(t *testing.T) {
 	assert.Equal(t, conf.Cluster.APIUrl, conf.APIUrl())
 }
 
+func TestEdition(t *testing.T) {
+	conf := &Config{Cluster: Cluster{Edition: types.CoreEdition}}
+	assert.Equal(t, types.CoreEdition, conf.Edition())
+
+	conf.Cluster.Edition = ""
+	assert.Equal(t, types.CoreEdition, conf.Edition())
+}
+
 func TestEnvironment(t *testing.T) {
 	conf := &Config{Profile: Profile{Environment: "dev"}}
 	assert.Equal(t, conf.Profile.Environment, conf.Environment())

--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -16,6 +16,13 @@ func (c *Config) SaveAPIUrl(url string) error {
 	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }
 
+// SaveEdition saves the Sensu edition to a configuration file
+func (c *Config) SaveEdition(edition string) error {
+	c.Cluster.Edition = edition
+
+	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
+}
+
 // SaveEnvironment saves the user's default environment to a configuration file
 func (c *Config) SaveEnvironment(env string) error {
 	c.Profile.Environment = env

--- a/cli/client/config/basic/writer_test.go
+++ b/cli/client/config/basic/writer_test.go
@@ -13,12 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSaveAPIUrl(t *testing.T) {
+func tmpDir(t *testing.T) (string, func()) {
+	t.Helper()
+
 	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup := func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return dir, cleanup
+}
+
+func TestSaveAPIUrl(t *testing.T) {
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -31,12 +45,23 @@ func TestSaveAPIUrl(t *testing.T) {
 	assert.Equal(t, url, config.APIUrl())
 }
 
+func TestSaveEdition(t *testing.T) {
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
+
+	// Set flags
+	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
+	flags.String("config-dir", dir, "")
+
+	config := Load(flags)
+
+	require.NoError(t, config.SaveEdition(types.CoreEdition))
+	assert.Equal(t, types.CoreEdition, config.Edition())
+}
+
 func TestSaveEnvironment(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -50,11 +75,8 @@ func TestSaveEnvironment(t *testing.T) {
 }
 
 func TestSaveFormat(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -68,11 +90,8 @@ func TestSaveFormat(t *testing.T) {
 }
 
 func TestSaveOrganization(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -86,11 +105,8 @@ func TestSaveOrganization(t *testing.T) {
 }
 
 func TestSaveTokens(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -105,11 +121,8 @@ func TestSaveTokens(t *testing.T) {
 
 func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 	// In case the API URL is passed with a flag, we don't want to save it
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("api-url", pflag.ContinueOnError)
@@ -137,11 +150,8 @@ func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	// DefaultEdition represents the default Sensu edition
+	DefaultEdition = types.CoreEdition
 	// DefaultEnvironment represents the default environment
 	DefaultEnvironment = "default"
 	// DefaultFormat represents the default format output when displaying objects
@@ -28,8 +30,9 @@ type Config interface {
 // Read contains all methods related to reading configuration
 type Read interface {
 	APIUrl() string
-	Format() string
+	Edition() string
 	Environment() string
+	Format() string
 	Organization() string
 	Tokens() *types.Tokens
 }
@@ -37,8 +40,9 @@ type Read interface {
 // Write contains all methods related to setting and writting configuration
 type Write interface {
 	SaveAPIUrl(string) error
-	SaveFormat(string) error
+	SaveEdition(string) error
 	SaveEnvironment(string) error
+	SaveFormat(string) error
 	SaveOrganization(string) error
 	SaveTokens(*types.Tokens) error
 }

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -34,7 +34,7 @@ type GenericClient interface {
 
 // AuthenticationAPIClient client methods for authenticating
 type AuthenticationAPIClient interface {
-	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, error)
+	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, string, error)
 	Logout(token string) error
 	RefreshAccessToken(refreshToken string) (*types.Tokens, error)
 }

--- a/cli/client/testing/mock_authentication_client.go
+++ b/cli/client/testing/mock_authentication_client.go
@@ -3,9 +3,9 @@ package testing
 import "github.com/sensu/sensu-go/types"
 
 // CreateAccessToken for use with mock lib
-func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, error) {
+func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, string, error) {
 	args := c.Called(url, u, p)
-	return args.Get(0).(*types.Tokens), args.Error(1)
+	return args.Get(0).(*types.Tokens), args.String(1), args.Error(2)
 }
 
 // Logout for use with mock lib

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -19,6 +19,12 @@ func (m *MockConfig) APIUrl() string {
 	return args.String(0)
 }
 
+// Edition mocks the cluster edition
+func (m *MockConfig) Edition() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Environment mocks the environment config
 func (m *MockConfig) Environment() string {
 	args := m.Called()
@@ -40,6 +46,12 @@ func (m *MockConfig) Organization() string {
 // SaveAPIUrl mocks saving the API URL
 func (m *MockConfig) SaveAPIUrl(url string) error {
 	args := m.Called(url)
+	return args.Error(0)
+}
+
+// SaveEdition mocks saving the environment
+func (m *MockConfig) SaveEdition(edition string) error {
+	args := m.Called(edition)
 	return args.Error(0)
 }
 

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/cli"
 	config "github.com/sensu/sensu-go/cli/client/config"
 	hooks "github.com/sensu/sensu-go/cli/commands/hooks"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,7 +70,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Authenticate
-			tokens, err := cli.Client.CreateAccessToken(
+			tokens, edition, err := cli.Client.CreateAccessToken(
 				answers.URL, answers.Username, answers.Password,
 			)
 			if err != nil {
@@ -82,6 +83,18 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 
 			// Write new credentials to disk
 			if err = cli.Config.SaveTokens(tokens); err != nil {
+				fmt.Fprintln(cmd.OutOrStderr())
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
+			// Write Sensu edition to disk
+			if edition == "" {
+				edition = types.CoreEdition
+			}
+			if err = cli.Config.SaveEdition(edition); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(
 					"unable to write new configuration file with error: %s",

--- a/cli/commands/root/templates.go
+++ b/cli/commands/root/templates.go
@@ -6,40 +6,74 @@ import (
 )
 
 var usageTemplate = `Usage:
+
 {{- if not .HasSubCommands}}	{{.UseLine}}{{end}}
 {{- if .HasSubCommands}}	{{ .CommandPath}} COMMAND{{end}}
+
 {{- if .HasAvailableLocalFlags}}
+
 Flags:
 {{ wrappedLocalFlagUsages . | trimRightSpace}}
+
 {{- end}}
+
 {{- if .HasAvailableInheritedFlags}}
+
 Global Flags:
 {{ wrappedInheritedFlagUsages . | trimRightSpace}}
+
 {{- end}}
+
 {{- if hasOperationalSubCommands . }}
+
 Commands:
+
 {{- range operationalSubCommands . }}
   {{rpad .Name .NamePadding }} {{.Short}}
 {{- end}}
 {{- end}}
+
 {{- if hasManagementSubCommands . }}
+
 Management Commands:
+
 {{- range managementSubCommands . }}
   {{rpad .Name .NamePadding }} {{.Short}}
 {{- end}}
 {{- end}}
+
+{{- if hasEnterpriseSubCommands . }}
+
+Enterprise Commands:
+
+{{- range enterpriseSubCommands . }}
+  {{rpad .Name .NamePadding }} {{.Short}}
+{{- end}}
+{{- end}}
+
 {{- if .HasSubCommands }}
+
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
 `
 
 func init() {
+	cobra.AddTemplateFunc("enterpriseSubCommands", enterpriseSubCommands)
+	cobra.AddTemplateFunc("hasEnterpriseSubCommands", hasEnterpriseSubCommands)
 	cobra.AddTemplateFunc("hasOperationalSubCommands", hasOperationalSubCommands)
 	cobra.AddTemplateFunc("hasManagementSubCommands", hasManagementSubCommands)
 	cobra.AddTemplateFunc("operationalSubCommands", operationalSubCommands)
 	cobra.AddTemplateFunc("managementSubCommands", managementSubCommands)
 	cobra.AddTemplateFunc("wrappedInheritedFlagUsages", wrappedInheritedFlagUsages)
 	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
+}
+
+func enterpriseSubCommands(cmd *cobra.Command) []*cobra.Command {
+	return []*cobra.Command{}
+}
+
+func hasEnterpriseSubCommands(cmd *cobra.Command) bool {
+	return false
 }
 
 func hasOperationalSubCommands(cmd *cobra.Command) bool {

--- a/cli/commands/user/change_password.go
+++ b/cli/commands/user/change_password.go
@@ -134,7 +134,7 @@ func verifyExistingPassword(cli *cli.SensuCli, flags *pflag.FlagSet, isInteracti
 	}
 
 	// Attempt to authenticate
-	if _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
+	if _, _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
 		return errBadCurrentPassword
 	}
 

--- a/types/edition.go
+++ b/types/edition.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	// CoreEdition represents the Sensu Core Edition (CE)
+	CoreEdition = "core"
+
+	// EditionHeader represents the HTTP header containing the edition value
+	EditionHeader = "Sensu-Edition"
+)


### PR DESCRIPTION
## What is this change?

It adds the notion of a Sensu _edition_ in sensuctl

More specifically:
- It retrieves a header containing the edition when running `sensuctl configure`
- It saves the edition name in the cluster configuration file
- Cleanup the help usage template for Cobra, since some white lines were missing
- Mocking of some enterprise template functions

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/42.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Non!

## Were there any complications while making this change?

Non!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Non!