### PR TITLE
Add edition header to middleware and build scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added Sensu edition detection in sensuctl.
 - Added sensuctl cluster member-add command.
 - Added API client support for enterprise license management.
+- Added a header to API calls that returns the current Sensu Edition.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization in

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/version"
 )
 
 // APId is the backend HTTP API.
@@ -165,6 +166,7 @@ func registerUnauthenticatedResources(
 			router.NewRoute(),
 			middlewares.SimpleLogger{},
 			middlewares.LimitRequest{},
+			middlewares.Edition{Name: version.Edition},
 		),
 		routers.NewStatusRouter(bStatus),
 	)
@@ -177,6 +179,7 @@ func registerAuthenticationResources(router *mux.Router, store store.Store) {
 			middlewares.SimpleLogger{},
 			middlewares.RefreshToken{},
 			middlewares.LimitRequest{},
+			middlewares.Edition{Name: version.Edition},
 		),
 		routers.NewAuthenticationRouter(store),
 	)
@@ -192,6 +195,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store, getter t
 			middlewares.AllowList{Store: store},
 			middlewares.Authorization{Store: store},
 			middlewares.LimitRequest{},
+			middlewares.Edition{Name: version.Edition},
 		),
 		routers.NewAssetRouter(store),
 		routers.NewChecksRouter(actions.NewCheckController(store, getter)),

--- a/backend/apid/middlewares/edition.go
+++ b/backend/apid/middlewares/edition.go
@@ -1,0 +1,20 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// Edition is an HTTP middleware that provides the Sensu Edition through a header
+type Edition struct {
+	Name string
+}
+
+// Then middleware
+func (e Edition) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(types.EditionHeader, e.Name)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/build.ps1
+++ b/build.ps1
@@ -83,11 +83,13 @@ function build_binary([string]$goos, [string]$goarch, [string]$bin, [string]$cmd
     $version = &"go" "run" "./version/cmd/version/version.go" "-v" | Out-String
     $build_date = Get-Date -format "yyyy'-'MM'-'dd'T'T'-'Z"
     $build_sha = (git rev-parse HEAD) | Out-String
+    $edition = "core"
 
     $version_pkg = "github.com/sensu/sensu-go/version"
     $ldflags = "-X $version_pkg.Version=$version"
     $ldflags = $ldflags + " -X $version_pkg.BuildDate=$build_date"
     $ldflags = $ldflags + " -X $version_pkg.BuildSHA=$build_sha"
+    $ldflags = $ldflags + " -X $version_pkg.Edition=$edition"
 
     If ($build_type -ne "nightly" -And $build_type -ne "stable") {
         $prerelease = &"go" "run" "./version/cmd/version/version.go" "-p" | Out-String

--- a/build.sh
+++ b/build.sh
@@ -96,12 +96,14 @@ build_binary () {
 
     local build_date=$(date +"%Y-%m-%dT%H:%M:%S%z")
     local build_sha=$(git rev-parse HEAD)
+    local edition="core"
 
     local version_pkg="github.com/sensu/sensu-go/version"
     local ldflags=" -X $version_pkg.Version=${version}"
     local ldflags+=" -X $version_pkg.PreReleaseIdentifier=${prerelease}"
     local ldflags+=" -X $version_pkg.BuildDate=${build_date}"
     local ldflags+=" -X $version_pkg.BuildSHA=${build_sha}"
+    local ldflags+=" -X $version_pkg.Edition=${edition}"
 
     # sensu-agent main package is still in a subdirectoy cmd package
     local main_pkg="cmd/${cmd_name}"

--- a/version/version.go
+++ b/version/version.go
@@ -25,11 +25,14 @@ var (
 	// BuildSHA stores the git sha of the build
 	// (e.g. 8673bed0a9705083987b9ecbbc1cc0758df13dd2)
 	BuildSHA string
+
+	// Edition stores the Sensu Edition of the current build (ex. core)
+	Edition string
 )
 
 var (
 	ErrNoBuildIteration = errors.New("Build iteration could not be found. If running locally you must set SENSU_BUILD_ITERATION.")
-	TagParseError       = errors.New("A build iteration could not be parsed from the tag")
+	ErrTagParse         = errors.New("A build iteration could not be parsed from the tag")
 )
 
 var (
@@ -114,7 +117,7 @@ func Iteration(tag string, bt BuildType) (string, error) {
 	bi := buildNumberRE.FindString(tag)
 	var err error
 	if bi == "" {
-		err = TagParseError
+		err = ErrTagParse
 	}
 	return bi, err
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds an edition header to api calls.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/47

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.