### PR TITLE
Do not use build flags for the Sensu edition

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -83,13 +83,11 @@ function build_binary([string]$goos, [string]$goarch, [string]$bin, [string]$cmd
     $version = &"go" "run" "./version/cmd/version/version.go" "-v" | Out-String
     $build_date = Get-Date -format "yyyy'-'MM'-'dd'T'T'-'Z"
     $build_sha = (git rev-parse HEAD) | Out-String
-    $edition = "core"
 
     $version_pkg = "github.com/sensu/sensu-go/version"
     $ldflags = "-X $version_pkg.Version=$version"
     $ldflags = $ldflags + " -X $version_pkg.BuildDate=$build_date"
     $ldflags = $ldflags + " -X $version_pkg.BuildSHA=$build_sha"
-    $ldflags = $ldflags + " -X $version_pkg.Edition=$edition"
 
     If ($build_type -ne "nightly" -And $build_type -ne "stable") {
         $prerelease = &"go" "run" "./version/cmd/version/version.go" "-p" | Out-String

--- a/build.sh
+++ b/build.sh
@@ -96,14 +96,12 @@ build_binary () {
 
     local build_date=$(date +"%Y-%m-%dT%H:%M:%S%z")
     local build_sha=$(git rev-parse HEAD)
-    local edition="core"
 
     local version_pkg="github.com/sensu/sensu-go/version"
     local ldflags=" -X $version_pkg.Version=${version}"
     local ldflags+=" -X $version_pkg.PreReleaseIdentifier=${prerelease}"
     local ldflags+=" -X $version_pkg.BuildDate=${build_date}"
     local ldflags+=" -X $version_pkg.BuildSHA=${build_sha}"
-    local ldflags+=" -X $version_pkg.Edition=${edition}"
 
     # sensu-agent main package is still in a subdirectoy cmd package
     local main_pkg="cmd/${cmd_name}"

--- a/version/version.go
+++ b/version/version.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/sensu/sensu-go/types"
 )
 
 // These values are baked into the sensu-agent and sensu-backend binaries
@@ -27,7 +29,7 @@ var (
 	BuildSHA string
 
 	// Edition stores the Sensu Edition of the current build (ex. core)
-	Edition string
+	Edition = types.CoreEdition
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes the build flag used to determine the Sensu edition. Instead, we will override the edition directly within the enterprise codebase.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/47

## Does your change need a Changelog entry?

Nah, I consider it's part of this entry
> Added a header to API calls that returns the current Sensu Edition

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope