### PR TITLE
Use gofmt 1.10 for linting

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -128,8 +128,8 @@ func Initialize(config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store:                   store,
-		Bus:                     bus,
+		Store: store,
+		Bus:   bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 	})
 	if err != nil {
@@ -175,9 +175,9 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:                   bus,
-		Store:                 store,
-		MonitorFactory:        monitor.EtcdFactory(client),
+		Bus:            bus,
+		Store:          store,
+		MonitorFactory: monitor.EtcdFactory(client),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err.Error())


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Reverts formatting in backend.go to gofmt v1.10.

## Why is this change necessary?

It makes CI happy!

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope