### PR TITLE
Bump gopsutil to v2.18.07 and wmi to b12b22c

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,11 +29,11 @@
   revision = "5032c8878b9dd46cfe8c625c0d9b9f258a560ee8"
 
 [[projects]]
-  digest = "1:80f75788f4df66bdfb52fe5c7714878b384ec172e9382ae01c809fe25c028e9b"
+  digest = "1:7b5a9a71572ba66376beb658b9309eef17fd8d2b8422fda02e71a395fb4f6dbb"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9f32b5905fd6ce7384093f9d048437e79f7b4d85"
+  revision = "b12b22c5341f0c26d88c4d66176330500e84db68"
 
 [[projects]]
   branch = "master"
@@ -703,7 +703,7 @@
   version = "v3.1.0"
 
 [[projects]]
-  digest = "1:6786113356facb95eafb16f32fc3af40e8dabc8cbf912d98b6d99fa410328509"
+  digest = "1:267c6a4d9d69c5d14f4f233d364a59eaea299ea17b29dfe9be07ce5226c19899"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -714,8 +714,8 @@
     "process",
   ]
   pruneopts = "T"
-  revision = "c95755e4bcd7a62bb8bd33f3a597a7c7f35e2cf3"
-  version = "v2.18.04"
+  revision = "8048a2e9c5773235122027dd585cf821b2af1249"
+  version = "v2.18.07"
 
 [[projects]]
   branch = "master"
@@ -1032,6 +1032,7 @@
     "github.com/coreos/etcd/clientv3",
     "github.com/coreos/etcd/clientv3/concurrency",
     "github.com/coreos/etcd/embed",
+    "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
     "github.com/coreos/etcd/etcdserver/etcdserverpb",
     "github.com/coreos/etcd/mvcc/mvccpb",
     "github.com/coreos/etcd/pkg/fileutil",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,7 +79,7 @@ required = [
 
 [[constraint]]
   name = "github.com/shirou/gopsutil"
-  version = "2.18.4"
+  version = "2.18.7"
 
 [[constraint]]
   name = "github.com/spf13/cobra"
@@ -120,7 +120,7 @@ required = [
 # Locked for Windows
 [[override]]
   name = "github.com/StackExchange/wmi"
-  revision = "9f32b5905fd6ce7384093f9d048437e79f7b4d85"
+  revision = "b12b22c5341f0c26d88c4d66176330500e84db68"
 
 # Locked for Windows
 [[override]]

--- a/vendor/github.com/StackExchange/wmi/README.md
+++ b/vendor/github.com/StackExchange/wmi/README.md
@@ -1,4 +1,6 @@
 wmi
 ===
 
-Package wmi provides a WQL interface for WMI on Windows.
+Package wmi provides a WQL interface to Windows WMI.
+
+Note: It interfaces with WMI on the local machine, therefore it only runs on Windows.

--- a/vendor/github.com/StackExchange/wmi/swbemservices.go
+++ b/vendor/github.com/StackExchange/wmi/swbemservices.go
@@ -77,7 +77,7 @@ func (s *SWbemServices) process(initError chan error) {
 	//fmt.Println("process: starting background thread initialization")
 	//All OLE/WMI calls must happen on the same initialized thead, so lock this goroutine
 	runtime.LockOSThread()
-	defer runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED)
 	if err != nil {

--- a/vendor/github.com/StackExchange/wmi/wmi.go
+++ b/vendor/github.com/StackExchange/wmi/wmi.go
@@ -285,6 +285,10 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 		}
 		defer prop.Clear()
 
+		if prop.Value() == nil {
+			continue
+		}
+
 		switch val := prop.Value().(type) {
 		case int8, int16, int32, int64, int:
 			v := reflect.ValueOf(val).Int()
@@ -370,32 +374,50 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 				}
 			}
 		default:
-			// Only support []string slices for now
-			if f.Kind() == reflect.Slice && f.Type().Elem().Kind() == reflect.String {
-				safeArray := prop.ToArray()
-				if safeArray != nil {
-					arr := safeArray.ToValueArray()
-					fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
-					for i, v := range arr {
-						s := fArr.Index(i)
-						s.SetString(v.(string))
+			if f.Kind() == reflect.Slice {
+				switch f.Type().Elem().Kind() {
+				case reflect.String:
+					safeArray := prop.ToArray()
+					if safeArray != nil {
+						arr := safeArray.ToValueArray()
+						fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+						for i, v := range arr {
+							s := fArr.Index(i)
+							s.SetString(v.(string))
+						}
+						f.Set(fArr)
 					}
-					f.Set(fArr)
+				case reflect.Uint8:
+					safeArray := prop.ToArray()
+					if safeArray != nil {
+						arr := safeArray.ToValueArray()
+						fArr := reflect.MakeSlice(f.Type(), len(arr), len(arr))
+						for i, v := range arr {
+							s := fArr.Index(i)
+							s.SetUint(reflect.ValueOf(v).Uint())
+						}
+						f.Set(fArr)
+					}
+				default:
+					return &ErrFieldMismatch{
+						StructType: of.Type(),
+						FieldName:  n,
+						Reason:     fmt.Sprintf("unsupported slice type (%T)", val),
+					}
+				}
+			} else {
+				typeof := reflect.TypeOf(val)
+				if typeof == nil && (isPtr || c.NonePtrZero) {
+					if (isPtr && c.PtrNil) || (!isPtr && c.NonePtrZero) {
+						of.Set(reflect.Zero(of.Type()))
+					}
 					break
 				}
-			}
-
-			typeof := reflect.TypeOf(val)
-			if typeof == nil && (isPtr || c.NonePtrZero) {
-				if (isPtr && c.PtrNil) || (!isPtr && c.NonePtrZero) {
-					of.Set(reflect.Zero(of.Type()))
+				return &ErrFieldMismatch{
+					StructType: of.Type(),
+					FieldName:  n,
+					Reason:     fmt.Sprintf("unsupported type (%T)", val),
 				}
-				break
-			}
-			return &ErrFieldMismatch{
-				StructType: of.Type(),
-				FieldName:  n,
-				Reason:     fmt.Sprintf("unsupported type (%T)", val),
 			}
 		}
 	}

--- a/vendor/github.com/shirou/gopsutil/README.rst
+++ b/vendor/github.com/shirou/gopsutil/README.rst
@@ -117,6 +117,10 @@ Several methods have been added which are not present in psutil, but will provid
   - VirtualizationSystem  (ex: "LXC")
   - VirtualizationRole    (ex: "guest"/"host")
 
+- IOCounters
+
+  - Label (linux only)    The registered `device mapper name <https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-block-dm>`_
+
 - cpu/CPUInfo()  (linux, freebsd)
 
   - CPU          (ex: 0, 1, ...)

--- a/vendor/github.com/shirou/gopsutil/disk/disk.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk.go
@@ -42,6 +42,7 @@ type IOCountersStat struct {
 	WeightedIO       uint64 `json:"weightedIO"`
 	Name             string `json:"name"`
 	SerialNumber     string `json:"serialNumber"`
+	Label            string `json:"label"`
 }
 
 func (d UsageStat) String() string {

--- a/vendor/github.com/shirou/gopsutil/disk/disk_darwin.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_darwin.go
@@ -23,7 +23,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 		return ret, err
 	}
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MntWait)
+	if _, err = Getfsstat(fs, MntWait); err != nil {
+		return ret, err
+	}
 	for _, stat := range fs {
 		opts := "rw"
 		if stat.Flags&MntReadOnly != 0 {

--- a/vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_freebsd.go
@@ -29,7 +29,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MNT_WAIT)
+	if _, err = Getfsstat(fs, MNT_WAIT); err != nil {
+		return ret, err
+	}
 
 	for _, stat := range fs {
 		opts := "rw"

--- a/vendor/github.com/shirou/gopsutil/disk/disk_linux.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_linux.go
@@ -3,9 +3,11 @@
 package disk
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
+	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -370,6 +372,8 @@ func IOCountersWithContext(ctx context.Context, names ...string) (map[string]IOC
 		d.Name = name
 
 		d.SerialNumber = GetDiskSerialNumber(name)
+		d.Label = GetLabel(name)
+
 		ret[name] = d
 	}
 	return ret, nil
@@ -382,28 +386,55 @@ func GetDiskSerialNumber(name string) string {
 }
 
 func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
-	n := fmt.Sprintf("--name=%s", name)
-	udevadm, err := exec.LookPath("/sbin/udevadm")
+	var stat unix.Stat_t
+	err := unix.Stat(name, &stat)
 	if err != nil {
 		return ""
 	}
+	major := unix.Major(uint64(stat.Rdev))
+	minor := unix.Minor(uint64(stat.Rdev))
 
-	out, err := invoke.CommandWithContext(ctx, udevadm, "info", "--query=property", n)
-
-	// does not return error, just an empty string
-	if err != nil {
-		return ""
-	}
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
-		values := strings.Split(line, "=")
-		if len(values) < 2 || values[0] != "ID_SERIAL" {
-			// only get ID_SERIAL, not ID_SERIAL_SHORT
-			continue
+	// Try to get the serial from udev data
+	udevDataPath := common.HostRun(fmt.Sprintf("udev/data/b%d:%d", major, minor))
+	if udevdata, err := ioutil.ReadFile(udevDataPath); err == nil {
+		scanner := bufio.NewScanner(bytes.NewReader(udevdata))
+		for scanner.Scan() {
+			values := strings.Split(scanner.Text(), "=")
+			if len(values) == 2 && values[0] == "E:ID_SERIAL" {
+				return values[1]
+			}
 		}
-		return values[1]
+	}
+
+	// Try to get the serial from sysfs, look at the disk device (minor 0) directly
+	// because if it is a partition it is not going to contain any device information
+	devicePath := common.HostSys(fmt.Sprintf("dev/block/%d:0/device", major))
+	model, _ := ioutil.ReadFile(filepath.Join(devicePath, "model"))
+	serial, _ := ioutil.ReadFile(filepath.Join(devicePath, "serial"))
+	if len(model) > 0 && len(serial) > 0 {
+		return fmt.Sprintf("%s_%s", string(model), string(serial))
 	}
 	return ""
+}
+
+// GetLabel returns label of given device or empty string on error.
+// Name of device is expected, eg. /dev/sda
+// Supports label based on devicemapper name
+// See https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-block-dm
+func GetLabel(name string) string {
+	// Try label based on devicemapper name
+	dmname_filename := common.HostSys(fmt.Sprintf("block/%s/dm/name", name))
+
+	if !common.PathExists(dmname_filename) {
+		return ""
+	}
+
+	dmname, err := ioutil.ReadFile(dmname_filename)
+	if err != nil {
+		return ""
+	} else {
+		return string(dmname)
+	}
 }
 
 func getFsType(stat unix.Statfs_t) string {

--- a/vendor/github.com/shirou/gopsutil/disk/disk_openbsd.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_openbsd.go
@@ -27,7 +27,9 @@ func PartitionsWithContext(ctx context.Context, all bool) ([]PartitionStat, erro
 	}
 
 	fs := make([]Statfs, count)
-	_, err = Getfsstat(fs, MNT_WAIT)
+	if _, err = Getfsstat(fs, MNT_WAIT); err != nil {
+		return ret, err
+	}
 
 	for _, stat := range fs {
 		opts := "rw"

--- a/vendor/github.com/shirou/gopsutil/disk/disk_unix.go
+++ b/vendor/github.com/shirou/gopsutil/disk/disk_unix.go
@@ -4,6 +4,7 @@ package disk
 
 import (
 	"context"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
@@ -24,7 +25,7 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 	bsize := stat.Bsize
 
 	ret := &UsageStat{
-		Path:        path,
+		Path:        unescapeFstab(path),
 		Fstype:      getFsType(stat),
 		Total:       (uint64(stat.Blocks) * uint64(bsize)),
 		Free:        (uint64(stat.Bavail) * uint64(bsize)),
@@ -46,11 +47,22 @@ func UsageWithContext(ctx context.Context, path string) (*UsageStat, error) {
 		ret.InodesUsedPercent = (float64(ret.InodesUsed) / float64(ret.InodesTotal)) * 100.0
 	}
 
-	if ret.Total == 0 {
+	if (ret.Used + ret.Free) == 0 {
 		ret.UsedPercent = 0
 	} else {
-		ret.UsedPercent = (float64(ret.Used) / float64(ret.Total)) * 100.0
+		// We don't use ret.Total to calculate percent.
+		// see https://github.com/shirou/gopsutil/issues/562
+		ret.UsedPercent = (float64(ret.Used) / float64(ret.Used+ret.Free)) * 100.0
 	}
 
 	return ret, nil
+}
+
+// Unescape escaped octal chars (like space 040, ampersand 046 and backslash 134) to their real value in fstab fields issue#555
+func unescapeFstab(path string) string {
+	escaped, err := strconv.Unquote(`"` + path + `"`)
+	if err != nil {
+		return path
+	}
+	return escaped
 }

--- a/vendor/github.com/shirou/gopsutil/host/host_linux.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_linux.go
@@ -319,6 +319,12 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 		if err == nil {
 			version = getRedhatishVersion(contents)
 		}
+	} else if common.PathExists(common.HostEtc("slackware-version")) {
+		platform = "slackware"
+		contents, err := common.ReadLines(common.HostEtc("slackware-version"))
+		if err == nil {
+			version = getSlackwareVersion(contents)
+		}
 	} else if common.PathExists(common.HostEtc("debian_version")) {
 		if lsb.ID == "Ubuntu" {
 			platform = "ubuntu"
@@ -439,6 +445,12 @@ func KernelVersionWithContext(ctx context.Context) (version string, err error) {
 	}
 
 	return version, nil
+}
+
+func getSlackwareVersion(contents []string) string {
+	c := strings.ToLower(strings.Join(contents, ""))
+	c = strings.Replace(c, "slackware ", "", 1)
+	return c
 }
 
 func getRedhatishVersion(contents []string) string {

--- a/vendor/github.com/shirou/gopsutil/host/host_windows.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_windows.go
@@ -5,10 +5,12 @@ package host
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -20,15 +22,31 @@ import (
 
 var (
 	procGetSystemTimeAsFileTime = common.Modkernel32.NewProc("GetSystemTimeAsFileTime")
-	osInfo                      *Win32_OperatingSystem
+	procGetTickCount32          = common.Modkernel32.NewProc("GetTickCount")
+	procGetTickCount64          = common.Modkernel32.NewProc("GetTickCount64")
+	procRtlGetVersion           = common.ModNt.NewProc("RtlGetVersion")
 )
 
-type Win32_OperatingSystem struct {
-	Version        string
-	Caption        string
-	ProductType    uint32
-	BuildNumber    string
-	LastBootUpTime time.Time
+// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/ns-wdm-_osversioninfoexw
+type osVersionInfoExW struct {
+	dwOSVersionInfoSize uint32
+	dwMajorVersion      uint32
+	dwMinorVersion      uint32
+	dwBuildNumber       uint32
+	dwPlatformId        uint32
+	szCSDVersion        [128]uint16
+	wServicePackMajor   uint16
+	wServicePackMinor   uint16
+	wSuiteMask          uint16
+	wProductType        uint8
+	wReserved           uint8
+}
+
+type msAcpi_ThermalZoneTemperature struct {
+	Active             bool
+	CriticalTripPoint  uint32
+	CurrentTemperature uint32
+	InstanceName       string
 }
 
 func Info() (*InfoStat, error) {
@@ -84,6 +102,8 @@ func InfoWithContext(ctx context.Context) (*InfoStat, error) {
 }
 
 func getMachineGuid() (string, error) {
+	// there has been reports of issues on 32bit using golang.org/x/sys/windows/registry, see https://github.com/shirou/gopsutil/pull/312#issuecomment-277422612
+	// for rationale of using windows.RegOpenKeyEx/RegQueryValueEx instead of registry.OpenKey/GetStringValue
 	var h windows.Handle
 	err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, windows.StringToUTF16Ptr(`SOFTWARE\Microsoft\Cryptography`), 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &h)
 	if err != nil {
@@ -111,40 +131,24 @@ func getMachineGuid() (string, error) {
 	return hostID, nil
 }
 
-func GetOSInfo() (Win32_OperatingSystem, error) {
-	return GetOSInfoWithContext(context.Background())
-}
-
-func GetOSInfoWithContext(ctx context.Context) (Win32_OperatingSystem, error) {
-	var dst []Win32_OperatingSystem
-	q := wmi.CreateQuery(&dst, "")
-	err := common.WMIQueryWithContext(ctx, q, &dst)
-	if err != nil {
-		return Win32_OperatingSystem{}, err
-	}
-
-	osInfo = &dst[0]
-
-	return dst[0], nil
-}
-
 func Uptime() (uint64, error) {
 	return UptimeWithContext(context.Background())
 }
 
 func UptimeWithContext(ctx context.Context) (uint64, error) {
-	if osInfo == nil {
-		_, err := GetOSInfoWithContext(ctx)
-		if err != nil {
-			return 0, err
-		}
+	procGetTickCount := procGetTickCount64
+	err := procGetTickCount64.Find()
+	if err != nil {
+		procGetTickCount = procGetTickCount32 // handle WinXP, but keep in mind that "the time will wrap around to zero if the system is run continuously for 49.7 days." from MSDN
 	}
-	now := time.Now()
-	t := osInfo.LastBootUpTime.Local()
-	return uint64(now.Sub(t).Seconds()), nil
+	r1, _, lastErr := syscall.Syscall(procGetTickCount.Addr(), 0, 0, 0, 0)
+	if lastErr != 0 {
+		return 0, lastErr
+	}
+	return uint64((time.Duration(r1) * time.Millisecond).Seconds()), nil
 }
 
-func bootTime(up uint64) uint64 {
+func bootTimeFromUptime(up uint64) uint64 {
 	return uint64(time.Now().Unix()) - up
 }
 
@@ -164,7 +168,7 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	t = bootTime(up)
+	t = bootTimeFromUptime(up)
 	atomic.StoreUint64(&cachedBootTime, t)
 	return t, nil
 }
@@ -174,18 +178,50 @@ func PlatformInformation() (platform string, family string, version string, err 
 }
 
 func PlatformInformationWithContext(ctx context.Context) (platform string, family string, version string, err error) {
-	if osInfo == nil {
-		_, err = GetOSInfoWithContext(ctx)
-		if err != nil {
-			return
-		}
+	// GetVersionEx lies on Windows 8.1 and returns as Windows 8 if we don't declare compatibility in manifest
+	// RtlGetVersion bypasses this lying layer and returns the true Windows version
+	// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/nf-wdm-rtlgetversion
+	// https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/wdm/ns-wdm-_osversioninfoexw
+	var osInfo osVersionInfoExW
+	osInfo.dwOSVersionInfoSize = uint32(unsafe.Sizeof(osInfo))
+	ret, _, err := procRtlGetVersion.Call(uintptr(unsafe.Pointer(&osInfo)))
+	if ret != 0 {
+		return
 	}
 
 	// Platform
-	platform = strings.Trim(osInfo.Caption, " ")
+	var h windows.Handle // like getMachineGuid(), we query the registry using the raw windows.RegOpenKeyEx/RegQueryValueEx
+	err = windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, windows.StringToUTF16Ptr(`SOFTWARE\Microsoft\Windows NT\CurrentVersion`), 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &h)
+	if err != nil {
+		return
+	}
+	defer windows.RegCloseKey(h)
+	var bufLen uint32
+	var valType uint32
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`ProductName`), nil, &valType, nil, &bufLen)
+	if err != nil {
+		return
+	}
+	regBuf := make([]uint16, bufLen/2+1)
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`ProductName`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+	if err != nil {
+		return
+	}
+	platform = windows.UTF16ToString(regBuf[:])
+	if !strings.HasPrefix(platform, "Microsoft") {
+		platform = "Microsoft " + platform
+	}
+	err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`CSDVersion`), nil, &valType, nil, &bufLen) // append Service Pack number, only on success
+	if err == nil {                                                                                       // don't return an error if only the Service Pack retrieval fails
+		regBuf = make([]uint16, bufLen/2+1)
+		err = windows.RegQueryValueEx(h, windows.StringToUTF16Ptr(`CSDVersion`), nil, &valType, (*byte)(unsafe.Pointer(&regBuf[0])), &bufLen)
+		if err == nil {
+			platform += " " + windows.UTF16ToString(regBuf[:])
+		}
+	}
 
 	// PlatformFamily
-	switch osInfo.ProductType {
+	switch osInfo.wProductType {
 	case 1:
 		family = "Standalone Workstation"
 	case 2:
@@ -195,9 +231,9 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 	}
 
 	// Platform Version
-	version = fmt.Sprintf("%s Build %s", osInfo.Version, osInfo.BuildNumber)
+	version = fmt.Sprintf("%d.%d.%d Build %d", osInfo.dwMajorVersion, osInfo.dwMinorVersion, osInfo.dwBuildNumber, osInfo.dwBuildNumber)
 
-	return
+	return platform, family, version, nil
 }
 
 func Users() ([]UserStat, error) {
@@ -215,7 +251,30 @@ func SensorsTemperatures() ([]TemperatureStat, error) {
 }
 
 func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, error) {
-	return []TemperatureStat{}, common.ErrNotImplementedError
+	var ret []TemperatureStat
+	var dst []msAcpi_ThermalZoneTemperature
+	q := wmi.CreateQuery(&dst, "")
+	if err := common.WMIQueryWithContext(ctx, q, &dst, nil, "root/wmi"); err != nil {
+		return ret, err
+	}
+
+	for _, v := range dst {
+		ts := TemperatureStat{
+			SensorKey:   v.InstanceName,
+			Temperature: kelvinToCelsius(v.CurrentTemperature, 2),
+		}
+		ret = append(ret, ts)
+	}
+
+	return ret, nil
+}
+
+func kelvinToCelsius(temp uint32, n int) float64 {
+	// wmi return temperature Kelvin * 10, so need to divide the result by 10,
+	// and then minus 273.15 to get °Celsius.
+	t := float64(temp/10) - 273.15
+	n10 := math.Pow10(n)
+	return math.Trunc((t+0.5/n10)*n10) / n10
 }
 
 func Virtualization() (string, string, error) {

--- a/vendor/github.com/shirou/gopsutil/internal/common/common.go
+++ b/vendor/github.com/shirou/gopsutil/internal/common/common.go
@@ -328,6 +328,10 @@ func HostVar(combineWith ...string) string {
 	return GetEnv("HOST_VAR", "/var", combineWith...)
 }
 
+func HostRun(combineWith ...string) string {
+	return GetEnv("HOST_RUN", "/run", combineWith...)
+}
+
 // https://gist.github.com/kylelemons/1525278
 func Pipeline(cmds ...*exec.Cmd) ([]byte, []byte, error) {
 	// Require at least one command

--- a/vendor/github.com/shirou/gopsutil/mem/mem.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem.go
@@ -46,17 +46,30 @@ type VirtualMemoryStat struct {
 	// https://www.centos.org/docs/5/html/5.1/Deployment_Guide/s2-proc-meminfo.html
 	// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 	// https://www.kernel.org/doc/Documentation/vm/overcommit-accounting
-	Buffers      uint64 `json:"buffers"`
-	Cached       uint64 `json:"cached"`
-	Writeback    uint64 `json:"writeback"`
-	Dirty        uint64 `json:"dirty"`
-	WritebackTmp uint64 `json:"writebacktmp"`
-	Shared       uint64 `json:"shared"`
-	Slab         uint64 `json:"slab"`
-	PageTables   uint64 `json:"pagetables"`
-	SwapCached   uint64 `json:"swapcached"`
-	CommitLimit  uint64 `json:"commitlimit"`
-	CommittedAS  uint64 `json:"committedas"`
+	Buffers        uint64 `json:"buffers"`
+	Cached         uint64 `json:"cached"`
+	Writeback      uint64 `json:"writeback"`
+	Dirty          uint64 `json:"dirty"`
+	WritebackTmp   uint64 `json:"writebacktmp"`
+	Shared         uint64 `json:"shared"`
+	Slab           uint64 `json:"slab"`
+	PageTables     uint64 `json:"pagetables"`
+	SwapCached     uint64 `json:"swapcached"`
+	CommitLimit    uint64 `json:"commitlimit"`
+	CommittedAS    uint64 `json:"committedas"`
+	HighTotal      uint64 `json:"hightotal"`
+	HighFree       uint64 `json:"highfree"`
+	LowTotal       uint64 `json:"lowtotal"`
+	LowFree        uint64 `json:"lowfree"`
+	SwapTotal      uint64 `json:"swaptotal"`
+	SwapFree       uint64 `json:"swapfree"`
+	Mapped         uint64 `json:"mapped"`
+	VMallocTotal   uint64 `json:"vmalloctotal"`
+	VMallocUsed    uint64 `json:"vmallocused"`
+	VMallocChunk   uint64 `json:"vmallocchunk"`
+	HugePagesTotal uint64 `json:"hugepagestotal"`
+	HugePagesFree  uint64 `json:"hugepagesfree"`
+	HugePageSize   uint64 `json:"hugepagesize"`
 }
 
 type SwapMemoryStat struct {

--- a/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_linux.go
@@ -69,6 +69,32 @@ func VirtualMemoryWithContext(ctx context.Context) (*VirtualMemoryStat, error) {
 			ret.CommitLimit = t * 1024
 		case "Committed_AS":
 			ret.CommittedAS = t * 1024
+		case "HighTotal":
+			ret.HighTotal = t * 1024
+		case "HighFree":
+			ret.HighFree = t * 1024
+		case "LowTotal":
+			ret.LowTotal = t * 1024
+		case "LowFree":
+			ret.LowFree = t * 1024
+		case "SwapTotal":
+			ret.SwapTotal = t * 1024
+		case "SwapFree":
+			ret.SwapFree = t * 1024
+		case "Mapped":
+			ret.Mapped = t * 1024
+		case "VmallocTotal":
+			ret.VMallocTotal = t * 1024
+		case "VmallocUsed":
+			ret.VMallocUsed = t * 1024
+		case "VmallocChunk":
+			ret.VMallocChunk = t * 1024
+		case "HugePages_Total":
+			ret.HugePagesTotal = t
+		case "HugePages_Free":
+			ret.HugePagesFree = t
+		case "Hugepagesize":
+			ret.HugePageSize = t * 1024
 		}
 	}
 	if !memavail {

--- a/vendor/github.com/shirou/gopsutil/mem/mem_windows.go
+++ b/vendor/github.com/shirou/gopsutil/mem/mem_windows.go
@@ -80,11 +80,17 @@ func SwapMemoryWithContext(ctx context.Context) (*SwapMemoryStat, error) {
 	tot := perfInfo.commitLimit * perfInfo.pageSize
 	used := perfInfo.commitTotal * perfInfo.pageSize
 	free := tot - used
+	var usedPercent float64
+	if tot == 0 {
+		usedPercent = 0
+	} else {
+		usedPercent = float64(used) / float64(tot)
+	}
 	ret := &SwapMemoryStat{
 		Total:       tot,
 		Used:        used,
 		Free:        free,
-		UsedPercent: float64(used) / float64(tot),
+		UsedPercent: usedPercent,
 	}
 
 	return ret, nil

--- a/vendor/github.com/shirou/gopsutil/net/net.go
+++ b/vendor/github.com/shirou/gopsutil/net/net.go
@@ -71,6 +71,7 @@ type FilterStat struct {
 }
 
 var constMap = map[string]int{
+	"unix": syscall.AF_UNIX,
 	"TCP":  syscall.SOCK_STREAM,
 	"UDP":  syscall.SOCK_DGRAM,
 	"IPv4": syscall.AF_INET,
@@ -178,8 +179,13 @@ func getIOCountersAll(n []IOCountersStat) ([]IOCountersStat, error) {
 
 func parseNetLine(line string) (ConnectionStat, error) {
 	f := strings.Fields(line)
-	if len(f) < 9 {
+	if len(f) < 8 {
 		return ConnectionStat{}, fmt.Errorf("wrong line,%s", line)
+	}
+
+	if len(f) == 8 {
+		f = append(f, f[7])
+		f[7] = "unix"
 	}
 
 	pid, err := strconv.Atoi(f[1])
@@ -199,9 +205,14 @@ func parseNetLine(line string) (ConnectionStat, error) {
 		return ConnectionStat{}, fmt.Errorf("unknown type, %s", f[7])
 	}
 
-	laddr, raddr, err := parseNetAddr(f[8])
-	if err != nil {
-		return ConnectionStat{}, fmt.Errorf("failed to parse netaddr, %s", f[8])
+	var laddr, raddr Addr
+	if f[7] == "unix" {
+		laddr.IP = f[8]
+	} else {
+		laddr, raddr, err = parseNetAddr(f[8])
+		if err != nil {
+			return ConnectionStat{}, fmt.Errorf("failed to parse netaddr, %s", f[8])
+		}
 	}
 
 	n := ConnectionStat{

--- a/vendor/github.com/shirou/gopsutil/net/net_unix.go
+++ b/vendor/github.com/shirou/gopsutil/net/net_unix.go
@@ -63,7 +63,7 @@ func ConnectionsPidWithContext(ctx context.Context, kind string, pid int32) ([]C
 	case "udp6":
 		args = append(args, "6udp")
 	case "unix":
-		return ret, common.ErrNotImplementedError
+		args = []string{"-U"}
 	}
 
 	r, err := common.CallLsofWithContext(ctx, invoke, pid, args...)

--- a/vendor/github.com/shirou/gopsutil/process/process_fallback.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_fallback.go
@@ -36,6 +36,14 @@ func PidsWithContext(ctx context.Context) ([]int32, error) {
 	return []int32{}, common.ErrNotImplementedError
 }
 
+func Processes() ([]*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+
+func ProcessesWithContext(ctx context.Context) ([]*Process, error) {
+	return nil, common.ErrNotImplementedError
+}
+
 func NewProcess(pid int32) (*Process, error) {
 	return nil, common.ErrNotImplementedError
 }

--- a/vendor/github.com/shirou/gopsutil/process/process_linux.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_linux.go
@@ -985,6 +985,8 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 					extendedName := filepath.Base(cmdlineSlice[0])
 					if strings.HasPrefix(extendedName, p.name) {
 						p.name = extendedName
+					} else {
+						p.name = cmdlineSlice[0]
 					}
 				}
 			}
@@ -1175,6 +1177,9 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 	createTime := int64(ctime * 1000)
 
 	rtpriority, err := strconv.ParseInt(fields[i+16], 10, 32)
+	if err != nil {
+		return 0, 0, nil, 0, 0, 0, err
+	}
 	if rtpriority < 0 {
 		rtpriority = rtpriority*-1 - 1
 	} else {

--- a/vendor/github.com/shirou/gopsutil/process/process_posix.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_posix.go
@@ -26,6 +26,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	defer d.Close()
 
 	devnames, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
 	for _, devname := range devnames {
 		if strings.HasPrefix(devname, "/dev/tty") {
 			termfiles = append(termfiles, "/dev/tty/"+devname)
@@ -45,6 +48,9 @@ func getTerminalMap() (map[uint64]string, error) {
 	if ptsnames == nil {
 		defer ptsd.Close()
 		ptsnames, err = ptsd.Readdirnames(-1)
+		if err != nil {
+			return nil, err
+		}
 		for _, ptsname := range ptsnames {
 			termfiles = append(termfiles, "/dev/pts/"+ptsname)
 		}

--- a/vendor/github.com/shirou/gopsutil/process/process_windows.go
+++ b/vendor/github.com/shirou/gopsutil/process/process_windows.go
@@ -236,12 +236,12 @@ func (p *Process) Parent() (*Process, error) {
 }
 
 func (p *Process) ParentWithContext(ctx context.Context) (*Process, error) {
-	dst, err := GetWin32Proc(p.Pid)
+	ppid, err := p.PpidWithContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get ParentProcessID: %s", err)
 	}
 
-	return NewProcess(int32(dst[0].ParentProcessID))
+	return NewProcess(ppid)
 }
 func (p *Process) Status() (string, error) {
 	return p.StatusWithContext(context.Background())
@@ -270,6 +270,9 @@ func (p *Process) UsernameWithContext(ctx context.Context) (string, error) {
 	}
 	defer token.Close()
 	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
 
 	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
 	return domain + "\\" + user, err
@@ -300,7 +303,7 @@ func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
 	return "", common.ErrNotImplementedError
 }
 
-// Nice returnes priority in Windows
+// Nice returns priority in Windows
 func (p *Process) Nice() (int32, error) {
 	return p.NiceWithContext(context.Background())
 }


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Bumps `gopsutil` to `v2.18.07` and updates `wmi` to the `b12b22c` SHA.

## Why is this change necessary?

An attempt to solve the `wmi` timeout we're hitting in https://github.com/sensu/sensu-go/issues/1829.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A