### PR TITLE
[Web UI] Use pre-packaged instead of referencing repo

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@10xjs/date-input-controller": "^0.1.5",
-    "@10xjs/form": "git+https://github.com/jamesdphillips/form.git#373871ea",
+    "@10xjs/form": "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz",
     "@material-ui/core": "^1.4.0",
     "@material-ui/icons": "^2.0.0",
     "apollo-cache-inmemory": "^1.1.12",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -6,9 +6,9 @@
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@10xjs/date-input-controller/-/date-input-controller-0.1.5.tgz#0532a68a46a7fdcc6990a0c05672750cbf4e8820"
 
-"@10xjs/form@git+https://github.com/jamesdphillips/form.git#373871ea":
+"@10xjs/form@https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz":
   version "0.1.6"
-  resolved "git+https://github.com/jamesdphillips/form.git#373871eab7216d072ddc098b967c7fabac57a308"
+  resolved "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz#bdbc1f39b912f8851880b0c6507c77afb144684d"
   dependencies:
     es6-error "^4.1.1"
     hoist-non-react-statics "^2.5.0"


### PR DESCRIPTION
## What is this change?

Use pre-packaged instead of referencing repo. 

Avoids issues seen on CI, such as:

```
[2/4] Fetching packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz: ENOENT: no such file or directory, chmod '/home/travis/.cache/yarn/v1/npm-jest-changed-files-22.4.3-8882181e022c38bd46a2e4d18d44d19d90a90fb2/build/index.js'".
info If you think this is a bug, please open a bug report with the information provided in "/home/travis/gopath/src/github.com/sensu/sensu-go/dashboard/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

## Why is this change necessary?

Stop the CI failures.

## Does your change need a Changelog entry?

Unlikely; tooling related.

## Do you need clarification on anything?

`undefined`

## Were there any complications while making this change?

`undefined`

## Have you reviewed and updated the documentation for this change? Is new documentation required?

`undefined`