### PR TITLE
Resolve panic in sensuctl cluster health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ check requests and use its default value instead.
 - sensu-agent & sensu-backend no longer display help usage and duplicated error
 message on startup failure.
 - `Issued` & `History` are now set on keepalive events.
+- Resolves a potential panic in `sensuctl cluster health`.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -35,7 +35,7 @@ func (s *Store) GetClusterHealth(ctx context.Context) []*types.ClusterHealth {
 			health.Err = cliErr
 			health.Healthy = false
 			healthList = append(healthList, health)
-			continue
+			return healthList
 		}
 		_, getErr := cli.Get(context.Background(), "health")
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Avoids a panic in `sensuctl cluster health` in the event there is an error creating a new client. Discovered when investigating https://github.com/sensu/sensu-go/issues/1928.

## Why is this change necessary?

Panic no good.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nah.