### PR TITLE
Testing/timeproxy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -239,6 +239,14 @@
   revision = "bb3d318650d48840a39aa21a027c6630e198e626"
 
 [[projects]]
+  branch = "master"
+  digest = "1:9d5bd7c02a73959247ccbf524180e363631ece23c58e12b21d697f4741c7926f"
+  name = "github.com/echlebek/timeproxy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d7c2918981322d4d437f7a52f3a15c7ec5a4f488"
+
+[[projects]]
   digest = "1:46831ac031ae286b36baca94e71eb83e0493ebae1dbcd04fea42fa4f503970c3"
   name = "github.com/emicklei/proto"
   packages = ["."]
@@ -706,10 +714,8 @@
   digest = "1:6786113356facb95eafb16f32fc3af40e8dabc8cbf912d98b6d99fa410328509"
   name = "github.com/shirou/gopsutil"
   packages = [
-    "cpu",
     "host",
     "internal/common",
-    "mem",
     "net",
     "process",
   ]
@@ -1032,6 +1038,7 @@
     "github.com/coreos/etcd/clientv3",
     "github.com/coreos/etcd/clientv3/concurrency",
     "github.com/coreos/etcd/embed",
+    "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
     "github.com/coreos/etcd/etcdserver/etcdserverpb",
     "github.com/coreos/etcd/mvcc/mvccpb",
     "github.com/coreos/etcd/pkg/fileutil",
@@ -1041,6 +1048,7 @@
     "github.com/dave/jennifer/jen",
     "github.com/dgrijalva/jwt-go",
     "github.com/docker/docker/pkg/term",
+    "github.com/echlebek/timeproxy",
     "github.com/emicklei/proto",
     "github.com/go-resty/resty",
     "github.com/gogo/protobuf/gogoproto",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,6 +240,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:4c6bcdba286b48fc683ed73c0e2d8248d3ba57b4431fd210f071279423d67d1f"
+  name = "github.com/echlebek/crock"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d3073eb0a044dbc6f88962d94ffb2e987b31c19a"
+
+[[projects]]
+  branch = "master"
   digest = "1:9d5bd7c02a73959247ccbf524180e363631ece23c58e12b21d697f4741c7926f"
   name = "github.com/echlebek/timeproxy"
   packages = ["."]
@@ -714,8 +722,10 @@
   digest = "1:6786113356facb95eafb16f32fc3af40e8dabc8cbf912d98b6d99fa410328509"
   name = "github.com/shirou/gopsutil"
   packages = [
+    "cpu",
     "host",
     "internal/common",
+    "mem",
     "net",
     "process",
   ]
@@ -1048,6 +1058,7 @@
     "github.com/dave/jennifer/jen",
     "github.com/dgrijalva/jwt-go",
     "github.com/docker/docker/pkg/term",
+    "github.com/echlebek/crock",
     "github.com/echlebek/timeproxy",
     "github.com/emicklei/proto",
     "github.com/go-resty/resty",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -182,3 +182,7 @@ required = [
 [[constraint]]
   branch = "master"
   name = "github.com/echlebek/timeproxy"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/echlebek/crock"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -178,3 +178,7 @@ required = [
 [[constraint]]
   name = "github.com/atlassian/gostatsd"
   version = "6.1.1"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/echlebek/timeproxy"

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -1,5 +1,3 @@
-// +build integration,race
-
 package schedulerd
 
 import (
@@ -66,8 +64,6 @@ func newScheduler(t *testing.T, ctx context.Context) *TestCheckScheduler {
 }
 
 func TestCheckSchedulerInterval(t *testing.T) {
-	t.Parallel()
-
 	assert := assert.New(t)
 
 	// Start a scheduler
@@ -103,13 +99,13 @@ func TestCheckSchedulerInterval(t *testing.T) {
 	}()
 
 	assert.NoError(scheduler.scheduler.Start())
+	mockTime.Start()
 	wg.Wait()
+	mockTime.Stop()
 	assert.NoError(scheduler.scheduler.Stop())
 }
 
 func TestCheckSubdueInterval(t *testing.T) {
-	t.Parallel()
-
 	assert := assert.New(t)
 
 	// Start a scheduler
@@ -152,7 +148,7 @@ func TestCheckSubdueInterval(t *testing.T) {
 	}()
 
 	assert.NoError(scheduler.scheduler.Start())
-	time.Sleep(1 * time.Second)
+	mockTime.Set(mockTime.Now().Add(2 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 
 	// We should have no element in our channel
@@ -160,8 +156,6 @@ func TestCheckSubdueInterval(t *testing.T) {
 }
 
 func TestCheckSchedulerCron(t *testing.T) {
-	t.Parallel()
-
 	assert := assert.New(t)
 
 	// Start a scheduler
@@ -203,13 +197,13 @@ func TestCheckSchedulerCron(t *testing.T) {
 	}()
 
 	assert.NoError(scheduler.scheduler.Start())
+	mockTime.Start()
 	wg.Wait()
+	mockTime.Stop()
 	assert.NoError(scheduler.scheduler.Stop())
 }
 
 func TestCheckSubdueCron(t *testing.T) {
-	t.Parallel()
-
 	assert := assert.New(t)
 
 	// Start a scheduler
@@ -253,7 +247,7 @@ func TestCheckSubdueCron(t *testing.T) {
 	}()
 
 	assert.NoError(scheduler.scheduler.Start())
-	time.Sleep(5 * time.Second)
+	mockTime.Set(mockTime.Now().Add(10 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 
 	// We should have no element in our channel

--- a/backend/schedulerd/check_timer.go
+++ b/backend/schedulerd/check_timer.go
@@ -3,8 +3,8 @@ package schedulerd
 import (
 	"crypto/md5"
 	"encoding/binary"
-	"time"
 
+	time "github.com/echlebek/timeproxy"
 	"github.com/robfig/cron"
 )
 

--- a/backend/schedulerd/check_timer_test.go
+++ b/backend/schedulerd/check_timer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNextCronTime(t *testing.T) {
-	now := time.Now()
+	now := mockTime.Now()
 
 	// Valid cron string will return a time in the future, on an even minute
 	nextCron, err := NextCronTime(now, "* * * * *")
@@ -40,7 +40,7 @@ func TestSplay(t *testing.T) {
 func TestInitialOffset(t *testing.T) {
 	inputs := []uint{1, 10, 60}
 	for _, intervalSeconds := range inputs {
-		now := time.Now()
+		now := mockTime.Now()
 		timer := NewIntervalTimer("check1", intervalSeconds)
 		nextExecution := timer.calcInitialOffset()
 		executionTime := now.Add(nextExecution)

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
+	time "github.com/echlebek/timeproxy"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"

--- a/backend/schedulerd/executor_test.go
+++ b/backend/schedulerd/executor_test.go
@@ -1,4 +1,4 @@
-// +build integration,race
+// +build integration
 
 package schedulerd
 

--- a/backend/schedulerd/proxy_check.go
+++ b/backend/schedulerd/proxy_check.go
@@ -3,8 +3,8 @@ package schedulerd
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
+	time "github.com/echlebek/timeproxy"
 	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -1,9 +1,10 @@
+// +build integration,!race
+
 package schedulerd
 
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/queue"
@@ -65,11 +66,8 @@ func TestSchedulerd(t *testing.T) {
 	assert.NoError(t, check.Validate())
 	assert.NoError(t, st.UpdateCheckConfig(ctx, check))
 
-	time.Sleep(1 * time.Second)
-
 	require.NoError(t, st.DeleteCheckConfigByName(ctx, check.Name))
 
-	time.Sleep(1 * time.Second)
 	sub.Cancel()
 	close(tsub.ch)
 

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type testSubscriber struct {
-	ch chan interface{}
-}
-
-func (ts testSubscriber) Receiver() chan<- interface{} {
-	return ts.ch
-}
-
 func TestSchedulerd(t *testing.T) {
 	// Setup wizard bus
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{

--- a/backend/schedulerd/testutil_test.go
+++ b/backend/schedulerd/testutil_test.go
@@ -1,0 +1,11 @@
+package schedulerd
+
+var _ = testSubscriber{}
+
+type testSubscriber struct {
+	ch chan interface{}
+}
+
+func (ts testSubscriber) Receiver() chan<- interface{} {
+	return ts.ch
+}

--- a/backend/schedulerd/timeproxy_test.go
+++ b/backend/schedulerd/timeproxy_test.go
@@ -1,0 +1,14 @@
+package schedulerd
+
+import (
+	"github.com/echlebek/crock"
+	time "github.com/echlebek/timeproxy"
+)
+
+var mockTime = crock.NewTime(time.Unix(0, 0))
+
+func init() {
+	mockTime.Resolution = time.Millisecond
+	mockTime.Multiplier = 1000
+	time.TimeProxy = mockTime
+}

--- a/vendor/github.com/echlebek/crock/LICENSE
+++ b/vendor/github.com/echlebek/crock/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2018, Eric Chlebek
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/echlebek/crock/README.md
+++ b/vendor/github.com/echlebek/crock/README.md
@@ -1,0 +1,4 @@
+crock
+=====
+
+Crock is a fake time library for testing Go programs that use time.

--- a/vendor/github.com/echlebek/crock/doc.go
+++ b/vendor/github.com/echlebek/crock/doc.go
@@ -1,0 +1,9 @@
+// Package crock provides mock implementations of functions from the stdlib
+// time package.
+//
+// crock deliberately does not specify any interfaces or shims for "real" time.
+// Consumers should create their own interfaces, and make a trivial shim to
+// integrate functions from package time into their code.
+//
+// See the example for some stuff you can lift for this purpose.
+package crock

--- a/vendor/github.com/echlebek/crock/ticker.go
+++ b/vendor/github.com/echlebek/crock/ticker.go
@@ -1,0 +1,65 @@
+package crock
+
+import (
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	timeproxy "github.com/echlebek/timeproxy"
+)
+
+// NewTicker creates a new crock ticker. It works like time.Ticker, except that
+// it only ticks when time is progressing.
+func (t *Time) NewTicker(d time.Duration) *timeproxy.Ticker {
+	ticker := newTicker(t, d)
+	// start guarantees that ticker will be reachable until stop is called
+	ticker.start()
+	// Make sure we don't keep creating tick events after the ticker has gone
+	// out of scope.
+	stopper := ticker.Stop
+	finalizer := func(interface{}) {
+		stopper()
+	}
+	runtime.SetFinalizer(ticker, finalizer)
+	return &timeproxy.Ticker{
+		C:        ticker.C,
+		StopFunc: ticker.Stop,
+	}
+}
+
+func newTicker(t *Time, d time.Duration) *ticker {
+	return &ticker{
+		time:     t,
+		duration: d,
+		C:        make(chan time.Time, 1),
+	}
+}
+
+func (t *ticker) start() {
+	t.running = 1
+	now := t.time.Now()
+	f := new(func())
+	// use a pointer to have this closure add itself to time events.
+	// the magic of indirection!
+	*f = func() {
+		now := t.time.Now()
+		if atomic.LoadInt64(&t.running) == 1 {
+			t.time.event(now.Add(t.duration), *f)
+		}
+		t.C <- now
+	}
+	t.time.event(now.Add(t.duration), *f)
+}
+
+// Ticker stops the ticker. No new events will be sent on ticker.C.
+func (t *ticker) Stop() {
+	atomic.StoreInt64(&t.running, 0)
+}
+
+// Ticker is like time.Ticker, but will tick only when time is progressing
+type ticker struct {
+	running  int64
+	time     *Time
+	duration time.Duration
+	C        chan time.Time
+}

--- a/vendor/github.com/echlebek/crock/time.go
+++ b/vendor/github.com/echlebek/crock/time.go
@@ -1,0 +1,199 @@
+package crock
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// DefaultResolution is the resolution at which crock time updates.
+	DefaultResolution = time.Second
+
+	// DefaultMultiplier is the relative speed at which crock time progresses.
+	DefaultMultiplier = 1.0
+)
+
+var (
+	funcIDCounter uint64
+)
+
+// Time is a crock implementation of time. New Times are halted by default -
+// they do not advance. Time proceeds according to the resolution and
+// multiplier settings. By default, the Resolution is DefaultResolution
+// and Multiplier is DefaultMultiplier.
+//
+// Don't change the Resolution and Multiplier fields when time is in motion.
+type Time struct {
+	running int64
+	now     time.Time
+	mu      sync.Mutex
+	done    chan struct{}
+	events  map[int64][]idFunc
+
+	// Resolution is the frequency events will be processed at once crock time
+	// is started.
+	Resolution time.Duration
+
+	// Multiplier controls the relative speed of crock time. A multiplier of
+	// 1.0 means crock time will proceed at nearly the same speed as real time.
+	Multiplier float64
+}
+
+// NewTime creates a new time, which is now. Resolution and Multiplier are
+// set to their defaults.
+func NewTime(now time.Time) *Time {
+	return &Time{
+		now:        now,
+		Resolution: DefaultResolution,
+		Multiplier: DefaultMultiplier,
+		events:     make(map[int64][]idFunc),
+	}
+}
+
+// Now returns t's current time.
+func (t *Time) Now() time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.now
+}
+
+// Sleep sleeps for real duration d / t.Multiplier.
+func (t *Time) Sleep(d time.Duration) {
+	time.Sleep(t.duration(d))
+}
+
+// Start causes crock time to progress at the rate determined by t.Multiplier.
+// For example, if t.Multiplier is 0.5, crock time will progress twice as slowly
+// as real time.
+//
+// Don't call Start concurrently with other methods.
+func (t *Time) Start() {
+	if atomic.CompareAndSwapInt64(&t.running, 0, 1) {
+		t.done = make(chan struct{})
+		go t.loop(t.done)
+	}
+}
+
+// Stop stops crock time.
+//
+// Don't call Stop concurrently with other methods.
+func (t *Time) Stop() {
+	if atomic.CompareAndSwapInt64(&t.running, 1, 0) {
+		close(t.done)
+	}
+}
+
+// Set sets crock time to a particular time. Can be invoked whether or not time
+// is currently progressing. If there are timer or ticker events that would
+// have occurred before the set crock time, they will fire.
+func (t *Time) Set(to time.Time) {
+	t.mu.Lock()
+	t.now = to
+	t.mu.Unlock()
+	t.processEvents()
+}
+
+// time event loop
+func (t *Time) loop(done chan struct{}) {
+	ticker := time.NewTicker(t.Resolution)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.Set(t.Now().Add(time.Duration(float64(t.Resolution) * t.Multiplier)))
+			go t.processEvents()
+		case <-done:
+			return
+		}
+	}
+}
+
+// duration = d / t.Multiplier
+func (t *Time) duration(d time.Duration) time.Duration {
+	return time.Duration(float64(d) / t.Multiplier)
+}
+
+type idFunc struct {
+	id uint64
+	f  func()
+}
+
+func (f idFunc) Call() {
+	f.f()
+}
+
+// event registers an event to be executed at a time.
+func (t *Time) event(at time.Time, do func()) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	fn := idFunc{
+		id: atomic.AddUint64(&funcIDCounter, 1),
+		f:  do,
+	}
+	t.events[at.UnixNano()] = append(t.events[at.UnixNano()], fn)
+
+	return fn.id
+}
+
+func (t *Time) cancelEvent(at time.Time, id uint64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	events := t.events[at.UnixNano()]
+	newEvents := []idFunc{}
+	for _, e := range events {
+		if e.id == id {
+			continue
+		}
+		newEvents = append(newEvents, e)
+	}
+	t.events[at.UnixNano()] = newEvents
+
+	return len(newEvents) < len(events)
+}
+
+// processEvents loops over all of the events that are registered,
+// executes them, and then deletes them.
+func (t *Time) processEvents() {
+	now := t.Now().UnixNano()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for nano, funcs := range t.events {
+		if nano <= now {
+			for i, fn := range funcs {
+				t.events[nano] = append(t.events[nano][:i], t.events[nano][i+1:]...)
+				go fn.Call()
+			}
+		}
+	}
+}
+
+// After works like time.After, except it only sends on the channel it returns
+// if crock time progresses enough.
+func (t *Time) After(d time.Duration) <-chan time.Time {
+	ch := make(chan time.Time, 1)
+
+	now := t.Now()
+	then := now.Add(d)
+
+	t.event(then, func() { ch <- then; close(ch) })
+
+	return ch
+}
+
+// Tick works like time.Tick, except it only ticks if crock time progresses
+// enough.
+func (t *Time) Tick(d time.Duration) <-chan time.Time {
+	return t.NewTicker(d).C
+}
+
+// Since works like time.Since, performing t.Now().Sub(s)
+func (t *Time) Since(s time.Time) time.Duration {
+	return t.Now().Sub(s)
+}
+
+// Until works like time.Until, performing s.Sub(t.Now())
+func (t *Time) Until(s time.Time) time.Duration {
+	return s.Sub(t.Now())
+}

--- a/vendor/github.com/echlebek/crock/timer.go
+++ b/vendor/github.com/echlebek/crock/timer.go
@@ -1,0 +1,89 @@
+package crock
+
+import (
+	"sync/atomic"
+	"time"
+
+	timeproxy "github.com/echlebek/timeproxy"
+)
+
+// NewTimer creates a new crock timer. It works like time.NewTimer except the
+// timer only sends
+func (t *Time) NewTimer(d Duration) *timeproxy.Timer {
+	timer := newTimer(t, d)
+	return &timeproxy.Timer{
+		C:         timer.C,
+		StopFunc:  timer.Stop,
+		ResetFunc: timer.Reset,
+	}
+}
+
+type timer struct {
+	running     int64
+	time        *Time
+	C           chan time.Time
+	duration    time.Duration
+	fireAt      time.Time
+	eventFuncID uint64
+	eventFunc   func()
+}
+
+func (t *timer) Stop() bool {
+	swapped := atomic.CompareAndSwapInt64(&t.running, 1, 0)
+	if !swapped {
+		return false
+	}
+	return t.time.cancelEvent(t.fireAt, t.eventFuncID)
+}
+
+func newTimer(t *Time, d time.Duration) *timer {
+	at := t.Now().Add(d)
+	timer := &timer{
+		time:     t,
+		C:        make(chan time.Time, 1),
+		duration: d,
+		fireAt:   at,
+		running:  1,
+	}
+	timer.eventFunc = func() {
+		timer.C <- t.Now()
+		atomic.StoreInt64(&timer.running, 0)
+	}
+	timer.eventFuncID = t.event(at, timer.eventFunc)
+	return timer
+}
+
+func newAfterTimer(t *Time, d time.Duration, f func()) *timer {
+	at := t.Now().Add(d)
+	timer := &timer{
+		time:      t,
+		C:         make(chan time.Time, 1),
+		duration:  d,
+		fireAt:    at,
+		eventFunc: f,
+	}
+	timer.eventFuncID = t.event(at, timer.eventFunc)
+	timer.running = 1
+
+	return timer
+}
+
+func (t *timer) Reset(d time.Duration) bool {
+	active := t.Stop()
+	at := t.time.Now().Add(d)
+	t.time.event(at, t.eventFunc)
+	t.fireAt = at
+
+	atomic.StoreInt64(&t.running, 1)
+
+	return active
+}
+
+func (t *Time) AfterFunc(d Duration, f func()) *timeproxy.Timer {
+	timer := newAfterTimer(t, d, f)
+	return &timeproxy.Timer{
+		C:         timer.C,
+		StopFunc:  timer.Stop,
+		ResetFunc: timer.Reset,
+	}
+}

--- a/vendor/github.com/echlebek/crock/types.go
+++ b/vendor/github.com/echlebek/crock/types.go
@@ -1,0 +1,5 @@
+package crock
+
+import "time"
+
+type Duration = time.Duration

--- a/vendor/github.com/echlebek/timeproxy/.gitignore
+++ b/vendor/github.com/echlebek/timeproxy/.gitignore
@@ -1,0 +1,12 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/vendor/github.com/echlebek/timeproxy/LICENSE
+++ b/vendor/github.com/echlebek/timeproxy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Eric Chlebek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/echlebek/timeproxy/doc.go
+++ b/vendor/github.com/echlebek/timeproxy/doc.go
@@ -1,0 +1,3 @@
+// Package timeproxy contains functions and data types for working with time.
+// The package exists so that time functionality can be mocked in tests.
+package timeproxy

--- a/vendor/github.com/echlebek/timeproxy/time.go
+++ b/vendor/github.com/echlebek/timeproxy/time.go
@@ -1,0 +1,265 @@
+package timeproxy
+
+import (
+	"time"
+)
+
+type (
+	Duration   = time.Duration
+	Location   = time.Location
+	Month      = time.Month
+	ParseError = time.ParseError
+	Time       = time.Time
+	Weekday    = time.Weekday
+)
+
+const (
+	ANSIC       = "Mon Jan _2 15:04:05 2006"
+	UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
+	RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
+	RFC822      = "02 Jan 06 15:04 MST"
+	RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
+	RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
+	RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
+	RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+	RFC3339     = "2006-01-02T15:04:05Z07:00"
+	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+	Kitchen     = "3:04PM"
+	Stamp       = "Jan _2 15:04:05"
+	StampMilli  = "Jan _2 15:04:05.000"
+	StampMicro  = "Jan _2 15:04:05.000000"
+	StampNano   = "Jan _2 15:04:05.000000000"
+)
+
+const (
+	Nanosecond  Duration = 1
+	Microsecond          = 1000 * Nanosecond
+	Millisecond          = 1000 * Microsecond
+	Second               = 1000 * Millisecond
+	Minute               = 60 * Second
+	Hour                 = 60 * Minute
+)
+
+const (
+	January Month = 1 + iota
+	February
+	March
+	April
+	May
+	June
+	July
+	August
+	September
+	October
+	November
+	December
+)
+
+const (
+	Sunday Weekday = iota
+	Monday
+	Tuesday
+	Wednesday
+	Thursday
+	Friday
+	Saturday
+)
+
+var (
+	Local *Location = time.Local
+	UTC   *Location = time.UTC
+)
+
+// TimeProxy is an interface that maps 1:1 with the standalone functions in
+// this pacakge. By default, TimeProxy uses the functions from the time package
+// in the standard library.
+//
+// Replace TimeProxy with a different implementation to gain control over time
+// in tests.
+var TimeProxy Proxy = RealTime{}
+
+// Proxy is a proxy for the time package. By default, the methods from
+// stdlib are called.
+type Proxy interface {
+	Now() Time
+	Tick(Duration) <-chan Time
+	After(Duration) <-chan Time
+	Sleep(Duration)
+	NewTicker(Duration) *Ticker
+	AfterFunc(Duration, func()) *Timer
+	NewTimer(Duration) *Timer
+	Since(Time) Duration
+	Until(Time) Duration
+}
+
+// Now calls TimeProxy.Now
+func Now() Time {
+	return TimeProxy.Now()
+}
+
+// Tick calls TimeProxy.Tick
+func Tick(d Duration) <-chan Time {
+	return TimeProxy.Tick(d)
+}
+
+// After calls TimeProxy.After
+func After(d Duration) <-chan Time {
+	return TimeProxy.After(d)
+}
+
+// Sleep calls TimeProxy.Sleep
+func Sleep(d Duration) {
+	TimeProxy.Sleep(d)
+}
+
+// NewTicker calls TimeProxy.NewTicker
+func NewTicker(d Duration) *Ticker {
+	return TimeProxy.NewTicker(d)
+}
+
+// RealTime dispatches all calls to the stdlib time package
+type RealTime struct{}
+
+// Now calls time.Now
+func (RealTime) Now() Time {
+	return time.Now()
+}
+
+// Sleep calls time.Sleep
+func (RealTime) Sleep(d Duration) {
+	time.Sleep(d)
+}
+
+// After calls time.After
+func (RealTime) After(d Duration) <-chan Time {
+	return time.After(d)
+}
+
+// Tick calls time.Tick
+func (RealTime) Tick(d Duration) <-chan Time {
+	//lint:ignore SA1015 (don't warn about leaking ticker)
+	return time.Tick(d)
+}
+
+// NewTicker calls time.NewTicker
+func (RealTime) NewTicker(d Duration) *Ticker {
+	ticker := time.NewTicker(d)
+	return &Ticker{
+		C:        ticker.C,
+		StopFunc: ticker.Stop,
+	}
+}
+
+// AfterFunc calls time.AfterFunc
+func (RealTime) AfterFunc(d Duration, f func()) *Timer {
+	timer := time.AfterFunc(d, f)
+	return &Timer{
+		C:         timer.C,
+		ResetFunc: timer.Reset,
+		StopFunc:  timer.Stop,
+	}
+}
+
+// NewTimer calls time.NewTimer. It returns a timeproxy Timer with StopFunc
+// set to the timer's Stop method and ResetFunc set to the timer's Reset
+// method.
+func (RealTime) NewTimer(d Duration) *Timer {
+	timer := time.NewTimer(d)
+	return &Timer{
+		C:         timer.C,
+		ResetFunc: timer.Reset,
+		StopFunc:  timer.Stop,
+	}
+}
+
+// Since calls time.Since
+func (RealTime) Since(t Time) Duration {
+	return time.Since(t)
+}
+
+// Until calls time.Until
+func (RealTime) Until(t Time) Duration {
+	return time.Until(t)
+}
+
+// ParseDuration calls time.ParseDuration
+func ParseDuration(s string) (Duration, error) {
+	return time.ParseDuration(s)
+}
+
+// FixedZone calls time.FixedZone
+func FixedZone(name string, offset int) *Location {
+	return time.FixedZone(name, offset)
+}
+
+// LoadLocation calls time.LoadLocation
+func LoadLocation(name string) (*Location, error) {
+	return time.LoadLocation(name)
+}
+
+// LoadLocationFromTZData calls time LoadLocationFromTZData
+func LoadLocationFromTZData(name string, data []byte) (*Location, error) {
+	return time.LoadLocationFromTZData(name, data)
+}
+
+// Parse calls time.Parse
+func Parse(layout, value string) (Time, error) {
+	return time.Parse(layout, value)
+}
+
+// ParseInLocation calls time.ParseInLocation
+func ParseInLocation(layout, value string, loc *Location) (Time, error) {
+	return time.ParseInLocation(layout, value, loc)
+}
+
+// Date calls time.Date
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time {
+	return time.Date(year, month, day, hour, min, sec, nsec, loc)
+}
+
+// Unix calls time.Unix
+func Unix(sec, nsec int64) Time {
+	return time.Unix(sec, nsec)
+}
+
+// Ticker is an abstraction of time.Ticker that can be patched more easily.
+type Ticker struct {
+	C        <-chan Time
+	StopFunc func()
+}
+
+func (t *Ticker) Stop() {
+	t.StopFunc()
+}
+
+// Timer is an abstraction of time.Timer that can be patched more easily.
+type Timer struct {
+	C         <-chan Time
+	ResetFunc func(Duration) bool
+	StopFunc  func() bool
+}
+
+// Reset calls t.ResetFunc
+func (t *Timer) Reset(d Duration) bool {
+	return t.ResetFunc(d)
+}
+
+// Stop calls t.StopFunc
+func (t *Timer) Stop() bool {
+	return t.StopFunc()
+}
+
+// Since calls TimeProxy.Since
+func Since(t Time) Duration {
+	return TimeProxy.Since(t)
+}
+
+// Until calls TimeProxy.Until
+func Until(t Time) Duration {
+	return TimeProxy.Until(t)
+}
+
+// NewTimer returns TimeProxy.NewTimer
+func NewTimer(d Duration) *Timer {
+	return TimeProxy.NewTimer(d)
+}


### PR DESCRIPTION
## What is this change?
```
    Use crock to mock out time in schedulerd.
    
    This commit abstracts the time package in schedulerd by using
    timeproxy. In tests, the time is mocked out with crock time.
    
    The result is that these tests no longer need to sleep in order
    to verify that scheduling is working properly.
    
    Test execution has been sped up by a factor of 10-30x as a result.
    
    Signed-off-by: Eric Chlebek <eric@sensu.io>
```

## Why is this change necessary?

## Does your change need a Changelog entry?

No, this is not a user-facing change.

## Were there any complications while making this change?

This was the first usage of the crock and timeproxy libraries in sensu-go. I had to make some minor changes to those libraries as I worked. Other than that, it was pretty smooth.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.