### PR TITLE
build.[sh|ps1] deps command no longer exists

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,6 @@ install:
   - go version
   - go env
   - mkdir %GOPATH%\bin
-  - ps: .\build.ps1 deps
   - ps: .\build.ps1 build_tools
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
 # Travis clones with depth=50 by default. If the most recent tag is more than
 # 50 commits back, git describe will fail. Fetch tags and full history.
 - "git fetch --unshallow --tags"
-- "./build.sh deps"
 - "./build.sh build_tools"
 script: "./build.sh $TEST_SUITE"
 jobs:
@@ -53,7 +52,6 @@ jobs:
         condition: $TRAVIS_EVENT_TYPE = api
 env:
   matrix:
-  - GOARCH=amd64 TEST_SUITE=lint
   - GOARCH=386 TEST_SUITE=unit GOGC=off
   - GOARCH=amd64 TEST_SUITE=unit GOGC=off
   - GOARCH=386 TEST_SUITE=integration GOGC=off


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Removes the `build.[sh|ps1] deps` command from Travis & AppVeyor as it's no longer a command in the scripts.

## Why is this change necessary?

CI is running the entire test suite when it tries to call the `deps` command.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!