### PR TITLE
[Agent] Use absolute path when obtaining lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 - Fixed a bug where assets could not extract git tarballs.
+- Fixed a bug where assets would not install if given cache directory was a
+  relative path.
 
 ## [2.0.0-beta.4] - 2018-08-14
 

--- a/agent/assetmanager/asset.go
+++ b/agent/assetmanager/asset.go
@@ -97,7 +97,12 @@ func (d *RuntimeAsset) markAsInstalled() error {
 
 // Avoid competing installation of assets
 func (d *RuntimeAsset) awaitLock() (*lockfile.Lockfile, error) {
-	lockfile, err := lockfile.New(filepath.Join(d.path, ".lock"))
+	lockpath, err := filepath.Abs(filepath.Join(d.path, ".lock"))
+	if err != nil {
+		return nil, err
+	}
+
+	lockfile, err := lockfile.New(lockpath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What is this change?

When installing assets, ensure that an absolute path is used to obtain the lockfile.

https://github.com/nightlyone/lockfile/blob/master/lockfile.go#L45-L47

## Why is this change necessary?

Discovered while helping debug #2003. If the agent is configured with a relative path asset installation will fail. (eg. `sensu-agent start --cache-dir ./tmp`.)

## Does your change need a Changelog entry?

It certainly should!