### PR TITLE
Remove race flag from build.sh integration tests

### DIFF
--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,4 +1,4 @@
-// +build integration,race
+// +build integration
 
 package backend
 

--- a/build.sh
+++ b/build.sh
@@ -208,21 +208,10 @@ unit_test_commands () {
 integration_test_commands () {
     echo "Running integration tests..."
 
-    go test -timeout=180s -tags=integration $RACE $(go list ./... | egrep -v '(testing|vendor|scripts)')
+    go test -timeout=180s -tags=integration $(go list ./... | egrep -v '(testing|vendor|scripts)')
     if [ $? -ne 0 ]; then
         echo "Integration testing failed..."
         exit 1
-    fi
-
-    # If the race detector was enabled, do a second pass without it
-    if [ ! -z "$RACE" ]; then
-        echo "Running integration tests without race detector..."
-
-        go test -timeout=180s -tags=integration $(go list ./... | egrep -v '(testing|vendor|scripts)')
-        if [ $? -ne 0 ]; then
-            echo "Integration testing failed..."
-            exit 1
-        fi
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Removes race flag from `build.sh` integration tests.

## Why is this change necessary?

Just an attempt to fix our CircleCI builds from OOM-ing.