### PR TITLE
Set issued & history on keepalive events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ environment & organization.
 check requests and use its default value instead.
 - sensu-agent & sensu-backend no longer display help usage and duplicated error
 message on startup failure.
+- `Issued` & `History` are now set on keepalive events.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -261,6 +261,13 @@ func createKeepaliveEvent(entity *types.Entity) *types.Event {
 		Environment:  entity.Environment,
 		Organization: entity.Organization,
 		Status:       1,
+		Issued:       time.Now().Unix(),
+		History: []types.CheckHistory{
+			{
+				Status:   1,
+				Executed: time.Now().Unix(),
+			},
+		},
 	}
 	keepaliveEvent := &types.Event{
 		Timestamp: time.Now().Unix(),

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -240,3 +240,15 @@ func TestProcessRegistration(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateKeepaliveEvent(t *testing.T) {
+	entity := types.FixtureEntity("entity1")
+	keepaliveEvent := createKeepaliveEvent(entity)
+	assert.Equal(t, "keepalive", keepaliveEvent.Check.Name)
+	assert.Equal(t, uint32(120), keepaliveEvent.Check.Interval)
+	assert.Equal(t, []string{"keepalive"}, keepaliveEvent.Check.Handlers)
+	assert.Equal(t, uint32(1), keepaliveEvent.Check.Status)
+	assert.NotEqual(t, int64(0), keepaliveEvent.Check.Issued)
+	assert.Equal(t, uint32(1), keepaliveEvent.Check.History[0].Status)
+	assert.NotEqual(t, int64(0), keepaliveEvent.Check.History[0].Executed)
+}


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Sets the `Issued` and `History` attributes on a keepalive event.

## Why is this change necessary?

Fixes #1440.
Fixes https://github.com/sensu/sensu-go/issues/1731.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation updates required.
