### PR TITLE
Use default value for splay_coverage in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ for backward compatibility.
 - Fixed agentd so it does not subscribe to empty subscriptions.
 - Rules are now implicitly granting read permission to their configured
 environment & organization.
+- The splay_coverage attribute is no longer mandatory in sensuctl for proxy
+check requests and use its default value instead.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/cli/commands/check/subcommands/set_proxy_request.go
+++ b/cli/commands/check/subcommands/set_proxy_request.go
@@ -43,10 +43,17 @@ func SetProxyRequestsCommand(cli *cli.SensuCli) *cobra.Command {
 			} else {
 				in = os.Stdin
 			}
+
 			var proxyRequest types.ProxyRequests
 			if err := json.NewDecoder(in).Decode(&proxyRequest); err != nil {
 				return err
 			}
+
+			// Set the default splay_coverage value if not configured
+			if proxyRequest.SplayCoverage == 0 {
+				proxyRequest.SplayCoverage = types.DefaultSplayCoverage
+			}
+
 			check.ProxyRequests = &proxyRequest
 			if err := check.Validate(); err != nil {
 				return err

--- a/cli/commands/check/subcommands/set_proxy_request_test.go
+++ b/cli/commands/check/subcommands/set_proxy_request_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSetProxyRequestsCommand(t *testing.T) {
 	const proxyJSON = `{"entity_attributes":["entity.Class == \"proxy\""], "splay":true, "splay_coverage":90}`
-	const invalidProxyJSON = `{"splay":true, "splay_coverage":0}`
+	const invalidProxyJSON = `{"splay":true, "splay_coverage":200}`
 	tests := []struct {
 		args           []string
 		useflag        bool


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures we use the default value for splay_coverage if not provided.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1470

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope