### PR TITLE
Fix a bug in sensuctl check update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where an agent's collection of system information could delay
   sending of keepalive messages.
 - Fixed a bug in nagios perfdata parsing.
+- Fixed a bug where output metric format could not be unset.
 
 ## [2.0.0-beta.4] - 2018-08-14
 

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -236,13 +236,18 @@ func (opts *checkOpts) administerQuestionnaire(editing bool) error {
 		},
 		{
 			Name: "output-metric-format",
-			Prompt: &survey.Input{
+			Prompt: &survey.Select{
 				Message: "Metric Format:",
-				Help:    "Optional output metric format used to parse check output for metric extraction. Valid formats include: nagios_perfdata, graphite_plaintext, opentsdb_line, and influxdb_line",
-				Default: opts.OutputMetricFormat,
+				Options: []string{
+					"nagios_perfdata",
+					"graphite_plaintext",
+					"opentsdb_line",
+					"influxdb_line",
+					"none",
+				},
 			},
 			Validate: func(val interface{}) error {
-				if val.(string) != "" {
+				if value := strings.TrimSpace(val.(string)); value != "" && value != "none" {
 					if err := types.ValidateOutputMetricFormat(val.(string)); err != nil {
 						return err
 					}
@@ -299,6 +304,9 @@ func (opts *checkOpts) Copy(check *types.CheckConfig) {
 	check.HighFlapThreshold = uint32(highFlap)
 	check.LowFlapThreshold = uint32(lowFlap)
 	check.OutputMetricFormat = opts.OutputMetricFormat
+	if check.OutputMetricFormat == "none" {
+		check.OutputMetricFormat = ""
+	}
 	check.OutputMetricHandlers = helpers.SafeSplitCSV(opts.OutputMetricHandlers)
 	check.RoundRobin, _ = strconv.ParseBool(opts.RoundRobin)
 }

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -238,13 +238,7 @@ func (opts *checkOpts) administerQuestionnaire(editing bool) error {
 			Name: "output-metric-format",
 			Prompt: &survey.Select{
 				Message: "Metric Format:",
-				Options: []string{
-					"nagios_perfdata",
-					"graphite_plaintext",
-					"opentsdb_line",
-					"influxdb_line",
-					"none",
-				},
+				Options: append(types.OutputMetricFormats, "none"),
 			},
 			Validate: func(val interface{}) error {
 				if value := strings.TrimSpace(val.(string)); value != "" && value != "none" {


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in sensuctl check update where once a
metrics output format had been set, it could no longer be unset.

## Why is this change necessary?

Closes #2023

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

## Were there any complications while making this change?

It seems likely that a slew of similar bugs exists in the interactive mode of sensuctl. We should discuss how to resolve this on a product-wide basis.