### PR TITLE
fmt.Errorf cleanup

### DIFF
--- a/agent/api.go
+++ b/agent/api.go
@@ -70,7 +70,7 @@ func addEvent(a *Agent) http.HandlerFunc {
 
 		msg, err := json.Marshal(event)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("error marshaling check result: %s", err.Error()), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("error marshaling check result: %s", err), http.StatusInternalServerError)
 			return
 		}
 

--- a/agent/token.go
+++ b/agent/token.go
@@ -15,7 +15,7 @@ import (
 func TokenSubstitution(data, input interface{}) ([]byte, error) {
 	inputBytes, err := json.Marshal(input)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal the provided template: %s", err.Error())
+		return nil, fmt.Errorf("could not marshal the provided template: %s", err)
 	}
 
 	// replace special character \" with " only if contained within {{ }}
@@ -36,13 +36,13 @@ func TokenSubstitution(data, input interface{}) ([]byte, error) {
 
 	tmpl, err = tmpl.Parse(inputString)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse the template: %s", err.Error())
+		return nil, fmt.Errorf("could not parse the template: %s", err)
 	}
 
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, data)
 	if err != nil {
-		return nil, fmt.Errorf("could not execute the template: %s", err.Error())
+		return nil, fmt.Errorf("could not execute the template: %s", err)
 	}
 
 	// Verify if the output contains the "<no value>" string, indicating that a
@@ -57,7 +57,7 @@ func TokenSubstitution(data, input interface{}) ([]byte, error) {
 			return nil, errors.New("unmatched token: found an undefined value but could not identify the token")
 		}
 
-		return nil, fmt.Errorf("unmatched token: %s", err.Error())
+		return nil, fmt.Errorf("unmatched token: %s", err)
 	}
 
 	return buf.Bytes(), nil

--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -29,7 +29,7 @@ func httpGet(url string) (io.ReadCloser, error) {
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching asset: %s", err.Error())
+		return nil, fmt.Errorf("error fetching asset: %s", err)
 	}
 
 	return resp.Body, nil

--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -27,7 +27,7 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 		// Query the store for an entity using the given proxy entity ID
 		entity, err := s.GetEntityByID(ctx, event.Check.ProxyEntityID)
 		if err != nil {
-			return fmt.Errorf("could not query the store for a proxy entity: %s", err.Error())
+			return fmt.Errorf("could not query the store for a proxy entity: %s", err)
 		}
 
 		// Check if an entity was found for this proxy entity. If not, we need to create it
@@ -41,7 +41,7 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 			}
 
 			if err := s.UpdateEntity(ctx, entity); err != nil {
-				return fmt.Errorf("could not create a proxy entity: %s", err.Error())
+				return fmt.Errorf("could not create a proxy entity: %s", err)
 			}
 		}
 

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -114,7 +114,7 @@ func (a *APId) Start() error {
 			err = a.HTTPServer.ListenAndServe()
 		}
 		if err != nil && err != http.ErrServerClosed {
-			a.errChan <- fmt.Errorf("failed to start http/https server %s", err.Error())
+			a.errChan <- fmt.Errorf("failed to start http/https server %s", err)
 		}
 	}()
 

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -50,7 +50,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// Create the token and a signed version
 	token, tokenString, err := jwt.AccessToken(user.Username)
 	if err != nil {
-		err = fmt.Errorf("could not issue an access token: %s", err.Error())
+		err = fmt.Errorf("could not issue an access token: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -59,7 +59,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// Retrieve the claims because we later need the expiration
 	claims, err := jwt.GetClaims(token)
 	if err != nil {
-		err = fmt.Errorf("could not get the access token claims: %s", err.Error())
+		err = fmt.Errorf("could not get the access token claims: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -67,7 +67,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	refreshToken, refreshTokenString, err := jwt.RefreshToken(user.Username)
 	if err != nil {
-		err = fmt.Errorf("could not issue a refresh token: %s", err.Error())
+		err = fmt.Errorf("could not issue a refresh token: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -75,7 +75,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	refreshClaims, err := jwt.GetClaims(refreshToken)
 	if err != nil {
-		err = fmt.Errorf("could not get the refresh token claims: %s", err.Error())
+		err = fmt.Errorf("could not get the refresh token claims: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -83,14 +83,14 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	// store the access and refresh tokens in the access list
 	if err = a.store.CreateToken(claims); err != nil {
-		err = fmt.Errorf("could not add the access token to the access list: %s", err.Error())
+		err = fmt.Errorf("could not add the access token to the access list: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	if err = a.store.CreateToken(refreshClaims); err != nil {
-		err = fmt.Errorf("could not add the refresh token to the access list: %s", err.Error())
+		err = fmt.Errorf("could not add the refresh token to the access list: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -105,7 +105,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	resBytes, err := json.Marshal(response)
 	if err != nil {
-		err = fmt.Errorf("could not not marshal response: %s", err.Error())
+		err = fmt.Errorf("could not not marshal response: %s", err)
 		logger.WithField("user", username).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -138,7 +138,7 @@ func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
 	// Remove the access & refresh tokens from the access list
 	tokensToRemove := []string{accessClaims.Id, refreshClaims.Id}
 	if err := a.store.DeleteTokens(refreshClaims.Subject, tokensToRemove); err != nil {
-		err = fmt.Errorf("could not remove the access and refresh tokens from the access list: %s", err.Error())
+		err = fmt.Errorf("could not remove the access and refresh tokens from the access list: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -176,7 +176,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 
 	// Make sure the refresh token is authorized in the access list
 	if _, err := a.store.GetToken(refreshClaims.Subject, refreshClaims.Id); err != nil {
-		err = fmt.Errorf("the refresh token is not authorized: %s", err.Error())
+		err = fmt.Errorf("the refresh token is not authorized: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -184,7 +184,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 
 	// Remove the old access token from the access list
 	if err := a.store.DeleteTokens(accessClaims.Subject, []string{accessClaims.Id}); err != nil {
-		err = fmt.Errorf("could not remove the access token from the access list: %s", err.Error())
+		err = fmt.Errorf("could not remove the access token from the access list: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -193,7 +193,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 	// Issue a new access token
 	accessToken, accessTokenString, err := jwt.AccessToken(refreshClaims.Subject)
 	if err != nil {
-		err = fmt.Errorf("could not issue a new access token: %s", err.Error())
+		err = fmt.Errorf("could not issue a new access token: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -202,7 +202,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 	// Retrieve the claims because we later need the expiration
 	accessClaims, err = jwt.GetClaims(accessToken)
 	if err != nil {
-		err = fmt.Errorf("could not issue a new access token: %s", err.Error())
+		err = fmt.Errorf("could not issue a new access token: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -210,7 +210,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 
 	// store the new access token in the access list
 	if err = a.store.CreateToken(accessClaims); err != nil {
-		err = fmt.Errorf("could not add the new access token to the access list: %s", err.Error())
+		err = fmt.Errorf("could not add the new access token to the access list: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -225,7 +225,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 
 	resBytes, err := json.Marshal(response)
 	if err != nil {
-		err = fmt.Errorf("could not not marshal response: %s", err.Error())
+		err = fmt.Errorf("could not not marshal response: %s", err)
 		logger.WithField("user", refreshClaims.Subject).Error(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/dashboardd/dashboardd.go
+++ b/backend/dashboardd/dashboardd.go
@@ -94,7 +94,7 @@ func (d *Dashboardd) Start() error {
 			err = d.httpServer.ListenAndServe()
 		}
 		if err != nil && err != http.ErrServerClosed {
-			d.errChan <- fmt.Errorf("failed to start http/https server %s", err.Error())
+			d.errChan <- fmt.Errorf("failed to start http/https server %s", err)
 		}
 	}()
 

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -30,12 +30,12 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 	ctx = context.WithValue(ctx, types.EnvironmentKey, entity.Environment)
 
 	if err := adapterPtr.Store.DeleteEntity(ctx, entity); err != nil {
-		return fmt.Errorf("error deleting entity in store: %s", err.Error())
+		return fmt.Errorf("error deleting entity in store: %s", err)
 	}
 
 	events, err := adapterPtr.Store.GetEventsByEntity(ctx, entity.ID)
 	if err != nil {
-		return fmt.Errorf("error fetching events for entity: %s", err.Error())
+		return fmt.Errorf("error fetching events for entity: %s", err)
 	}
 
 	for _, event := range events {
@@ -46,7 +46,7 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 		if err := adapterPtr.Store.DeleteEventByEntityCheck(
 			ctx, entity.ID, event.Check.Name,
 		); err != nil {
-			return fmt.Errorf("error deleting event for entity: %s", err.Error())
+			return fmt.Errorf("error deleting event for entity: %s", err)
 		}
 
 		event.Check.Output = "Resolving due to entity deregistering"
@@ -54,7 +54,7 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 		event.Check.History = []types.CheckHistory{}
 
 		if err := adapterPtr.MessageBus.Publish(messaging.TopicEvent, event); err != nil {
-			return fmt.Errorf("error publishing deregistration event: %s", err.Error())
+			return fmt.Errorf("error publishing deregistration event: %s", err)
 		}
 	}
 

--- a/cmd/sensu-agent/main.go
+++ b/cmd/sensu-agent/main.go
@@ -13,6 +13,6 @@ var (
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		logger.Fatal(err.Error())
+		logger.WithError(err).Fatal("error executing sensu-agent")
 	}
 }

--- a/cmd/sensu-backend/main.go
+++ b/cmd/sensu-backend/main.go
@@ -9,6 +9,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(backend.Initialize); err != nil {
-		logger.Fatal(err)
+		logger.WithError(err).Fatal("error executing sensu-backend")
 	}
 }

--- a/types/dynamic/redact.go
+++ b/types/dynamic/redact.go
@@ -66,7 +66,7 @@ func redactValue(original, redacted reflect.Value, fieldName string, fields []st
 		// Unmarshal the extended attributes so we can deal with them
 		var attrs interface{}
 		if err := json.Unmarshal(original.Bytes(), &attrs); err != nil {
-			return fmt.Errorf("could not unmarshal the redacted version of extended attribute: %s", err.Error())
+			return fmt.Errorf("could not unmarshal the redacted version of extended attribute: %s", err)
 		}
 
 		// Get the underlying value of the extended attributes
@@ -83,7 +83,7 @@ func redactValue(original, redacted reflect.Value, fieldName string, fields []st
 		// Marshal back the extended attributes so we can set them back into redacted
 		bytes, err := json.Marshal(redactedValue.Interface())
 		if err != nil {
-			return fmt.Errorf("could not marshal the redacted version of extended attribute: %s", err.Error())
+			return fmt.Errorf("could not marshal the redacted version of extended attribute: %s", err)
 		}
 
 		redacted.SetBytes(bytes)

--- a/util/eval/predicate.go
+++ b/util/eval/predicate.go
@@ -34,7 +34,7 @@ func NewPredicate(expression string) (*Predicate, error) {
 
 	expr, err := govaluate.NewEvaluableExpressionWithFunctions(expression, funcs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse the expression: %s", err.Error())
+		return nil, fmt.Errorf("failed to parse the expression: %s", err)
 	}
 	return &Predicate{expr}, nil
 }
@@ -45,7 +45,7 @@ func NewPredicate(expression string) (*Predicate, error) {
 func (p *Predicate) Eval(parameters govaluate.Parameters) (bool, error) {
 	result, err := p.expression.Eval(parameters)
 	if err != nil {
-		return false, fmt.Errorf("failed to evaluate the expression: %s", err.Error())
+		return false, fmt.Errorf("failed to evaluate the expression: %s", err)
 	}
 
 	match, ok := result.(bool)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Uses `err` (type `error`) in place of `err.Error()` (type `string`) when called from `fmt`.

## Why is this change necessary?

Quality of life.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.