### PR TITLE
Add windows/386 support to build-gcs-release.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Add windows/386 to binary gcs releases
+
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 - Fixed a bug where assets could not extract git tarballs.

--- a/build-gcs-release.sh
+++ b/build-gcs-release.sh
@@ -38,21 +38,28 @@ clean_target_dir() {
 build_supported_binaries() {
   clean_target_dir
 
+  # ctl binaries
   GOOS=darwin GOARCH=amd64 ./build.sh build_cli
   GOOS=linux GOARCH=amd64 ./build.sh build_cli
   GOOS=linux GOARCH=386 ./build.sh build_cli
   GOOS=freebsd GOARCH=amd64 ./build.sh build_cli
   GOOS=windows GOARCH=amd64 ./build.sh build_cli
+  GOOS=windows GOARCH=386 ./build.sh build_cli
+
+  # backend binaries
   GOOS=darwin GOARCH=amd64 ./build.sh build_backend
   GOOS=linux GOARCH=amd64 ./build.sh build_backend
   GOOS=linux GOARCH=386 ./build.sh build_backend
   GOOS=freebsd GOARCH=amd64 ./build.sh build_backend
   GOOS=windows GOARCH=amd64 ./build.sh build_backend
+
+  # agent binaries
   GOOS=darwin GOARCH=amd64 ./build.sh build_agent
   GOOS=linux GOARCH=amd64 ./build.sh build_agent
   GOOS=linux GOARCH=386 ./build.sh build_agent
   GOOS=freebsd GOARCH=amd64 ./build.sh build_agent
   GOOS=windows GOARCH=amd64 ./build.sh build_agent
+  GOOS=windows GOARCH=386 ./build.sh build_agent
 }
 
 upload_supported_binaries() {
@@ -61,6 +68,7 @@ upload_supported_binaries() {
   upload_binary linux 386
   upload_binary linux amd64
   upload_binary windows amd64
+  upload_binary windows 386
 }
 
 upload_binary() {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds windows/386 support to `build-gcs-release.sh` for sensu-agent and sensuctl.

## Why is this change necessary?

We were already building 32-bit windows packages but we missed adding support for 32-bit binary releases.

## Does your change need a Changelog entry?

Yes, updated.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I'll look into this.
