### PR TITLE
Deprecate custom-attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ re-implemented in https://github.com/sensu/sensu-go/issues/1739).
 - The sensu-backend flags related to etcd are now all prefixed with `etcd` and
 the older versions are now deprecated.
 - Web ui entity recent events are sorted by last ok
+- Deprecated --custom-attributes in the sensu-agent command, changed to
+--extended-attributes.
 
 ### Fixed
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -86,7 +86,7 @@ type Config struct {
 	DeregistrationHandler string
 	// Environment sets the Agent's RBAC environment identifier
 	Environment string
-	// ExtendedAttributes contains any custom attributes passed to the agent on
+	// ExtendedAttributes contains any extended attributes passed to the agent on
 	// start
 	ExtendedAttributes []byte
 	// KeepaliveInterval is the interval, in seconds, when agents will send a

--- a/packaging/files/agent.yml.example
+++ b/packaging/files/agent.yml.example
@@ -47,6 +47,6 @@
 #deregistration-handler: ""
 #keepalive-timeout: 120
 #keepalive-interval: 20
-#custom-attributes: ""
+#extended-attributes: ""
 #log-level: "warn"
 #redact: ""

--- a/packaging/files/windows/agent.yml.example
+++ b/packaging/files/windows/agent.yml.example
@@ -47,6 +47,6 @@
 #deregistration-handler: ""
 #keepalive-timeout: 120
 #keepalive-interval: 20
-#custom-attributes: ""
+#extended-attributes: ""
 #log-level: "warn"
 #redact: ""

--- a/types/dynamic/dynamic.go
+++ b/types/dynamic/dynamic.go
@@ -212,7 +212,7 @@ func Synthesize(v AttrGetter) (map[string]interface{}, error) {
 			continue
 		}
 
-		// Determine if we are handling custom attributes
+		// Determine if we are handling extended attributes
 		if !empty && isExtendedAttributes(extendedAttributesAddress, value.Field(i)) {
 			var attrs interface{}
 			if err := json.Unmarshal(value.Field(i).Bytes(), &attrs); err != nil {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Deprecates --custom-attributes in the sensu-agent command and changes it to --extended-attributes.

## Why is this change necessary?

Closes #2051 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

No, but filed https://github.com/sensu/sensu-go/issues/2079 to address a concern that was brought up in the original issue.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.