### PR TITLE
Fine tune mock time for CI

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -100,7 +100,7 @@ func TestReceiveLoop(t *testing.T) {
 }
 
 // TestPeriodicKeepalive checks that a running Agent sends its periodic
-// keepalive messages at the expected frequency, allowing for +/- 1s drift.
+// keepalive messages at the expected frequency, allowing for +/- 2s drift.
 func TestPeriodicKeepalive(t *testing.T) {
 	done := make(chan struct{})
 
@@ -122,7 +122,7 @@ func TestPeriodicKeepalive(t *testing.T) {
 				if keepaliveCount > 0 {
 					expected := lastKeepalive.Add(keepaliveInterval)
 					actual := mockTime.Now()
-					assert.WithinDuration(t, expected, actual, (1 * time.Second))
+					assert.WithinDuration(t, expected, actual, (2 * time.Second))
 				}
 				lastKeepalive = mockTime.Now()
 			}

--- a/agent/timeproxy_test.go
+++ b/agent/timeproxy_test.go
@@ -10,9 +10,9 @@ var mockTime = crock.NewTime(time.Unix(0, 0))
 func init() {
 	// Resolution and Multiplier make the mock time advance every `Resolution`
 	// by `Resolution * Multiplier`. That is, for the values defined here:
-	// advance the mock time by 100ms every 1ms of real time, giving us a
-	// precision of about 100ms for the mock time.
-	mockTime.Resolution = time.Millisecond
-	mockTime.Multiplier = 100
+	// advance the mock time by 500ms every 10ms of real time, giving us a
+	// precision of about 500ms for the mock time.
+	mockTime.Resolution = 10 * time.Millisecond
+	mockTime.Multiplier = 50
 	time.TimeProxy = mockTime
 }


### PR DESCRIPTION
## What is this change?

The `TestPeriodicKeepalive` test in the `agent` package still fails
intermittently, even after 4fd2ce93.

In an attempt to stop those intermittent failures, this commit:
- makes the mock time 5 times coarser
- makes the mock time tick 10 times less
- doubles the allowed time drift in the test

## Why is this change necessary?

Stop intermittent test failures on CircleCI.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not needed.
