### PR TITLE
Add gen-register, a tool for generating type registries.

### DIFF
--- a/internal/apis/meta/meta.go
+++ b/internal/apis/meta/meta.go
@@ -2,26 +2,17 @@ package meta
 
 import "strings"
 
-// TypeMetaAccessor returns a GroupVersionKind if the Object has type
-// metadata associated with it, otherwise it returns nil.
-func GetGroupVersionKind(obj Object) GroupVersionKind {
-	gvk, ok := obj.(GroupVersionKind)
-	if ok {
-		return gvk
-	}
-
-	return nil
-}
-
 type GroupVersionKind interface {
 	GetKind() string
 	GetGroup() string
 	GetVersion() string
+	GetTypeMeta() TypeMeta
 }
 
-func (gvk TypeMeta) GetKind() string    { return gvk.Kind }
-func (gvk TypeMeta) GetGroup() string   { return strings.Split(gvk.APIVersion, "/")[0] }
-func (gvk TypeMeta) GetVersion() string { return strings.Split(gvk.APIVersion, "/")[1] }
+func (tm TypeMeta) GetTypeMeta() TypeMeta { return tm }
+func (gvk TypeMeta) GetKind() string      { return gvk.Kind }
+func (gvk TypeMeta) GetGroup() string     { return strings.Split(gvk.APIVersion, "/")[0] }
+func (gvk TypeMeta) GetVersion() string   { return strings.Split(gvk.APIVersion, "/")[1] }
 
 // Object lets you work with object metadata from any of the versioned or
 // internal API objects. Attempting to set or retrieve a field on an object that does

--- a/internal/cmd/gen-register/main.go
+++ b/internal/cmd/gen-register/main.go
@@ -24,8 +24,17 @@ var (
 	outPath     = flag.String("o", "", "Output path")
 )
 
+const TypeMetaName = "TypeMeta"
+
 func main() {
 	log.SetFlags(log.Lshortfile)
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintf(w, "%s: Generate a type registry for sensu-go API types.\n", os.Args[0])
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -t register.go.tmpl -o register.go")
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	if *packagePath == "" {
 		log.Fatal("no package path supplied (-pkg)")
@@ -42,7 +51,7 @@ func main() {
 		log.Fatalf("couldn't read template: %s", err)
 	}
 
-	types, err := getPackageTypes(*packagePath)
+	kinds, err := getPackageKinds(*packagePath)
 	if err != nil {
 		log.Fatalf("couldn't get package types: %s", err)
 	}
@@ -52,12 +61,14 @@ func main() {
 		log.Fatalf("couldn't open output for writing: %s", err)
 	}
 
-	if err := tmpl.Execute(w, types); err != nil {
+	if err := tmpl.Execute(w, kinds); err != nil {
 		log.Fatalf("couldn't write registry: %s", err)
 	}
 }
 
-func getPackageTypes(path string) (templateData, error) {
+// getPackageKinds recursively traverses the package and all sub-packages for
+// sensu-go kinds (structs that embed meta.TypeMeta).
+func getPackageKinds(path string) (templateData, error) {
 	root := filepath.Join(build.Default.GOPATH, "src", path)
 	walker := &walker{
 		fset:     token.NewFileSet(),
@@ -70,34 +81,24 @@ func getPackageTypes(path string) (templateData, error) {
 	return td, nil
 }
 
+// scanPackages scans all of the collected packages for kinds and collects them
+// into a slice.
 func scanPackages(packages map[string]*ast.Package) templateData {
 	td := make(templateData, 0)
 	for _, pkg := range packages {
 		if strings.HasSuffix(pkg.Name, "_test") {
 			continue
 		}
-		data := scanPackage(pkg)
-		td = append(td, data...)
+		kinds := getKinds(pkg)
+		for _, kind := range kinds {
+			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
+		}
 	}
 	return td
 }
 
-func scanPackage(pkg *ast.Package) templateData {
-	result := make(templateData, 0)
-	kinds := getTypeKinds(pkg)
-	for _, kind := range kinds {
-		result = append(result, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
-	}
-	return result
-}
-
-type walker struct {
-	packages map[string]*ast.Package
-	fset     *token.FileSet
-}
-
-func getTypeKinds(pkg *ast.Package) []string {
-	result := make([]string, 0)
+// getKinds finds all the sensu-go kinds in a package.
+func getKinds(pkg *ast.Package) (result []string) {
 	for _, f := range pkg.Files {
 		for _, decl := range f.Decls {
 			gendecl, ok := decl.(*ast.GenDecl)
@@ -109,22 +110,8 @@ func getTypeKinds(pkg *ast.Package) []string {
 				if !ok || !ts.Name.IsExported() {
 					continue
 				}
-				strukt, ok := ts.Type.(*ast.StructType)
-				if !ok {
-					continue
-				}
-				for _, field := range strukt.Fields.List {
-					if len(field.Names) != 0 {
-						// not embedded
-						continue
-					}
-					expr, ok := field.Type.(*ast.SelectorExpr)
-					if !ok {
-						continue
-					}
-					if expr.Sel.Name == "TypeMeta" {
-						result = append(result, ts.Name.Name)
-					}
+				if isKind(ts.Type) {
+					result = append(result, ts.Name.Name)
 				}
 			}
 		}
@@ -132,14 +119,43 @@ func getTypeKinds(pkg *ast.Package) []string {
 	return result
 }
 
+// isKind returns true if the type is an *ast.StructType, and it embeds
+// meta.TypeMeta.
+func isKind(typ ast.Expr) bool {
+	strukt, ok := typ.(*ast.StructType)
+	if !ok {
+		return false
+	}
+	for _, field := range strukt.Fields.List {
+		if len(field.Names) != 0 {
+			// not embedded
+			continue
+		}
+		expr, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if expr.Sel.Name == TypeMetaName {
+			return true
+		}
+	}
+	return false
+}
+
+// walker walks a filesystem recursively, looking for Go packages to parse.
+type walker struct {
+	packages map[string]*ast.Package
+	fset     *token.FileSet
+}
+
 func (w *walker) walk(path string, fi os.FileInfo, err error) error {
-	if !fi.IsDir() {
+	if fi == nil || !fi.IsDir() {
 		return nil
 	}
-	if fi.IsDir() && fi.Name() == "internal" {
+	if strings.HasPrefix(fi.Name(), ".") {
 		return filepath.SkipDir
 	}
-	if fi.IsDir() && strings.HasPrefix(fi.Name(), ".") {
+	if fi.Name() == "vendor" {
 		return filepath.SkipDir
 	}
 	packages, err := parser.ParseDir(w.fset, path, nil, 0)

--- a/internal/cmd/gen-register/main.go
+++ b/internal/cmd/gen-register/main.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type templateData []meta.TypeMeta
+
+var (
+	packagePath = flag.String("pkg", "", "Path to package to generate registry for")
+	tmplPath    = flag.String("t", "", "Path to template file")
+	outPath     = flag.String("o", "", "Output path")
+)
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	flag.Parse()
+	if *packagePath == "" {
+		log.Fatal("no package path supplied (-pkg)")
+	}
+	if *tmplPath == "" {
+		log.Fatal("no template path supplied (-t)")
+	}
+	if *outPath == "" {
+		log.Fatal("no output path supplied (-o)")
+	}
+
+	tmpl, err := template.ParseFiles(*tmplPath)
+	if err != nil {
+		log.Fatalf("couldn't read template: %s", err)
+	}
+
+	types, err := getPackageTypes(*packagePath)
+	if err != nil {
+		log.Fatalf("couldn't get package types: %s", err)
+	}
+
+	w, err := os.OpenFile(*outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("couldn't open output for writing: %s", err)
+	}
+
+	if err := tmpl.Execute(w, types); err != nil {
+		log.Fatalf("couldn't write registry: %s", err)
+	}
+}
+
+func getPackageTypes(path string) (templateData, error) {
+	root := filepath.Join(build.Default.GOPATH, "src", path)
+	walker := &walker{
+		fset:     token.NewFileSet(),
+		packages: make(map[string]*ast.Package),
+	}
+	if err := filepath.Walk(root, walker.walk); err != nil {
+		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
+	}
+	td := scanPackages(walker.packages)
+	return td, nil
+}
+
+func scanPackages(packages map[string]*ast.Package) templateData {
+	td := make(templateData, 0)
+	for _, pkg := range packages {
+		if strings.HasSuffix(pkg.Name, "_test") {
+			continue
+		}
+		data := scanPackage(pkg)
+		td = append(td, data...)
+	}
+	return td
+}
+
+func scanPackage(pkg *ast.Package) templateData {
+	result := make(templateData, 0)
+	kinds := getTypeKinds(pkg)
+	for _, kind := range kinds {
+		result = append(result, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
+	}
+	return result
+}
+
+type walker struct {
+	packages map[string]*ast.Package
+	fset     *token.FileSet
+}
+
+func getTypeKinds(pkg *ast.Package) []string {
+	result := make([]string, 0)
+	for _, f := range pkg.Files {
+		for _, decl := range f.Decls {
+			gendecl, ok := decl.(*ast.GenDecl)
+			if !ok || gendecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gendecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
+					continue
+				}
+				strukt, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				for _, field := range strukt.Fields.List {
+					if len(field.Names) != 0 {
+						// not embedded
+						continue
+					}
+					expr, ok := field.Type.(*ast.SelectorExpr)
+					if !ok {
+						continue
+					}
+					if expr.Sel.Name == "TypeMeta" {
+						result = append(result, ts.Name.Name)
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (w *walker) walk(path string, fi os.FileInfo, err error) error {
+	if !fi.IsDir() {
+		return nil
+	}
+	if fi.IsDir() && fi.Name() == "internal" {
+		return filepath.SkipDir
+	}
+	if fi.IsDir() && strings.HasPrefix(fi.Name(), ".") {
+		return filepath.SkipDir
+	}
+	packages, err := parser.ParseDir(w.fset, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("couldn't parse directory: %s", err)
+	}
+	for k, v := range packages {
+		w.packages[k] = v
+	}
+	return nil
+}

--- a/runtime/registry/registry.go
+++ b/runtime/registry/registry.go
@@ -1,0 +1,32 @@
+package registry
+
+// automatically generated file, do not edit!
+
+import (
+	"fmt"
+
+	"github.com/sensu/sensu-go/internal/apis/core"
+	"github.com/sensu/sensu-go/internal/apis/meta"
+	"github.com/sensu/sensu-go/internal/apis/rbac"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{
+	meta.TypeMeta{Kind: "Namespace", APIVersion: "core"}:          core.Namespace{},
+	meta.TypeMeta{Kind: "Role", APIVersion: "rbac"}:               rbac.Role{},
+	meta.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac"}:        rbac.ClusterRole{},
+	meta.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac"}: rbac.ClusterRoleBinding{},
+	meta.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac"}:        rbac.RoleBinding{},
+	meta.TypeMeta{Kind: "Subject", APIVersion: "rbac"}:            rbac.Subject{},
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+	if !ok {
+		return nil, fmt.Errorf("type could not be found: %v", mt)
+	}
+	return t, nil
+}

--- a/runtime/registry/registry.go.tmpl
+++ b/runtime/registry/registry.go.tmpl
@@ -1,0 +1,26 @@
+package registry
+
+// automatically generated file, do not edit!
+
+import (
+  "fmt"
+  "reflect"
+
+  "github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{ {{ range $index, $t := . }}
+  meta.TypeMeta{Kind: "{{ $t.Kind }}", APIVersion: "{{ $t.APIVersion }}"}: {{ $t.APIVersion }}.{{ $t.Kind }}{}, {{ end }}
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+  if !ok {
+    return nil, fmt.Errorf("type could not be found: %v", mt)
+  }
+  return t, nil
+}

--- a/runtime/registry/registry_gen.go
+++ b/runtime/registry/registry_gen.go
@@ -1,5 +1,5 @@
 package registry
 
 //go:generate go install github.com/sensu/sensu-go/internal/cmd/gen-register
-//go:generate gen-register -pkg github.com/sensu/sensu-go/api -t registry.go.tmpl -o registry.go
+//go:generate gen-register -pkg github.com/sensu/sensu-go -t registry.go.tmpl -o registry.go
 //go:generate goimports -w registry.go

--- a/runtime/registry/registry_gen.go
+++ b/runtime/registry/registry_gen.go
@@ -1,0 +1,5 @@
+package registry
+
+//go:generate go install github.com/sensu/sensu-go/internal/cmd/gen-register
+//go:generate gen-register -pkg github.com/sensu/sensu-go/api -t registry.go.tmpl -o registry.go
+//go:generate goimports -w registry.go


### PR DESCRIPTION
## What is this change?

This PR adds the gen-register tool, and an initial generated registry for the new sensu-go types.

## Why is this change necessary?

A type registry is necessary for features like `sensuctl create`.