### PR TITLE
Fixup redirect loop encountered when backend is missing dashboard

### DIFF
--- a/dashboard/fallback.go
+++ b/dashboard/fallback.go
@@ -13,24 +13,35 @@ type fallbackFS struct {
 }
 
 func (f *fallbackFS) Open(path string) (http.File, error) {
+	if len(path) == 0 || path == "/" {
+		info := fallbackFileInfo{name: ".", body: []byte(f.msg), isDir: true}
+		dir := fallbackFile{&info, bytes.NewReader(info.body)}
+		return &dir, nil
+	}
+
 	info := fallbackFileInfo{name: path, body: []byte(f.msg)}
 	file := fallbackFile{&info, bytes.NewReader(info.body)}
 	return &file, nil
 }
 
 type fallbackFileInfo struct {
-	name string
-	body []byte
+	name  string
+	body  []byte
+	isDir bool
 }
 
 func (f *fallbackFileInfo) Name() string               { return f.name }
 func (f *fallbackFileInfo) Size() int64                { return int64(len(f.body)) }
 func (f *fallbackFileInfo) Mode() os.FileMode          { return 0444 }
 func (f *fallbackFileInfo) ModTime() time.Time         { return time.Now() }
-func (f *fallbackFileInfo) IsDir() bool                { return false }
+func (f *fallbackFileInfo) IsDir() bool                { return f.isDir }
 func (f *fallbackFileInfo) Sys() interface{}           { return nil }
 func (f *fallbackFileInfo) Stat() (os.FileInfo, error) { return f, nil }
 func (f *fallbackFileInfo) Readdir(count int) ([]os.FileInfo, error) {
+	if f.isDir {
+		newFile := fallbackFileInfo{name: "index.html", body: f.body}
+		return []os.FileInfo{&newFile}, nil
+	}
 	return nil, fmt.Errorf("cannot Readdir from file %s", f.name)
 }
 


### PR DESCRIPTION
## What is this change?

Eliminates redirect loop encountered when backend is missing dashboard and user attempts to navigate to the root path.

## Why is this change necessary?

Closes #1908 

## Does your change need a Changelog entry?

Primarily DX related so it's unlikely.

## Do you need clarification on anything?

nada

## Were there any complications while making this change?

nada

## Have you reviewed and updated the documentation for this change? Is new documentation required?

nada