### PR TITLE
Issue 2119, part 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,19 +87,29 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              ignore: /.*/
       - test:
           requires:
             - build
+          filters:
+            tags:
+              ignore: /.*/
   rel_build_and_test:
     jobs:
       - build:
           filters:
             tags:
               only: /^\d\.\d\.\d\-beta.\d+.+/
+            branches:
+              ignore: /.*/
       - test:
           requires:
             - build
           filters:
             tags:
               only: /^\d\.\d\.\d\-beta.\d+.+/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,3 +100,6 @@ workflows:
       - test:
           requires:
             - build
+          filters:
+            tags:
+              only: /^\d\.\d\.\d\-beta.\d+.+/


### PR DESCRIPTION
Cleans up the CircleCI config, so jobs don't double-fire.