### PR TITLE
[Web UI] Targeted events page tweaks

### DIFF
--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -264,6 +264,8 @@ func (r *envImpl) Events(p schema.EnvironmentEventsFieldResolverParams) (interfa
 	// sort records
 	if p.Args.OrderBy == schema.EventsListOrders.SEVERITY {
 		sort.Sort(types.EventsBySeverity(filteredEvents))
+	} else if p.Args.OrderBy == schema.EventsListOrders.LASTOK {
+		sort.Sort(types.EventsByLastOk(filteredEvents))
 	} else {
 		sort.Sort(types.EventsByTimestamp(
 			filteredEvents,

--- a/backend/apid/graphql/event.go
+++ b/backend/apid/graphql/event.go
@@ -42,6 +42,18 @@ func (r *eventImpl) IsIncident(p graphql.ResolveParams) (bool, error) {
 	return event.IsIncident(), nil
 }
 
+// IsNewIncident implements response to request for 'isNewIncident' field.
+func (r *eventImpl) IsNewIncident(p graphql.ResolveParams) (bool, error) {
+	event := p.Source.(*types.Event)
+	check := event.Check
+	if check == nil || check.Status == 0 || len(check.History) == 0 {
+		return false, nil
+	}
+
+	lastExecution := check.History[0].Status
+	return lastExecution == 0, nil
+}
+
 // IsResolution implements response to request for 'isResolution' field.
 func (r *eventImpl) IsResolution(p graphql.ResolveParams) (bool, error) {
 	event := p.Source.(*types.Event)

--- a/backend/apid/graphql/event_test.go
+++ b/backend/apid/graphql/event_test.go
@@ -1,0 +1,51 @@
+package graphql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/sensu/sensu-go/graphql"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventTypeIsNewIncidentFieldImpl(t *testing.T) {
+	mkEvent := func(status, lastStatus uint32) *types.Event {
+		event := types.Event{
+			Check: &types.Check{
+				Status: status,
+				History: []types.CheckHistory{
+					{Status: lastStatus},
+				},
+			},
+		}
+		return &event
+	}
+
+	testCases := []struct {
+		assertion      string
+		expectedResult bool
+		event          *types.Event
+	}{
+		{"no check", false, &types.Event{Check: nil, Timestamp: 12345678}},
+		{"no history", false, &types.Event{Check: &types.Check{}}},
+		{"currently OK", false, mkEvent(0, 0)},
+		{"ongoing incident", false, mkEvent(2, 2)},
+		{"ongoing incident w/ new code", false, mkEvent(2, 1)},
+		{"new incident", true, mkEvent(2, 0)},
+		{"new unknown incident", true, mkEvent(127, 0)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("event %s", tc.assertion), func(t *testing.T) {
+			params := graphql.ResolveParams{}
+			params.Source = tc.event
+
+			impl := eventImpl{}
+			res, err := impl.IsNewIncident(params)
+			require.NoError(t, err)
+			assert.Equal(t, res, tc.expectedResult)
+		})
+	}
+}

--- a/backend/apid/graphql/schema/environment.gql.go
+++ b/backend/apid/graphql/schema/environment.gql.go
@@ -869,6 +869,7 @@ type EventsListOrder string
 
 // EventsListOrders holds enum values
 var EventsListOrders = _EnumTypeEventsListOrderValues{
+	LASTOK:   "LASTOK",
 	NEWEST:   "NEWEST",
 	OLDEST:   "OLDEST",
 	SEVERITY: "SEVERITY",
@@ -886,6 +887,11 @@ func _EnumTypeEventsListOrderConfigFn() graphql1.EnumConfig {
 		Description: "self descriptive",
 		Name:        "EventsListOrder",
 		Values: graphql1.EnumValueConfigMap{
+			"LASTOK": &graphql1.EnumValueConfig{
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Value:             "LASTOK",
+			},
 			"NEWEST": &graphql1.EnumValueConfig{
 				DeprecationReason: "",
 				Description:       "self descriptive",
@@ -909,10 +915,12 @@ func _EnumTypeEventsListOrderConfigFn() graphql1.EnumConfig {
 var _EnumTypeEventsListOrderDesc = graphql.EnumDesc{Config: _EnumTypeEventsListOrderConfigFn}
 
 type _EnumTypeEventsListOrderValues struct {
-	// OLDEST - self descriptive
-	OLDEST EventsListOrder
+	// LASTOK - self descriptive
+	LASTOK EventsListOrder
 	// NEWEST - self descriptive
 	NEWEST EventsListOrder
+	// OLDEST - self descriptive
+	OLDEST EventsListOrder
 	// SEVERITY - self descriptive
 	SEVERITY EventsListOrder
 }

--- a/backend/apid/graphql/schema/environment.graphql
+++ b/backend/apid/graphql/schema/environment.graphql
@@ -101,8 +101,9 @@ enum EntityListOrder {
 }
 
 enum EventsListOrder {
-  OLDEST
+  LASTOK
   NEWEST
+  OLDEST
   SEVERITY
 }
 

--- a/backend/apid/graphql/schema/event.gql.go
+++ b/backend/apid/graphql/schema/event.gql.go
@@ -51,6 +51,12 @@ type EventIsIncidentFieldResolver interface {
 	IsIncident(p graphql.ResolveParams) (bool, error)
 }
 
+// EventIsNewIncidentFieldResolver implement to resolve requests for the Event's isNewIncident field.
+type EventIsNewIncidentFieldResolver interface {
+	// IsNewIncident implements response to request for isNewIncident field.
+	IsNewIncident(p graphql.ResolveParams) (bool, error)
+}
+
 // EventIsResolutionFieldResolver implement to resolve requests for the Event's isResolution field.
 type EventIsResolutionFieldResolver interface {
 	// IsResolution implements response to request for isResolution field.
@@ -132,6 +138,7 @@ type EventFieldResolvers interface {
 	EventCheckFieldResolver
 	EventHooksFieldResolver
 	EventIsIncidentFieldResolver
+	EventIsNewIncidentFieldResolver
 	EventIsResolutionFieldResolver
 	EventIsSilencedFieldResolver
 }
@@ -246,6 +253,19 @@ func (_ EventAliases) IsIncident(p graphql.ResolveParams) (bool, error) {
 	return ret, err
 }
 
+// IsNewIncident implements response to request for 'isNewIncident' field.
+func (_ EventAliases) IsNewIncident(p graphql.ResolveParams) (bool, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(bool)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'isNewIncident'")
+	}
+	return ret, err
+}
+
 // IsResolution implements response to request for 'isResolution' field.
 func (_ EventAliases) IsResolution(p graphql.ResolveParams) (bool, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
@@ -328,6 +348,13 @@ func _ObjTypeEventIsIncidentHandler(impl interface{}) graphql1.FieldResolveFn {
 	}
 }
 
+func _ObjTypeEventIsNewIncidentHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(EventIsNewIncidentFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.IsNewIncident(frp)
+	}
+}
+
 func _ObjTypeEventIsResolutionHandler(impl interface{}) graphql1.FieldResolveFn {
 	resolver := impl.(EventIsResolutionFieldResolver)
 	return func(frp graphql1.ResolveParams) (interface{}, error) {
@@ -381,6 +408,13 @@ func _ObjectTypeEventConfigFn() graphql1.ObjectConfig {
 				Name:              "isIncident",
 				Type:              graphql1.NewNonNull(graphql1.Boolean),
 			},
+			"isNewIncident": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "isNewIncident returns true if the event is an incident but it's previous\niteration was OK.",
+				Name:              "isNewIncident",
+				Type:              graphql1.NewNonNull(graphql1.Boolean),
+			},
 			"isResolution": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
@@ -428,15 +462,16 @@ func _ObjectTypeEventConfigFn() graphql1.ObjectConfig {
 var _ObjectTypeEventDesc = graphql.ObjectDesc{
 	Config: _ObjectTypeEventConfigFn,
 	FieldHandlers: map[string]graphql.FieldHandler{
-		"check":        _ObjTypeEventCheckHandler,
-		"entity":       _ObjTypeEventEntityHandler,
-		"hooks":        _ObjTypeEventHooksHandler,
-		"id":           _ObjTypeEventIDHandler,
-		"isIncident":   _ObjTypeEventIsIncidentHandler,
-		"isResolution": _ObjTypeEventIsResolutionHandler,
-		"isSilenced":   _ObjTypeEventIsSilencedHandler,
-		"namespace":    _ObjTypeEventNamespaceHandler,
-		"timestamp":    _ObjTypeEventTimestampHandler,
+		"check":         _ObjTypeEventCheckHandler,
+		"entity":        _ObjTypeEventEntityHandler,
+		"hooks":         _ObjTypeEventHooksHandler,
+		"id":            _ObjTypeEventIDHandler,
+		"isIncident":    _ObjTypeEventIsIncidentHandler,
+		"isNewIncident": _ObjTypeEventIsNewIncidentHandler,
+		"isResolution":  _ObjTypeEventIsResolutionHandler,
+		"isSilenced":    _ObjTypeEventIsSilencedHandler,
+		"namespace":     _ObjTypeEventNamespaceHandler,
+		"timestamp":     _ObjTypeEventTimestampHandler,
 	},
 }
 

--- a/backend/apid/graphql/schema/event.graphql
+++ b/backend/apid/graphql/schema/event.graphql
@@ -29,6 +29,12 @@ type Event implements Node {
   "isIncident determines if an event indicates an incident."
   isIncident: Boolean!
 
+  """
+  isNewIncident returns true if the event is an incident but it's previous
+  iteration was OK.
+  """
+  isNewIncident: Boolean!
+
   "isResolution returns true if an event has just transitions from an incident."
   isResolution: Boolean!
 

--- a/dashboard/src/apollo/schema/combined.graphql
+++ b/dashboard/src/apollo/schema/combined.graphql
@@ -749,6 +749,12 @@ type Event implements Node {
   isIncident: Boolean!
 
   """
+  isNewIncident returns true if the event is an incident but it's previous
+  iteration was OK.
+  """
+  isNewIncident: Boolean!
+
+  """
   isResolution returns true if an event has just transitions from an incident.
   """
   isResolution: Boolean!
@@ -1091,7 +1097,7 @@ type ProxyRequests {
   splayCoverage is the percentage used for proxy check request splay
   calculation.
   """
-  splay_coverage: Int!
+  splayCoverage: Int!
 }
 
 """The query root of Sensu's GraphQL interface."""

--- a/dashboard/src/apollo/schema/combined.graphql
+++ b/dashboard/src/apollo/schema/combined.graphql
@@ -776,6 +776,8 @@ enum EventsListOrder {
   OLDEST
   NEWEST
   SEVERITY
+  LASTOK
+  LASTOK_DESC
 }
 
 input ExecuteCheckInput {

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsEvents.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsEvents.js
@@ -3,15 +3,15 @@ import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
-import Typography from "@material-ui/core/Typography";
-import List from "@material-ui/core/List";
-import { RelativeToCurrentDate } from "/components/RelativeDate";
-import StatusIcon from "/components/CheckStatusIcon";
+import EventStatusDescriptor from "/components/partials/EventStatusDescriptor";
 import InlineLink from "/components/InlineLink";
+import List from "@material-ui/core/List";
 import ListItem, {
   ListItemTitle,
   ListItemSubtitle,
 } from "/components/DetailedListItem";
+import StatusIcon from "/components/CheckStatusIcon";
+import Typography from "@material-ui/core/Typography";
 
 class EntityDetailsEvents extends React.PureComponent {
   static propTypes = {
@@ -28,6 +28,7 @@ class EntityDetailsEvents extends React.PureComponent {
         check {
           name
           status
+          ...EventStatusDescriptor_check
         }
         entity {
           name
@@ -36,7 +37,11 @@ class EntityDetailsEvents extends React.PureComponent {
         id
         timestamp
         isSilenced
+        ...EventStatusDescriptor_event
       }
+
+      ${EventStatusDescriptor.fragments.check}
+      ${EventStatusDescriptor.fragments.event}
     `,
   };
 
@@ -69,8 +74,7 @@ class EntityDetailsEvents extends React.PureComponent {
           </InlineLink>
         </ListItemTitle>
         <ListItemSubtitle inset>
-          Exited with status {check.status};{" "}
-          <RelativeToCurrentDate dateTime={event.timestamp} />
+          <EventStatusDescriptor compact event={event} check={check} />
         </ListItemSubtitle>
       </ListItem>
     );

--- a/dashboard/src/components/partials/EventStatusDescriptor/EventStatusDescriptor.js
+++ b/dashboard/src/components/partials/EventStatusDescriptor/EventStatusDescriptor.js
@@ -33,6 +33,7 @@ class EventStatusDescriptor extends React.PureComponent {
 
   numFormatter = new Intl.NumberFormat();
 
+  // Metric received X minutes ago.
   renderMetricDescription() {
     const { event } = this.props;
 
@@ -46,7 +47,8 @@ class EventStatusDescriptor extends React.PureComponent {
     );
   }
 
-  renderOKDescription() {
+  // Last executed X minutes ago.
+  renderLastExecution() {
     const { event } = this.props;
 
     return (
@@ -59,6 +61,8 @@ class EventStatusDescriptor extends React.PureComponent {
     );
   }
 
+  // Incident started X minutes ago and has continued for Y consecutive
+  // executions.
   renderIncidentDescription() {
     const { check, compact } = this.props;
 
@@ -68,31 +72,33 @@ class EventStatusDescriptor extends React.PureComponent {
         <strong>
           <RelativeToCurrentDate dateTime={check.lastOK} />
         </strong>
-        {!compact && this.renderExtendedDescription()}
+        {!compact && (
+          <React.Fragment>
+            {" "}
+            and has continued for{" "}
+            <strong>{this.numFormatter.format(check.occurrences)}</strong>{" "}
+            consecutive executions
+          </React.Fragment>
+        )}
         .
       </React.Fragment>
     );
   }
 
-  renderExtendedDescription() {
+  // Event began returning unknown status {status} Y minutes ago.
+  // Starting X minutes ago, began returning unknown status code Y.
+  renderUnknownStatusDescription() {
     const { check } = this.props;
-
-    if (check.status > 2) {
-      return (
-        <React.Fragment>
-          {" "}
-          and the last execution exited with status{" "}
-          <strong>{check.status}</strong>
-        </React.Fragment>
-      );
-    }
 
     return (
       <React.Fragment>
-        {" "}
-        and has continued for{" "}
-        <strong>{this.numFormatter.format(check.occurrences)}</strong>{" "}
-        consecutive executions
+        Starting{" "}
+        <strong>
+          <RelativeToCurrentDate dateTime={check.lastOK} />
+        </strong>
+        {", "}
+        event began returning unknown status code{" "}
+        <strong>{check.status}</strong>.
       </React.Fragment>
     );
   }
@@ -105,7 +111,11 @@ class EventStatusDescriptor extends React.PureComponent {
     }
 
     if (check.status === 0 || check.lastOK === null) {
-      return this.renderOKDescription();
+      return this.renderLastExecution();
+    }
+
+    if (check.status > 2) {
+      return this.renderUnknownStatusDescription();
     }
 
     return this.renderIncidentDescription();

--- a/dashboard/src/components/partials/EventStatusDescriptor/EventStatusDescriptor.js
+++ b/dashboard/src/components/partials/EventStatusDescriptor/EventStatusDescriptor.js
@@ -1,0 +1,115 @@
+import React from "react";
+import PropTypes from "prop-types";
+import gql from "graphql-tag";
+
+import { RelativeToCurrentDate } from "/components/RelativeDate";
+
+class EventStatusDescriptor extends React.PureComponent {
+  static propTypes = {
+    check: PropTypes.object,
+    compact: PropTypes.bool,
+    event: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    check: null,
+    compact: false,
+  };
+
+  static fragments = {
+    check: gql`
+      fragment EventStatusDescriptor_check on Check {
+        lastOK
+        status
+        occurrences
+      }
+    `,
+    event: gql`
+      fragment EventStatusDescriptor_event on Event {
+        timestamp
+      }
+    `,
+  };
+
+  numFormatter = new Intl.NumberFormat();
+
+  renderMetricDescription() {
+    const { event } = this.props;
+
+    return (
+      <React.Fragment>
+        Metric received
+        <strong>
+          <RelativeToCurrentDate dateTime={event.timestamp} />
+        </strong>.
+      </React.Fragment>
+    );
+  }
+
+  renderOKDescription() {
+    const { event } = this.props;
+
+    return (
+      <React.Fragment>
+        Last executed{" "}
+        <strong>
+          <RelativeToCurrentDate dateTime={event.timestamp} />
+        </strong>.
+      </React.Fragment>
+    );
+  }
+
+  renderIncidentDescription() {
+    const { check, compact } = this.props;
+
+    return (
+      <React.Fragment>
+        Incident started{" "}
+        <strong>
+          <RelativeToCurrentDate dateTime={check.lastOK} />
+        </strong>
+        {!compact && this.renderExtendedDescription()}
+        .
+      </React.Fragment>
+    );
+  }
+
+  renderExtendedDescription() {
+    const { check } = this.props;
+
+    if (check.status > 2) {
+      return (
+        <React.Fragment>
+          {" "}
+          and the last execution exited with status{" "}
+          <strong>{check.status}</strong>
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        {" "}
+        and has continued for{" "}
+        <strong>{this.numFormatter.format(check.occurrences)}</strong>{" "}
+        consecutive executions
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    const { check } = this.props;
+
+    if (check === null) {
+      return this.renderMetricDescription();
+    }
+
+    if (check.status === 0 || check.lastOK === null) {
+      return this.renderOKDescription();
+    }
+
+    return this.renderIncidentDescription();
+  }
+}
+
+export default EventStatusDescriptor;

--- a/dashboard/src/components/partials/EventStatusDescriptor/index.js
+++ b/dashboard/src/components/partials/EventStatusDescriptor/index.js
@@ -1,0 +1,1 @@
+export { default } from "./EventStatusDescriptor";

--- a/dashboard/src/components/partials/EventsList/EventsList.js
+++ b/dashboard/src/components/partials/EventsList/EventsList.js
@@ -198,6 +198,7 @@ class EventsContainer extends React.Component {
       selected={selected}
       onChangeSelected={setSelected}
       onClickClearSilences={() => this.clearSilences([event])}
+      onClickSilencePair={() => this.silenceEvents([event])}
       onClickSilenceEntity={() => this.silenceEntity(event.entity)}
       onClickSilenceCheck={() => this.silenceCheck(event.check)}
       onClickResolve={() => this.resolveEvents([event])}

--- a/dashboard/src/components/partials/EventsList/EventsListHeader.js
+++ b/dashboard/src/components/partials/EventsList/EventsListHeader.js
@@ -89,8 +89,10 @@ class EventsListHeader extends React.PureComponent {
         const val = newValue.join(",");
         this.props.onChangeQuery({ filter: `Check.Status IN (${val})` });
       }
-    } else {
+    } else if (newValue === "") {
       this.props.onChangeQuery(query => query.delete("filter"));
+    } else {
+      this.props.onChangeQuery({ filter: newValue });
     }
   };
 

--- a/dashboard/src/components/partials/EventsList/EventsListHeader.js
+++ b/dashboard/src/components/partials/EventsList/EventsListHeader.js
@@ -247,15 +247,20 @@ class EventsListHeader extends React.PureComponent {
               pinned
               renderMenu={({ anchorEl, close }) => (
                 <Menu open onClose={close} anchorEl={anchorEl}>
-                  {["SEVERITY", "NEWEST", "OLDEST"].map(name => (
+                  {[
+                    { name: "Last OK", value: "LASTOK" },
+                    { name: "Severity", value: "SEVERITY" },
+                    { name: "Newest", value: "NEWEST" },
+                    { name: "Oldest", value: "OLDEST" },
+                  ].map(option => (
                     <MenuItem
-                      key={name}
+                      key={option.value}
                       onClick={() => {
-                        this._handleChangeSort(name);
+                        this._handleChangeSort(option.value);
                         close();
                       }}
                     >
-                      <ListItemText primary={capitalize(name)} />
+                      <ListItemText primary={option.name} />
                     </MenuItem>
                   ))}
                 </Menu>

--- a/dashboard/src/components/partials/EventsList/EventsListItem.js
+++ b/dashboard/src/components/partials/EventsList/EventsListItem.js
@@ -79,15 +79,6 @@ class EventListItem extends React.PureComponent {
     return (
       <Menu open onClose={close} anchorEl={anchorEl}>
         <MenuItem
-          key={"silence-pair"}
-          onClick={() => {
-            this.props.onClickSilencePair();
-            close();
-          }}
-        >
-          Silence Pair
-        </MenuItem>
-        <MenuItem
           key={"silence-Entity"}
           onClick={() => {
             this.props.onClickSilenceEntity();
@@ -104,6 +95,15 @@ class EventListItem extends React.PureComponent {
           }}
         >
           Silence Check
+        </MenuItem>
+        <MenuItem
+          key={"silence-pair"}
+          onClick={() => {
+            this.props.onClickSilencePair();
+            close();
+          }}
+        >
+          Silence Both
         </MenuItem>
         {event.check.isSilenced && (
           <MenuItem

--- a/dashboard/src/components/partials/EventsList/EventsListItem.js
+++ b/dashboard/src/components/partials/EventsList/EventsListItem.js
@@ -26,6 +26,7 @@ class EventListItem extends React.PureComponent {
     selected: PropTypes.bool.isRequired,
     onChangeSelected: PropTypes.func.isRequired,
     onClickClearSilences: PropTypes.func.isRequired,
+    onClickSilencePair: PropTypes.func.isRequired,
     onClickSilenceEntity: PropTypes.func.isRequired,
     onClickSilenceCheck: PropTypes.func.isRequired,
     onClickResolve: PropTypes.func.isRequired,
@@ -75,6 +76,15 @@ class EventListItem extends React.PureComponent {
 
     return (
       <Menu open onClose={close} anchorEl={anchorEl}>
+        <MenuItem
+          key={"silence-pair"}
+          onClick={() => {
+            this.props.onClickSilencePair();
+            close();
+          }}
+        >
+          Silence Pair
+        </MenuItem>
         <MenuItem
           key={"silence-Entity"}
           onClick={() => {

--- a/dashboard/src/components/partials/EventsList/EventsListItem.js
+++ b/dashboard/src/components/partials/EventsList/EventsListItem.js
@@ -45,13 +45,13 @@ class EventListItem extends React.PureComponent {
       fragment EventsListItem_event on Event {
         id
         isSilenced
+        isNewIncident
+        timestamp
         deleted @client
         check {
           name
           isSilenced
-          history(first: 1) {
-            status
-          }
+          status
           ...EventStatusDescriptor_check
         }
         entity {
@@ -135,14 +135,12 @@ class EventListItem extends React.PureComponent {
 
     // Try to determine if the failing check just started failing and if so
     // highlight the row.
-    const incidentStarted =
-      check.status > 0 &&
-      check.history.length > 0 &&
-      check.history[0].status !== check.status &&
+    const isNewIncident =
+      event.isNewIncident &&
       new Date(new Date(timestamp).valueOf() + 2500) >= new Date();
 
     return (
-      <TableSelectableRow selected={selected} highlight={incidentStarted}>
+      <TableSelectableRow selected={selected} highlight={isNewIncident}>
         <TableCell padding="checkbox">
           <Checkbox
             color="primary"

--- a/dashboard/src/components/partials/EventsList/EventsListItem.js
+++ b/dashboard/src/components/partials/EventsList/EventsListItem.js
@@ -10,14 +10,13 @@ import MoreVert from "@material-ui/icons/MoreVert";
 import RootRef from "@material-ui/core/RootRef";
 import TableCell from "@material-ui/core/TableCell";
 
-import { RelativeToCurrentDate } from "/components/RelativeDate";
-
 import MenuController from "/components/controller/MenuController";
 
 import ResourceDetails from "/components/partials/ResourceDetails";
 import TableOverflowCell from "/components/partials/TableOverflowCell";
 import TableSelectableRow from "/components/partials/TableSelectableRow";
 
+import EventStatusDescriptor from "/components/partials/EventStatusDescriptor";
 import NamespaceLink from "/components/util/NamespaceLink";
 import CheckStatusIcon from "/components/CheckStatusIcon";
 
@@ -45,16 +44,15 @@ class EventListItem extends React.PureComponent {
     event: gql`
       fragment EventsListItem_event on Event {
         id
-        timestamp
         isSilenced
         deleted @client
         check {
-          status
           name
           isSilenced
           history(first: 1) {
             status
           }
+          ...EventStatusDescriptor_check
         }
         entity {
           name
@@ -63,7 +61,11 @@ class EventListItem extends React.PureComponent {
           organization
           environment
         }
+        ...EventStatusDescriptor_event
       }
+
+      ${EventStatusDescriptor.fragments.check}
+      ${EventStatusDescriptor.fragments.event}
     `,
   };
 
@@ -169,13 +171,7 @@ class EventListItem extends React.PureComponent {
               </NamespaceLink>
             }
             details={
-              <React.Fragment>
-                Last occurred{" "}
-                <strong>
-                  <RelativeToCurrentDate dateTime={timestamp} />
-                </strong>{" "}
-                and exited with status <strong>{check.status}</strong>.
-              </React.Fragment>
+              <EventStatusDescriptor event={event} check={event.check} />
             }
           />
         </TableOverflowCell>

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -39,7 +39,7 @@ class EventsContent extends React.Component {
   static query = gql`
     query EnvironmentViewEventsContentQuery(
       $filter: String = "${defaultExpression}"
-      $order: EventsListOrder = SEVERITY
+      $order: EventsListOrder = LASTOK
       $limit: Int,
       $offset: Int,
       $environment: String!

--- a/types/event.go
+++ b/types/event.go
@@ -201,8 +201,9 @@ func EventsByTimestamp(es []*Event, asc bool) sort.Interface {
 
 // EventsByLastOk can be used to sort a given collection of events by time it
 // last received an OK status.
-func EventsByLastOk(es []*Event, asc bool) sort.Interface {
+func EventsByLastOk(es []*Event) sort.Interface {
 	return &eventSorter{es, createCmpEvents(
+		cmpByIncident,
 		cmpByLastOk,
 		cmpByEntityID,
 	)}
@@ -232,6 +233,18 @@ func cmpBySeverity(a, b *Event) int {
 	if ap == bp {
 		return 0
 	} else if ap < bp {
+		return 1
+	}
+	return -1
+}
+
+func cmpByIncident(a, b *Event) int {
+	av, bv := a.IsIncident(), b.IsIncident()
+
+	// Rank higher if incident
+	if av == bv {
+		return 0
+	} else if av {
 		return 1
 	}
 	return -1


### PR DESCRIPTION
## What is this change?

Includes targeted improvements for issues identified during QA and VQA process.
 
- Incident filter now fills search box.
- Include option to silence event's check entity pair from list item's menu.
- For incidents displays last ok value on the events list instead of last occurrence.
- Omit status code unless the status is "unknown". Updates copy.
- By default list is sorted by lastOK value.

## Why is this change necessary?

Closes #1936

## Does your change need a Changelog entry?

`undefined`

## Do you need clarification on anything?

`null`

## Were there any complications while making this change?

Consulted @annaplotkin for help with copy changes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

`undefined`