### PR TITLE
Fix interactive selection of output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ the older versions are now deprecated.
 - Web ui entity recent events are sorted by last ok
 
 ### Fixed
+- Fixed a bug in `sensuctl configure` where an output format called `none` could
+  be selected instead of `tabular`.
 - Fixes a bug in `sensuctl cluster health` so the correct error is handled.
 - Fixed a bug where assets could not extract git tarballs.
 - Fixed a bug where assets would not install if given cache directory was a

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -10,7 +10,7 @@ const (
 	// DefaultEnvironment represents the default environment
 	DefaultEnvironment = "default"
 	// DefaultFormat represents the default format output when displaying objects
-	DefaultFormat = "tabular"
+	DefaultFormat = FormatTabular
 	// DefaultOrganization represents the default organization
 	DefaultOrganization = "default"
 	// FormatTabular represents the string for tabular format

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -200,7 +200,7 @@ func askForDefaultFormat(c config.Config) *survey.Question {
 		Name: "format",
 		Prompt: &survey.Select{
 			Message: "Preferred output format:",
-			Options: []string{"none", config.FormatJSON, config.FormatWrappedJSON},
+			Options: []string{config.FormatTabular, config.FormatJSON, config.FormatWrappedJSON},
 			Default: format,
 		},
 	}

--- a/cli/commands/configure/configure_test.go
+++ b/cli/commands/configure/configure_test.go
@@ -3,8 +3,10 @@ package configure
 import (
 	"testing"
 
+	"github.com/sensu/sensu-go/cli/client/config"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,9 +14,9 @@ func TestCommand(t *testing.T) {
 	assert := assert.New(t)
 
 	cli := test.NewMockCLI()
-	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("none")
-	config.On("APIUrl").Return("http://127.0.0.1:8080")
+	mockConfig := cli.Config.(*client.MockConfig)
+	mockConfig.On("Format").Return(config.DefaultFormat)
+	mockConfig.On("APIUrl").Return("http://127.0.0.1:8080")
 
 	cmd := Command(cli)
 


### PR DESCRIPTION
## What is this change?

Fixes the interactive selection of the preferred output format when using `sensuctl configure`: an incorrect option called `none` has been replaced with `tabular` in accordance with the documentation.

## Why is this change necessary?

Fixes #2063 

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required. This change brings the `sensuctl configure` interface in line with the current documentation.
