### PR TITLE
[Web UI] Update to patched @10xjs/form release

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@10xjs/date-input-controller": "^0.1.5",
-    "@10xjs/form": "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz",
+    "@10xjs/form": "^0.1.7",
     "@material-ui/core": "^1.4.0",
     "@material-ui/icons": "^2.0.0",
     "apollo-cache-inmemory": "^1.1.12",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -6,9 +6,9 @@
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@10xjs/date-input-controller/-/date-input-controller-0.1.5.tgz#0532a68a46a7fdcc6990a0c05672750cbf4e8820"
 
-"@10xjs/form@https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz":
-  version "0.1.6"
-  resolved "https://github.com/jamesdphillips/form/releases/download/0.1.7/form.tgz#2d061718de4ded68e79b99afb687159d13f7acfa"
+"@10xjs/form@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@10xjs/form/-/form-0.1.7.tgz#ada3beffb0dc9f16d79650c56f82c126dad1bad3"
   dependencies:
     es6-error "^4.1.1"
     hoist-non-react-statics "^2.5.0"


### PR DESCRIPTION
## What is this change?

Fixes an issue where event objects and raw values were not correctly differentiated in minified builds.

## Why is this change necessary?

Closes sensu/sensu-go#1967
Closes #1982 
Closes #1986 

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No


## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No