### PR TITLE
Issue 2011-Validate Go code style formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ jobs:
       - run: sudo $CIRCLE_WORKING_DIRECTORY/build/ci/circle-ci-setup.sh
       - run: $SENSU_RELEASE_REPO/install-awscli.sh
 
-      # *Now* get to building...
+      # *Now* get to initial linting/building...
+      - run: ./build/ci/gofmt-linting-check.sh
       - run: ./build.sh build_tools
       - run: make
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: $SENSU_RELEASE_REPO/install-awscli.sh
 
       # *Now* get to initial linting/building...
-      - run: ./build/ci/gofmt-linting-check.sh
+      - run: GOFMT=/usr/local/go/bin/gofmt ./build/ci/gofmt-linting-check.sh
       - run: ./build.sh build_tools
       - run: make
 

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	bolt "go.etcd.io/bbolt"
+
 	"github.com/sensu/sensu-go/types"
 )
 

--- a/asset/boltdb_manager_test.go
+++ b/asset/boltdb_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
+
 	"github.com/sensu/sensu-go/types"
 )
 

--- a/asset/integration_test.go
+++ b/asset/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
+
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/types"
 )

--- a/backend/apid/graphql/relay/node.go
+++ b/backend/apid/graphql/relay/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
 	"github.com/sensu/sensu-go/graphql"
 )

--- a/backend/apid/middlewares/allowlist.go
+++ b/backend/apid/middlewares/allowlist.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
 )

--- a/backend/apid/middlewares/refresh_token.go
+++ b/backend/apid/middlewares/refresh_token.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/types"
 )

--- a/backend/etcd/logrus_formatter.go
+++ b/backend/etcd/logrus_formatter.go
@@ -3,8 +3,8 @@ package etcd
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/sirupsen/logrus"
 )
 
 type logrusFormatter struct {

--- a/backend/store/etcd/logrus_formatter.go
+++ b/backend/store/etcd/logrus_formatter.go
@@ -3,8 +3,8 @@ package etcd
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/sirupsen/logrus"
 )
 
 type logrusFormatter struct {

--- a/build/ci/gofmt-linting-check.sh
+++ b/build/ci/gofmt-linting-check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+#set -e
+#set -x
+
+readonly FIND="${FIND:-/usr/bin/find}"
+readonly GOFMT="${GOFMT:-/usr/bin/gofmt}"
+readonly GREP="${GREP:-/bin/grep}"
+
+# If we're not running on CircleCI, then allow a directory to be passed in via
+# the command line
+if [[ -z "$CIRCLE_WORKING_DIRECTORY" ]]; then
+	CIRCLE_WORKING_DIRECTORY="$1"
+	if [[ -z "$CIRCLE_WORKING_DIRECTORY" ]]; then
+		echo "CIRCLE_WORKING_DIRECTORY must be defined. Bailing." >&2
+		exit 1
+	fi
+fi
+
+cd $CIRCLE_WORKING_DIRECTORY
+
+different_files="$($GOFMT -l . | $GREP -v ^vendor)"
+
+for file in $different_files; do
+	echo
+	$GOFMT -d $file
+done
+
+# Fail if gofmt identifies diff files
+if [[ -n "$different_files" ]]; then
+	exit 1
+else
+	exit 0
+fi
+

--- a/cli/elements/report/report.go
+++ b/cli/elements/report/report.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/sensu/sensu-go/cli/elements/globals"
 )
 

--- a/scripts/gengraphql/gengraphql.go
+++ b/scripts/gengraphql/gengraphql.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/sensu/sensu-go/graphql/generator"
 )
 


### PR DESCRIPTION
Addresses #2011.

Adds a tiny script to call `gofmt` on the `sensu-go` repo, but excludes the `vendor` directory.

Also fixes the few errors doing this check on CircleCI surfaced.

Example of linting failure: https://circleci.com/gh/sensu/sensu-go/731
Example of success: https://circleci.com/gh/sensu/sensu-go/734

From an engineering process perspective, tapping @oferrigni and @grepory too.