### PR TITLE
Attempt to fix TestPeriodicKeepalive()

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -100,7 +100,7 @@ func TestReceiveLoop(t *testing.T) {
 }
 
 // TestPeriodicKeepalive checks that a running Agent sends its periodic
-// keepalive messages at the expected frequency, allowing for +/- 3s drift.
+// keepalive messages at the expected frequency, allowing for +/- 1s drift.
 func TestPeriodicKeepalive(t *testing.T) {
 	done := make(chan struct{})
 
@@ -122,7 +122,7 @@ func TestPeriodicKeepalive(t *testing.T) {
 				if keepaliveCount > 0 {
 					expected := lastKeepalive.Add(keepaliveInterval)
 					actual := mockTime.Now()
-					assert.WithinDuration(t, expected, actual, (3 * time.Second))
+					assert.WithinDuration(t, expected, actual, (1 * time.Second))
 				}
 				lastKeepalive = mockTime.Now()
 			}

--- a/agent/timeproxy_test.go
+++ b/agent/timeproxy_test.go
@@ -8,7 +8,11 @@ import (
 var mockTime = crock.NewTime(time.Unix(0, 0))
 
 func init() {
-	mockTime.Resolution = time.Microsecond
-	mockTime.Multiplier = 5000
+	// Resolution and Multiplier make the mock time advance every `Resolution`
+	// by `Resolution * Multiplier`. That is, for the values defined here:
+	// advance the mock time by 100ms every 1ms of real time, giving us a
+	// precision of about 100ms for the mock time.
+	mockTime.Resolution = time.Millisecond
+	mockTime.Multiplier = 100
 	time.TimeProxy = mockTime
 }


### PR DESCRIPTION
## What is this change?

This test uses mocked time provided by the `timeproxy` and `crock` library
but the settings we were using for the mocked time appeared to be
problematic and made the test fail intermittently.

This commit attempt to solve that by more carefully choosing the
settings for the mocked time.

## Why is this change necessary?

Test would fail intermittently.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Making sure I fully understood the actual meaning and influence of the mocked time's `Resolution` and `Multiplier`.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not needed.
