### PR TITLE
Silence usage on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ for backward compatibility.
 - Fixed agentd so it does not subscribe to empty subscriptions.
 - Rules are now implicitly granting read permission to their configured
 environment & organization.
+- sensu-agent & sensu-backend no longer display help usage and duplicated error
+message on startup failure.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -101,8 +101,10 @@ func newStartCommand() *cobra.Command {
 	var setupErr error
 
 	cmd := &cobra.Command{
-		Use:   "start",
-		Short: "start the sensu agent",
+		Use:           "start",
+		Short:         "start the sensu agent",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -88,6 +88,7 @@ func newStartCommand() *cobra.Command {
 		Use:           "start",
 		Short:         "start the sensu backend",
 		SilenceErrors: true,
+		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = viper.BindPFlags(cmd.Flags())
 			if setupErr != nil {


### PR DESCRIPTION
## What is this change?

It prevents help usage and duplicated error message from being  printed on sensu-backend & sensu-agent startup. 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1814

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope