### PR TITLE
Add agent ID and IP address to agentd session logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Added the Sensu edition in sensuctl config view subcommand.
 - List the supported resource types in sensuctl.
+- Added agent ID and IP address to backend session connect/disconnect logs
 
 ### Changed
 - API responses are inspected after each request for the Sensu Edition header.

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -143,12 +143,13 @@ func (a *Agentd) Name() string {
 func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		logger.WithError(err).Error("transport error on websocket upgrade")
+		logger.WithField("addr", r.RemoteAddr).WithError(err).Error("transport error on websocket upgrade")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	cfg := SessionConfig{
+		AgentAddr:     r.RemoteAddr,
 		AgentID:       r.Header.Get(transport.HeaderKeyAgentID),
 		Environment:   r.Header.Get(transport.HeaderKeyEnvironment),
 		Organization:  r.Header.Get(transport.HeaderKeyOrganization),


### PR DESCRIPTION
Signed-off-by: Terrance Kennedy <terrancerkennedy@gmail.com>

## What is this change?

Added information as to which agent is connecting and disconnecting in the agentd session logs in sensu-backend.

Before
```
{"component":"agentd","id":"t-sensu","level":"info","msg":"agent connected","subscriptions":["","entity:t-sensu"],"time":"2018-08-06T17:27:32-06:00"}
{"component":"agentd","level":"warning","msg":"stopping session","recv error":"Connection closed: websocket: close 1001 (going away): bye","session":"91c9cb92-bf1c-49b4-bfa1-e68d99940bf9","time":"2018-08-06T17:27:58-06:00"}
```

After:
```
{"addr":"127.0.0.1:52888","id":"t-sensu","component":"agentd","level":"info","msg":"agent connected","subscriptions":["","entity:t-sensu"],"time":"2018-08-06T17:15:57-06:00"}
{"addr":"127.0.0.1:52888","id":"t-sensu","component":"agentd","level":"warning","msg":"stopping session","recv error":"Connection closed: websocket: close 1001 (going away): bye","time":"2018-08-06T17:16:18-06:00"}
```

## Why is this change necessary?

Closes #1838 

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

N/A


## Were there any complications while making this change?

I also removed the session UUID as it wasn't being used anywhere and was only being logged on session close. We can always add it back, but I'd want a specific reason for having them before doing that.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A
