### PR TITLE
InfluxDB metric transformer allows the 3rd timestamp argument to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ check requests and use its default value instead.
 message on startup failure.
 - `Issued` & `History` are now set on keepalive events.
 - Resolves a potential panic in `sensuctl cluster health`.
+- Fixed a bug in InfluxDB metric parsing. The timestamp is now optional and
+compliant with InfluxDB line protocol.
 
 ## [2.0.0-beta.3-1] - 2018-08-02
 

--- a/agent/transformers/influx_db_test.go
+++ b/agent/transformers/influx_db_test.go
@@ -11,9 +11,10 @@ func TestParseInflux(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		metric         string
-		expectedFormat InfluxList
-		expectedErr    bool
+		metric           string
+		expectedFormat   InfluxList
+		expectedErr      bool
+		timeInconclusive bool
 	}{
 		{
 			metric: "weather,location=us-midwest,season=summer temperature=82,humidity=30 1465839830100400200",
@@ -104,7 +105,12 @@ func TestParseInflux(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			metric:         "weather temperature=82",
+			metric:           "weather temperature=82",
+			timeInconclusive: true,
+			expectedErr:      false,
+		},
+		{
+			metric:         "weather temperature=82 12345 blah",
 			expectedFormat: InfluxList{},
 			expectedErr:    true,
 		},
@@ -133,7 +139,9 @@ func TestParseInflux(t *testing.T) {
 			} else {
 				assert.NoError(err)
 			}
-			assert.Equal(tc.expectedFormat, graphite)
+			if !tc.timeInconclusive {
+				assert.Equal(tc.expectedFormat, graphite)
+			}
 		})
 	}
 }
@@ -230,9 +238,10 @@ func TestParseAndTransformInflux(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		metric         string
-		expectedFormat []*types.MetricPoint
-		expectedErr    bool
+		metric           string
+		expectedFormat   []*types.MetricPoint
+		expectedErr      bool
+		timeInconclusive bool
 	}{
 		{
 			metric: "weather,location=us-midwest,season=summer temperature=82,humidity=30 1465839830100400200",
@@ -319,7 +328,12 @@ func TestParseAndTransformInflux(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			metric:      "weather temperature=82",
+			metric:           "weather temperature=82",
+			timeInconclusive: true,
+			expectedErr:      false,
+		},
+		{
+			metric:      "weather temperature=82 12345 blah",
 			expectedErr: true,
 		},
 		{
@@ -344,7 +358,9 @@ func TestParseAndTransformInflux(t *testing.T) {
 			} else {
 				assert.NoError(err)
 				mp := influx.Transform()
-				assert.Equal(tc.expectedFormat, mp)
+				if !tc.timeInconclusive {
+					assert.Equal(tc.expectedFormat, mp)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a bug in InfluxDB metric parsing. The timestamp is now optional and compliant with InfluxDB line protocol.

## Why is this change necessary?

Closes #1882 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.