### PR TITLE
sensuctl cluster health response contains string representation of error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ sending of keepalive messages.
 - Etcd client URLs can now be a comma-separated list.
 - Fixed a bug where output metric format could not be unset.
 - Fixed a bug where the agent does not validate the ID at startup.
+- Fixed a bug in `sensuctl cluster health` that resulted in an unmarshal
+error in an unhealthy cluster.
 
 ### Breaking Changes
 - Removed the KeepaliveTimeout attribute from entities.

--- a/backend/apid/routers/status_test.go
+++ b/backend/apid/routers/status_test.go
@@ -2,7 +2,6 @@ package routers
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -116,7 +115,7 @@ func TestHealthyClusterStatus(t *testing.T) {
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend0",
-		Err:      nil,
+		Err:      "",
 		Healthy:  true,
 	})
 	healthResponse.ClusterHealth = clusterHealth
@@ -145,13 +144,13 @@ func TestUnHealthyClusterStatus(t *testing.T) {
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend0",
-		Err:      nil,
+		Err:      "",
 		Healthy:  true,
 	})
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend1",
-		Err:      errors.New("cluster error"),
+		Err:      "cluster error",
 		Healthy:  false,
 	})
 

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -33,7 +33,7 @@ func (s *Store) GetClusterHealth(ctx context.Context) *types.HealthResponse {
 
 		if cliErr != nil {
 			logger.WithField("member", member.ID).WithError(cliErr).Error("unhealthy cluster member")
-			health.Err = cliErr
+			health.Err = cliErr.Error()
 			health.Healthy = false
 			healthResponse.ClusterHealth = append(healthResponse.ClusterHealth, health)
 			continue
@@ -43,10 +43,10 @@ func (s *Store) GetClusterHealth(ctx context.Context) *types.HealthResponse {
 		_, getErr := cli.Get(context.Background(), "health")
 
 		if getErr == nil || getErr == rpctypes.ErrPermissionDenied {
-			health.Err = nil
+			health.Err = ""
 			health.Healthy = true
 		} else {
-			health.Err = getErr
+			health.Err = getErr.Error()
 			health.Healthy = false
 		}
 

--- a/backend/store/etcd/health_store_test.go
+++ b/backend/store/etcd/health_store_test.go
@@ -13,6 +13,6 @@ import (
 func TestGetClusterHealth(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
 		healthResult := store.GetClusterHealth(context.Background())
-		assert.NoError(t, healthResult.ClusterHealth[0].Err)
+		assert.Empty(t, healthResult.ClusterHealth[0].Err)
 	})
 }

--- a/cli/commands/cluster/health_test.go
+++ b/cli/commands/cluster/health_test.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
@@ -32,13 +31,13 @@ func TestHealthCommandAlarmCorrupt(t *testing.T) {
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend0",
-		Err:      nil,
+		Err:      "",
 		Healthy:  true,
 	})
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend1",
-		Err:      errors.New("error"),
+		Err:      "error",
 		Healthy:  false,
 	})
 
@@ -79,7 +78,7 @@ func TestHealthCommandAlarmNoSpace(t *testing.T) {
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
 		Name:     "backend1",
-		Err:      errors.New("error"),
+		Err:      "error",
 		Healthy:  false,
 	})
 

--- a/types/health.go
+++ b/types/health.go
@@ -8,8 +8,8 @@ type ClusterHealth struct {
 	MemberID uint64
 	// Name is the cluster member's name.
 	Name string
-	// Err holds any errors encountered while checking the member's health.
-	Err error
+	// Err holds the string representation of any errors encountered while checking the member's health.
+	Err string
 	// Healthy describes the health of the cluster member.
 	Healthy bool
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Changes `ClusterHealth.Err` to a string rather than an error. This fixes a bug associated to an unmarshal error in sensuctl when a cluster is unhealthy.

Before:
```
$ ~/sensuctl cluster health
Error: json: cannot unmarshal object into Go struct field ClusterHealth.Err of type error
```

After:
```
$ ~/sensuctl cluster health
         ID            Name                              Error                           Healthy  
 ────────────────── ─────────── ─────────────────────────────────────────────────────── ───────── 
  1e8b542f60611ee    backend-2   dial tcp x:2379: connect: connection refused            false    
  7918dd0d1856841b   backend-0                                                           true     
  f7cdce3577ddf3fc   backend-1                                                           true     
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2029

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

I noticed that `/health` has a dependency on the status map that is to be deprecated in https://github.com/sensu/sensu-go/issues/1854. We should consider refactoring `/health` to `/cluster/health` and removing the dependency on the status map before #1854 can be addressed.

Filed https://github.com/sensu/sensu-go/issues/2061

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.