### PR TITLE
Use EtcdClientTLSInfo for external etcd cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ sensu-backend.
 empty.
 - Fixed a bug in `sensuctl check update` interactive mode. Boolean defaults
 were being displayed rather than the check's current values.
+- Use the provided etcd client TLS information when the flag `--no-embed-etcd` 
+is used.
 
 ### Breaking Changes
 - Removed the KeepaliveTimeout attribute from entities.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
 	"github.com/sensu/sensu-go/backend/agentd"
 	"github.com/sensu/sensu-go/backend/apid"
 	"github.com/sensu/sensu-go/backend/daemon"
@@ -43,19 +43,13 @@ type Backend struct {
 }
 
 func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
-	// Intialize the TLS configuration
-	var (
-		tlsConfig *tls.Config
-		err       error
-	)
-	if config.TLS != nil {
-		tlsConfig, err = config.TLS.ToTLSConfig()
+	if config.NoEmbedEtcd {
+		tlsInfo := (transport.TLSInfo)(config.EtcdClientTLSInfo)
+		tlsConfig, err := tlsInfo.ClientConfig()
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	if config.NoEmbedEtcd {
 		// Don't start up an embedded etcd, return a client that connects to an
 		// external etcd instead.
 		return clientv3.New(clientv3.Config{
@@ -134,8 +128,8 @@ func Initialize(config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store: store,
-		Bus:   bus,
+		Store:                   store,
+		Bus:                     bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 	})
 	if err != nil {
@@ -181,9 +175,9 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:            bus,
-		Store:          store,
-		MonitorFactory: monitor.EtcdFactory(client),
+		Bus:                   bus,
+		Store:                 store,
+		MonitorFactory:        monitor.EtcdFactory(client),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err.Error())


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures the etcd client uses the proper TLS configuration when connecting to an external etcd cluster. 

## Why is this change necessary?

Fix a problem encountered while writing the clustering docs.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope
