### PR TITLE
Support using sensu-backend with external etcd instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ keepalive events.
 - The backend no longer requires embedded etcd. External etcd instances can be
 used by providing the --no-embed option. In this case, the client will dial
 the URLs provided by --listen-client-urls.
+- The sensu-agent binary is now located at ./cmd/sensu-agent.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ used by providing the --no-embed option. In this case, the client will dial
 the URLs provided by --listen-client-urls.
 - The sensu-agent binary is now located at ./cmd/sensu-agent.
 - Sensuctl no longer uses auto text wrapping.
+- The backend no longer requires embedded etcd. External etcd instances can be
+used by providing the --no-embed option. In this case, the client will dial
+the URLs provided by --listen-client-urls.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ text.
 keepalive events.
 - The sensu-agent binary is now located at ./cmd/sensu-agent.
 - Sensuctl no longer uses auto text wrapping.
+- The backend no longer requires embedded etcd. External etcd instances can be
+used by providing the --no-embed option. In this case, the client will dial
+the URLs provided by --listen-client-urls.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ keepalive events.
 used by providing the --no-embed option. In this case, the client will dial
 the URLs provided by --listen-client-urls.
 - The sensu-agent binary is now located at ./cmd/sensu-agent.
+- Sensuctl no longer uses auto text wrapping.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,11 +1,13 @@
 package backend
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/agentd"
@@ -36,21 +38,12 @@ type Backend struct {
 	Etcd    *etcd.Etcd
 	Store   store.Store
 
-	done         chan struct{}
-	shutdownChan chan struct{}
+	done   chan struct{}
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
-// Initialize instantiates a Backend struct with the provided config, by
-// configuring etcd and establishing a list of daemons, which constitute our
-// backend. The daemons will later be started according to their position in the
-// b.Daemons list, and stopped in reverse order
-func Initialize(config *Config) (*Backend, error) {
-	// Initialize a Backend struct
-	b := &Backend{}
-
-	b.done = make(chan struct{})
-	b.shutdownChan = make(chan struct{})
-
+func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 	// Intialize the TLS configuration
 	var (
 		tlsConfig *tls.Config
@@ -61,6 +54,16 @@ func Initialize(config *Config) (*Backend, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if config.NoEmbed {
+		// Don't start up an embedded etcd, return a client that connects to an
+		// external etcd instead.
+		return clientv3.New(clientv3.Config{
+			Endpoints:   strings.Split(config.EtcdListenClientURL, ","),
+			DialTimeout: 5 * time.Second,
+			TLS:         tlsConfig,
+		})
 	}
 
 	// Initialize and start etcd, because we'll need to provide an etcd client to
@@ -88,27 +91,52 @@ func Initialize(config *Config) (*Backend, error) {
 	// Start etcd
 	e, err := etcd.NewEtcd(cfg)
 	if err != nil {
-		return nil, errors.New("error starting etcd: " + err.Error())
+		return nil, fmt.Errorf("error starting etcd: %s", err)
 	}
 
-	// Create an etcd client for our daemons
-	client, err := e.NewClient()
+	backend.Etcd = e
+
+	// Create an etcd client
+	return e.NewClient()
+}
+
+// Initialize instantiates a Backend struct with the provided config, by
+// configuring etcd and establishing a list of daemons, which constitute our
+// backend. The daemons will later be started according to their position in the
+// b.Daemons list, and stopped in reverse order
+func Initialize(config *Config) (*Backend, error) {
+	// Initialize a Backend struct
+	b := &Backend{}
+
+	b.done = make(chan struct{})
+	b.ctx, b.cancel = context.WithCancel(context.Background())
+
+	client, err := newClient(config, b)
 	if err != nil {
-		return nil, errors.New("error initializing an etcd client: " + err.Error())
+		return nil, err
 	}
 
 	// Initialize the store, which lives on top of etcd
-	store := etcdstore.NewStore(client, e.Name())
+	logger.Debug("Initializing store...")
+	store := etcdstore.NewStore(client, config.EtcdName)
 	if err = seeds.SeedInitialData(store); err != nil {
 		return nil, errors.New("error initializing the store: " + err.Error())
 	}
+	logger.Debug("Done initializing store")
+
+	logger.Debug("Registering backend...")
+	backendID, err := etcd.BackendID(b.ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("error creating backend ID: %s", err)
+	}
+	logger.Debug("Done registering backend.")
 
 	// Initialize an etcd getter
-	queueGetter := queue.EtcdGetter{Client: client, BackendID: e.BackendID()}
+	queueGetter := queue.EtcdGetter{Client: client, BackendID: backendID}
 
 	// Initialize the bus
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
-		RingGetter: ring.EtcdGetter{Client: client, BackendID: e.BackendID()},
+		RingGetter: ring.EtcdGetter{Client: client, BackendID: fmt.Sprintf("%x", backendID)},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", bus.Name(), err.Error())
@@ -201,8 +229,7 @@ func Initialize(config *Config) (*Backend, error) {
 	}
 	b.Daemons = append(b.Daemons, dashboard)
 
-	// Add etcd and store to our backend, since it's needed across the methods
-	b.Etcd = e
+	// Add store to our backend, since it's needed across the methods
 	b.Store = store
 
 	return b, nil
@@ -238,30 +265,34 @@ func (b *Backend) Run() error {
 		sg[i], sg[opp] = sg[opp], sg[i]
 	}
 
-	// Add etcd to our errGroup, since it's not included in the daemon list
-	eg.errors = append(eg.errors, b.Etcd)
+	if b.Etcd != nil {
+		// Add etcd to our errGroup, since it's not included in the daemon list
+		eg.errors = append(eg.errors, b.Etcd)
+	}
 	eg.Go()
 
 	select {
 	case err := <-eg.Err():
 		logger.Error(err.Error())
-	case <-b.shutdownChan:
+	case <-b.ctx.Done():
 		logger.Info("backend shutting down")
 	}
 
 	var derr error
-	logger.Info("shutting down etcd")
-	defer func() {
-		if err := recover(); err != nil {
-			trace := string(debug.Stack())
-			logger.WithField("panic", trace).WithError(err.(error)).
-				Error("recovering from panic due to error, shutting down etcd")
-		}
-		err := b.Etcd.Shutdown()
-		if derr == nil {
-			derr = err
-		}
-	}()
+	if b.Etcd != nil {
+		logger.Info("shutting down etcd")
+		defer func() {
+			if err := recover(); err != nil {
+				trace := string(debug.Stack())
+				logger.WithField("panic", trace).WithError(err.(error)).
+					Error("recovering from panic due to error, shutting down etcd")
+			}
+			err := b.Etcd.Shutdown()
+			if derr == nil {
+				derr = err
+			}
+		}()
+	}
 
 	if err := sg.Stop(); err != nil {
 		if derr == nil {
@@ -322,8 +353,12 @@ func (e errGroup) Err() <-chan error {
 
 // Migration performs the migration of data inside the store
 func (b *Backend) Migration() error {
-	logger.Infof("starting migration on the store with URL '%s'", b.Etcd.LoopbackURL())
-	migration.Run(b.Etcd.LoopbackURL())
+	clientURLs := b.Etcd.ClientURLs()
+	if len(clientURLs) == 0 {
+		return errors.New("no client URLs specified")
+	}
+	logger.Infof("starting migration on the store with URL %q", clientURLs[0])
+	migration.Run(clientURLs[0])
 	return nil
 }
 
@@ -342,6 +377,6 @@ func (b *Backend) Status() types.StatusMap {
 
 // Stop the Backend cleanly.
 func (b *Backend) Stop() {
-	close(b.shutdownChan)
+	b.cancel()
 	<-b.done
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -125,18 +125,15 @@ func Initialize(config *Config) (*Backend, error) {
 	logger.Debug("Done initializing store")
 
 	logger.Debug("Registering backend...")
-	backendID, err := etcd.BackendID(b.ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("error creating backend ID: %s", err)
-	}
+	backendID := etcd.NewBackendIDGetter(b.ctx, client)
 	logger.Debug("Done registering backend.")
 
 	// Initialize an etcd getter
-	queueGetter := queue.EtcdGetter{Client: client, BackendID: backendID}
+	queueGetter := queue.EtcdGetter{Client: client, BackendIDGetter: backendID}
 
 	// Initialize the bus
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
-		RingGetter: ring.EtcdGetter{Client: client, BackendID: fmt.Sprintf("%x", backendID)},
+		RingGetter: ring.EtcdGetter{Client: client, BackendID: fmt.Sprintf("%x", backendID.GetBackendID())},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", bus.Name(), err.Error())

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -56,7 +56,7 @@ func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 		}
 	}
 
-	if config.NoEmbed {
+	if config.NoEmbedEtcd {
 		// Don't start up an embedded etcd, return a client that connects to an
 		// external etcd instead.
 		return clientv3.New(clientv3.Config{

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -47,6 +47,7 @@ const (
 	flagStoreInitialClusterState     = "initial-cluster-state"
 	flagStoreInitialClusterToken     = "initial-cluster-token"
 	flagStoreNodeName                = "name"
+	flagNoEmbed                      = "no-embed"
 
 	// Default values
 
@@ -118,6 +119,7 @@ func newStartCommand() *cobra.Command {
 				EtcdInitialAdvertisePeerURL: viper.GetString(flagStoreInitialAdvertisePeerURL),
 				EtcdInitialClusterToken:     viper.GetString(flagStoreInitialClusterToken),
 				EtcdName:                    viper.GetString(flagStoreNodeName),
+				NoEmbed:                     viper.GetBool(flagNoEmbed),
 			}
 
 			certFile := viper.GetString(flagCertFile)
@@ -218,6 +220,7 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagStoreInitialClusterState, etcd.ClusterStateNew)
 	viper.SetDefault(flagStoreInitialClusterToken, "")
 	viper.SetDefault(flagStoreNodeName, defaultEtcdName)
+	viper.SetDefault(flagNoEmbed, false)
 
 	// Merge in config flag set so that it appears in command usage
 	cmd.Flags().AddFlagSet(configFlagSet)
@@ -246,6 +249,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagStoreInitialClusterState, viper.GetString(flagStoreInitialClusterState), "store initial cluster state")
 	cmd.Flags().String(flagStoreInitialClusterToken, viper.GetString(flagStoreInitialClusterToken), "store initial cluster token")
 	cmd.Flags().String(flagStoreNodeName, viper.GetString(flagStoreNodeName), "store cluster member node name")
+	cmd.Flags().Bool(flagNoEmbed, viper.GetBool(flagNoEmbed), "don't embed etcd, use external etcd instead")
 
 	// Load the configuration file but only error out if flagConfigFile is used
 	if err := viper.ReadInConfig(); err != nil && configFile != "" {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -47,7 +47,7 @@ const (
 	flagStoreInitialClusterState     = "initial-cluster-state"
 	flagStoreInitialClusterToken     = "initial-cluster-token"
 	flagStoreNodeName                = "name"
-	flagNoEmbed                      = "no-embed"
+	flagNoEmbedEtcd                  = "no-embed-etcd"
 
 	// Default values
 
@@ -119,7 +119,7 @@ func newStartCommand() *cobra.Command {
 				EtcdInitialAdvertisePeerURL: viper.GetString(flagStoreInitialAdvertisePeerURL),
 				EtcdInitialClusterToken:     viper.GetString(flagStoreInitialClusterToken),
 				EtcdName:                    viper.GetString(flagStoreNodeName),
-				NoEmbed:                     viper.GetBool(flagNoEmbed),
+				NoEmbedEtcd:                 viper.GetBool(flagNoEmbedEtcd),
 			}
 
 			certFile := viper.GetString(flagCertFile)
@@ -220,7 +220,7 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagStoreInitialClusterState, etcd.ClusterStateNew)
 	viper.SetDefault(flagStoreInitialClusterToken, "")
 	viper.SetDefault(flagStoreNodeName, defaultEtcdName)
-	viper.SetDefault(flagNoEmbed, false)
+	viper.SetDefault(flagNoEmbedEtcd, false)
 
 	// Merge in config flag set so that it appears in command usage
 	cmd.Flags().AddFlagSet(configFlagSet)
@@ -249,7 +249,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagStoreInitialClusterState, viper.GetString(flagStoreInitialClusterState), "store initial cluster state")
 	cmd.Flags().String(flagStoreInitialClusterToken, viper.GetString(flagStoreInitialClusterToken), "store initial cluster token")
 	cmd.Flags().String(flagStoreNodeName, viper.GetString(flagStoreNodeName), "store cluster member node name")
-	cmd.Flags().Bool(flagNoEmbed, viper.GetBool(flagNoEmbed), "don't embed etcd, use external etcd instead")
+	cmd.Flags().Bool(flagNoEmbedEtcd, viper.GetBool(flagNoEmbedEtcd), "don't embed etcd, use external etcd instead")
 
 	// Load the configuration file but only error out if flagConfigFile is used
 	if err := viper.ReadInConfig(); err != nil && configFile != "" {

--- a/backend/config.go
+++ b/backend/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	EtcdListenClientURL         string
 	EtcdListenPeerURL           string
 	EtcdName                    string
+	NoEmbed                     bool
 
 	TLS *types.TLSOptions
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	EtcdListenClientURL         string
 	EtcdListenPeerURL           string
 	EtcdName                    string
-	NoEmbed                     bool
+	NoEmbedEtcd                 bool
 
 	TLS *types.TLSOptions
 }

--- a/backend/etcd/id.go
+++ b/backend/etcd/id.go
@@ -1,0 +1,45 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+var (
+	backendIDKeyPrefix         = store.NewKeyBuilder("backends").Build()
+	backendIDLeasePeriod int64 = 60
+)
+
+// BackendID creates and returns a new leased backend ID.
+func BackendID(ctx context.Context, client *clientv3.Client) (int64, error) {
+	// Grant a lease for 60 seconds
+	resp, err := client.Grant(ctx, backendIDLeasePeriod)
+	if err != nil {
+		return 0, fmt.Errorf("error creating backend ID: error granting lease: %s", err)
+	}
+
+	// Register the backend's lease - this is for clients that need to be
+	// able to send specific backends messages
+	value := fmt.Sprintf("%x", resp.ID)
+	key := path.Join(backendIDKeyPrefix, value)
+	_, err = client.Put(ctx, key, value, clientv3.WithLease(resp.ID))
+	if err != nil {
+		return 0, fmt.Errorf("error creating backend ID: error creating key: %s", err)
+	}
+
+	// Keep the lease alive indefinitely
+	ch, err := client.KeepAlive(ctx, resp.ID)
+	if err != nil {
+		return 0, fmt.Errorf("error creating backend ID: error creating keepalive: %s", err)
+	}
+	go func() {
+		for range ch {
+		}
+	}()
+
+	return int64(resp.ID), nil
+}

--- a/backend/etcd/id.go
+++ b/backend/etcd/id.go
@@ -4,42 +4,125 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/util/retry"
 )
 
 var (
 	backendIDKeyPrefix         = store.NewKeyBuilder("backends").Build()
 	backendIDLeasePeriod int64 = 60
+	minRetryLeaseDelay         = time.Second
+	maxRetryLeaseDelay         = time.Minute
+	retryLeaseTimeout          = time.Hour
+	retryLeaseMultiplier       = 2.0
 )
 
-// BackendID creates and returns a new leased backend ID.
-func BackendID(ctx context.Context, client *clientv3.Client) (int64, error) {
+// BackendIDGetterClient represents the dependencies for BackendIDGetter.
+type BackendIDGetterClient interface {
+	Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error)
+	KeepAlive(ctx context.Context, id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error)
+	Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error)
+}
+
+// BackendIDGetter is a type that facilitates identifying a sensu backend.
+type BackendIDGetter struct {
+	id     int64
+	wg     sync.WaitGroup
+	ctx    context.Context
+	client BackendIDGetterClient
+}
+
+func (b *BackendIDGetter) GetBackendID() int64 {
+	// The backend ID might have been invalidated by a lease that was allowed
+	// to expire. If that's the case, wait for a new lease to be granted.
+	b.wg.Wait()
+
+	return atomic.LoadInt64(&b.id)
+}
+
+// NewBackendIDGetter creates a new BackendIDGetter. It uses a context that
+// should be valid for the life of the application, to pass to etcd.
+// It requires a BackendIDGetterClient, which users can provide by using
+// an etcd *clientv3.Client.
+func NewBackendIDGetter(ctx context.Context, client BackendIDGetterClient) *BackendIDGetter {
+	getter := &BackendIDGetter{
+		client: client,
+		ctx:    ctx,
+	}
+	// Wait until the backend ID has been created
+	getter.wg.Add(1)
+
+	// Start the async worker that populates the backend ID
+	go getter.retryAcquireLease()
+
+	// Wait until the worker has acquired a backend ID
+	getter.wg.Wait()
+
+	return getter
+}
+
+func leaseRetryBackoff() *retry.ExponentialBackoff {
+	return &retry.ExponentialBackoff{
+		InitialDelayInterval: minRetryLeaseDelay,
+		MaxDelayInterval:     maxRetryLeaseDelay,
+		MaxElapsedTime:       retryLeaseTimeout,
+		Multiplier:           retryLeaseMultiplier,
+	}
+}
+
+func (b *BackendIDGetter) retryAcquireLease() {
+	backoff := leaseRetryBackoff()
+	for {
+		var ch <-chan *clientv3.LeaseKeepAliveResponse
+		err := backoff.Retry(func(retries int) (bool, error) {
+			var err error
+			var id int64
+			id, ch, err = b.getLease()
+			if err != nil {
+				logger.WithError(err).Error("error generating backend ID")
+				return false, nil
+			}
+			atomic.StoreInt64(&b.id, id)
+			b.wg.Done()
+			return true, nil
+		})
+		if err != nil && err != b.ctx.Err() {
+			// Crash at this point. The system could not acquire a lease for
+			// retryLeaseTimeout duration.
+			panic(fmt.Sprintf("couldn't acquire an etcd lease for %v", retryLeaseTimeout))
+		}
+		for resp := range ch {
+			if resp.ID == clientv3.NoLease {
+				break
+			}
+		}
+		b.wg.Add(1)
+	}
+}
+
+func (b *BackendIDGetter) getLease() (int64, <-chan *clientv3.LeaseKeepAliveResponse, error) {
 	// Grant a lease for 60 seconds
-	resp, err := client.Grant(ctx, backendIDLeasePeriod)
+	resp, err := b.client.Grant(b.ctx, backendIDLeasePeriod)
 	if err != nil {
-		return 0, fmt.Errorf("error creating backend ID: error granting lease: %s", err)
+		return 0, nil, fmt.Errorf("error creating backend ID: error granting lease: %s", err)
 	}
 
 	// Register the backend's lease - this is for clients that need to be
 	// able to send specific backends messages
 	value := fmt.Sprintf("%x", resp.ID)
 	key := path.Join(backendIDKeyPrefix, value)
-	_, err = client.Put(ctx, key, value, clientv3.WithLease(resp.ID))
+	_, err = b.client.Put(b.ctx, key, value, clientv3.WithLease(resp.ID))
 	if err != nil {
-		return 0, fmt.Errorf("error creating backend ID: error creating key: %s", err)
+		return 0, nil, fmt.Errorf("error creating backend ID: error creating key: %s", err)
 	}
 
-	// Keep the lease alive indefinitely
-	ch, err := client.KeepAlive(ctx, resp.ID)
-	if err != nil {
-		return 0, fmt.Errorf("error creating backend ID: error creating keepalive: %s", err)
-	}
-	go func() {
-		for range ch {
-		}
-	}()
+	// Keep the lease alive
+	ch, err := b.client.KeepAlive(b.ctx, resp.ID)
 
-	return int64(resp.ID), nil
+	return int64(resp.ID), ch, err
 }

--- a/backend/etcd/id_test.go
+++ b/backend/etcd/id_test.go
@@ -1,0 +1,109 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+type mockBackendIDGetterClient struct {
+	grantResp    *clientv3.LeaseGrantResponse
+	grantErr     error
+	keepaliveCh  chan *clientv3.LeaseKeepAliveResponse
+	keepaliveErr error
+	putResp      *clientv3.PutResponse
+	putErr       error
+	puts         []string
+	grantCh      chan struct{}
+	sync.Mutex
+}
+
+func (m *mockBackendIDGetterClient) Grant(ctx context.Context, period int64) (*clientv3.LeaseGrantResponse, error) {
+	m.Lock()
+	defer m.Unlock()
+	defer func() {
+		// This is a way to wait for calls to Grant() elsewhere
+		m.grantCh <- struct{}{}
+	}()
+	return m.grantResp, m.grantErr
+}
+
+func (m *mockBackendIDGetterClient) KeepAlive(ctx context.Context, id clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.keepaliveCh, m.keepaliveErr
+}
+
+func (m *mockBackendIDGetterClient) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	m.Lock()
+	defer m.Unlock()
+	m.puts = append(m.puts, fmt.Sprintf("%s=%s", key, val))
+	return m.putResp, m.putErr
+}
+
+func (m *mockBackendIDGetterClient) clearGrantCh() {
+	for {
+		select {
+		case <-m.grantCh:
+		default:
+			return
+		}
+	}
+}
+
+func newMockBackendIDGetterClient() *mockBackendIDGetterClient {
+	return &mockBackendIDGetterClient{
+		grantResp: &clientv3.LeaseGrantResponse{
+			ID: clientv3.LeaseID(1234),
+		},
+		keepaliveCh: make(chan *clientv3.LeaseKeepAliveResponse),
+		putResp:     &clientv3.PutResponse{},
+		grantCh:     make(chan struct{}, 1000),
+	}
+}
+
+func TestBackendIDGetter(t *testing.T) {
+	client := newMockBackendIDGetterClient()
+	getter := NewBackendIDGetter(context.TODO(), client)
+
+	got := getter.GetBackendID()
+	if want := int64(1234); got != want {
+		t.Fatalf("bad backend id: got %d, want %d", got, want)
+	}
+}
+
+func TestBackendIDGetterRetry(t *testing.T) {
+	// Look, there are some frankly quite concerning concurrency constructs
+	// present in this test. I'm sure you aren't thrilled to see them.
+	// However they were necessary for me to safely test this thing.
+	// Change at your peril :)
+	client := newMockBackendIDGetterClient()
+	getter := NewBackendIDGetter(context.TODO(), client)
+
+	got := getter.GetBackendID()
+	if want := int64(1234); got != want {
+		t.Fatalf("bad backend id: got %d, want %d", got, want)
+	}
+
+	client.Lock()
+	// We need an empty grantCh before progressing
+	client.clearGrantCh()
+
+	close(client.keepaliveCh)
+	client.grantResp = &clientv3.LeaseGrantResponse{
+		ID: clientv3.LeaseID(2345),
+	}
+	client.keepaliveCh = make(chan *clientv3.LeaseKeepAliveResponse)
+	client.Unlock()
+
+	// Wait for Grant() to get called before progressing with the test
+	<-client.grantCh
+
+	got = getter.GetBackendID()
+	if want := int64(2345); got != want {
+		t.Fatalf("bad backend id: got %d, want %d", got, want)
+	}
+}

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -43,7 +43,7 @@ func (e EtcdGetter) GetQueue(path ...string) types.Queue {
 	return New(queueKeyBuilder.Build(path...), e.Client, e.BackendIDGetter)
 }
 
-// Queue is a durable FIFO queue that is backed by etcd.
+// Queue is a non-durable FIFO queue that is backed by etcd.
 // When an item is received by a client, it is deleted from
 // the work lane, and added to the in-flight lane. The item stays in the
 // in-flight lane until it is Acked by the client, or returned to the work


### PR DESCRIPTION
## What is this change?

This commit adds the --no-embed flag to the backend. When this flag
is specified, sensu-backend will dial whatever URLs are specified
in the --listen-client-urls flag, and not start up etcd.

## Why is this change necessary?

Closes #2015 
Closes #1963

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

## Were there any complications while making this change?
This change required some refactoring of the queue package, which
depended on the cluster member ID for operation. This ID has been
replaced by a client lease ID which is created on backend startup.

As a result, this made queue garbage collection easier to
guarantee, because now all queue keys are created with a lease.
The test that tested queue garbage collection has been removed,
because the logic that removes the keys is no longer part of the
queue package.

Testing was done by starting up an external etcd instance and
pointing the backend at it. No issues were observed, and the etcd
instance was correctly populated on startup.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe we need to explicitly mention this in the docs for now, given what we have currently. I think we should mention this in the upcoming clustering documentation however.