### PR TITLE
[WIP] Fix issue with multi-asset checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 - Fixed a bug where assets could not extract git tarballs.
+- Fixed a bug where a check with multiple assets will only install the first asset.
 
 ## [2.0.0-beta.4] - 2018-08-14
 

--- a/agent/assetmanager/asset.go
+++ b/agent/assetmanager/asset.go
@@ -35,11 +35,11 @@ const (
 // A RuntimeAsset refers to an asset that is currently in use by the agent.
 type RuntimeAsset struct {
 	path  string
-	asset *types.Asset
+	asset types.Asset
 }
 
 // NewRuntimeAsset given asset and pathPrefix return new managed asset
-func NewRuntimeAsset(asset *types.Asset, pathPrefix string) *RuntimeAsset {
+func NewRuntimeAsset(asset types.Asset, pathPrefix string) *RuntimeAsset {
 	path := filepath.Join(pathPrefix, asset.Sha512)
 	return &RuntimeAsset{path: path, asset: asset}
 }

--- a/agent/assetmanager/asset_test.go
+++ b/agent/assetmanager/asset_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type runtimeAssetTest struct {
-	asset        *types.Asset
+	asset        types.Asset
 	runtimeAsset *RuntimeAsset
 
 	responseBody string
@@ -48,7 +48,7 @@ func newTest(t *testing.T) (*httptest.Server, *runtimeAssetTest) {
 	test.workDir = tmpDir
 
 	// Test asset
-	test.asset = &types.Asset{
+	test.asset = types.Asset{
 		Name:   "ruby24",
 		Sha512: "123456",
 		URL:    server.URL + "/myfile",
@@ -85,7 +85,7 @@ func TestIsRelevant(t *testing.T) {
 			Platform: "darwin",
 		},
 	}
-	test.asset.Filters = []string{
+	test.runtimeAsset.asset.Filters = []string{
 		`entity.System.Hostname == 'space.localdomain'`, // same
 		`entity.System.Platform == 'darwin'`,            // same
 	}
@@ -95,7 +95,7 @@ func TestIsRelevant(t *testing.T) {
 	assert.True(t, ok, "filters match entity's system definition")
 
 	// Failing
-	test.asset.Filters = []string{
+	test.runtimeAsset.asset.Filters = []string{
 		`entity.System.Hostname == 'space.localdomain'`, // same
 		`entity.System.Platform == 'ubuntu'`,            // diff
 	}
@@ -105,7 +105,7 @@ func TestIsRelevant(t *testing.T) {
 	assert.False(t, ok, "filters do not match entity's system definition")
 
 	// With error
-	test.asset.Filters = []string{
+	test.runtimeAsset.asset.Filters = []string{
 		`entity.System.Hostname == 'space.localdomain'`, // same
 		`entity.System.Platform =  'ubuntu'`,            // bad syntax
 	}
@@ -115,7 +115,7 @@ func TestIsRelevant(t *testing.T) {
 	assert.False(t, ok)
 
 	// Filter is not predicate
-	test.asset.Filters = []string{
+	test.runtimeAsset.asset.Filters = []string{
 		`entity.System.Hostname == 'space.localdomain'`, // same
 		`entity.LastSeen + 10`,                          // returns int64
 	}
@@ -131,7 +131,7 @@ func TestInstall(t *testing.T) {
 	defer test.Dispose(t)
 
 	test.responseBody = readFixture("rubby-on-rails.tar")
-	test.asset.Sha512 = stringToSHA512(test.responseBody)
+	test.runtimeAsset.asset.Sha512 = stringToSHA512(test.responseBody)
 
 	require.NoError(t, test.runtimeAsset.install())
 }
@@ -142,7 +142,7 @@ func TestParallelInstall(t *testing.T) {
 	defer test.Dispose(t)
 
 	test.responseBody = readFixture("rubby-on-rails.tar")
-	test.asset.Sha512 = stringToSHA512(test.responseBody)
+	test.runtimeAsset.asset.Sha512 = stringToSHA512(test.responseBody)
 
 	errs := make(chan error, 5)
 

--- a/agent/assetmanager/factory.go
+++ b/agent/assetmanager/factory.go
@@ -13,7 +13,7 @@ type AssetFactory struct {
 }
 
 // NewAsset returns a new RuntimeAsset given an asset
-func (factory AssetFactory) NewAsset(asset *types.Asset) *RuntimeAsset {
+func (factory AssetFactory) NewAsset(asset types.Asset) *RuntimeAsset {
 	return NewRuntimeAsset(asset, factory.CacheDir)
 }
 

--- a/agent/assetmanager/manager.go
+++ b/agent/assetmanager/manager.go
@@ -31,8 +31,9 @@ func New(agentCacheDir string, entity *types.Entity) *Manager {
 // RegisterSet - registers given assets and returns resulting set
 func (mngrPtr *Manager) RegisterSet(assets []types.Asset) *RuntimeAssetSet {
 	runtimeAssets := make([]*RuntimeAsset, len(assets))
+
 	for i, asset := range assets {
-		runtimeAsset := mngrPtr.store.FetchAsset(&asset, mngrPtr.factory.NewAsset)
+		runtimeAsset := mngrPtr.store.FetchAsset(asset, mngrPtr.factory.NewAsset)
 		runtimeAssets[i] = runtimeAsset
 	}
 

--- a/agent/assetmanager/manager_test.go
+++ b/agent/assetmanager/manager_test.go
@@ -70,7 +70,7 @@ func TestReset(t *testing.T) {
 func TestRegisterSet(t *testing.T) {
 	test := newManagerTest(t)
 	defer test.Dispose(t)
-	assets := []types.Asset{*types.FixtureAsset("asset")}
+	assets := []types.Asset{types.FixtureAsset("asset")}
 	assetSet := test.manager.RegisterSet(assets)
 	assert.NotEmpty(t, assetSet.Env)
 	assert.NotEmpty(t, assetSet.assets)

--- a/agent/assetmanager/store.go
+++ b/agent/assetmanager/store.go
@@ -15,7 +15,7 @@ type AssetStore struct {
 	rwMutex   *sync.RWMutex
 }
 
-type newAssetFn func(*types.Asset) *RuntimeAsset
+type newAssetFn func(types.Asset) *RuntimeAsset
 type newSetFn func([]*RuntimeAsset) *RuntimeAssetSet
 
 // NewAssetStore ...
@@ -28,7 +28,7 @@ func NewAssetStore() *AssetStore {
 }
 
 // FetchAsset - fetches asset from store, otherwise creates & adds it
-func (storePtr *AssetStore) FetchAsset(asset *types.Asset, newFn newAssetFn) *RuntimeAsset {
+func (storePtr *AssetStore) FetchAsset(asset types.Asset, newFn newAssetFn) *RuntimeAsset {
 	key := asset.Sha512
 
 	// Return asset if it is already in the store
@@ -38,6 +38,7 @@ func (storePtr *AssetStore) FetchAsset(asset *types.Asset, newFn newAssetFn) *Ru
 
 	// Instantiate & store
 	runtimeAsset := newFn(asset)
+
 	storePtr.setAsset(key, runtimeAsset)
 
 	return runtimeAsset
@@ -95,7 +96,7 @@ func (storePtr *AssetStore) Clear() {
 func concatAssetSetKey(runtimeAssets []*RuntimeAsset) string {
 	names := make([]string, len(runtimeAssets))
 	for _, runtimeAsset := range runtimeAssets {
-		names = append(names, runtimeAsset.asset.Sha512[:7])
+		names = append(names, runtimeAsset.asset.Sha512)
 	}
 
 	sort.Strings(names)

--- a/agent/assetmanager/store_test.go
+++ b/agent/assetmanager/store_test.go
@@ -9,14 +9,14 @@ import (
 
 type storeTest struct {
 	store      *AssetStore
-	newAssetFn func(*types.Asset) *RuntimeAsset
+	newAssetFn func(types.Asset) *RuntimeAsset
 	newSetFn   func([]*RuntimeAsset) *RuntimeAssetSet
 }
 
 func newStoreTest() *storeTest {
 	return &storeTest{
 		store: NewAssetStore(),
-		newAssetFn: func(a *types.Asset) *RuntimeAsset {
+		newAssetFn: func(a types.Asset) *RuntimeAsset {
 			return NewRuntimeAsset(a, "")
 		},
 		newSetFn: func(a []*RuntimeAsset) *RuntimeAssetSet {

--- a/types/asset.go
+++ b/types/asset.go
@@ -85,12 +85,12 @@ func (a *Asset) Filename() string {
 }
 
 // FixtureAsset given a name returns a valid asset for use in tests
-func FixtureAsset(name string) *Asset {
+func FixtureAsset(name string) Asset {
 	bytes := make([]byte, 10)
 	_, _ = rand.Read(bytes)
 	hash := hex.EncodeToString(bytes)
 
-	return &Asset{
+	return Asset{
 		Name:   name,
 		Sha512: "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
 		URL:    "https://localhost/" + hash + ".zip",

--- a/types/check.go
+++ b/types/check.go
@@ -351,7 +351,7 @@ func FixtureCheckRequest(id string) *CheckRequest {
 	return &CheckRequest{
 		Config: config,
 		Assets: []Asset{
-			*FixtureAsset("ruby-2-4-2"),
+			FixtureAsset("ruby-2-4-2"),
 		},
 		Hooks: []HookConfig{
 			*FixtureHookConfig("hook1"),


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Fixes a bug where a check with multiple assets would only ever install
the first asset. Also updates the assetmanager store to use the entire
asset SHA as an identifier rather than the first 7 digits.

## Why is this change necessary?

Checks with multiple assets will only ever install the first asset. Also, using the first 7 digits of a SHA as an identifier may cause collisions.

## Does your change need a Changelog entry?

Updated.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

(Sometimes) the use of pointers can lead to some not so fun debugging sessions.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A
