### PR TITLE
[Web UI] Sort entity events by last ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ used by providing the --no-embed option. In this case, the client will dial
 the URLs provided by --listen-client-urls.
 - Deprecated daemon `Status()` functions and `/info` (`/info` will be
 re-implemented in https://github.com/sensu/sensu-go/issues/1739).
+- Web ui entity recent events are sorted by last ok
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsContainer.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsContainer.js
@@ -27,7 +27,7 @@ class EntityDetailsContainer extends React.PureComponent {
     entity: gql`
       fragment EntityDetailsContainer_entity on Entity {
         id
-        events {
+        events(orderBy: LASTOK) {
           ...EntityDetailsEvents_event
         }
 


### PR DESCRIPTION
## What is this change?
Closes #1989
Sorts the entity recent events list by `LASTOK` as opposed to the default of `SEVERITY`

## Why is this change necessary?
I believe it was for consistency between the events page list and this component

## Does your change need a Changelog entry?
Not entirely sure, but I added it for safety.

## Have you reviewed and updated the documentation for this change? Is new documentation required?
Not needed.
