### PR TITLE
Remove unused golint from build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,6 @@ function install_deps
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
     go get github.com/kisielk/errcheck
-    go get github.com/golang/lint/golint
 }
 
 function build_tool_binary([string]$goos, [string]$goarch, [string]$bin, [string]$subdir)
@@ -184,7 +183,7 @@ function linter_commands
 {
     echo "Running linter..."
 
-    gometalinter.v2 --vendor --disable-all --enable=vet --linter='vet:go tool vet -composites=false {paths}:PATH:LINE:MESSAGE' --enable=golint --enable=ineffassign --enable=goconst --tests ./...
+    gometalinter.v2 --vendor --disable-all --enable=vet --linter='vet:go tool vet -composites=false {paths}:PATH:LINE:MESSAGE' --enable=ineffassign --enable=goconst --tests ./...
     If ($LASTEXITCODE -ne 0) {
         echo "Linting failed..."
         exit 1

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,6 @@ install_deps () {
     go get github.com/gordonklaus/ineffassign
     go get github.com/jgautheron/goconst/cmd/goconst
     go get honnef.co/go/tools/cmd/megacheck
-    go get github.com/golang/lint/golint
 }
 
 cmd_name_map() {


### PR DESCRIPTION
Signed-off-by: Terrance Kennedy <terrancerkennedy@gmail.com>

## What is this change?

Remove unused golint tool installation from Travis and Appveyor CIs.

## Why is this change necessary?

The `golint` tool is being installed but not used on both travis and appveyor configs. Furthermore, golint isn't meant to be used as part of a build pipeline according to its readme https://github.com/golang/lint#purpose.

## Does your change need a Changelog entry?

N/A

## Do you need clarification on anything?

The Travis changes will probably be made irrelevant with the upcoming migration to CircleCI, but I think there's still value in removing it from Appveyor.

We are not running any linting on Appveyor. Should we be?

## Were there any complications while making this change?

N/A

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A
