### PR TITLE
Avoid fetch dependency failure on nightly builds

### DIFF
--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -8,7 +8,7 @@
 
 "@10xjs/form@https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz":
   version "0.1.6"
-  resolved "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz#bdbc1f39b912f8851880b0c6507c77afb144684d"
+  resolved "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz#2d061718de4ded68e79b99afb687159d13f7acfa"
   dependencies:
     es6-error "^4.1.1"
     hoist-non-react-statics "^2.5.0"


### PR DESCRIPTION
## What is this change?

Previously linked package included dotfiles that were causing `git clean` to skip it. This (likely) led to permissions issues when trying to overwrite it.

## Why is this change necessary?

Nightlies have been failing to build consistently.