### PR TITLE
Fix some Go 1.11 issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ were being displayed rather than the check's current values.
 - Use the provided etcd client TLS information when the flag `--no-embed-etcd` 
 is used.
 - Increase duration delta in TestPeriodicKeepalive integration test.
+- Fixed some problems introduced by Go 1.11.
 
 ### Breaking Changes
 - Removed the KeepaliveTimeout attribute from entities.

--- a/agent/token.go
+++ b/agent/token.go
@@ -79,6 +79,9 @@ func defaultFunc(v ...interface{}) interface{} {
 	if len(v) == 1 {
 		return v[0]
 	} else if len(v) == 2 {
+		if v[1] == nil {
+			return v[0]
+		}
 		return v[1]
 	}
 	return nil

--- a/backend/monitor/supervisor.go
+++ b/backend/monitor/supervisor.go
@@ -106,7 +106,7 @@ func (m *EtcdSupervisor) Monitor(ctx context.Context, name string, event *types.
 	}
 
 	shutdownFunc := func() {
-		logger.Info("shutting down monitor for %s", key)
+		logger.Infof("shutting down monitor for %s", key)
 	}
 
 	// start the watcher
@@ -172,7 +172,7 @@ func watchMon(ctx context.Context, cli *clientv3.Client, mon *monitor, failureHa
 		)
 
 		if _, err := cli.Lease.Revoke(ctx, mon.leaseID); err != nil {
-			logger.WithError(err).Warningf("could not revoke the lease %s for the key %s",
+			logger.WithError(err).Warningf("could not revoke the lease %v for the key %s",
 				mon.leaseID, mon.key,
 			)
 		}

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -235,7 +235,6 @@ func TestDequeueParallel(t *testing.T) {
 	// If we had multiple errors, only the last one is saved
 	require.NoError(t, errEnqueue)
 	results := make(map[string]struct{})
-	var errDequeue error
 	wg.Add(len(items))
 	for range items {
 		go func() {
@@ -245,7 +244,6 @@ func TestDequeueParallel(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
-				errDequeue = err
 				return
 			}
 			results[item.Value()] = struct{}{}


### PR DESCRIPTION
## What is this change?

In Go 1.11, functions called by the template package are always
handed two arguments, instead of one or conditionally two.

This commit also fixes some formatting directives that were not
previously noticed by the old go vet.

## Why is this change necessary?

Closes #2073

<!-- A brief description of why the change of behavior is necessary. -->

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No