### PR TITLE
Allow updateCheck mutation to update individual fields

### DIFF
--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -79,7 +79,9 @@ func (r *mutationsImpl) CreateCheck(p schema.MutationCreateCheckFieldResolverPar
 	check.Environment = inputs.Ns.Environment
 
 	rawArgs := p.ResolveParams.Args
-	copyCheckInputs(&check, rawArgs["input"])
+	if err := copyCheckInputs(&check, rawArgs["input"]); err != nil {
+		return nil, err
+	}
 
 	err := r.checkCreator.Create(p.Context, check)
 	if err != nil {
@@ -102,7 +104,9 @@ func (r *mutationsImpl) UpdateCheck(p schema.MutationUpdateCheckFieldResolverPar
 	}
 
 	rawArgs := p.ResolveParams.Args
-	copyCheckInputs(check, rawArgs["input"])
+	if err := copyCheckInputs(check, rawArgs["input"]); err != nil {
+		return nil, err
+	}
 
 	err = r.checkReplacer.CreateOrReplace(p.Context, *check)
 	if err != nil {
@@ -148,17 +152,17 @@ func (r *mutationsImpl) ExecuteCheck(p schema.MutationExecuteCheckFieldResolverP
 	}, nil
 }
 
-func copyCheckInputs(r *types.CheckConfig, in interface{}) {
+func copyCheckInputs(r *types.CheckConfig, in interface{}) error {
 	ins, ok := in.(map[string]interface{})
 	if !ok {
-		return
+		return errors.New("given unexpected arguments")
 	}
 	props, ok := ins["props"].(map[string]interface{})
 	if !ok {
-		return
+		return errors.New("given unexpected arguments; props is not a map")
 	}
 
-	mapstructure.Decode(props, r)
+	return mapstructure.Decode(props, r)
 }
 
 type checkMutationPayload struct {

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -152,12 +152,12 @@ func (r *mutationsImpl) ExecuteCheck(p schema.MutationExecuteCheckFieldResolverP
 	}, nil
 }
 
-func copyCheckInputs(r *types.CheckConfig, in interface{}) error {
-	ins, ok := in.(map[string]interface{})
+func copyCheckInputs(r *types.CheckConfig, args interface{}) error {
+	input, ok := args.(map[string]interface{})
 	if !ok {
 		return errors.New("given unexpected arguments")
 	}
-	props, ok := ins["props"].(map[string]interface{})
+	props, ok := input["props"].(map[string]interface{})
 	if !ok {
 		return errors.New("given unexpected arguments; props is not a map")
 	}

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -33,6 +33,13 @@ func TestMutationTypeUpdateCheck(t *testing.T) {
 	inputs := schema.UpdateCheckInput{}
 	params := schema.MutationUpdateCheckFieldResolverParams{}
 	params.Args.Input = &inputs
+	params.ResolveParams.Args = map[string]interface{}{
+		"input": map[string]interface{}{
+			"props": map[string]interface{}{
+				"command": "yes",
+			},
+		},
+	}
 
 	check := types.FixtureCheckConfig("a")
 	impl := mutationsImpl{}

--- a/backend/apid/graphql/services.go
+++ b/backend/apid/graphql/services.go
@@ -8,12 +8,24 @@ import (
 
 // checks
 
+type checkCreator interface {
+	Create(context.Context, types.CheckConfig) error
+}
+
+type checkDestroyer interface {
+	Destroy(context.Context, string) error
+}
+
 type checkFinder interface {
 	Find(ctx context.Context, name string) (*types.CheckConfig, error)
 }
 
 type checkExecutor interface {
 	QueueAdhocRequest(context.Context, string, *types.AdhocRequest) error
+}
+
+type checkReplacer interface {
+	CreateOrReplace(context.Context, types.CheckConfig) error
 }
 
 // entities

--- a/backend/apid/graphql/services_test.go
+++ b/backend/apid/graphql/services_test.go
@@ -16,6 +16,23 @@ func (m mockCheckExecutor) QueueAdhocRequest(_ context.Context, _ string, _ *typ
 	return m.err
 }
 
+type mockCheckReplacer struct {
+	err error
+}
+
+func (m mockCheckReplacer) CreateOrReplace(_ context.Context, _ types.CheckConfig) error {
+	return m.err
+}
+
+type mockCheckFinder struct {
+	record *types.CheckConfig
+	err    error
+}
+
+func (m mockCheckFinder) Find(_ context.Context, _ string) (*types.CheckConfig, error) {
+	return m.record, m.err
+}
+
 // entities
 
 type mockEntityFetcher struct {


### PR DESCRIPTION
## What is this change?

Allow updateCheck mutation to update individual fields of given check.

---

![2018-09-19 13 51 15](https://user-images.githubusercontent.com/194892/45780851-56b67a00-bc13-11e8-9fd9-4901f702f82b.gif)

## Why is this change necessary?

Unblocks #1935.

## Does your change need a Changelog entry?

unlikely

## Do you need clarification on anything?

n/a

## Were there any complications while making this change?

Without any mocks / stubs for the actions package we continue to accrue redundant code when writing field resolver tests.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

n/a