### PR TITLE
RBAC bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ enterprise edition.
 the enterprise edition.
 - Upgrade dep to v0.5.0
 - Added cluster health information to /health endpoint in sensu-backend.
+- Rename list-rules subcommand to info in sensuctl role commmand with alias
+for backward compatibility.
 
 ### Fixed
 - Fixed `sensuctl completion` help for bash and zsh.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ generated correctly.
 future.
 - Fixed a bug where clustered round robin check execution executed checks
 too often.
+- Rules are now implicitly granting read permission to their configured
+environment & organization.
 
 ### Removed
 - Removed check subdue e2e test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added API client support for enterprise license management.
 - Added a header to API calls that returns the current Sensu Edition.
 - Added sensuctl cluster health command.
+- List the supported resource types in sensuctl.
 
 ### Changed
 - The Backend struct has been refactored to allow easier customization in

--- a/backend/authorization/authorization_test.go
+++ b/backend/authorization/authorization_test.go
@@ -106,6 +106,10 @@ func TestCanAccessResource(t *testing.T) {
 	}{
 		{"NoMatches", "checks", "prod", "notsensu", types.RulePermCreate, false},
 		{"AllMatch", "entities", "dev", "sensu", types.RulePermRead, true},
+		{"ReadItsEnvironment", types.RuleTypeEnvironment, "dev", "sensu", types.RulePermRead, true},
+		{"ReadItsOrganization", types.RuleTypeOrganization, "", "sensu", types.RulePermRead, true},
+		{"ReadAnotherEnvironment", types.RuleTypeEnvironment, "prod", "sensu", types.RulePermRead, false},
+		{"ReadAnotherOrganization", types.RuleTypeOrganization, "", "acme", types.RulePermRead, false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.TestName, func(t *testing.T) {

--- a/cli/commands/role/add_rule.go
+++ b/cli/commands/role/add_rule.go
@@ -3,6 +3,7 @@ package role
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey"
 	"github.com/sensu/sensu-go/cli"
@@ -82,7 +83,10 @@ func AddRuleCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	_ = cmd.Flags().StringP("type", "t", "", "type associated with the rule")
+	_ = cmd.Flags().StringP("type", "t", "",
+		"type associated with the rule, "+
+			"allowed values: "+strings.Join(types.AllTypes, ", "),
+	)
 	_ = cmd.Flags().BoolP("create", "c", false, "create permission")
 	_ = cmd.Flags().BoolP("read", "r", false, "read permission")
 	_ = cmd.Flags().BoolP("update", "u", false, "update permission")
@@ -144,9 +148,9 @@ func (opts *ruleOpts) administerQuestionnaire() error {
 		},
 		{
 			Name: "type",
-			Prompt: &survey.Input{
+			Prompt: &survey.Select{
 				Message: "Rule Type:",
-				Default: opts.Type,
+				Options: types.AllTypes,
 			},
 			Validate: survey.Required,
 		},

--- a/cli/commands/role/create.go
+++ b/cli/commands/role/create.go
@@ -3,6 +3,7 @@ package role
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/types"
@@ -50,7 +51,10 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	_ = cmd.Flags().StringP("type", "t", "", "type associated with the rule")
+	_ = cmd.Flags().StringP("type", "t", "",
+		"type associated with the rule, "+
+			"allowed values: "+strings.Join(types.AllTypes, ", "),
+	)
 	_ = cmd.Flags().BoolP("create", "c", false, "create permission")
 	_ = cmd.Flags().BoolP("read", "r", false, "read permission")
 	_ = cmd.Flags().BoolP("update", "u", false, "update permission")

--- a/cli/commands/role/help.go
+++ b/cli/commands/role/help.go
@@ -18,7 +18,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		DeleteCommand(cli),
 		ListCommand(cli),
 		AddRuleCommand(cli),
-		ListRulesCommand(cli),
+		InfoCommand(cli),
 		RemoveRuleCommand(cli),
 	)
 

--- a/cli/commands/role/info.go
+++ b/cli/commands/role/info.go
@@ -13,11 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListRulesCommand defines new command to list rules associated w/ a role
-func ListRulesCommand(cli *cli.SensuCli) *cobra.Command {
+// InfoCommand defines new command to list rules associated w/ a role
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "list-rules [ROLE]",
-		Short:        "list rules associated with a role",
+		Use:          "info [ROLE]",
+		Aliases:      []string{"list-rules"}, // backward compatibility
+		Short:        "show detailed role information",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cli/commands/role/info_test.go
+++ b/cli/commands/role/info_test.go
@@ -10,22 +10,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListRulesCommand(t *testing.T) {
+func TestInfoCommand(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := test.NewMockCLI()
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("json")
 
-	cmd := ListRulesCommand(cli)
+	cmd := InfoCommand(cli)
 
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
-	assert.Regexp("list-rules", cmd.Use)
-	assert.Regexp("list rules", cmd.Short)
+	assert.Regexp("info", cmd.Use)
+	assert.Regexp("show detailed role information", cmd.Short)
 }
 
-func TestListRulesCommandRunEWithError(t *testing.T) {
+func TestInfoCommandRunEWithError(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 
@@ -38,14 +38,14 @@ func TestListRulesCommandRunEWithError(t *testing.T) {
 		errors.New("sadfa"),
 	)
 
-	cmd := ListRulesCommand(cli)
+	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"abc"})
 
 	assert.Empty(out)
 	assert.Error(err)
 }
 
-func TestListRulesCommandRunEClosure(t *testing.T) {
+func TestInfoCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 
@@ -58,7 +58,7 @@ func TestListRulesCommandRunEClosure(t *testing.T) {
 		nil,
 	)
 
-	cmd := ListRulesCommand(cli)
+	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"abc"})
 
 	assert.NotEmpty(out)
@@ -69,7 +69,7 @@ func TestListRulesCommandRunEClosure(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestListRulesCommandRunEJSON(t *testing.T) {
+func TestInfoCommandRunEJSON(t *testing.T) {
 	assert := assert.New(t)
 	cli := newCLI()
 
@@ -79,7 +79,7 @@ func TestListRulesCommandRunEJSON(t *testing.T) {
 		nil,
 	)
 
-	cmd := ListRulesCommand(cli)
+	cmd := InfoCommand(cli)
 	out, err := test.RunCmd(cmd, []string{"abc"})
 
 	assert.NotEmpty(out)

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -76,6 +76,25 @@ var (
 		RulePermUpdate,
 		RulePermDelete,
 	}
+
+	// AllTypes specifies all possible types
+	AllTypes = []string{
+		RuleTypeAll,
+		RuleTypeAsset,
+		RuleTypeCheck,
+		RuleTypeEntity,
+		RuleTypeEnvironment,
+		RuleTypeEvent,
+		RuleTypeEventFilter,
+		RuleTypeExtension,
+		RuleTypeHandler,
+		RuleTypeHook,
+		RuleTypeMutator,
+		RuleTypeOrganization,
+		RuleTypeRole,
+		RuleTypeSilenced,
+		RuleTypeUser,
+	}
 )
 
 //


### PR DESCRIPTION
## What is this change?

This PR introduces several bug fixes for RBAC, which I discovered with Jason. Each bug fix has its own commit for simplicity.

- I renamed the `sensuctl role list-rules` subcommand to `sensuctl role info` so it's consistent with other commands. I also added an alias to this subcommand for backward compatibility so you can still run the subcommand with its previous name.
- The allowed values for a rule type are now directly displayed in the help usage in `sensuctl role create` & `sensuctl role add-rule`, so users don't have to look in the docs.
- The rules are now implicitly granting read access to their organization and environment, so a user can list the environments & organization it has access to without having to explicitly give these permissions.

## Why is this change necessary?

It fixes small UX problems we discovered while doing a demo of RBAC.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I will make a PR to sensu-docs to document the implicit read access behaviour.