### PR TITLE
Bugfix for sensuctl cluster health error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ message on startup failure.
 compliant with InfluxDB line protocol.
 - Fixed an issue where adhoc checks would not be issued to all agents in a
 clustered installation.
+- Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 
 ### Breaking Changes
 - Corrects the check field `total_state-change` json tag to `total_state_change`.

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -31,7 +31,8 @@ func (s *Store) GetClusterHealth(ctx context.Context) []*types.ClusterHealth {
 			DialTimeout: 5 * time.Second,
 		})
 
-		if err != nil || cli == nil {
+		if cliErr != nil {
+			logger.WithField("member", member.ID).WithError(cliErr).Error("unhealthy cluster member")
 			health.Err = cliErr
 			health.Healthy = false
 			healthList = append(healthList, health)

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -30,7 +30,6 @@ func (s *Store) GetClusterHealth(ctx context.Context) []*types.ClusterHealth {
 			Endpoints:   member.ClientURLs,
 			DialTimeout: 5 * time.Second,
 		})
-		defer cli.Close()
 
 		if err != nil || cli == nil {
 			health.Err = cliErr
@@ -38,6 +37,8 @@ func (s *Store) GetClusterHealth(ctx context.Context) []*types.ClusterHealth {
 			healthList = append(healthList, health)
 			continue
 		}
+		defer cli.Close()
+
 		_, getErr := cli.Get(context.Background(), "health")
 
 		if getErr == nil || getErr == rpctypes.ErrPermissionDenied {

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -30,12 +30,13 @@ func (s *Store) GetClusterHealth(ctx context.Context) []*types.ClusterHealth {
 			Endpoints:   member.ClientURLs,
 			DialTimeout: 5 * time.Second,
 		})
+		defer cli.Close()
 
-		if err != nil {
+		if err != nil || cli == nil {
 			health.Err = cliErr
 			health.Healthy = false
 			healthList = append(healthList, health)
-			return healthList
+			continue
 		}
 		_, getErr := cli.Get(context.Background(), "health")
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Prevents panic and closes the client.

## Why is this change necessary?

Fixes bug in `sensuctl cluster health` so that the proper error is handled.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.