### PR TITLE
[Web UI] Drop in replacement for Apollo's Query component

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
     "esm": "3.0.31",
+    "fbjs": "^1.0.0",
     "file-loader": "^1.1.11",
     "git-rev-sync": "^1.12.0",
     "glob": "^7.1.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -31,7 +31,6 @@
     "apollo-link": "^1.2.2",
     "apollo-link-batch-http": "^1.2.2",
     "apollo-link-context": "^1.0.7",
-    "apollo-link-http": "^1.5.3",
     "apollo-link-state": "^0.4.1",
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.26.3",

--- a/dashboard/src/apollo/authLink.js
+++ b/dashboard/src/apollo/authLink.js
@@ -4,8 +4,8 @@ import { when } from "/utils/promise";
 import { UnauthorizedError } from "/errors/FetchError";
 import QueryAbortedError from "/errors/QueryAbortedError";
 
-import flagTokens from "/mutations/flagTokens";
 import refreshTokens from "/mutations/refreshTokens";
+import flagTokens from "/mutations/flagTokens";
 
 const EXPIRY_THRESHOLD_MS = 13 * 60 * 1000;
 const MAX_REFRESHES = 3;
@@ -35,8 +35,12 @@ const authLink = ({ getClient }) =>
                 });
 
                 const nextObserver = {
-                  next: observer.next.bind(observer),
-                  complete: observer.complete.bind(observer),
+                  next: (...args) => {
+                    observer.next(...args);
+                  },
+                  complete: () => {
+                    observer.complete();
+                  },
 
                   // If chain results in an unauthorized error being thrown,
                   // either attempt to create a new access token or flag the

--- a/dashboard/src/apollo/authLink.js
+++ b/dashboard/src/apollo/authLink.js
@@ -4,8 +4,8 @@ import { when } from "/utils/promise";
 import { UnauthorizedError } from "/errors/FetchError";
 import QueryAbortedError from "/errors/QueryAbortedError";
 
-import refreshTokens from "/mutations/refreshTokens";
 import flagTokens from "/mutations/flagTokens";
+import refreshTokens from "/mutations/refreshTokens";
 
 const EXPIRY_THRESHOLD_MS = 13 * 60 * 1000;
 const MAX_REFRESHES = 3;
@@ -35,12 +35,8 @@ const authLink = ({ getClient }) =>
                 });
 
                 const nextObserver = {
-                  next: (...args) => {
-                    observer.next(...args);
-                  },
-                  complete: () => {
-                    observer.complete();
-                  },
+                  next: observer.next.bind(observer),
+                  complete: observer.complete.bind(observer),
 
                   // If chain results in an unauthorized error being thrown,
                   // either attempt to create a new access token or flag the

--- a/dashboard/src/components/util/Query.js
+++ b/dashboard/src/components/util/Query.js
@@ -1,88 +1,324 @@
+/* eslint-disable react/no-unused-prop-types */
+
 import React from "react";
 import PropTypes from "prop-types";
 import { ApolloError } from "apollo-client";
-import { Query as BaseQuery } from "react-apollo";
+import { withApollo } from "react-apollo";
+import shallowEqual from "fbjs/lib/shallowEqual";
+import equal from "lodash/isEqual";
 
 import QueryAbortedError from "/errors/QueryAbortedError";
 
+const extractQueryOpts = props => {
+  const {
+    variables,
+    pollInterval,
+    fetchPolicy,
+    errorPolicy,
+    notifyOnNetworkStatusChange,
+    query,
+  } = props;
+
+  return {
+    variables,
+    pollInterval,
+    query,
+    fetchPolicy,
+    errorPolicy,
+    notifyOnNetworkStatusChange,
+    context: {},
+  };
+};
+
+class Poller {
+  constructor(observable, interval) {
+    this._observable = observable;
+    this._interval = interval;
+    this._running = interval > 0;
+  }
+
+  isRunning() {
+    return this._running;
+  }
+
+  getInterval() {
+    return this._interval;
+  }
+
+  setInterval(newInterval) {
+    if (newInterval === this._interval) {
+      return;
+    }
+
+    if (newInterval > 0) {
+      this.start(newInterval);
+    } else {
+      this._interval = newInterval;
+      this.stop();
+    }
+  }
+
+  start(newInterval = null) {
+    if (this._running && newInterval) {
+      this.setInterval(newInterval);
+    } else if (!this._running) {
+      this._interval = newInterval || this._interval;
+      this._running = true;
+
+      this._observable.startPolling(this._interval);
+    }
+  }
+
+  stop() {
+    this._running = false;
+    this._observable.stopPolling();
+  }
+
+  toggle(newInterval = null) {
+    if (this._running) {
+      this.stop();
+    } else {
+      this.start(newInterval);
+    }
+  }
+}
+
+//
+// Drop in replacement for react-apollo's Query component.
+//
+// Differs from official implementation by:
+//
+// - reflecting the value last emitted by the configured watcher instead of
+//   firing a forceUpdate and relying the observer's currentResult. By doing so,
+//   given data should be more consistent (see apollographql/apollo-client#3947)
+//   and should be slightly more efficient by not having to reselect the same
+//   data from the cache on each render.
+// - allows us to handle error's however we perfer.
+//
 class Query extends React.PureComponent {
   static propTypes = {
-    onError: PropTypes.func.isRequired,
+    // Provided by withApollo
+    client: PropTypes.object.isRequired,
     children: PropTypes.func.isRequired,
+    errorPolicy: PropTypes.oneOf(["none", "ignore", "all"]),
+    fetchPolicy: PropTypes.oneOf([
+      "cache-first",
+      "cache-and-network",
+      "network-only",
+      "cache-only",
+      "no-cache",
+      "standby",
+    ]),
+    notifyOnNetworkStatusChange: PropTypes.bool,
+    onComplete: PropTypes.func,
+    onError: PropTypes.func.isRequired,
     pollInterval: PropTypes.number,
+    query: PropTypes.object.isRequired,
+    variables: PropTypes.object,
   };
 
   static defaultProps = {
-    pollInterval: 0,
+    errorPolicy: "all",
+    fetchPolicy: "cache-and-network",
+    notifyOnNetworkStatusChange: false,
+    onComplete: () => null,
     onError(error) {
       throw error;
     },
+    pollInterval: 0,
+    variables: {},
   };
+
+  static getDerivedStateFromProps(props, state) {
+    const nextState = {};
+
+    const queryOpts = extractQueryOpts(props);
+    if (!shallowEqual(queryOpts, state.queryOpts)) {
+      nextState.queryOpts = queryOpts;
+    }
+
+    // If client changed we need to tear everything and observe new client
+    if (props.client !== state.client) {
+      nextState.observable = props.client.watchQuery(queryOpts);
+      nextState.poller = new Poller(nextState.observable, props.pollInterval);
+      return nextState;
+    }
+
+    // If query options change by client did not apply new set of options
+    if (nextState.queryOpts) {
+      state.observable.setOptions(queryOpts);
+    }
+
+    // If the polling interval was updated do update poller.
+    if (props.pollInterval !== state.poller.getInterval()) {
+      state.poller.setInterval(props.pollInterval);
+    }
+
+    if (Object.keys(nextState).length === 0) {
+      return null;
+    }
+    return nextState;
+  }
 
   constructor(props) {
     super(props);
+
+    // Setup query observable
+    const queryOpts = extractQueryOpts(props);
+    const observable = props.client.watchQuery(queryOpts);
+    const poller = new Poller(observable, props.pollInterval);
+
+    // Fetch current state of query
+    const { data, loading, networkStatus } = observable.currentResult();
+
+    // Add initial data and observable to the component's state
     this.state = {
-      pollInterval: props.pollInterval,
+      client: props.client,
+      data,
+      loading,
+      observable,
+      networkStatus,
+      poller,
+      queryOpts,
     };
   }
 
   componentDidMount() {
-    const { onError } = this.props;
-    this.querySubscription = this.queryRef.current.queryObservable.subscribe({
-      next(result) {
-        if (result.errors && result.errors.length > 0) {
-          throw new ApolloError({ graphQLErrors: result.errors });
-        }
-      },
-      error(error) {
-        if (!(error.networkError instanceof QueryAbortedError)) {
-          onError(error);
-        }
-      },
-    });
+    this.subscribe();
+  }
+
+  componentDidUpdate() {
+    this.subscribe();
   }
 
   componentWillUnmount() {
-    if (this.querySubscription) {
-      this.querySubscription.unsubscribe();
-    }
+    this.disconnect();
   }
 
-  queryRef = React.createRef();
+  subscribe = () => {
+    const { observable } = this.state;
+
+    // We only want to subscribe if a subscription has not already been setup
+    if (this.query && this.query.observable === observable) {
+      return;
+    }
+
+    // Ensure that the old subscription is torn down
+    if (this.query) {
+      this.query.subscription.unsubscribe();
+    }
+
+    const subscription = observable.subscribe({
+      next: result => {
+        // if any errors are present in the response throw
+        if (result.errors && result.errors.length > 0) {
+          throw new ApolloError({ graphQLErrors: result.errors });
+        }
+
+        this.setState(state => {
+          let nextState = {
+            error: result.error,
+            loading: result.loading,
+            networkStatus: result.networkStatus,
+          };
+          const prevState = {
+            error: state.error,
+            loading: state.loading,
+            networkStatus: state.networkStatus,
+          };
+
+          if (shallowEqual(nextState, prevState)) {
+            nextState = {};
+          }
+
+          // Only update reference if deep compare fails; can enable
+          // optimizations in downstream components.
+          if (!equal(result.data, state.data)) {
+            // NOTE: maybe this behaviour should be opt-out?
+            nextState.data = result.data;
+          }
+
+          if (Object.keys(nextState).length === 0) {
+            return null;
+          }
+          return nextState;
+        });
+      },
+      error: error => {
+        this.resubscribeToQuery();
+
+        // Reimplemented from react-apollo
+        // https://github.com/apollographql/react-apollo/blob/master/src/Query.tsx#L320-L321
+        // eslint-disable-next-line no-prototype-builtins
+        if (!error.hasOwnProperty("graphQLErrors")) {
+          throw error;
+        } else if (!(error.networkError instanceof QueryAbortedError)) {
+          this.props.onError(error);
+        }
+      },
+    });
+
+    this.query = {
+      observable,
+      subscription,
+    };
+  };
+
+  resubscribeToQuery = () => {
+    this.disconnect();
+
+    //
+    // Reimplemented from react-apollo
+    // https://github.com/apollographql/react-apollo/blob/master/src/Query.tsx#L340-L343
+    //
+    // If lastError is set, the observable will immediately
+    // send it, causing the stream to terminate on initialization.
+    // We clear everything here and restore it afterward to
+    // make sure the new subscription sticks.
+    //
+    const lastError = this.query.observable.getLastError();
+    const lastResult = this.query.observable.getLastResult();
+    this.query.observable.resetLastResults();
+    this.subscribe();
+    Object.assign(this.query.observable, { lastError, lastResult });
+  };
+
+  disconnect = () => {
+    if (this.query) {
+      this.query.subscription.unsubscribe();
+    }
+  };
 
   render() {
-    const {
-      onError,
-      children,
-      pollInterval: pollIntervalProp,
-      ...props
-    } = this.props;
+    const { client } = this.props;
+    const { data, loading, networkStatus, observable, poller } = this.state;
 
-    // Overwrites Apollo's existing start / stop methods and includes
-    // `isPolling` prop so that the UI can reflect the current state.
-    const { pollInterval } = this.state;
-    const childProps = {
-      isPolling: pollInterval > 0,
-      startPolling: i => this.setState({ pollInterval: i || pollIntervalProp }),
-      stopPolling: () => this.setState({ pollInterval: 0 }),
-    };
+    let error = this.state.error;
+    let aborted = false;
+    if (error && error.networkError instanceof QueryAbortedError) {
+      error = undefined;
+      aborted = true;
+    }
 
-    return (
-      <BaseQuery ref={this.queryRef} pollInterval={pollInterval} {...props}>
-        {queryResult => {
-          const { error, ...rest } = queryResult;
-          if (error && error.networkError instanceof QueryAbortedError) {
-            return children({ aborted: true, ...rest, ...childProps });
-          }
-          return children({
-            aborted: false,
-            ...queryResult,
-            ...childProps,
-          });
-        }}
-      </BaseQuery>
-    );
+    return this.props.children({
+      client,
+      data,
+      loading,
+      networkStatus,
+      poller,
+      error,
+      aborted,
+
+      // TODO: Move into state?
+      variables: observable.variables,
+      refetch: observable.refetch.bind(observable),
+      fetchMore: observable.fetchMore.bind(observable),
+      updateQuery: observable.updateQuery.bind(observable),
+      startPolling: observable.startPolling.bind(observable),
+      stopPolling: observable.stopPolling.bind(observable),
+      subscribeToMore: observable.subscribeToMore.bind(observable),
+    });
   }
 }
 
-export default Query;
+export default withApollo(Query);

--- a/dashboard/src/components/views/EnvironmentView/CheckDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/CheckDetailsContent.js
@@ -47,7 +47,7 @@ class CheckDetailsContent extends React.PureComponent {
           client,
           data: { check } = {},
           loading,
-          isPolling,
+          poller,
           refetch,
         }) => {
           if (!loading && !aborted && (!check || check.deleted)) {
@@ -58,7 +58,7 @@ class CheckDetailsContent extends React.PureComponent {
             <CheckDetailsContainer
               client={client}
               check={check}
-              loading={(loading && !isPolling) || aborted}
+              loading={(loading && !poller.isRunning()) || aborted}
               refetch={refetch}
             />
           );

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -49,7 +49,7 @@ class ChecksContent extends React.Component {
       aborted,
       data: { environment } = {},
       loading,
-      isPolling,
+      poller,
       refetch,
     } = renderProps;
 
@@ -77,7 +77,9 @@ class ChecksContent extends React.Component {
                 offset={offset}
                 onChangeQuery={setQueryParams}
                 environment={environment}
-                loading={(loading && (!environment || !isPolling)) || aborted}
+                loading={
+                  (loading && (!environment || !poller.isRunning())) || aborted
+                }
                 refetch={refetch}
                 order={queryParams.order}
                 addToast={addToast}

--- a/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
@@ -51,7 +51,7 @@ class EntitiesContent extends React.PureComponent {
       loading,
       aborted,
       refetch,
-      isPolling,
+      poller,
     } = renderProps;
 
     if (!environment && !loading && !aborted) {
@@ -72,7 +72,9 @@ class EntitiesContent extends React.PureComponent {
           <EntitiesList
             limit={limit}
             offset={offset}
-            loading={(loading && (!environment || !isPolling)) || aborted}
+            loading={
+              (loading && (!environment || !poller.isRunning())) || aborted
+            }
             onChangeQuery={setQueryParams}
             environment={environment}
             refetch={refetch}

--- a/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
@@ -39,13 +39,16 @@ class EntityDetailsContent extends React.PureComponent {
         pollInterval={pollInterval}
         variables={{ ...params, ns }}
       >
-        {({ data: { entity } = {}, loading, aborted, isPolling, refetch }) => {
+        {({ data: { entity } = {}, loading, aborted, poller, refetch }) => {
           if (!loading && !aborted && (!entity || entity.deleted)) {
             return <NotFound />;
           }
 
           return (
-            <Loader loading={(loading && !isPolling) || aborted} passthrough>
+            <Loader
+              loading={(loading && !poller.isRunning()) || aborted}
+              passthrough
+            >
               {entity && (
                 <EntityDetailsContainer entity={entity} refetch={refetch} />
               )}

--- a/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
@@ -45,7 +45,7 @@ class EventDetailsContent extends React.PureComponent {
         pollInterval={pollInterval}
         variables={{ ...match.params, ns }}
       >
-        {({ data: { event } = {}, loading, aborted, isPolling }) => {
+        {({ data: { event } = {}, loading, aborted, poller }) => {
           if (!loading && !aborted && (!event || event.deleted)) {
             return <NotFound />;
           }
@@ -53,7 +53,7 @@ class EventDetailsContent extends React.PureComponent {
           return (
             <Container
               event={event}
-              loading={(loading && !isPolling) || aborted}
+              loading={(loading && !poller.isRunning()) || !!aborted}
             />
           );
         }}

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -57,7 +57,7 @@ class EventsContent extends React.Component {
       data: { environment } = {},
       loading,
       aborted,
-      isPolling,
+      poller,
       refetch,
     } = renderProps;
 
@@ -83,7 +83,9 @@ class EventsContent extends React.Component {
             offset={offset}
             onChangeQuery={setQueryParams}
             environment={environment}
-            loading={(loading && (!environment || !isPolling)) || aborted}
+            loading={
+              (loading && (!environment || !poller.isRunning())) || aborted
+            }
             refetch={refetch}
           />
         </AppLayout.MobileFullWidthContent>

--- a/dashboard/src/components/views/EnvironmentView/SilencesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/SilencesContent.js
@@ -62,7 +62,7 @@ class SilencesContent extends React.Component {
       loading,
       aborted,
       refetch,
-      isPolling,
+      poller,
     } = renderProps;
 
     if (!environment && !loading && !aborted) {
@@ -109,7 +109,9 @@ class SilencesContent extends React.Component {
             order={order}
             onChangeQuery={setQueryParams}
             environment={environment}
-            loading={(loading && (!environment || !isPolling)) || aborted}
+            loading={
+              (loading && (!environment || !poller.isRunning())) || aborted
+            }
             refetch={refetch}
           />
         </AppLayout.MobileFullWidthContent>

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -177,10 +177,6 @@
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
 
-"@types/graphql@0.12.6":
-  version "0.12.6"
-  resolved "http://registry.npmjs.org/@types/graphql/-/graphql-0.12.6.tgz#3d619198585fcabe5f4e1adfb5cf5f3388c66c13"
-
 "@types/jss@^9.5.3":
   version "9.5.4"
   resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.4.tgz#89a4ee32a14a8d2937187b1a7f443750e964a74d"
@@ -211,9 +207,9 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/zen-observable@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
+"@types/zen-observable@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
 
 "@webassemblyjs/ast@1.4.3":
   version "1.4.3"
@@ -454,90 +450,85 @@ anymatch@^2.0.0:
     normalize-path "^2.1.1"
 
 apollo-cache-inmemory@^1.1.12:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.1.tgz#1f8222270aa7983eb9d2ac30057196378ab3bb01"
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.10.tgz#362d6c36cfd815a309b966f71e5d2b6c770c7989"
   dependencies:
-    apollo-cache "^1.1.8"
-    apollo-utilities "^1.0.12"
-    graphql-anywhere "^4.1.10"
+    apollo-cache "^1.1.17"
+    apollo-utilities "^1.0.21"
+    graphql-anywhere "^4.1.19"
 
-apollo-cache@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.8.tgz#b078d33dec876d52b5a81a325d3c254d4e362d3c"
+apollo-cache@1.1.17, apollo-cache@^1.1.17:
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.17.tgz#1fcca8423125223723b97fd72808be91a1a76490"
   dependencies:
-    apollo-utilities "^1.0.12"
+    apollo-utilities "^1.0.21"
 
 apollo-client@^2.2.8:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.3.1.tgz#64b204779b7e8b21f901529527a9a9c973eb7fd4"
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.4.2.tgz#d2f044d8740723bf98a6d8d8b9684ee8c36150e6"
   dependencies:
-    "@types/zen-observable" "^0.5.3"
-    apollo-cache "^1.1.8"
+    "@types/zen-observable" "^0.8.0"
+    apollo-cache "1.1.17"
     apollo-link "^1.0.0"
     apollo-link-dedup "^1.0.0"
-    apollo-utilities "^1.0.12"
+    apollo-utilities "1.0.21"
     symbol-observable "^1.0.2"
     zen-observable "^0.8.0"
   optionalDependencies:
     "@types/async" "2.0.49"
 
 apollo-link-batch-http@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.2.tgz#4dc98e16dca063cc66db3311cc71a855a4bac9c9"
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch-http/-/apollo-link-batch-http-1.2.3.tgz#cd3bbc0489bab8164618bafbae8796e26c51c278"
   dependencies:
-    apollo-link "^1.2.2"
-    apollo-link-batch "^1.1.3"
-    apollo-link-http-common "^0.2.4"
+    apollo-link "^1.2.3"
+    apollo-link-batch "^1.1.4"
+    apollo-link-http-common "^0.2.5"
 
-apollo-link-batch@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.3.tgz#c1d04256ef41af43e23854fab72cd3986a7648ad"
+apollo-link-batch@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/apollo-link-batch/-/apollo-link-batch-1.1.4.tgz#a2f483d5d6a9e9904210e74ab71c3d44f20ac5a7"
   dependencies:
-    apollo-link "^1.2.2"
+    apollo-link "^1.2.3"
 
 apollo-link-context@^1.0.7:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.8.tgz#c967a56ac6ed32add748937735bcb57c5cc64c95"
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.9.tgz#7fbc034de44546e957a840be76b2f6277c785e8f"
   dependencies:
-    apollo-link "^1.2.2"
+    apollo-link "^1.2.3"
 
 apollo-link-dedup@^1.0.0:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.9.tgz#3c4e4af88ef027cbddfdb857c043fd0574051dad"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz#7b94589fe7f969777efd18a129043c78430800ae"
   dependencies:
-    apollo-link "^1.2.2"
+    apollo-link "^1.2.3"
 
-apollo-link-http-common@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.4.tgz#877603f7904dc8f70242cac61808b1f8d034b2c3"
+apollo-link-http-common@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz#d094beb7971523203359bf830bfbfa7b4e7c30ed"
   dependencies:
-    apollo-link "^1.2.2"
-
-apollo-link-http@^1.5.3:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.4.tgz#b80b7b4b342c655b6a5614624b076a36be368f43"
-  dependencies:
-    apollo-link "^1.2.2"
-    apollo-link-http-common "^0.2.4"
+    apollo-link "^1.2.3"
 
 apollo-link-state@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.4.1.tgz#65e9e0e12c67936b8c4b12b8438434f393104579"
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.4.2.tgz#ac00e9be9b0ca89eae0be6ba31fe904b80bbe2e8"
   dependencies:
     apollo-utilities "^1.0.8"
     graphql-anywhere "^4.1.0-alpha.0"
 
-apollo-link@^1.0.0, apollo-link@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.2.tgz#54c84199b18ac1af8d63553a68ca389c05217a03"
+apollo-link@^1.0.0, apollo-link@^1.2.2, apollo-link@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.3.tgz#9bd8d5fe1d88d31dc91dae9ecc22474d451fb70d"
   dependencies:
-    "@types/graphql" "0.12.6"
     apollo-utilities "^1.0.0"
-    zen-observable-ts "^0.8.9"
+    zen-observable-ts "^0.8.10"
 
-apollo-utilities@^1.0.0, apollo-utilities@^1.0.12, apollo-utilities@^1.0.8:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.12.tgz#9e2b2a34cf89f3bf0d73a664effd8c1bb5d1b7f7"
+apollo-utilities@1.0.21, apollo-utilities@^1.0.0, apollo-utilities@^1.0.21, apollo-utilities@^1.0.8:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.21.tgz#cb8b5779fe275850b16046ff8373f4af2de90765"
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
+    fclone "^1.0.11"
 
 app-root-path@^2.0.1:
   version "2.0.1"
@@ -3046,6 +3037,10 @@ fbjs@^0.8.6:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fclone@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -3420,11 +3415,11 @@ graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-graphql-anywhere@^4.1.0-alpha.0, graphql-anywhere@^4.1.10:
-  version "4.1.10"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.10.tgz#247ada0c8d85b9d5d6b37180973442ac68ff15de"
+graphql-anywhere@^4.1.0-alpha.0, graphql-anywhere@^4.1.19:
+  version "4.1.19"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.19.tgz#5f6ca3b58218e5449f4798e3c6d942fcd2fef082"
   dependencies:
-    apollo-utilities "^1.0.12"
+    apollo-utilities "^1.0.21"
 
 graphql-config@^2.0.1:
   version "2.0.1"
@@ -5079,13 +5074,13 @@ lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-
 lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lodash@^4.17.10:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 log-symbols@^2.1.0:
   version "2.2.0"
@@ -6217,13 +6212,13 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-apollo@^2.1.3:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.1.4.tgz#a51059ac56f1a7997cad636a5d36398b9c93ff12"
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.1.11.tgz#ef4805f07af1d732ec94caebf7ba0728e2d162ca"
   dependencies:
     fbjs "^0.8.16"
     hoist-non-react-statics "^2.5.0"
     invariant "^2.2.2"
-    lodash "4.17.5"
+    lodash "^4.17.10"
     prop-types "^15.6.0"
 
 react-dev-utils@^5.0.1:
@@ -8078,12 +8073,12 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-zen-observable-ts@^0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz#d3c97af08c0afdca37ebcadf7cc3ee96bda9bab1"
+zen-observable-ts@^0.8.10:
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz#18e2ce1c89fe026e9621fd83cc05168228fce829"
   dependencies:
     zen-observable "^0.8.0"
 
 zen-observable@^0.8.0:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.8.tgz#1ea93995bf098754a58215a1e0a7309e5749ec42"
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.9.tgz#0475c760ff0eda046bbdfa4dc3f95d392807ac53"

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2004,7 +2004,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.3:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.3:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -3013,6 +3013,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz#836d876e887d702f45610f5ebd2fbeef649527fc"
+
 fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
@@ -3036,6 +3040,19 @@ fbjs@^0.8.6:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fclone@^1.0.11:
   version "1.0.11"


### PR DESCRIPTION
What's that? deja vu? Nah, you're crazy.

Originally #2133 was open for this issue, however, after merging it I was made aware that the base branch was not master. The change is large enough that it deserves its own merge commit and not bundled into a different changeset. As such I've reset the other branch and opened this new PR to pull the changes into master.

...back to our previously scheduled programming. 

## What is this change?

Differs from `react-apollo`'s implementation by:

- reflecting the value last emitted by the configured watcher instead of
  firing a `forceUpdate` and relying the observer's currentResult. By
  doing so, re-renders should not be affected by the inconsistent behavior
  of the observer's `currentResult` method (see apollographql/apollo-client#3947).
  As well as being slightly more efficient by virtue of not having to reselect
  the same data from the cache on each render.
- gives us more control so that we can handle error's however we like.

## Why is this change necessary?

Closes #2062 

## Does your change need a Changelog entry?

Probably not. Issue #2062 likely started after the AppLayout changes, which were merged since the last release.

## Do you need clarification on anything?

nada.

## Were there any complications while making this change?

Debugging the issue was tricky. 

Still not 100% on the correct behavior of the QueryObserver's `currentResult` method. Opened issue on `apollo-client`.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

nada.