### PR TITLE
Add test for privilege escalation in rbac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add windows/386 to binary gcs releases
 - TLS authentication and encryption for etcd client and peer communication.
 - Added a debug log message for interval timer initial offset.
+- Added a privilege escalation test for RBAC.
 
 ### Removed
 - Staging resources and configurations have been removed from sensu-go.

--- a/backend/authorization/authorization_test.go
+++ b/backend/authorization/authorization_test.go
@@ -130,3 +130,46 @@ func TestCanAccessResource(t *testing.T) {
 		})
 	}
 }
+
+func TestPrivilegeEscalation(t *testing.T) {
+	assert := assert.New(t)
+	actor := Actor{
+		Name: "bob",
+		Rules: []types.Rule{
+			{
+				Type:         "rules",
+				Organization: "hasaccess",
+				Environment:  "hasaccess",
+				Permissions:  []string{types.RulePermCreate},
+			},
+			{
+				Type:         "roles",
+				Organization: "hasaccess",
+				Environment:  "hasaccess",
+				Permissions:  []string{types.RulePermCreate},
+			},
+		},
+	}
+
+	assert.Equal(
+		false,
+		CanAccessResource(
+			actor,
+			"doesnothaveaccess",
+			"doesnothaveaccess",
+			"roles",
+			types.RulePermCreate,
+		),
+	)
+
+	assert.Equal(
+		false,
+		CanAccessResource(
+			actor,
+			"doesnothaveaccess",
+			"doesnothaveaccess",
+			"rules",
+			types.RulePermCreate,
+		),
+	)
+}


### PR DESCRIPTION
## What is this change?

This adds a test for privilege escalation in the authorization component apid.

## Why is this change necessary?

As we go forward refactoring RBAC, it will be important to make sure that we do not inadvertently allow privilege escalation.
