### PR TITLE
Update archiver sha to fix git tarball bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0-beta.4] - 2018-08-14
 
+### Fixed
+- Fixed a bug where assets could not extract git tarballs.
+
 ### Added
 - Added the Sensu edition in sensuctl config view subcommand.
 - List the supported resource types in sensuctl.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -556,11 +556,11 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
-  digest = "1:54810f1da274687d725732a273e250c59ac0374cdbf6288ac206ef24c53c5478"
+  digest = "1:4f17855b701d15f25e282fe70d432ecb023c9f115c79b211a06845e50dce7c48"
   name = "github.com/mholt/archiver"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e4ef56d48eb029648b0e895bb0b6a393ef0829c3"
+  revision = "85d3d0b511eae05958ddb34e9eac57d8ffea03bf"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@ required = [
 
 [[constraint]]
   name = "github.com/mholt/archiver"
-  revision = "e4ef56d48eb029648b0e895bb0b6a393ef0829c3"
+  revision = "85d3d0b511eae05958ddb34e9eac57d8ffea03bf"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/mholt/archiver/tar.go
+++ b/vendor/github.com/mholt/archiver/tar.go
@@ -235,6 +235,9 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
 		return writeNewSymbolicLink(destpath, header.Linkname)
 	case tar.TypeLink:
 		return writeNewHardLink(destpath, filepath.Join(destination, header.Linkname))
+	case tar.TypeXGlobalHeader:
+		// ignore the pax global header from git generated tarballs
+		return nil
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Updates the archiver dependency to fix a bug with extracting git tarballs.

## Why is this change necessary?

Closes #1700

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

I had to open a pr to the dependency: https://github.com/mholt/archiver/commit/85d3d0b511eae05958ddb34e9eac57d8ffea03bf

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/pull/667