### PR TITLE
[Web UI] Clear filter button

### DIFF
--- a/dashboard/src/components/SearchBox/SearchBox.js
+++ b/dashboard/src/components/SearchBox/SearchBox.js
@@ -7,7 +7,8 @@ import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import Icon from "@material-ui/icons/FilterList";
 import IconButton from "@material-ui/core/IconButton";
-import ClearIcon from "@material-ui/icons/Clear";
+import ClearIcon from "@material-ui/icons/Cancel";
+import Slide from "@material-ui/core/Slide";
 
 const Keycap = withStyles(theme => ({
   root: {
@@ -47,6 +48,7 @@ const SearchInput = withStyles(theme => ({
 
 const styles = theme => ({
   root: {
+    overflow: "hidden",
     minWidth: 300,
     display: "flex",
     border: "1px solid",
@@ -71,9 +73,6 @@ const styles = theme => ({
     alignItems: "center",
     width: "100%",
     fontFamily: theme.typography.monospace.fontFamily,
-  },
-  clearButton: {
-    marginTop: "-2px",
   },
 });
 
@@ -168,14 +167,17 @@ class SearchBox extends React.Component {
             value={value}
           />
           {this.state.focus && <Keycap>return</Keycap>}
-          <div
-            className={classes.clearButton}
-            style={{ visibility: value.length > 0 ? "visible" : "hidden" }}
+          <Slide
+            direction="left"
+            in={value.length > 0}
+            timeout={200}
+            mountOnEnter
+            unmountOnExit
           >
             <IconButton>
               <ClearIcon />
             </IconButton>
-          </div>
+          </Slide>
         </Typography>
       </Paper>
     );

--- a/dashboard/src/components/SearchBox/SearchBox.js
+++ b/dashboard/src/components/SearchBox/SearchBox.js
@@ -108,6 +108,11 @@ class SearchBox extends React.Component {
     this.setState(defaultState);
   }
 
+  clearFilter = () => {
+    this.resetState();
+    this.props.onSearch("");
+  };
+
   handleChange = ev => {
     this.setState({ value: ev.currentTarget.value || "" });
   };
@@ -174,7 +179,7 @@ class SearchBox extends React.Component {
             mountOnEnter
             unmountOnExit
           >
-            <IconButton>
+            <IconButton onClick={this.clearFilter}>
               <ClearIcon />
             </IconButton>
           </Slide>

--- a/dashboard/src/components/SearchBox/SearchBox.js
+++ b/dashboard/src/components/SearchBox/SearchBox.js
@@ -58,10 +58,6 @@ const styles = theme => ({
     paddingRight: theme.spacing.unit,
     height: theme.spacing.unit * 5,
   },
-  filterContainer: {
-    display: "flex",
-    width: "100%",
-  },
   iconContainer: {
     display: "flex",
     alignItems: "center",

--- a/dashboard/src/components/SearchBox/SearchBox.js
+++ b/dashboard/src/components/SearchBox/SearchBox.js
@@ -6,6 +6,8 @@ import { withStyles } from "@material-ui/core/styles";
 import Paper from "@material-ui/core/Paper";
 import Typography from "@material-ui/core/Typography";
 import Icon from "@material-ui/icons/FilterList";
+import IconButton from "@material-ui/core/IconButton";
+import ClearIcon from "@material-ui/icons/Clear";
 
 const Keycap = withStyles(theme => ({
   root: {
@@ -54,6 +56,10 @@ const styles = theme => ({
     paddingRight: theme.spacing.unit,
     height: theme.spacing.unit * 5,
   },
+  filterContainer: {
+    display: "flex",
+    width: "100%",
+  },
   iconContainer: {
     display: "flex",
     alignItems: "center",
@@ -65,6 +71,9 @@ const styles = theme => ({
     alignItems: "center",
     width: "100%",
     fontFamily: theme.typography.monospace.fontFamily,
+  },
+  clearButton: {
+    marginTop: "-2px",
   },
 });
 
@@ -159,6 +168,14 @@ class SearchBox extends React.Component {
             value={value}
           />
           {this.state.focus && <Keycap>return</Keycap>}
+          <div
+            className={classes.clearButton}
+            style={{ visibility: value.length > 0 ? "visible" : "hidden" }}
+          >
+            <IconButton>
+              <ClearIcon />
+            </IconButton>
+          </div>
         </Typography>
       </Paper>
     );


### PR DESCRIPTION
## What is this change?
Closes #2094 
![2018-10-12 09 59 53](https://user-images.githubusercontent.com/1707663/46883504-1b206180-ce07-11e8-8b0d-0b63503a7ac9.gif)

## Why is this change necessary?
Allows the user to clear their filter easier

## Does your change need a Changelog entry?
I don't think so

## Were there any complications while making this change?
I did notice that when applying filters (like on the Events List) the `AppLayout-content` div occasionally moves approx. 5px to the right. It looks like it's related to the automatic margins. Setting it to a pixel value would stop this, but be frustrating due to having to add more breakpoints to make it scale nicely. A percent value would help with scaling, but still moves slightly when the data set is empty. 