### PR TITLE
Add a newline after asset creation confirmation

### DIFF
--- a/cli/commands/asset/create.go
+++ b/cli/commands/asset/create.go
@@ -76,7 +76,7 @@ func (exePtr *CreateExecutor) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Fprint(cmd.OutOrStdout(), "OK")
+	fmt.Fprintln(cmd.OutOrStdout(), "OK")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a newline after "OK" during interactive asset creation.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1906

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.