### PR TITLE
Add support for licensing in API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added sensuctl cluster member-list command.
 - Added Sensu edition detection in sensuctl.
 - Added sensuctl cluster member-add command.
+- Added API client support for enterprise license management.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization in

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -6,12 +6,16 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/go-resty/resty"
 	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Entry
+
+// ErrNotImplemented is returned by client methods that haven't been
+// implemented in Sensu Core.
+var ErrNotImplemented = errors.New("method not implemented")
 
 // RestClient wraps resty.Client
 type RestClient struct {

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -24,6 +24,7 @@ type APIClient interface {
 	SilencedAPIClient
 	GenericClient
 	ClusterMemberClient
+	LicenseClient
 }
 
 // GenericClient exposes generic resource methods.
@@ -194,4 +195,15 @@ type ClusterMemberClient interface {
 
 	// MemberRemove removes a cluster member
 	MemberRemove(id uint64) (*clientv3.MemberRemoveResponse, error)
+}
+
+// LicenseClient specifies the enteprise client methods for license management.
+// This is a temporary workaround until
+// https://github.com/sensu/sensu-go/issues/1870 is implemented
+type LicenseClient interface {
+	// FetchLicense fetches the installed license
+	FetchLicense() (interface{}, error)
+
+	// UpdateLicense updates the installed enterprise license
+	UpdateLicense(license interface{}) error
 }

--- a/cli/client/license.go
+++ b/cli/client/license.go
@@ -1,0 +1,14 @@
+package client
+
+// FetchLicense fetches the installed license. This is a temporary workaround
+// until https://github.com/sensu/sensu-go/issues/1870 is implemented
+func (client *RestClient) FetchLicense() (interface{}, error) {
+	return nil, nil
+}
+
+// UpdateLicense updates the installed license with the given one. This is a
+// temporary workaround until https://github.com/sensu/sensu-go/issues/1870 is
+// implemented
+func (client *RestClient) UpdateLicense(license interface{}) error {
+	return nil
+}

--- a/cli/client/license.go
+++ b/cli/client/license.go
@@ -3,12 +3,12 @@ package client
 // FetchLicense fetches the installed license. This is a temporary workaround
 // until https://github.com/sensu/sensu-go/issues/1870 is implemented
 func (client *RestClient) FetchLicense() (interface{}, error) {
-	return nil, nil
+	return nil, ErrNotImplemented
 }
 
 // UpdateLicense updates the installed license with the given one. This is a
 // temporary workaround until https://github.com/sensu/sensu-go/issues/1870 is
 // implemented
 func (client *RestClient) UpdateLicense(license interface{}) error {
-	return nil
+	return ErrNotImplemented
 }

--- a/cli/client/testing/mock_license_client.go
+++ b/cli/client/testing/mock_license_client.go
@@ -1,0 +1,13 @@
+package testing
+
+// FetchLicense for use with mock lib
+func (c *MockClient) FetchLicense() (interface{}, error) {
+	args := c.Called()
+	return args.Get(0), args.Error(1)
+}
+
+// UpdateLicense for use with mock lib
+func (c *MockClient) UpdateLicense(license interface{}) error {
+	args := c.Called(license)
+	return args.Error(0)
+}


### PR DESCRIPTION
## What is this change?

It adds support for licensing in the API client, so these methods can be overridden in the enterprise codebase. This is a workaround until https://github.com/sensu/sensu-go/issues/1870 is implemented.

I locally tested the complete solution, which works great.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/17
Required by https://github.com/sensu/sensu-enterprise-go/issues/34

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
