### PR TITLE
Use crock for unit testing jwt package.

### DIFF
--- a/backend/authentication/jwt/jwt.go
+++ b/backend/authentication/jwt/jwt.go
@@ -6,16 +6,16 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	time "github.com/echlebek/timeproxy"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	utilbytes "github.com/sensu/sensu-go/util/bytes"
 )
 
 var (
-	defaultExpiration = time.Minute * time.Duration(15)
+	defaultExpiration = time.Minute * 15
 	secret            []byte
 )
 


### PR DESCRIPTION
Speeds up test execution dramatically by avoiding time.Sleep.

Before:
ok  	github.com/sensu/sensu-go/backend/authentication/jwt	6.005s

After:
ok  	github.com/sensu/sensu-go/backend/authentication/jwt	0.003s

Signed-off-by: Eric Chlebek <eric@sensu.io>

This is part of a continuing effort, #1611