### PR TITLE
[CLI] Use terminals configured default text colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Add windows/386 to binary gcs releases
 
+### Changed
+- Changed sensuctl title colour to use terminal's configured default for bold
+  text.
+
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 - Fixed a bug where assets could not extract git tarballs.

--- a/cli/elements/globals/colors.go
+++ b/cli/elements/globals/colors.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// TitleStyle can be used to format a string; suitable for titles
-	TitleStyle = ansi.ColorFunc("white+bh")
+	TitleStyle = ansi.ColorFunc("default+bh")
 
 	// PrimaryTextStyle can be used to format a string; suitable for emphasis
 	PrimaryTextStyle = ansi.ColorFunc("blue+b")

--- a/cli/elements/table/standard.go
+++ b/cli/elements/table/standard.go
@@ -4,19 +4,19 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/mgutz/ansi"
 	"github.com/olekukonko/tablewriter"
+	"github.com/sensu/sensu-go/cli/elements/globals"
 )
 
 var (
 	// TitleStyle can be used to format a string; suitable for titles
-	TitleStyle = ansi.ColorFunc("white+bh")
+	TitleStyle = globals.TitleStyle
 
 	// PrimaryTextStyle can be used to format a string; suitable for emphasis
-	PrimaryTextStyle = ansi.ColorFunc("blue+b")
+	PrimaryTextStyle = globals.PrimaryTextStyle
 
 	// CTATextStyle can be used to format a string; important text
-	CTATextStyle = ansi.ColorFunc("red+b:white+h") // Call To Action
+	CTATextStyle = globals.CTATextStyle
 )
 
 // Row describes a value that will represent a row in our table


### PR DESCRIPTION
## What is this change?

Use terminals configured default text colour.

<img width="600" alt="solar" src="https://user-images.githubusercontent.com/194892/44804991-4402d500-ab80-11e8-8777-c15aed08dbff.png">
<img width="590" alt="dark" src="https://user-images.githubusercontent.com/194892/44804992-4402d500-ab80-11e8-85a3-64b2649277d8.png">

## Why is this change necessary?

Fixes #2006 

## Does your change need a Changelog entry?

Yes!

## Do you need clarification on anything?

NO!

## Were there any complications while making this change?

No [exclaimation mark]

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Unlikely.