### PR TITLE
Separate system info collection from getAgentEntity()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where assets could not extract git tarballs.
 - Fixed a bug where assets would not install if given cache directory was a
   relative path.
+- Fixed a bug where an agent's collection of system information could delay
+  sending of keepalive messages.
 
 ## [2.0.0-beta.4] - 2018-08-14
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,6 +63,9 @@ const (
 	DefaultStatsdMetricsHost = "127.0.0.1"
 	// DefaultStatsdMetricsPort specifies the default metrics port for statsd server
 	DefaultStatsdMetricsPort = 8125
+	// DefaultSystemInfoRefreshInterval specifies the default refresh interval
+	// (in seconds) for the agent's cached system information.
+	DefaultSystemInfoRefreshInterval = 20
 	// DefaultUser specifies the default user
 	DefaultUser = "agent"
 )
@@ -429,8 +432,7 @@ func (a *Agent) Run() error {
 	}
 
 	go func() {
-		// TODO(cyril): create a separate config knob for system info refresh interval?
-		systemInfoTicker := time.NewTicker(time.Duration(a.config.KeepaliveInterval) * time.Second)
+		systemInfoTicker := time.NewTicker(time.Duration(DefaultSystemInfoRefreshInterval) * time.Second)
 		for {
 			select {
 			case <-systemInfoTicker.C:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,7 +91,7 @@ type Config struct {
 	// keepalive to sensu-backend. Default: 60
 	KeepaliveInterval int
 	// KeepaliveTimeout is the time after which a sensu-agent is considered dead
-	// back the backend.
+	// by the backend.
 	KeepaliveTimeout uint32
 	// Organization sets the Agent's RBAC organization identifier
 	Organization string

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/sensu/sensu-go/system"
 	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"
 )
@@ -43,10 +42,10 @@ func (a *Agent) getAgentEntity() *types.Entity {
 			}
 		}
 
-		s, err := system.Info()
-		if err == nil {
-			e.System = s
-		}
+		// Retrieve the system info from the agent's cached value
+		a.systemInfoMu.RLock()
+		e.System = *a.systemInfo
+		a.systemInfoMu.RUnlock()
 
 		a.entity = e
 	}

--- a/agent/entity_test.go
+++ b/agent/entity_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
@@ -48,6 +49,9 @@ func TestGetAgentEntity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.agent.systemInfo = &types.System{}
+			tc.agent.systemInfoMu = &sync.RWMutex{}
+
 			entity := tc.agent.getAgentEntity()
 			assert.Equal(tc.expectedAgentID, entity.ID)
 			assert.Equal(tc.extendedAttributes, entity.ExtendedAttributes)
@@ -91,6 +95,9 @@ func TestGetEntities(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.agent.systemInfo = &types.System{}
+			tc.agent.systemInfoMu = &sync.RWMutex{}
+
 			tc.agent.getEntities(tc.event)
 			assert.Equal(tc.expectedAgentID, tc.event.Entity.ID)
 			assert.Equal(tc.expectedSource, tc.event.Check.ProxyEntityID)


### PR DESCRIPTION
## What is this change?

Instead of `agent.getAgentEntity()` being responsible for gathering system info, the agent itself now spawns a goroutine responsible for periodically updating a local cache of system info.

`agent.getAgentEntity()` now reads that cache whenever it needs to retrieve system information.

## Why is this change necessary?

Closes #1947.
Might help #1829. 

## Does your change need a Changelog entry?

Yes, added as part of of the change.

## Do you need clarification on anything?

- Initial keepalive message might not have system info. That doesn't change how
  it used to work, but is that OK?
- Unsure how/if I should add tests for the change. It might lead to some refactoring?
- Any potential impact I might be missing? Would you have done it differently?
  
## Were there any complications while making this change?

- `lsb_release` needed for some distros to pass tests in `system` package (eg:
  Arch). I'll open a separate issue for which the "fix" would probably simply be
  an update to the README.
- unsure about testing (reproducing #1947 easily, need for test in the first
  place, ease of testing without needlessly refactoring)
  
## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nothing relevant to change that I could find in the "Sensu Core" doc set for
v2.0.
