### PR TITLE
Remove code duplication from newCLI() func

### DIFF
--- a/cli/commands/asset/info_test.go
+++ b/cli/commands/asset/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestInfoCommand(t *testing.T) {
 func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchAsset", "in").Return(types.FixtureAsset("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchAsset", "in").Return(types.FixtureAsset("name-one"), nil)
 
@@ -72,7 +72,7 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchAsset", "in").Return(&types.Asset{}, errors.New("my-err"))
 

--- a/cli/commands/asset/list_test.go
+++ b/cli/commands/asset/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -28,7 +27,7 @@ func TestListCommand(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("none")
@@ -48,7 +47,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 
 func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("none")
@@ -69,7 +68,7 @@ func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 func TestListCommandRunEClosureWithJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListAssets", mock.Anything).Return([]types.Asset{
 		*types.FixtureAsset("one"),
@@ -86,7 +85,7 @@ func TestListCommandRunEClosureWithJSON(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListAssets", mock.Anything).Return([]types.Asset{}, errors.New("fire"))
 
@@ -101,7 +100,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -109,12 +108,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/check/info_test.go
+++ b/cli/commands/check/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestInfoCommand(t *testing.T) {
 func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchCheck", "in").Return(types.FixtureCheckConfig("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	require.Error(t, err)
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchCheck", "in").Return(types.FixtureCheckConfig("name-one"), nil)
 
@@ -79,7 +79,7 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchCheck", "in").Return(&types.CheckConfig{}, errors.New("my-err"))
 

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListChecks", mock.Anything).Return([]types.CheckConfig{
 		*types.FixtureCheckConfig("name-one"),
@@ -49,7 +48,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListChecks", "*").Return([]types.CheckConfig{
 		*types.FixtureCheckConfig("name-one"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	check := types.FixtureCheckConfig("name-one")
 	check.RuntimeAssets = []string{"asset-one"}
@@ -93,7 +92,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListChecks", mock.Anything).Return([]types.CheckConfig{}, errors.New("my-err"))
 
@@ -108,7 +107,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	checkConfig := types.FixtureCheckConfig("name-one")
 	checkConfig.Command = "echo foo && exit 1"
@@ -128,7 +127,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -136,12 +135,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/cluster/health_test.go
+++ b/cli/commands/cluster/health_test.go
@@ -3,8 +3,6 @@ package cluster
 import (
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
-	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,19 +10,11 @@ import (
 func TestHealthCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := HealthCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("health", cmd.Use)
 	assert.Regexp("get sensu health status", cmd.Short)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/entity/info_test.go
+++ b/cli/commands/entity/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestInfoCommand(t *testing.T) {
 func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(types.FixtureEntity("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(types.FixtureEntity("name-one"), nil)
 
@@ -71,7 +71,7 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(&types.Entity{}, errors.New("my-err"))
 

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListEntities", mock.Anything).Return([]types.Entity{
 		*types.FixtureEntity("name-one"),
@@ -48,7 +47,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListEntities", "*").Return([]types.Entity{
 		*types.FixtureEntity("name-two"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListEntities", mock.Anything).Return([]types.Entity{
 		*types.FixtureEntity("name-one"),
@@ -88,7 +87,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListEntities", mock.Anything).Return([]types.Entity{}, errors.New("my-err"))
 
@@ -103,7 +102,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -111,12 +110,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/extension/list_test.go
+++ b/cli/commands/extension/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/sensu/sensu-go/types"
@@ -15,7 +14,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +25,7 @@ func TestListCommand(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("none")
@@ -46,7 +45,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 
 func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("none")
@@ -66,7 +65,7 @@ func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 func TestListCommandRunEClosureWithJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListExtensions", mock.Anything).Return([]types.Extension{
 		*types.FixtureExtension("one"),
@@ -83,7 +82,7 @@ func TestListCommandRunEClosureWithJSON(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListExtensions", mock.Anything).Return([]types.Extension{}, errors.New("fire"))
 
@@ -93,12 +92,4 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/filter/info_test.go
+++ b/cli/commands/filter/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestShowCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestShowCommand(t *testing.T) {
 func TestShowCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchFilter", "in").Return(types.FixtureEventFilter("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestShowCommandRunEClosure(t *testing.T) {
 func TestShowCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -53,7 +53,7 @@ func TestShowCommandRunMissingArgs(t *testing.T) {
 func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchFilter", "in").Return(types.FixtureEventFilter("name-one"), nil)
 
@@ -72,7 +72,7 @@ func TestShowCommandRunEClosureWithTable(t *testing.T) {
 func TestShowCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchFilter", "in").Return(&types.EventFilter{}, errors.New("my-err"))
 

--- a/cli/commands/filter/list_test.go
+++ b/cli/commands/filter/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListFilters", mock.Anything).Return([]types.EventFilter{
 		*types.FixtureEventFilter("name-one"),
@@ -49,7 +48,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListFilters", "*").Return([]types.EventFilter{
 		*types.FixtureEventFilter("name-one"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	filter := types.FixtureEventFilter("name-one")
 
@@ -87,7 +86,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListFilters", mock.Anything).Return([]types.EventFilter{}, errors.New("my-err"))
 
@@ -102,7 +101,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	filter := types.FixtureEventFilter("name-one")
 	filter.Statements = append(filter.Statements, "10 > 0")
@@ -120,7 +119,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -128,12 +127,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/handler/list_test.go
+++ b/cli/commands/handler/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHandlers", mock.Anything).Return([]types.Handler{
 		*types.FixtureHandler("one"),
@@ -46,7 +45,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHandlers", "*").Return([]types.Handler{
 		*types.FixtureHandler("one"),
@@ -63,7 +62,7 @@ func TestListCommandRunEClosureWithAllOrgs(t *testing.T) {
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHandlers", mock.Anything).Return([]types.Handler{
 		*types.FixtureSetHandler("one", "two", "three"),
@@ -82,7 +81,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHandlers", mock.Anything).Return([]types.Handler{}, errors.New("fire"))
 
@@ -97,7 +96,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -105,12 +104,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/hook/info_test.go
+++ b/cli/commands/hook/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestInfoCommand(t *testing.T) {
 func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchHook", "in").Return(types.FixtureHookConfig("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchHook", "in").Return(types.FixtureHookConfig("name-one"), nil)
 
@@ -72,7 +72,7 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchHook", "in").Return(&types.HookConfig{}, errors.New("my-err"))
 

--- a/cli/commands/hook/list_test.go
+++ b/cli/commands/hook/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHooks", mock.Anything).Return([]types.HookConfig{
 		*types.FixtureHookConfig("name-one"),
@@ -49,7 +48,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHooks", "*").Return([]types.HookConfig{
 		*types.FixtureHookConfig("name-one"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	hook := types.FixtureHookConfig("name-one")
 
@@ -88,7 +87,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHooks", mock.Anything).Return([]types.HookConfig{}, errors.New("my-err"))
 
@@ -103,7 +102,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	hookConfig := types.FixtureHookConfig("name-one")
 	hookConfig.Command = "echo foo && exit 1"
@@ -123,7 +122,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -131,12 +130,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/mutator/info_test.go
+++ b/cli/commands/mutator/info_test.go
@@ -14,7 +14,7 @@ import (
 func TestShowCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +26,7 @@ func TestShowCommand(t *testing.T) {
 func TestShowCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchMutator", "in").Return(types.FixtureMutator("name-one"), nil)
 
@@ -41,7 +41,7 @@ func TestShowCommandRunEClosure(t *testing.T) {
 func TestShowCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
@@ -53,7 +53,7 @@ func TestShowCommandRunMissingArgs(t *testing.T) {
 func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchMutator", "in").Return(types.FixtureMutator("name-one"), nil)
 
@@ -72,7 +72,7 @@ func TestShowCommandRunEClosureWithTable(t *testing.T) {
 func TestShowCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchMutator", "in").Return(&types.Mutator{}, errors.New("my-err"))
 

--- a/cli/commands/mutator/list_test.go
+++ b/cli/commands/mutator/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListMutators", mock.Anything).Return([]types.Mutator{
 		*types.FixtureMutator("name-one"),
@@ -49,7 +48,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListMutators", "*").Return([]types.Mutator{
 		*types.FixtureMutator("name-one"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	mutator := types.FixtureMutator("name-one")
 
@@ -87,7 +86,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListMutators", mock.Anything).Return([]types.Mutator{}, errors.New("my-err"))
 
@@ -102,7 +101,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	mutator := types.FixtureMutator("name-one")
 	mutator.Command = "echo foo && exit 1"
@@ -120,7 +119,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -128,12 +127,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/organization/list_test.go
+++ b/cli/commands/organization/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/sensu/sensu-go/types"
@@ -14,7 +13,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +25,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListOrganizations").Return([]types.Organization{
 		*types.FixtureOrganization("one"),
@@ -43,7 +42,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListOrganizations").Return([]types.Organization{}, errors.New("fire"))
 
@@ -53,12 +52,4 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/role/list_rules_test.go
+++ b/cli/commands/role/list_rules_test.go
@@ -71,7 +71,7 @@ func TestListRulesCommandRunEClosure(t *testing.T) {
 
 func TestListRulesCommandRunEJSON(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchRole", "abc").Return(

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/sensu/sensu-go/types"
@@ -14,7 +13,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -26,7 +25,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{
 		*types.FixtureRole("one", "*", "*"),
@@ -67,7 +66,7 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{}, errors.New("fire"))
 
@@ -77,12 +76,4 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/silenced/info_test.go
+++ b/cli/commands/silenced/info_test.go
@@ -15,7 +15,7 @@ import (
 func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -27,7 +27,7 @@ func TestInfoCommand(t *testing.T) {
 func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchSilenced", mock.Anything).Return(types.FixtureSilenced("foo:bar"), nil)
 
@@ -42,7 +42,7 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 func TestInfoCommandRunMissingArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"wrong", "stuff"})
 
@@ -54,7 +54,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchSilenced", mock.Anything).Return(types.FixtureSilenced("foo:bar"), nil)
 
@@ -73,7 +73,7 @@ func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchSilenced", mock.Anything).Return(&types.Silenced{}, errors.New("my-err"))
 

--- a/cli/commands/silenced/list_test.go
+++ b/cli/commands/silenced/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -17,7 +16,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -29,7 +28,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{
 		*types.FixtureSilenced("foo:bar"),
@@ -49,7 +48,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{
 		*types.FixtureSilenced("foo:bar"),
@@ -65,7 +64,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	silenced := types.FixtureSilenced("foo:bar")
 	silenced.Reason = "justcause!"
@@ -106,7 +105,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{}, errors.New("my-err"))
 
@@ -121,7 +120,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 func TestListFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	flag := cmd.Flag("all-organizations")
@@ -129,12 +128,4 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }

--- a/cli/commands/testing/cli.go
+++ b/cli/commands/testing/cli.go
@@ -12,6 +12,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// NewCLI returns a SensuCLI instace with mocked values with json format
+func NewCLI() *cli.SensuCli {
+	cli := NewMockCLI()
+	config := cli.Config.(*clientmock.MockConfig)
+	config.On("Format").Return("json")
+
+	return cli
+}
+
 // NewMockCLI return SensuCLI instance w/ mocked values
 func NewMockCLI() *cli.SensuCli {
 	config := &clientmock.MockConfig{}

--- a/cli/commands/user/list_test.go
+++ b/cli/commands/user/list_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sensu/sensu-go/cli"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/sensu/sensu-go/types"
@@ -15,7 +14,7 @@ import (
 func TestListCommand(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	cmd := ListCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -27,7 +26,7 @@ func TestListCommand(t *testing.T) {
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListUsers").Return([]types.User{
 		*types.FixtureUser("one"),
@@ -44,7 +43,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := newCLI()
+	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListUsers").Return([]types.User{}, errors.New("fire"))
 
@@ -57,7 +56,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newCLI()
+	cli := test.NewCLI()
 
 	client := cli.Client.(*client.MockClient)
 	client.On("ListUsers").Return([]types.User{
@@ -77,12 +76,4 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert.Contains(out, "two")
 	assert.Contains(out, "true")
 	assert.NoError(err)
-}
-
-func newCLI() *cli.SensuCli {
-	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Removes a redundant code block and adds it as a helper function for testing. Noticed this when reviewing https://github.com/sensu/sensu-go/pull/1885.

## Why is this change necessary?

Good coding practices.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.