### PR TITLE
Disable grpc extensions functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ enterprise edition.
 the enterprise edition.
 - Upgrade dep to v0.5.0
 - Added cluster health information to /health endpoint in sensu-backend.
+- Temporarily disabled grpc extensions functionality.
 
 ### Fixed
 - Fixed `sensuctl completion` help for bash and zsh.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
-	"github.com/sensu/sensu-go/rpc"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -118,7 +117,9 @@ func Initialize(config *Config) (*Backend, error) {
 	pipeline, err := pipelined.New(pipelined.Config{
 		Store: store,
 		Bus:   bus,
-		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
+		// TODO: Re-enable the following functionality
+		// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+		// ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", pipeline.Name(), err.Error())

--- a/backend/pipelined/filter.go
+++ b/backend/pipelined/filter.go
@@ -141,29 +141,32 @@ func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool
 			continue
 		}
 
-		// If the filter didn't exist, it might be an extension filter
-		ext, err := p.store.GetExtension(ctx, filterName)
-		if err != nil {
-			logger.WithFields(fields).WithError(err).
-				Warningf("could not retrieve the filter %s", filterName)
-			continue
-		}
+		// TODO: Re-enable the following functionality
+		// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+		// // If the filter didn't exist, it might be an extension filter
+		// ext, err := p.store.GetExtension(ctx, filterName)
+		// if err != nil {
+		// 	logger.WithFields(fields).WithError(err).
+		// 		Warningf("could not retrieve the filter %s", filterName)
+		// 	continue
+		// }
 
-		executor, err := p.extensionExecutor(ext)
-		if err != nil {
-			logger.WithFields(fields).WithError(err).
-				Errorf("could not execute the filter %s", filterName)
-			continue
-		}
-		filtered, err := executor.FilterEvent(event)
-		if err != nil {
-			logger.WithFields(fields).WithError(err).
-				Errorf("could not execute the filter %s", filterName)
-			continue
-		}
-		if filtered {
-			return true
-		}
+		// executor, err := p.extensionExecutor(ext)
+		// if err != nil {
+		// 	logger.WithFields(fields).WithError(err).
+		// 		Errorf("could not execute the filter %s", filterName)
+		// 	continue
+		// }
+		// filtered, err := executor.FilterEvent(event)
+		// if err != nil {
+		// 	logger.WithFields(fields).WithError(err).
+		// 		Errorf("could not execute the filter %s", filterName)
+		// 	continue
+		// }
+		// if filtered {
+		// 	return true
+		// }
+		logger.WithFields(fields).Error("grpc filter temporarily disabled")
 	}
 
 	return false

--- a/backend/pipelined/filter_test.go
+++ b/backend/pipelined/filter_test.go
@@ -171,9 +171,12 @@ func TestPipelinedFilter(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "Extension filter",
-			filters:  []string{"extension_filter"},
-			expected: true,
+			name:    "Extension filter",
+			filters: []string{"extension_filter"},
+			// TODO: Re-enable the following functionality
+			// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+			// expected: true,
+			expected: false,
 		},
 	}
 

--- a/backend/pipelined/handle.go
+++ b/backend/pipelined/handle.go
@@ -88,9 +88,12 @@ func (p *Pipelined) handleEvent(event *types.Event) error {
 				logger.WithFields(fields).Error(err)
 			}
 		case "grpc":
-			if _, err := p.grpcHandler(u.Extension, event, eventData); err != nil {
-				logger.WithFields(fields).Error(err)
-			}
+			// TODO: Re-enable the following functionality
+			// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+			// if _, err := p.grpcHandler(u.Extension, event, eventData); err != nil {
+			// 	logger.WithFields(fields).Error(err)
+			// }
+			logger.WithFields(fields).Error("grpc handler temporarily disabled")
 		default:
 			return errors.New("unknown handler type")
 		}

--- a/backend/pipelined/handle_test.go
+++ b/backend/pipelined/handle_test.go
@@ -95,9 +95,9 @@ func TestPipelinedHandleEvent(t *testing.T) {
 		return m, nil
 	}
 
+	assert.NoError(t, p.handleEvent(event))
 	// TODO: Re-enable the following functionality
 	// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
-	// assert.NoError(t, p.handleEvent(event))
 	// m.AssertCalled(t, "HandleEvent", event, mock.Anything)
 }
 

--- a/backend/pipelined/handle_test.go
+++ b/backend/pipelined/handle_test.go
@@ -95,8 +95,10 @@ func TestPipelinedHandleEvent(t *testing.T) {
 		return m, nil
 	}
 
-	assert.NoError(t, p.handleEvent(event))
-	m.AssertCalled(t, "HandleEvent", event, mock.Anything)
+	// TODO: Re-enable the following functionality
+	// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+	// assert.NoError(t, p.handleEvent(event))
+	// m.AssertCalled(t, "HandleEvent", event, mock.Anything)
 }
 
 func TestPipelinedExpandHandlers(t *testing.T) {

--- a/backend/pipelined/mutate.go
+++ b/backend/pipelined/mutate.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/command"
 	"github.com/sensu/sensu-go/types"
 	utillogging "github.com/sensu/sensu-go/util/logging"
@@ -48,23 +47,26 @@ func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]b
 	}
 
 	if mutator == nil {
-		// Check to see if there is an extension matching the mutator
-		extension, err := p.store.GetExtension(ctx, handler.Mutator)
-		if err != nil {
-			if err == store.ErrNoExtension {
-				return nil, nil
-			}
-			return nil, err
-		}
-		executor, err := p.extensionExecutor(extension)
-		if err != nil {
-			return nil, err
-		}
-		eventData, err := executor.MutateEvent(event)
-		if err != nil {
-			return nil, err
-		}
-		return eventData, nil
+		// TODO: Re-enable the following functionality
+		// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+		// // Check to see if there is an extension matching the mutator
+		// extension, err := p.store.GetExtension(ctx, handler.Mutator)
+		// if err != nil {
+		// 	if err == store.ErrNoExtension {
+		// 		return nil, nil
+		// 	}
+		// 	return nil, err
+		// }
+		// executor, err := p.extensionExecutor(extension)
+		// if err != nil {
+		// 	return nil, err
+		// }
+		// eventData, err := executor.MutateEvent(event)
+		// if err != nil {
+		// 	return nil, err
+		// }
+		// return eventData, nil
+		return nil, errors.New("grpc mutator temporarily disabled")
 	}
 
 	eventData, err := p.pipeMutator(mutator, event)

--- a/backend/pipelined/mutate_test.go
+++ b/backend/pipelined/mutate_test.go
@@ -117,13 +117,13 @@ func TestPipelinedExtensionMutator(t *testing.T) {
 	handler := &types.Handler{}
 	handler.Mutator = "extension"
 
+	eventData, err := p.mutateEvent(handler, event)
 	// TODO: Re-enable the following functionality
 	// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
-	// eventData, err := p.mutateEvent(handler, event)
 	// require.NoError(t, err)
 	// require.Equal(t, []byte("remote"), eventData)
-	_, err = p.mutateEvent(handler, event)
 	require.Error(t, err)
+	require.Nil(t, eventData)
 }
 
 func TestPipelinedPipeMutator(t *testing.T) {

--- a/backend/pipelined/mutate_test.go
+++ b/backend/pipelined/mutate_test.go
@@ -117,9 +117,13 @@ func TestPipelinedExtensionMutator(t *testing.T) {
 	handler := &types.Handler{}
 	handler.Mutator = "extension"
 
-	eventData, err := p.mutateEvent(handler, event)
-	require.NoError(t, err)
-	require.Equal(t, []byte("remote"), eventData)
+	// TODO: Re-enable the following functionality
+	// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+	// eventData, err := p.mutateEvent(handler, event)
+	// require.NoError(t, err)
+	// require.Equal(t, []byte("remote"), eventData)
+	_, err = p.mutateEvent(handler, event)
+	require.Error(t, err)
 }
 
 func TestPipelinedPipeMutator(t *testing.T) {

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -50,14 +50,16 @@ type Option func(*Pipelined) error
 // New creates a new Pipelined with supplied Options applied.
 func New(c Config, options ...Option) (*Pipelined, error) {
 	p := &Pipelined{
-		store:             c.Store,
-		bus:               c.Bus,
-		extensionExecutor: c.ExtensionExecutorGetter,
-		stopping:          make(chan struct{}, 1),
-		running:           &atomic.Value{},
-		wg:                &sync.WaitGroup{},
-		errChan:           make(chan error, 1),
-		eventChan:         make(chan interface{}, 100),
+		store: c.Store,
+		bus:   c.Bus,
+		// TODO: Re-enable the following functionality
+		// Feature temporarily disabled: https://github.com/sensu/sensu-go/issues/1883
+		// extensionExecutor: c.ExtensionExecutorGetter,
+		stopping:  make(chan struct{}, 1),
+		running:   &atomic.Value{},
+		wg:        &sync.WaitGroup{},
+		errChan:   make(chan error, 1),
+		eventChan: make(chan interface{}, 100),
 	}
 	for _, o := range options {
 		if err := o(p); err != nil {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Disables grpc extension functionality. It will be re-enabled when #1883 is addressed.

## Why is this change necessary?

Was supposed to `close` #1750.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Extensions aren't yet documented in sensu/sensu-docs. Documentation should be updated when the feature is re-enabled in #1883.