### PR TITLE
Only allow creating gRPC handlers with /extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ generated correctly.
 future.
 - Fixed a bug where clustered round robin check execution executed checks
 too often.
+- Fixed a bug where users could accidentally create invalid gRPC handlers.
 
 ### Removed
 - Removed check subdue e2e test.

--- a/backend/apid/actions/handlers.go
+++ b/backend/apid/actions/handlers.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
@@ -58,6 +59,10 @@ func (c HandlerController) Create(ctx context.Context, handler types.Handler) er
 		return NewError(InvalidArgument, err)
 	}
 
+	if handler.Type == types.HandlerGRPCType {
+		return NewError(InvalidArgument, errors.New("use the extensions API for this handler type"))
+	}
+
 	// Persist
 	if err := c.Store.UpdateHandler(ctx, &handler); err != nil {
 		return NewError(InternalErr, err)
@@ -83,6 +88,10 @@ func (c HandlerController) CreateOrReplace(ctx context.Context, handler types.Ha
 	// Validate
 	if err := handler.Validate(); err != nil {
 		return NewError(InvalidArgument, err)
+	}
+
+	if handler.Type == types.HandlerGRPCType {
+		return NewError(InvalidArgument, errors.New("use the extensions API for this handler type"))
 	}
 
 	// Persist

--- a/backend/apid/actions/handlers_test.go
+++ b/backend/apid/actions/handlers_test.go
@@ -136,6 +136,9 @@ func TestHandlerCreateOrReplace(t *testing.T) {
 	badHandler := types.FixtureHandler("bad")
 	badHandler.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
+	grpcHandler := types.FixtureHandler("grpc")
+	grpcHandler.Type = types.HandlerGRPCType
+
 	tests := []struct {
 		name            string
 		ctx             context.Context
@@ -169,6 +172,13 @@ func TestHandlerCreateOrReplace(t *testing.T) {
 			name:            "Validation Error",
 			ctx:             defaultCtx,
 			argument:        badHandler,
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Bad handler type",
+			ctx:             defaultCtx,
+			argument:        grpcHandler,
 			expectedErr:     true,
 			expectedErrCode: InvalidArgument,
 		},

--- a/types/handler.go
+++ b/types/handler.go
@@ -23,6 +23,9 @@ const (
 	// HandlerUDPType represents handlers that send event data to a remote UDP
 	// socket
 	HandlerUDPType = "udp"
+
+	// HandlerGRPCType is a special kind of handler that represents an extension
+	HandlerGRPCType = "grpc"
 )
 
 // Validate returns an error if the handler does not pass validation tests.


### PR DESCRIPTION
This commit restricts users from accidentally creating invalid
gRPC handlers by checking the /handlers API for handlers of type
"grpc".

gRPC handlers should only be created with the /extensions API.

Closes #1893

Signed-off-by: Eric Chlebek <eric@sensu.io>