### PR TITLE
Prevent empty subscriptions in agentd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ future.
 too often.
 - Catch errors in type assertions in cli.
 - Fixed a bug where users could accidentally create invalid gRPC handlers.
+- Fixed agentd so it does not subscribe to empty subscriptions.
 
 ### Removed
 - Removed check subdue e2e test.

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -220,6 +220,11 @@ func (s *Session) Start() (err error) {
 	}()
 
 	for _, sub := range s.cfg.Subscriptions {
+		// Ignore empty subscriptions
+		if sub == "" {
+			continue
+		}
+
 		topic := messaging.SubscriptionTopic(org, env, sub)
 		logger.WithField("topic", topic).Debug("subscribing to topic")
 		subscription, err := s.bus.Subscribe(topic, agentID, s)


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It prevents agentd from subscribing to empty subscriptions, because the `transport.HeaderKeySubscriptions` header could be empty.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1853

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope