### PR TITLE
Issue 2121-Post build/test logs as artifacts to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       - run: make
 
       # Post packages to S3
+      - run: $SENSU_RELEASE_REPO/collect-circle-log.sh $CIRCLE_WORKING_DIRECTORY/out
       - run: $SENSU_RELEASE_REPO/post-packages-s3.sh $CIRCLE_WORKING_DIRECTORY/out
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ sensu_go_build_env: &sensu_go_build_env
   environment:
     # Hard-coding this for now.
     - SENSU_BUILD_ITERATION: 1
-    - SENSU_RELEASE_REPO: /home/circleci/sensu-release
-    - SECURE_VARIABLES_PLAINTEXT_FILE: /home/circleci/secure-variables.plain
+    - SENSU_RELEASE_REPO: /go/sensu-release
+    - SECURE_VARIABLES_PLAINTEXT_FILE: /go/secure-variables.plain
 
   working_directory: /go/src/github.com/sensu/sensu-go
   docker:
@@ -47,23 +47,28 @@ jobs:
       - run: make
 
       # Post packages to S3
-      - run: $SENSU_RELEASE_REPO/collect-circle-log.sh $CIRCLE_WORKING_DIRECTORY/out
+      - run: $SENSU_RELEASE_REPO/collect-circle-log.sh $CIRCLE_WORKING_DIRECTORY/out log-build.txt
       - run: $SENSU_RELEASE_REPO/post-packages-s3.sh $CIRCLE_WORKING_DIRECTORY/out
 
       - persist_to_workspace:
-          root: /go/src/github.com/
+          root: /go
           paths:
-            - sensu
+            - src/github.com/sensu
+            - sensu-release
 
   test:
     <<: *sensu_go_build_env
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: /go/src/github.com
+          at: /go
+      - run: cat $SECURE_VARIABLES_PLAINTEXT_FILE >> $BASH_ENV
+      - run: mkdir -pv $CIRCLE_WORKING_DIRECTORY/out
       - run: ./build.sh unit
       - run: ./build.sh integration
       - run: ./build.sh e2e
+      - run: $SENSU_RELEASE_REPO/collect-circle-log.sh $CIRCLE_WORKING_DIRECTORY/out log-test.txt
+      - run: $SENSU_RELEASE_REPO/post-packages-s3.sh $CIRCLE_WORKING_DIRECTORY/out
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,9 @@ jobs:
       # Set up items in the test container that we still need
       - run: cat $SECURE_VARIABLES_PLAINTEXT_FILE >> $BASH_ENV
       - run: $SENSU_RELEASE_REPO/install-awscli.sh
+
+      # Clean out the "out" directory from the build workspace run
+      - run: rm -rf $CIRCLE_WORKING_DIRECTORY/out
       - run: mkdir -pv $CIRCLE_WORKING_DIRECTORY/out
 
       # Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ sensu_go_build_env: &sensu_go_build_env
     # Hard-coding this for now.
     - SENSU_BUILD_ITERATION: 1
     - SENSU_RELEASE_REPO: /go/sensu-release
-    - SECURE_VARIABLES_PLAINTEXT_FILE: /go/secure-variables.plain
+    - SECURE_VARIABLES_PLAINTEXT_FILE: /go/build-tmp/secure-variables.plain
+    - BUILD_TMP: /go/build-tmp
 
   working_directory: /go/src/github.com/sensu/sensu-go
   docker:
@@ -30,6 +31,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - f0:2b:79:fb:d8:c1:69:93:78:33:86:9f:31:f3:4e:51
+      - run: mkdir -pv $BUILD_TMP
       - run: git clone git@github.com:sensu/sensu-release $SENSU_RELEASE_REPO
       - run: cd $SENSU_RELEASE_REPO && git rev-parse --short HEAD
 
@@ -55,6 +57,7 @@ jobs:
           paths:
             - src/github.com/sensu
             - sensu-release
+            - build-tmp
 
   test:
     <<: *sensu_go_build_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,18 @@ jobs:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: /go
+
+      # Set up items in the test container that we still need
       - run: cat $SECURE_VARIABLES_PLAINTEXT_FILE >> $BASH_ENV
+      - run: $SENSU_RELEASE_REPO/install-awscli.sh
       - run: mkdir -pv $CIRCLE_WORKING_DIRECTORY/out
+
+      # Run tests
       - run: ./build.sh unit
       - run: ./build.sh integration
       - run: ./build.sh e2e
+
+      # Upload test logs
       - run: $SENSU_RELEASE_REPO/collect-circle-log.sh $CIRCLE_WORKING_DIRECTORY/out log-test.txt
       - run: $SENSU_RELEASE_REPO/post-packages-s3.sh $CIRCLE_WORKING_DIRECTORY/out
 

--- a/build/ci/circle-ci-setup.sh
+++ b/build/ci/circle-ci-setup.sh
@@ -19,5 +19,3 @@ apt-get update
 apt-get install yarn
 gem install --no-ri --no-rdoc fpm
 apt-get clean
-
-apt-get install python-setuptools


### PR DESCRIPTION
Changes required to post the CircleCI workspace logs (from both the build and test stages) to S3, making those logs a first-class artifact.

This PR depends on https://github.com/sensu/sensu-release/pull/1

