### PR TITLE
Resolve some etcd configuration and operation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Changed sensuctl title colour to use terminal's configured default for bold
   text.
+- The backend no longer forcibly binds to localhost.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
@@ -22,6 +23,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where an agent's collection of system information could delay
   sending of keepalive messages.
 - Fixed a bug in nagios perfdata parsing.
+- Etcd client URLs can now be a comma-separated list.
 
 ## [2.0.0-beta.4] - 2018-08-14
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/agentd"
@@ -66,7 +67,7 @@ func Initialize(config *Config) (*Backend, error) {
 	// the Wizard bus, which requires etcd to be started.
 	cfg := etcd.NewConfig()
 	cfg.DataDir = config.StateDir
-	cfg.ListenClientURL = config.EtcdListenClientURL
+	cfg.ListenClientURLs = strings.Split(config.EtcdListenClientURL, ",")
 	cfg.ListenPeerURL = config.EtcdListenPeerURL
 	cfg.InitialCluster = config.EtcdInitialCluster
 	cfg.InitialClusterState = config.EtcdInitialClusterState

--- a/backend/etcd/testing.go
+++ b/backend/etcd/testing.go
@@ -25,7 +25,7 @@ func NewTestEtcd(t *testing.T) (*Etcd, func()) {
 
 	cfg := NewConfig()
 	cfg.DataDir = tmpDir
-	cfg.ListenClientURL = clURL
+	cfg.ListenClientURLs = []string{clURL}
 	cfg.ListenPeerURL = apURL
 	cfg.InitialCluster = initCluster
 	cfg.InitialClusterState = ClusterStateNew

--- a/backend/store/etcd/testutil/store.go
+++ b/backend/store/etcd/testutil/store.go
@@ -51,7 +51,7 @@ func NewStoreInstance() (*IntegrationTestStore, error) {
 
 	peerURL := fmt.Sprintf("http://127.0.0.1:%d", p[1])
 
-	cfg.ListenClientURL = fmt.Sprintf("http://127.0.0.1:%d", p[0])
+	cfg.ListenClientURLs = []string{fmt.Sprintf("http://127.0.0.1:%d", p[0])}
 	cfg.ListenPeerURL = peerURL
 	cfg.InitialCluster = fmt.Sprintf("default=http://127.0.0.1:%d", p[1])
 	cfg.InitialAdvertisePeerURL = peerURL


### PR DESCRIPTION
## What is this change?

* --listen-client-urls can now be a comma-separated list.
* The etcd service no longer forcibly binds to localhost.

## Why is this change necessary?

There were a couple of etcd configuration issues that I thought were closely related enough to be worthwhile folding together into a single commit.

Closes #1965
Closes #2016 

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation requires updating, as clustering documentation is still an outstanding effort.