### PR TITLE
Re-work queue to support one-to-many messaging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ message on startup failure.
 - Resolves a potential panic in `sensuctl cluster health`.
 - Fixed a bug in InfluxDB metric parsing. The timestamp is now optional and
 compliant with InfluxDB line protocol.
+- Fixed an issue where adhoc checks would not be issued to all agents in a
+clustered installation.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -103,11 +103,11 @@ func Initialize(config *Config) (*Backend, error) {
 	}
 
 	// Initialize an etcd getter
-	queueGetter := queue.EtcdGetter{Client: client}
+	queueGetter := queue.EtcdGetter{Client: client, BackendID: e.BackendID()}
 
 	// Initialize the bus
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
-		RingGetter: ring.EtcdGetter{Client: client},
+		RingGetter: ring.EtcdGetter{Client: client, BackendID: e.BackendID()},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", bus.Name(), err.Error())

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -112,6 +112,11 @@ type Etcd struct {
 	loopbackURL string
 }
 
+// BackendID returns the ID of the etcd cluster member
+func (e *Etcd) BackendID() (result string) {
+	return e.etcd.Server.ID().String()
+}
+
 // NewEtcd returns a new, configured, and running Etcd. The running Etcd will
 // panic on error. The calling goroutine should recover() from the panic and
 // shutdown accordingly. Callers must also ensure that the running Etcd is

--- a/backend/etcd/sequence.go
+++ b/backend/etcd/sequence.go
@@ -1,0 +1,76 @@
+package etcd
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+var initialItemKey []byte
+
+func init() {
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, uint64(0)); err != nil {
+		// Should never happen
+		panic(err)
+	}
+	initialItemKey = buf.Bytes()
+}
+
+// Sequence provides an incrementing sequence ID. The ID is a big-endian
+// encoded uint64 value that starts at 0.
+//
+// If the key provided does not contain a sequence yet, one is created and
+// incremented to 1. If the sequence already exists, then the next ID in the
+// sequence will be returned.
+//
+// Because sequence IDs are big-endian encoded strings, they can be ordered
+// with lexicographic sorting. This makes them a useful key for ordered
+// collections.
+//
+// Sequence is not transactional, but is safe to use concurrently. If two
+// clients are both using Sequence on the same key, they will race to be the
+// one who updates the sequence. The loser of the race will execute the routine
+// again.
+func Sequence(kv clientv3.KV, key string) (result string, err error) {
+	// Get the current key, or initialize it to be the first item key
+	exists := clientv3.Compare(clientv3.Value(key), ">", string(initialItemKey))
+	put := clientv3.OpPut(key, string(initialItemKey))
+	get := clientv3.OpGet(key)
+
+	resp, err := kv.Txn(context.Background()).If(exists).Then(get).Else(put, get).Commit()
+	if err != nil {
+		return "", fmt.Errorf("sequence error: %s", err)
+	}
+
+	respIdx := len(resp.Responses) - 1
+	value := resp.Responses[respIdx].GetResponseRange().Kvs[0].Value
+
+	// decode the key into an integer
+	var n uint64
+	if err := binary.Read(bytes.NewReader(value), binary.BigEndian, &n); err != nil {
+		return "", fmt.Errorf("sequence error: %s", err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	if err := binary.Write(buf, binary.BigEndian, n+1); err != nil {
+		return "", fmt.Errorf("sequence error: %s", err)
+	}
+
+	notModified := clientv3.Compare(clientv3.Value(key), "=", string(value))
+	put = clientv3.OpPut(key, buf.String())
+
+	resp, err = kv.Txn(context.Background()).If(notModified).Then(put).Commit()
+	if err != nil {
+		return "", fmt.Errorf("sequence error: %s", err)
+	}
+	if !resp.Succeeded {
+		return Sequence(kv, key)
+	}
+
+	return buf.String(), nil
+}

--- a/backend/etcd/sequence_test.go
+++ b/backend/etcd/sequence_test.go
@@ -1,0 +1,47 @@
+//+build integration
+
+package etcd
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// this is little more than a smoke test, it could use improvement
+func TestSequence(t *testing.T) {
+	e, cleanup := NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seqA, err := Sequence(client, "/sensu.io/foobars/seq")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seqB, err := Sequence(client, "/sensu.io/foobars/seq")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var n1, n2 uint64
+	if err := binary.Read(strings.NewReader(seqA), binary.BigEndian, &n1); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := n1, uint64(1); got != want {
+		t.Errorf("bad id: got %d, want %d", got, want)
+	}
+
+	if err := binary.Read(strings.NewReader(seqB), binary.BigEndian, &n2); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := n2, uint64(2); got != want {
+		t.Errorf("bad id: got %d, want %d", got, want)
+	}
+}

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -4,15 +4,24 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
+
+type QueueClient interface {
+	clientv3.KV
+	clientv3.Cluster
+	clientv3.Watcher
+}
 
 const (
 	queuePrefix     = "queue"
@@ -27,12 +36,13 @@ var (
 
 // EtcdGetter provides access to the etcd client for creating a new queue.
 type EtcdGetter struct {
-	Client *clientv3.Client
+	Client    *clientv3.Client
+	BackendID string
 }
 
 // GetQueue gets a new Queue.
 func (e EtcdGetter) GetQueue(path ...string) types.Queue {
-	return New(queueKeyBuilder.Build(path...), e.Client)
+	return New(queueKeyBuilder.Build(path...), e.Client, e.BackendID)
 }
 
 // Queue is a durable FIFO queue that is backed by etcd.
@@ -41,21 +51,31 @@ func (e EtcdGetter) GetQueue(path ...string) types.Queue {
 // until it is acked by the client, or returned to the work queue in case the
 // client nacks it or times out.
 type Queue struct {
-	client      *clientv3.Client
-	work        string
-	inFlight    string
 	kv          clientv3.KV
+	cluster     clientv3.Cluster
+	watcher     clientv3.Watcher
 	itemTimeout time.Duration
+	name        string
+	backendID   string
+}
+
+func (q *Queue) workPrefix() string {
+	return path.Join(q.name, q.backendID, workPostfix)
+}
+
+func (q *Queue) inFlightPrefix() string {
+	return path.Join(q.name, q.backendID, inFlightPostfix)
 }
 
 // New returns an instance of Queue.
-func New(name string, client *clientv3.Client) *Queue {
+func New(name string, client QueueClient, backendID string) *Queue {
 	queue := &Queue{
-		client:      client,
-		work:        path.Join(name, workPostfix),
-		inFlight:    path.Join(name, inFlightPostfix),
-		kv:          clientv3.NewKV(client),
+		name:        name,
+		kv:          client,
+		cluster:     client,
+		watcher:     client,
 		itemTimeout: itemTimeout,
+		backendID:   backendID,
 	}
 	return queue
 }
@@ -84,7 +104,7 @@ func (i *Item) Ack(ctx context.Context) error {
 	i.once.Do(func() {
 		i.mu.Lock()
 		delCmp := clientv3.Compare(clientv3.ModRevision(i.key), "=", i.revision)
-		delReq := clientv3.OpDelete(i.value)
+		delReq := clientv3.OpDelete(i.key)
 		_, err = i.queue.kv.Txn(ctx).If(delCmp).Then(delReq).Commit()
 		i.mu.Unlock()
 		i.cancel()
@@ -98,7 +118,7 @@ func (i *Item) Nack(ctx context.Context) error {
 	var err error
 	i.once.Do(func() {
 		i.mu.Lock()
-		err = i.queue.swapLane(ctx, i.key, i.revision, i.value, i.queue.work)
+		err = i.queue.swapLane(ctx, i.key, i.revision, i.value, i.queue.workPrefix())
 		i.mu.Unlock()
 		i.cancel()
 	})
@@ -115,11 +135,12 @@ func (i *Item) keepalive(ctx context.Context) {
 			select {
 			case <-ticker.C:
 				// create new key with new timestamp
-				uName, err := i.queue.uniqueName()
+				seq, err := i.queue.timeStamp()
 				if err != nil {
 					logger.WithError(err).Error("error creating unique name for item keepalive")
+					return
 				}
-				updateKey := path.Join(i.queue.inFlight, uName)
+				updateKey := path.Join(i.queue.inFlightPrefix(), seq)
 
 				i.mu.Lock()
 				// create new key, delete old key
@@ -132,7 +153,11 @@ func (i *Item) keepalive(ctx context.Context) {
 
 				if err != nil {
 					// log error
-					logger.WithError(err).Error("error updating item keepalive timestamp")
+					if err != context.Canceled {
+						logger.WithError(err).Error("error updating item keepalive timestamp")
+					}
+					i.mu.Unlock()
+					return
 				}
 
 				i.key = updateKey
@@ -144,14 +169,15 @@ func (i *Item) keepalive(ctx context.Context) {
 	}()
 }
 
+// swapLane swaps a key/value pair from one place to another
 func (q *Queue) swapLane(ctx context.Context, currentKey string, currentRevision int64, value string, lane string) error {
-	uName, err := q.uniqueName()
-	if err != nil {
-		return err
-	}
-	uKey := path.Join(lane, uName)
-
 	for {
+		seq, err := q.timeStamp()
+		if err != nil {
+			return fmt.Errorf("queue error: %s", err)
+		}
+		uKey := path.Join(lane, seq)
+
 		putCmp := clientv3.Compare(clientv3.ModRevision(uKey), "=", 0)
 		delCmp := clientv3.Compare(clientv3.ModRevision(currentKey), "=", currentRevision)
 		putReq := clientv3.OpPut(uKey, value)
@@ -171,24 +197,22 @@ func (q *Queue) swapLane(ctx context.Context, currentKey string, currentRevision
 // Enqueue adds a new value to the queue. It returns an error if the context is
 // canceled, the deadline exceeded, or if the client encounters an error.
 func (q *Queue) Enqueue(ctx context.Context, value string) error {
-	return q.tryPut(ctx, value)
-}
-
-func (q *Queue) tryPut(ctx context.Context, value string) error {
+	resp, err := q.cluster.MemberList(ctx)
+	if err != nil {
+		return fmt.Errorf("queue: couldn't enqueue item: %s", err)
+	}
+	if err := q.cleanup(ctx, resp.Members); err != nil {
+		return fmt.Errorf("queue: couldn't enqueue item: %s", err)
+	}
+	cmps, ops, err := q.enqueueOps(resp.Members, value)
+	if err != nil {
+		return fmt.Errorf("queue: couldn't enqueue item: %s", err)
+	}
 	for {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return fmt.Errorf("queue: couldn't enqueue item: %s", ctx.Err())
 		}
-
-		un, err := q.uniqueName()
-		if err != nil {
-			return err
-		}
-
-		key := path.Join(q.work, un)
-		cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
-		req := clientv3.OpPut(key, value)
-		response, err := q.kv.Txn(ctx).If(cmp).Then(req).Commit()
+		response, err := q.kv.Txn(ctx).If(cmps...).Then(ops...).Commit()
 		if err == nil && response.Succeeded {
 			return nil
 		}
@@ -198,13 +222,48 @@ func (q *Queue) tryPut(ctx context.Context, value string) error {
 	}
 }
 
-func (q *Queue) uniqueName() (string, error) {
-	now := time.Now().UnixNano()
-	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.BigEndian, now); err != nil {
-		return "", err
+// cleanup stale queue entries belonging to backends that no longer exist
+func (q *Queue) cleanup(ctx context.Context, members []*etcdserverpb.Member) error {
+	memberSet := make(map[string]struct{})
+	for _, member := range members {
+		memberSet[fmt.Sprintf("%x", member.ID)] = struct{}{}
 	}
-	return buf.String(), nil
+	resp, err := q.kv.Get(ctx, q.name, clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+	ops := []clientv3.Op{}
+	for _, kv := range resp.Kvs {
+		// Look for backends that are not present anymore in the member list
+		key := string(kv.Key)
+		parts := strings.Split(key, "/")
+		backendID := parts[len(parts)-3]
+		if _, ok := memberSet[backendID]; !ok {
+			ops = append(ops, clientv3.OpDelete(key))
+		}
+	}
+	_, err = q.kv.Txn(ctx).If().Then(ops...).Commit()
+	return err
+}
+
+func (q *Queue) enqueueOps(members []*etcdserverpb.Member, value string) ([]clientv3.Cmp, []clientv3.Op, error) {
+	cmps := []clientv3.Cmp{}
+	ops := []clientv3.Op{}
+
+	for _, m := range members {
+		backendID := fmt.Sprintf("%x", m.ID)
+		seq, err := q.timeStamp()
+		if err != nil {
+			return nil, nil, fmt.Errorf("queue error: %s", err)
+		}
+		workKey := path.Join(q.name, backendID, workPostfix, seq)
+		cmp := clientv3.Compare(clientv3.ModRevision(workKey), "=", 0)
+		op := clientv3.OpPut(workKey, value)
+		cmps = append(cmps, cmp)
+		ops = append(ops, op)
+	}
+
+	return cmps, ops, nil
 }
 
 // Dequeue gets a value from the queue. It returns an error if the context
@@ -215,21 +274,20 @@ func (q *Queue) Dequeue(ctx context.Context) (types.QueueItem, error) {
 		return nil, err
 	}
 
-	response, err := q.client.Get(ctx, q.work, clientv3.WithFirstKey()...)
+	response, err := q.kv.Get(ctx, q.workPrefix(), clientv3.WithFirstKey()...)
 	if err != nil {
 		return nil, err
 	}
-	if len(response.Kvs) > 0 {
-		item, err := q.tryDelete(ctx, response.Kvs[0])
+
+	for _, kv := range response.Kvs {
+		item, err := q.tryDelete(ctx, kv)
 		if err != nil {
 			return nil, err
 		}
 		if item != nil {
 			return item, nil
 		}
-	}
-	if response.More {
-		// Need to retry, we are promised that there will be more.
+		// no item - we lost the race to another consumer
 		return q.Dequeue(ctx)
 	}
 
@@ -264,10 +322,11 @@ func (q *Queue) getItemTimestamp(key []byte) (time.Time, error) {
 
 func (q *Queue) nackExpiredItems(ctx context.Context, timeout time.Duration) error {
 	// get all items in the inflight queue
-	inFlightItems, err := q.client.Get(ctx, q.inFlight, clientv3.WithPrefix())
+	inFlightItems, err := q.kv.Get(ctx, q.inFlightPrefix(), clientv3.WithPrefix())
 	if err != nil {
 		return err
 	}
+
 	// get the timestamp from each key
 	for _, item := range inFlightItems.Kvs {
 		itemTimestamp, err := q.getItemTimestamp(item.Key)
@@ -277,8 +336,7 @@ func (q *Queue) nackExpiredItems(ctx context.Context, timeout time.Duration) err
 		// If the item has timed out or the client has disconnected, the item is
 		// considered expired and should be moved back to the work queue.
 		if time.Since(itemTimestamp) > timeout || ctx.Err() != nil {
-
-			err = q.swapLane(ctx, string(item.Key), item.ModRevision, string(item.Value), q.work)
+			err = q.swapLane(ctx, string(item.Key), item.ModRevision, string(item.Value), q.workPrefix())
 			if err != nil {
 				return err
 			}
@@ -291,14 +349,14 @@ func (q *Queue) tryDelete(ctx context.Context, kv *mvccpb.KeyValue) (types.Queue
 	key := string(kv.Key)
 
 	// generate a new key name
-	uName, err := q.uniqueName()
+	seq, err := q.timeStamp()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error deleting queue item: %s", err)
 	}
-	uKey := path.Join(q.inFlight, uName)
+	uKey := path.Join(q.inFlightPrefix(), seq)
 
-	delCmp := clientv3.Compare(clientv3.ModRevision(key), "=", kv.ModRevision)
-	putCmp := clientv3.Compare(clientv3.ModRevision(uKey), "=", 0)
+	delCmp := clientv3.Compare(clientv3.Version(key), ">", 0)
+	putCmp := clientv3.Compare(clientv3.Version(uKey), "=", 0)
 	putReq := clientv3.OpPut(uKey, string(kv.Value))
 	delReq := clientv3.OpDelete(key)
 
@@ -328,10 +386,19 @@ func (q *Queue) tryDelete(ctx context.Context, kv *mvccpb.KeyValue) (types.Queue
 	return nil, nil
 }
 
+// The queue uses timestamps to order its queue items, and also to
+// determine how old queue items are.
+func (q *Queue) timeStamp() (string, error) {
+	now := time.Now().UnixNano()
+	buf := new(bytes.Buffer)
+	if err := binary.Write(buf, binary.BigEndian, now); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 func (q *Queue) waitPutEvent(ctx context.Context) (*clientv3.Event, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	wc := q.client.Watch(ctx, q.work, clientv3.WithPrefix())
+	wc := q.watcher.Watch(ctx, q.workPrefix(), clientv3.WithPrefix())
 	// wc is a channel
 	if wc == nil {
 		return nil, ctx.Err()

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -280,7 +280,8 @@ func (q *Queue) Dequeue(ctx context.Context) (types.QueueItem, error) {
 		return nil, err
 	}
 
-	for _, kv := range response.Kvs {
+	if len(response.Kvs) > 0 {
+		kv := response.Kvs[0]
 		item, err := q.tryDelete(ctx, kv)
 		if err != nil {
 			return nil, err

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build integration,!race
 
 package queue
 

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -375,7 +375,7 @@ func TestDequeueParallel(t *testing.T) {
 		}(item)
 	}
 	wg.Wait()
-	// Make sure we didn't encountered any error when adding items to the queue.
+	// Make sure we didn't encounter any error when adding items to the queue.
 	// If we had multiple errors, only the last one is saved
 	require.NoError(t, errEnqueue)
 	results := make(map[string]struct{})
@@ -396,7 +396,7 @@ func TestDequeueParallel(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	// Make sure we didn't encountered any error while dequeuing items from the
+	// Make sure we didn't encounter any error while dequeuing items from the
 	// queue. If we had multiple errors, only the last one is saved
 	require.NoError(t, errEnqueue)
 	assert.Equal(t, items, results)

--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -111,7 +111,7 @@ func (r *Ring) supervise() error {
 		defer mu.Unlock(context.Background())
 		for range r.wakeup {
 			if err := r.advance(); err != nil {
-				logger.WithError(err).Error("supervisor error")
+				logger.WithError(err).Error("supervisor: couldn't get the next ring item")
 			}
 		}
 	}()

--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -28,9 +28,6 @@ var (
 	ringPathPrefix = "rings"
 	ringKeyBuilder = store.NewKeyBuilder(ringPathPrefix)
 
-	backendID   string
-	backendOnce sync.Once
-
 	leaseIDCache = make(map[string]clientv3.LeaseID)
 	pkgMu        sync.Mutex
 

--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -207,9 +207,6 @@ func (r *Ring) Add(ctx context.Context, value string) error {
 			return fmt.Errorf("couldn't add item to ring: %s", err)
 		}
 		key := path.Join(r.itemPrefix, seq)
-		if err != nil {
-			return err
-		}
 		putCmp := clientv3.Compare(clientv3.Version(key), "=", 0)
 		leaseID, err := r.getLeaseID()
 		if err != nil {


### PR DESCRIPTION
This commit modifies the queue so that each backend can consume
messages from it - also known as fan-out.

As an unrelated refactoring change, this commit also factors out
the sequencing method from the ring and places it in the etcd
package.

I initially intended to use the ring sequencing method for the
queue, but later remembered that the queue uses timestamps, as it
relies on the timestamp value to compute queue item freshness.

During the course of this work, I discovered that the queue is not
safe to use with multiple producers and consumers for the same
backend. To support this use case, I believe we would need to
use etcd's concurrency.STM datatype.

However, we do not currently have this use case, so I think such
a feature is not needed. Therefore, the test case that tests
concurrent Enqueue and Dequeue has been removed, as it can
sometimes fail.

I have tested this commit with clustered sensu, and have observed
that ad-hoc checks now function as expected.

Closes #1904

Signed-off-by: Eric Chlebek <eric@sensu.io>