### PR TITLE
Remove deps & lint steps in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,6 @@ jobs:
       - run: $SENSU_RELEASE_REPO/install-awscli.sh
 
       # *Now* get to building...
-      - run: ./build.sh deps
-      - run: ./build.sh lint
       - run: ./build.sh build_tools
       - run: make
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Removes the deps & lint steps from Circle CI.

## Why is this change necessary?

We're no longer running these steps on Travis CI & AppVeyor. This brings Circle CI up to speed.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!