### PR TITLE
Add sensuctl cluster member-remove command.

### DIFF
--- a/cli/client/cluster.go
+++ b/cli/client/cluster.go
@@ -50,3 +50,16 @@ func (c *RestClient) MemberUpdate(id uint64, peerAddrs []string) (*clientv3.Memb
 	var result clientv3.MemberUpdateResponse
 	return &result, json.Unmarshal(res.Body(), &result)
 }
+
+func (c *RestClient) MemberRemove(id uint64) (*clientv3.MemberRemoveResponse, error) {
+	endpoint := fmt.Sprintf("%s/%x", clusterMembersBasePath, id)
+	res, err := c.R().Delete(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("DELETE %q: %s", endpoint, err)
+	}
+	if res.StatusCode() >= 400 {
+		return nil, unmarshalError(res)
+	}
+	var result clientv3.MemberRemoveResponse
+	return &result, json.Unmarshal(res.Body(), &result)
+}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -191,4 +191,7 @@ type ClusterMemberClient interface {
 
 	// MemberUpdate updates a cluster member
 	MemberUpdate(id uint64, peerAddrs []string) (*clientv3.MemberUpdateResponse, error)
+
+	// MemberRemove removes a cluster member
+	MemberRemove(id uint64) (*clientv3.MemberRemoveResponse, error)
 }

--- a/cli/client/testing/mock_cluster_client.go
+++ b/cli/client/testing/mock_cluster_client.go
@@ -16,3 +16,8 @@ func (c *MockClient) MemberUpdate(id uint64, peerAddrs []string) (*clientv3.Memb
 	args := c.Called(id, peerAddrs)
 	return args.Get(0).(*clientv3.MemberUpdateResponse), args.Error(1)
 }
+
+func (c *MockClient) MemberRemove(id uint64) (*clientv3.MemberRemoveResponse, error) {
+	args := c.Called(id)
+	return args.Get(0).(*clientv3.MemberRemoveResponse), args.Error(1)
+}

--- a/cli/commands/cluster/help.go
+++ b/cli/commands/cluster/help.go
@@ -16,6 +16,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		MemberListCommand(cli),
 		MemberAddCommand(cli),
 		MemberUpdateCommand(cli),
+		MemberRemoveCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/cluster/member-remove.go
+++ b/cli/commands/cluster/member-remove.go
@@ -1,0 +1,36 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+func MemberRemoveCommand(cli *cli.SensuCli) *cobra.Command {
+	return &cobra.Command{
+		Use:          "member-remove [ID]",
+		Short:        "remove cluster member by ID",
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			memberID := args[0]
+			id, err := strconv.ParseUint(memberID, 16, 64)
+			if err != nil {
+				return fmt.Errorf("invalid id: %s", err)
+			}
+
+			if _, err := cli.Client.MemberRemove(id); err != nil {
+				return fmt.Errorf("error removing cluster member: %s", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed member %x from cluster\n", id)
+			return nil
+		},
+	}
+}

--- a/cli/commands/cluster/member-update.go
+++ b/cli/commands/cluster/member-update.go
@@ -26,7 +26,7 @@ func MemberUpdateCommand(cli *cli.SensuCli) *cobra.Command {
 
 			id, err := strconv.ParseUint(memberID, 16, 64)
 			if err != nil {
-				return fmt.Errorf("invalid id: %x", err)
+				return fmt.Errorf("invalid id: %s", err)
 			}
 
 			if _, err := cli.Client.MemberUpdate(id, peerAddrs); err != nil {


### PR DESCRIPTION
This commit adds the sensuctl cluster member-remove command.
Operators can use the member-remove command to remove cluster
members.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Closes #1721 