### PR TITLE
Add a debug log message for interval timer initial offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Add windows/386 to binary gcs releases
 - TLS authentication and encryption for etcd client and peer communication.
+- Added a debug log message for interval timer initial offset.
 
 ### Removed
 - Staging resources and configurations have been removed from sensu-go.

--- a/backend/schedulerd/check_timer.go
+++ b/backend/schedulerd/check_timer.go
@@ -81,6 +81,7 @@ func (timerPtr *IntervalTimer) Stop() {
 func (timerPtr *IntervalTimer) calcInitialOffset() time.Duration {
 	now := uint64(time.Now().UnixNano())
 	offset := (timerPtr.splay - now) % uint64(timerPtr.interval)
+	logger.WithField("offset", time.Duration(offset)/time.Second).Debug("initial offset for interval timer (in seconds)")
 	return time.Duration(offset) / time.Nanosecond
 }
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a debug log message for interval timer initial offset.

## Why is this change necessary?

Closes #2053.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Proxy splay vs initial offset/timer splay is confusing (see https://github.com/sensu/sensu-go/issues/2053#issuecomment-423290142).

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I'm gonna add a note to the docs about this to avoid future confusion: https://github.com/sensu/sensu-docs/pull/752