### PR TITLE
Create a "release" build_and_test job that fires on release tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,3 +91,12 @@ workflows:
       - test:
           requires:
             - build
+  rel_build_and_test:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^\d\.\d\.\d\-beta.\d+.+/
+      - test:
+          requires:
+            - build


### PR DESCRIPTION
This will mimic behavior we had on TravisCI; while it isn't distinct (in terms of tasks run) from the build_and_test job, I could easily see a future where it _is_ distinct and does additional release-related takss, so creating is as a separate job now.

Signed-off-by: J. Paul Reed <preed@release-approaches.com>