### PR TITLE
Increase duration delta in TestPeriodicKeepalive integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ empty.
 were being displayed rather than the check's current values.
 - Use the provided etcd client TLS information when the flag `--no-embed-etcd` 
 is used.
+- Increase duration delta in TestPeriodicKeepalive integration test.
 
 ### Breaking Changes
 - Removed the KeepaliveTimeout attribute from entities.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -100,7 +100,7 @@ func TestReceiveLoop(t *testing.T) {
 }
 
 // TestPeriodicKeepalive checks that a running Agent sends its periodic
-// keepalive messages at the expected frequency, allowing for +/- 1s drift.
+// keepalive messages at the expected frequency, allowing for +/- 3s drift.
 func TestPeriodicKeepalive(t *testing.T) {
 	done := make(chan struct{})
 
@@ -122,7 +122,7 @@ func TestPeriodicKeepalive(t *testing.T) {
 				if keepaliveCount > 0 {
 					expected := lastKeepalive.Add(keepaliveInterval)
 					actual := mockTime.Now()
-					assert.WithinDuration(t, expected, actual, (2 * time.Second))
+					assert.WithinDuration(t, expected, actual, (3 * time.Second))
 				}
 				lastKeepalive = mockTime.Now()
 			}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures our integration test does not fail when running in CircleCI.

## Why is this change necessary?

So CircleCI is happy.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope
