### PR TITLE
Add freeze-api conversion utility.

### DIFF
--- a/internal/astutil/kind.go
+++ b/internal/astutil/kind.go
@@ -1,0 +1,65 @@
+package astutil
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+)
+
+const TypeMetaName = "TypeMeta"
+
+// GetKindNames finds all the sensu-go kinds in a package. It returns a
+// lexicographically sorted slice.
+func GetKindNames(pkg *ast.Package) (result []string) {
+	kinds := GetKinds(pkg)
+	for k := range kinds {
+		result = append(result, k)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// IsKind returns true if the type is an *ast.StructType, and it embeds
+// meta.TypeMeta.
+func IsKind(typ ast.Expr) bool {
+	strukt, ok := typ.(*ast.StructType)
+	if !ok {
+		return false
+	}
+	for _, field := range strukt.Fields.List {
+		if len(field.Names) != 0 {
+			// not embedded
+			continue
+		}
+		expr, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if expr.Sel.Name == TypeMetaName {
+			return true
+		}
+	}
+	return false
+}
+
+func GetKinds(pkg *ast.Package) map[string]*ast.TypeSpec {
+	result := make(map[string]*ast.TypeSpec)
+	for _, f := range pkg.Files {
+		for _, decl := range f.Decls {
+			gendecl, ok := decl.(*ast.GenDecl)
+			if !ok || gendecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gendecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
+					continue
+				}
+				if IsKind(ts.Type) {
+					result[ts.Name.Name] = ts
+				}
+			}
+		}
+	}
+	return result
+}

--- a/internal/cmd/freeze-api/convert.go
+++ b/internal/cmd/freeze-api/convert.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/sensu/sensu-go/internal/astutil"
+)
+
+type templateData struct {
+	// ToPackage is the name of the destination package.
+	ToPackage string
+
+	// FromPackage is the name of the source package.
+	FromPackage string
+
+	// ImportPackage is the fully qualified package path of ToPackage
+	ImportPackage string
+
+	// Types is a list of types to generate converters for
+	Types []conversionType
+}
+
+type conversionType struct {
+	// TypeName is the name of the type being converted.
+	TypeName string
+
+	// Simple informs the template whether or not to do a simple conversion.
+	// If the two types are structurally equivalent, then the type will be
+	// converted with an unsafe pointer conversion.
+	Simple bool
+
+	// TODO(echlebek): support complex conversions
+	ComplexFields map[string]reflect.Kind
+}
+
+const converterTmplStr = `package {{ .FromPackage }}
+
+import (
+	"unsafe"
+
+	"{{ .ImportPackage }}"
+)
+{{ $toPackage := .ToPackage }}{{ range $idx, $t := .Types }}
+// Convert converts a *{{ $t.TypeName }} to a *{{ $toPackage }}.{{ $t.TypeName }}. It panics if the
+// to parameter is not a *{{ $t.TypeName }}.
+func (r *{{ $t.TypeName }}) Convert(to interface{}) {
+	ptr := to.(*{{ $toPackage }}.{{ $t.TypeName }})
+	convert_{{ $t.TypeName }}_To_{{ $toPackage }}_{{ $t.TypeName }}(r, ptr)
+}
+
+var convert_{{ $t.TypeName }}_To_{{ $toPackage }}_{{ $t.TypeName}} = func(from *{{ $t.TypeName }}, to *{{ $toPackage}}.{{ $t.TypeName }}) {
+	{{ if $t.Simple }} *to = *(*{{ $toPackage }}.{{ $t.TypeName }})(unsafe.Pointer(from))
+	{{ else }}panic("not supported yet")
+{{end }}}
+{{ end }}
+`
+
+var converterTmpl = template.Must(template.New("converter").Parse(converterTmplStr))
+
+func removeTestPackages(packages map[string]*ast.Package) {
+	for k := range packages {
+		if strings.HasSuffix(k, "_test") {
+			delete(packages, k)
+		}
+	}
+}
+
+func getPackage(pkg string) (*ast.Package, error) {
+	path := packagePath(pkg)
+	fset := token.NewFileSet()
+	packages, err := parser.ParseDir(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing package: %s", err)
+	}
+	removeTestPackages(packages)
+	if len(packages) > 1 {
+		return nil, errors.New("too many 'from' packages")
+	}
+	for _, v := range packages {
+		return v, nil
+	}
+	return nil, errors.New("no packages found")
+}
+
+func createConverters(from, to string) error {
+	fromPackage, err := getPackage(from)
+	if err != nil {
+		return err
+	}
+
+	toPackage, err := getPackage(to)
+	if err != nil {
+		return err
+	}
+
+	fromTypes := astutil.GetKinds(fromPackage)
+	toTypes := astutil.GetKinds(toPackage)
+
+	td := templateData{
+		ToPackage:     path.Base(to),
+		FromPackage:   path.Base(from),
+		ImportPackage: to,
+	}
+
+	for _, typeName := range astutil.GetKindNames(fromPackage) {
+		fromType := fromTypes[typeName]
+		toType, ok := toTypes[typeName]
+		if !ok {
+			continue
+		}
+		simple := typesEquivalent(fromType, toType)
+		td.Types = append(td.Types, conversionType{
+			Simple:   simple,
+			TypeName: typeName,
+		})
+	}
+
+	outPath := path.Join(packagePath(from), "converters.go")
+	w, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("couldn't create converters: %s", err)
+	}
+
+	return converterTmpl.Execute(w, td)
+}
+
+func typesEquivalent(a, b *ast.TypeSpec) bool {
+	t1 := reflect.Indirect(reflect.ValueOf(a.Type)).Type()
+	t2 := reflect.Indirect(reflect.ValueOf(b.Type)).Type()
+
+	return t1 == t2
+}

--- a/internal/cmd/freeze-api/copy.go
+++ b/internal/cmd/freeze-api/copy.go
@@ -16,8 +16,8 @@ var packageDeclRe = regexp.MustCompile(`([\/\*]*[pP]ackage)[ ]+([_a-z0-9]+)`)
 // copyPackage naively copies a package from one place to another, updating its
 // package declaration.
 func copyPackage(fromPackage, toPackage string) error {
-	from := findPackageDir(fromPackage)
-	to := findPackageDir(toPackage)
+	from := packagePath(fromPackage)
+	to := packagePath(toPackage)
 	if err := os.MkdirAll(to, os.ModeDir|0755); err != nil {
 		return fmt.Errorf("couldn't copy package: %s", err)
 	}
@@ -87,6 +87,6 @@ func copyFile(from, to string) error {
 	return ioutil.WriteFile(to, b, 0644)
 }
 
-func findPackageDir(path string) string {
+func packagePath(path string) string {
 	return filepath.Join(build.Default.GOPATH, "src", path)
 }

--- a/internal/cmd/freeze-api/main.go
+++ b/internal/cmd/freeze-api/main.go
@@ -21,6 +21,8 @@ func main() {
 	if err := freezeAPI(*fromPath, *toPath); err != nil {
 		log.Fatal(err)
 	}
+	successMessage := fmt.Sprintf("Froze API to %q. Now run: 'go generate github.com/sensu/sensu-go/runtime/registry'.")
+	fmt.Fprintln(flag.CommandLine.Output(), successMessage)
 }
 
 func freezeAPI(from, to string) error {
@@ -30,12 +32,5 @@ func freezeAPI(from, to string) error {
 	if err := createConverters(to, from); err != nil {
 		return fmt.Errorf("error creating converters: %s", err)
 	}
-	if err := registerTypes(to); err != nil {
-		return fmt.Errorf("error registering types: %s", err)
-	}
-	return nil
-}
-
-func registerTypes(to string) error {
 	return nil
 }

--- a/internal/cmd/freeze-api/main.go
+++ b/internal/cmd/freeze-api/main.go
@@ -27,16 +27,12 @@ func freezeAPI(from, to string) error {
 	if err := copyPackage(from, to); err != nil {
 		return fmt.Errorf("error copying packages: %s", err)
 	}
-	if err := createConverters(from, to); err != nil {
+	if err := createConverters(to, from); err != nil {
 		return fmt.Errorf("error creating converters: %s", err)
 	}
 	if err := registerTypes(to); err != nil {
 		return fmt.Errorf("error registering types: %s", err)
 	}
-	return nil
-}
-
-func createConverters(from, to string) error {
 	return nil
 }
 

--- a/internal/cmd/gen-register/main.go
+++ b/internal/cmd/gen-register/main.go
@@ -3,25 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
-	"go/ast"
-	"go/build"
-	"go/parser"
-	"go/token"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
-	"text/template"
 
-	"github.com/sensu/sensu-go/internal/apis/meta"
-	"github.com/sensu/sensu-go/internal/astutil"
+	"github.com/sensu/sensu-go/internal/registry"
 )
-
-type templateData []meta.TypeMeta
 
 var (
 	packagePath = flag.String("pkg", "", "Path to package to generate registry for")
-	tmplPath    = flag.String("t", "", "Path to template file")
 	outPath     = flag.String("o", "", "Output path")
 )
 
@@ -31,93 +20,17 @@ func main() {
 		w := flag.CommandLine.Output()
 		fmt.Fprintf(w, "%s: Generate a type registry for sensu-go API types.\n", os.Args[0])
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -t register.go.tmpl -o register.go")
+		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -o register.go")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
 	if *packagePath == "" {
 		log.Fatal("no package path supplied (-pkg)")
 	}
-	if *tmplPath == "" {
-		log.Fatal("no template path supplied (-t)")
-	}
 	if *outPath == "" {
 		log.Fatal("no output path supplied (-o)")
 	}
-
-	tmpl, err := template.ParseFiles(*tmplPath)
-	if err != nil {
-		log.Fatalf("couldn't read template: %s", err)
+	if err := registry.RegisterTypes(*packagePath, *outPath); err != nil {
+		log.Fatal(err)
 	}
-
-	kinds, err := getPackageKinds(*packagePath)
-	if err != nil {
-		log.Fatalf("couldn't get package types: %s", err)
-	}
-
-	w, err := os.OpenFile(*outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatalf("couldn't open output for writing: %s", err)
-	}
-
-	if err := tmpl.Execute(w, kinds); err != nil {
-		log.Fatalf("couldn't write registry: %s", err)
-	}
-}
-
-// getPackageKinds recursively traverses the package and all sub-packages for
-// sensu-go kinds (structs that embed meta.TypeMeta).
-func getPackageKinds(path string) (templateData, error) {
-	root := filepath.Join(build.Default.GOPATH, "src", path)
-	walker := &walker{
-		fset:     token.NewFileSet(),
-		packages: make(map[string]*ast.Package),
-	}
-	if err := filepath.Walk(root, walker.walk); err != nil {
-		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
-	}
-	td := scanPackages(walker.packages)
-	return td, nil
-}
-
-// scanPackages scans all of the collected packages for kinds and collects them
-// into a slice.
-func scanPackages(packages map[string]*ast.Package) templateData {
-	td := make(templateData, 0)
-	for _, pkg := range packages {
-		if strings.HasSuffix(pkg.Name, "_test") {
-			continue
-		}
-		kinds := astutil.GetKindNames(pkg)
-		for _, kind := range kinds {
-			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
-		}
-	}
-	return td
-}
-
-// walker walks a filesystem recursively, looking for Go packages to parse.
-type walker struct {
-	packages map[string]*ast.Package
-	fset     *token.FileSet
-}
-
-func (w *walker) walk(path string, fi os.FileInfo, err error) error {
-	if fi == nil || !fi.IsDir() {
-		return nil
-	}
-	if strings.HasPrefix(fi.Name(), ".") {
-		return filepath.SkipDir
-	}
-	if fi.Name() == "vendor" {
-		return filepath.SkipDir
-	}
-	packages, err := parser.ParseDir(w.fset, path, nil, 0)
-	if err != nil {
-		return fmt.Errorf("couldn't parse directory: %s", err)
-	}
-	for k, v := range packages {
-		w.packages[k] = v
-	}
-	return nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,129 @@
+package registry
+
+import (
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sensu/sensu-go/internal/apis/meta"
+	"github.com/sensu/sensu-go/internal/astutil"
+)
+
+const templateText = `package registry
+
+// automatically generated file, do not edit!
+
+import (
+  "fmt"
+  "reflect"
+
+  "github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{ {{ range $index, $t := . }}
+  meta.TypeMeta{Kind: "{{ $t.Kind }}", APIVersion: "{{ $t.APIVersion }}"}: {{ $t.APIVersion }}.{{ $t.Kind }}{}, {{ end }}
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+  if !ok {
+    return nil, fmt.Errorf("type could not be found: %v", mt)
+  }
+  return t, nil
+}
+`
+
+var (
+	registryTmpl = template.Must(template.New("registry").Parse(templateText))
+)
+
+type templateData []meta.TypeMeta
+
+func RegisterTypes(packagePath, outPath string) error {
+	kinds, err := getPackageKinds(packagePath)
+	if err != nil {
+		return fmt.Errorf("couldn't get package types: %s", err)
+	}
+
+	w, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("couldn't open output for writing: %s", err)
+	}
+
+	if err := registryTmpl.Execute(w, kinds); err != nil {
+		return fmt.Errorf("couldn't write registry: %s", err)
+	}
+	return nil
+}
+
+// getPackageKinds recursively traverses the package and all sub-packages for
+// sensu-go kinds (structs that embed meta.TypeMeta).
+func getPackageKinds(path string) (templateData, error) {
+	root := filepath.Join(build.Default.GOPATH, "src", path)
+	walker := &walker{
+		fset:     token.NewFileSet(),
+		packages: make(map[string]*ast.Package),
+	}
+	if err := filepath.Walk(root, walker.walk); err != nil {
+		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
+	}
+	td := scanPackages(walker.packages)
+	return td, nil
+}
+
+// scanPackages scans all of the collected packages for kinds and collects them
+// into a slice.
+func scanPackages(packages map[string]*ast.Package) templateData {
+	td := make(templateData, 0)
+	for _, pkg := range packages {
+		if strings.HasSuffix(pkg.Name, "_test") {
+			continue
+		}
+		kinds := astutil.GetKindNames(pkg)
+		for _, kind := range kinds {
+			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
+		}
+	}
+	return td
+}
+
+// walker walks a filesystem recursively, looking for Go packages to parse.
+type walker struct {
+	packages map[string]*ast.Package
+	fset     *token.FileSet
+}
+
+func (w *walker) walk(path string, fi os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+	if fi == nil || !fi.IsDir() {
+		return nil
+	}
+	if strings.HasPrefix(fi.Name(), ".") {
+		return filepath.SkipDir
+	}
+	// special case for vendor directory and types package
+	// we can eventually remove the special case for the types package
+	if fi.Name() == "vendor" || fi.Name() == "types" {
+		return filepath.SkipDir
+	}
+	packages, err := parser.ParseDir(w.fset, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("couldn't parse directory: %s", err)
+	}
+	for k, v := range packages {
+		w.packages[k] = v
+	}
+	return nil
+}

--- a/runtime/registry/registry_gen.go
+++ b/runtime/registry/registry_gen.go
@@ -1,5 +1,5 @@
 package registry
 
 //go:generate go install github.com/sensu/sensu-go/internal/cmd/gen-register
-//go:generate gen-register -pkg github.com/sensu/sensu-go -t registry.go.tmpl -o registry.go
+//go:generate gen-register -pkg github.com/sensu/sensu-go -o registry.go
 //go:generate goimports -w registry.go


### PR DESCRIPTION
Add a conversion utility to the freeze-api command. This feature
generates type converters between the package being frozen and
the package being created.

For now, only pointer conversions are supported. In the future,
a more featureful conversion interface will be required.

Signed-off-by: Eric Chlebek <eric@sensu.io>

Here is an example of code generated by this utility:

```go
package v1

import (
	"unsafe"

	"github.com/sensu/sensu-go/internal/apis/rbac"
)

// Convert converts a *ClusterRole to a *rbac.ClusterRole. It panics if the
// to parameter is not a *ClusterRole.
func (r *ClusterRole) Convert(to interface{}) {
	ptr := to.(*rbac.ClusterRole)
	convert_ClusterRole_To_rbac_ClusterRole(r, ptr)
}

var convert_ClusterRole_To_rbac_ClusterRole = func(from *ClusterRole, to *rbac.ClusterRole) {
	*to = *(*rbac.ClusterRole)(unsafe.Pointer(from))
}

// Convert converts a *ClusterRoleBinding to a *rbac.ClusterRoleBinding. It panics if the
// to parameter is not a *ClusterRoleBinding.
func (r *ClusterRoleBinding) Convert(to interface{}) {
	ptr := to.(*rbac.ClusterRoleBinding)
	convert_ClusterRoleBinding_To_rbac_ClusterRoleBinding(r, ptr)
}

var convert_ClusterRoleBinding_To_rbac_ClusterRoleBinding = func(from *ClusterRoleBinding, to *rbac.ClusterRoleBinding) {
	*to = *(*rbac.ClusterRoleBinding)(unsafe.Pointer(from))
}

// Convert converts a *Role to a *rbac.Role. It panics if the
// to parameter is not a *Role.
func (r *Role) Convert(to interface{}) {
	ptr := to.(*rbac.Role)
	convert_Role_To_rbac_Role(r, ptr)
}

var convert_Role_To_rbac_Role = func(from *Role, to *rbac.Role) {
	*to = *(*rbac.Role)(unsafe.Pointer(from))
}

// Convert converts a *RoleBinding to a *rbac.RoleBinding. It panics if the
// to parameter is not a *RoleBinding.
func (r *RoleBinding) Convert(to interface{}) {
	ptr := to.(*rbac.RoleBinding)
	convert_RoleBinding_To_rbac_RoleBinding(r, ptr)
}

var convert_RoleBinding_To_rbac_RoleBinding = func(from *RoleBinding, to *rbac.RoleBinding) {
	*to = *(*rbac.RoleBinding)(unsafe.Pointer(from))
}

// Convert converts a *Subject to a *rbac.Subject. It panics if the
// to parameter is not a *Subject.
func (r *Subject) Convert(to interface{}) {
	ptr := to.(*rbac.Subject)
	convert_Subject_To_rbac_Subject(r, ptr)
}

var convert_Subject_To_rbac_Subject = func(from *Subject, to *rbac.Subject) {
	*to = *(*rbac.Subject)(unsafe.Pointer(from))
}
```
