### PR TITLE
Improve Sensu edition header handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added API client support for enterprise license management.
 - Added a header to API calls that returns the current Sensu Edition.
 - Added sensuctl cluster health command.
+- Added the Sensu edition in sensuctl config view subcommand.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ enterprise edition.
 the enterprise edition.
 - Upgrade dep to v0.5.0
 - Added cluster health information to /health endpoint in sensu-backend.
+- API responses are inspected after each request for the Sensu Edition header.
 
 ### Fixed
 - Fixed `sensuctl completion` help for bash and zsh.

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateAccessToken returns a new access token given userid and password
-func (client *RestClient) CreateAccessToken(url, userid, password string) (*types.Tokens, string, error) {
+func (client *RestClient) CreateAccessToken(url, userid, password string) (*types.Tokens, error) {
 	// Make sure any existing auth token doesn't get injected instead
 	client.ClearAuthToken()
 	defer client.Reset()
@@ -17,24 +17,22 @@ func (client *RestClient) CreateAccessToken(url, userid, password string) (*type
 	// Execute
 	res, err := client.R().SetBasicAuth(userid, password).Get(url + "/auth")
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	if res.StatusCode() == 401 {
-		return nil, "", errors.New(string(res.Body()))
+		return nil, errors.New(string(res.Body()))
 	} else if res.StatusCode() >= 400 {
 		// TODO: (JK) we may want to expose a bit more of the error here
-		return nil, "", errors.New("Received an unexpected response from the API")
+		return nil, errors.New("Received an unexpected response from the API")
 	}
 
 	var tokens types.Tokens
 	if err = json.Unmarshal(res.Body(), &tokens); err != nil {
-		return nil, "", errors.New("Unable to unmarshal response from server")
+		return nil, errors.New("Unable to unmarshal response from server")
 	}
 
-	edition := res.Header().Get(types.EditionHeader)
-
-	return &tokens, edition, err
+	return &tokens, err
 }
 
 // Logout performs a logout of the configured user

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -17,7 +17,6 @@ func TestCreateAccessToken(t *testing.T) {
 		assert.NotEmpty(t, r.Header["Authorization"])
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set(types.EditionHeader, types.CoreEdition)
 		_, _ = w.Write([]byte(`{"access_token": "foo", "expires_at": 123456789, "refresh_token": "bar"}`))
 	}
 	server := httptest.NewServer(http.HandlerFunc(testHandler))
@@ -30,10 +29,9 @@ func TestCreateAccessToken(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	token, edition, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	token, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.NoError(t, err)
 	assert.NotNil(t, token)
-	assert.Equal(t, types.CoreEdition, edition)
 }
 
 func TestCreateAccessTokenForbidden(t *testing.T) {
@@ -50,7 +48,7 @@ func TestCreateAccessTokenForbidden(t *testing.T) {
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&types.Tokens{})
 
-	_, _, err := client.CreateAccessToken(server.URL, "foo", "bar")
+	_, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.Error(t, err)
 }
 

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-resty/resty"
 	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -109,6 +110,23 @@ func New(config config.Config) *RestClient {
 		client.expiredToken = false
 
 		c.SetAuthToken(tokens.Access)
+
+		return nil
+	})
+
+	// Verify the Sensu edition and update the sensuctl configuration if required
+	restyInst.OnAfterResponse(func(c *resty.Client, resp *resty.Response) error {
+		// Retrieve the Sensu edition from the response header
+		headerEdition := resp.Header().Get(types.EditionHeader)
+		if headerEdition == "" {
+			return nil
+		}
+
+		// Verify if the edition from the header differs from the configured one
+		if headerEdition != config.Edition() {
+			// Update the configured edition in sensuctl
+			return config.SaveEdition(headerEdition)
+		}
 
 		return nil
 	})

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -36,7 +36,7 @@ type GenericClient interface {
 
 // AuthenticationAPIClient client methods for authenticating
 type AuthenticationAPIClient interface {
-	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, string, error)
+	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, error)
 	Logout(token string) error
 	RefreshAccessToken(refreshToken string) (*types.Tokens, error)
 }

--- a/cli/client/testing/mock_authentication_client.go
+++ b/cli/client/testing/mock_authentication_client.go
@@ -3,9 +3,9 @@ package testing
 import "github.com/sensu/sensu-go/types"
 
 // CreateAccessToken for use with mock lib
-func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, string, error) {
+func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, error) {
 	args := c.Called(url, u, p)
-	return args.Get(0).(*types.Tokens), args.String(1), args.Error(2)
+	return args.Get(0).(*types.Tokens), args.Error(1)
 }
 
 // Logout for use with mock lib

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -20,6 +20,7 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			activeConfig := map[string]string{
 				"api-url":      cli.Config.APIUrl(),
+				"edition":      cli.Config.Edition(),
 				"environment":  cli.Config.Environment(),
 				"organization": cli.Config.Organization(),
 				"format":       cli.Config.Format(),
@@ -54,6 +55,10 @@ func printToList(v interface{}, writer io.Writer) error {
 			{
 				Label: "API URL",
 				Value: r["api-url"],
+			},
+			{
+				Label: "Sensu Edition",
+				Value: r["edition"],
 			},
 			{
 				Label: "Environment",

--- a/cli/commands/config/view_test.go
+++ b/cli/commands/config/view_test.go
@@ -5,6 +5,7 @@ import (
 
 	clienttest "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,6 +17,7 @@ func TestViewCommand(t *testing.T) {
 
 	config := cli.Config.(*clienttest.MockConfig)
 	config.On("APIUrl").Return("http://127.0.0.1:8080")
+	config.On("Edition").Return(types.CoreEdition)
 	config.On("Format").Return("none")
 
 	assert.NotNil(cmd, "cmd should be returned")
@@ -32,6 +34,7 @@ func TestViewExec(t *testing.T) {
 
 	config := cli.Config.(*clienttest.MockConfig)
 	config.On("APIUrl").Return("http://127.0.0.1:8080")
+	config.On("Edition").Return(types.CoreEdition)
 	config.On("Format").Return("none")
 
 	out, err := test.RunCmd(cmd, []string{"default"})

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sensu/sensu-go/cli"
 	config "github.com/sensu/sensu-go/cli/client/config"
 	hooks "github.com/sensu/sensu-go/cli/commands/hooks"
-	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -70,7 +69,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Authenticate
-			tokens, edition, err := cli.Client.CreateAccessToken(
+			tokens, err := cli.Client.CreateAccessToken(
 				answers.URL, answers.Username, answers.Password,
 			)
 			if err != nil {
@@ -83,18 +82,6 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 
 			// Write new credentials to disk
 			if err = cli.Config.SaveTokens(tokens); err != nil {
-				fmt.Fprintln(cmd.OutOrStderr())
-				return fmt.Errorf(
-					"unable to write new configuration file with error: %s",
-					err,
-				)
-			}
-
-			// Write Sensu edition to disk
-			if edition == "" {
-				edition = types.CoreEdition
-			}
-			if err = cli.Config.SaveEdition(edition); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(
 					"unable to write new configuration file with error: %s",

--- a/cli/commands/user/change_password.go
+++ b/cli/commands/user/change_password.go
@@ -134,7 +134,7 @@ func verifyExistingPassword(cli *cli.SensuCli, flags *pflag.FlagSet, isInteracti
 	}
 
 	// Attempt to authenticate
-	if _, _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
+	if _, err := cli.Client.CreateAccessToken(cli.Config.APIUrl(), username, input.Password); err != nil {
 		return errBadCurrentPassword
 	}
 


### PR DESCRIPTION
## What is this change?

It inspects the headers returned by the Sensu API on each request to verify the Sensu edition, and updates sensuctl configuration if required.

## Why is this change necessary?

It ensures a user has access to the enterprise version of sensuctl whenever they upgrade Sensu Backend.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope