### PR TITLE
Add freeze-api tool.

### DIFF
--- a/internal/apis/meta/meta.go
+++ b/internal/apis/meta/meta.go
@@ -2,26 +2,17 @@ package meta
 
 import "strings"
 
-// TypeMetaAccessor returns a GroupVersionKind if the Object has type
-// metadata associated with it, otherwise it returns nil.
-func GetGroupVersionKind(obj Object) GroupVersionKind {
-	gvk, ok := obj.(GroupVersionKind)
-	if ok {
-		return gvk
-	}
-
-	return nil
-}
-
 type GroupVersionKind interface {
 	GetKind() string
 	GetGroup() string
 	GetVersion() string
+	GetTypeMeta() TypeMeta
 }
 
-func (gvk TypeMeta) GetKind() string    { return gvk.Kind }
-func (gvk TypeMeta) GetGroup() string   { return strings.Split(gvk.APIVersion, "/")[0] }
-func (gvk TypeMeta) GetVersion() string { return strings.Split(gvk.APIVersion, "/")[1] }
+func (tm TypeMeta) GetTypeMeta() TypeMeta { return tm }
+func (gvk TypeMeta) GetKind() string      { return gvk.Kind }
+func (gvk TypeMeta) GetGroup() string     { return strings.Split(gvk.APIVersion, "/")[0] }
+func (gvk TypeMeta) GetVersion() string   { return strings.Split(gvk.APIVersion, "/")[1] }
 
 // Object lets you work with object metadata from any of the versioned or
 // internal API objects. Attempting to set or retrieve a field on an object that does

--- a/internal/astutil/kind.go
+++ b/internal/astutil/kind.go
@@ -1,0 +1,65 @@
+package astutil
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+)
+
+const TypeMetaName = "TypeMeta"
+
+// GetKindNames finds all the sensu-go kinds in a package. It returns a
+// lexicographically sorted slice.
+func GetKindNames(pkg *ast.Package) (result []string) {
+	kinds := GetKinds(pkg)
+	for k := range kinds {
+		result = append(result, k)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// IsKind returns true if the type is an *ast.StructType, and it embeds
+// meta.TypeMeta.
+func IsKind(typ ast.Expr) bool {
+	strukt, ok := typ.(*ast.StructType)
+	if !ok {
+		return false
+	}
+	for _, field := range strukt.Fields.List {
+		if len(field.Names) != 0 {
+			// not embedded
+			continue
+		}
+		expr, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if expr.Sel.Name == TypeMetaName {
+			return true
+		}
+	}
+	return false
+}
+
+func GetKinds(pkg *ast.Package) map[string]*ast.TypeSpec {
+	result := make(map[string]*ast.TypeSpec)
+	for _, f := range pkg.Files {
+		for _, decl := range f.Decls {
+			gendecl, ok := decl.(*ast.GenDecl)
+			if !ok || gendecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gendecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
+					continue
+				}
+				if IsKind(ts.Type) {
+					result[ts.Name.Name] = ts
+				}
+			}
+		}
+	}
+	return result
+}

--- a/internal/cmd/freeze-api/convert.go
+++ b/internal/cmd/freeze-api/convert.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"text/template"
+
+	"github.com/sensu/sensu-go/internal/astutil"
+)
+
+type templateData struct {
+	// ToPackage is the name of the destination package.
+	ToPackage string
+
+	// FromPackage is the name of the source package.
+	FromPackage string
+
+	// ImportPackage is the fully qualified package path of ToPackage
+	ImportPackage string
+
+	// Types is a list of types to generate converters for
+	Types []conversionType
+}
+
+type conversionType struct {
+	// TypeName is the name of the type being converted.
+	TypeName string
+
+	// Simple informs the template whether or not to do a simple conversion.
+	// If the two types are structurally equivalent, then the type will be
+	// converted with an unsafe pointer conversion.
+	Simple bool
+
+	// TODO(echlebek): support complex conversions
+	ComplexFields map[string]reflect.Kind
+}
+
+const converterTmplStr = `package {{ .FromPackage }}
+
+import (
+	"unsafe"
+
+	"{{ .ImportPackage }}"
+)
+{{ $toPackage := .ToPackage }}{{ range $idx, $t := .Types }}
+// Convert converts a *{{ $t.TypeName }} to a *{{ $toPackage }}.{{ $t.TypeName }}. It panics if the
+// to parameter is not a *{{ $t.TypeName }}.
+func (r *{{ $t.TypeName }}) Convert(to interface{}) {
+	ptr := to.(*{{ $toPackage }}.{{ $t.TypeName }})
+	convert_{{ $t.TypeName }}_To_{{ $toPackage }}_{{ $t.TypeName }}(r, ptr)
+}
+
+var convert_{{ $t.TypeName }}_To_{{ $toPackage }}_{{ $t.TypeName}} = func(from *{{ $t.TypeName }}, to *{{ $toPackage}}.{{ $t.TypeName }}) {
+	{{ if $t.Simple }} *to = *(*{{ $toPackage }}.{{ $t.TypeName }})(unsafe.Pointer(from))
+	{{ else }}panic("not supported yet")
+{{end }}}
+{{ end }}
+`
+
+var converterTmpl = template.Must(template.New("converter").Parse(converterTmplStr))
+
+func removeTestPackages(packages map[string]*ast.Package) {
+	for k := range packages {
+		if strings.HasSuffix(k, "_test") {
+			delete(packages, k)
+		}
+	}
+}
+
+func getPackage(pkg string) (*ast.Package, error) {
+	path := packagePath(pkg)
+	fset := token.NewFileSet()
+	packages, err := parser.ParseDir(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing package: %s", err)
+	}
+	removeTestPackages(packages)
+	if len(packages) > 1 {
+		return nil, errors.New("too many 'from' packages")
+	}
+	for _, v := range packages {
+		return v, nil
+	}
+	return nil, errors.New("no packages found")
+}
+
+func createConverters(from, to string) error {
+	fromPackage, err := getPackage(from)
+	if err != nil {
+		return err
+	}
+
+	toPackage, err := getPackage(to)
+	if err != nil {
+		return err
+	}
+
+	fromTypes := astutil.GetKinds(fromPackage)
+	toTypes := astutil.GetKinds(toPackage)
+
+	td := templateData{
+		ToPackage:     path.Base(to),
+		FromPackage:   path.Base(from),
+		ImportPackage: to,
+	}
+
+	for _, typeName := range astutil.GetKindNames(fromPackage) {
+		fromType := fromTypes[typeName]
+		toType, ok := toTypes[typeName]
+		if !ok {
+			continue
+		}
+		simple := typesEquivalent(fromType, toType)
+		td.Types = append(td.Types, conversionType{
+			Simple:   simple,
+			TypeName: typeName,
+		})
+	}
+
+	outPath := path.Join(packagePath(from), "converters.go")
+	w, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("couldn't create converters: %s", err)
+	}
+
+	return converterTmpl.Execute(w, td)
+}
+
+func typesEquivalent(a, b *ast.TypeSpec) bool {
+	t1 := reflect.Indirect(reflect.ValueOf(a.Type)).Type()
+	t2 := reflect.Indirect(reflect.ValueOf(b.Type)).Type()
+
+	return t1 == t2
+}

--- a/internal/cmd/freeze-api/copy.go
+++ b/internal/cmd/freeze-api/copy.go
@@ -16,8 +16,8 @@ var packageDeclRe = regexp.MustCompile(`([\/\*]*[pP]ackage)[ ]+([_a-z0-9]+)`)
 // copyPackage naively copies a package from one place to another, updating its
 // package declaration.
 func copyPackage(fromPackage, toPackage string) error {
-	from := findPackageDir(fromPackage)
-	to := findPackageDir(toPackage)
+	from := packagePath(fromPackage)
+	to := packagePath(toPackage)
 	if err := os.MkdirAll(to, os.ModeDir|0755); err != nil {
 		return fmt.Errorf("couldn't copy package: %s", err)
 	}
@@ -87,6 +87,6 @@ func copyFile(from, to string) error {
 	return ioutil.WriteFile(to, b, 0644)
 }
 
-func findPackageDir(path string) string {
+func packagePath(path string) string {
 	return filepath.Join(build.Default.GOPATH, "src", path)
 }

--- a/internal/cmd/freeze-api/copy.go
+++ b/internal/cmd/freeze-api/copy.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var packageDeclRe = regexp.MustCompile(`([\/\*]*[pP]ackage)[ ]+([_a-z0-9]+)`)
+
+// copyPackage naively copies a package from one place to another, updating its
+// package declaration.
+func copyPackage(fromPackage, toPackage string) error {
+	from := findPackageDir(fromPackage)
+	to := findPackageDir(toPackage)
+	if err := os.MkdirAll(to, os.ModeDir|0755); err != nil {
+		return fmt.Errorf("couldn't copy package: %s", err)
+	}
+	files, err := ioutil.ReadDir(from)
+	if err != nil {
+		return fmt.Errorf("couldn't copy package: %s", err)
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		oldFileName := filepath.Join(from, f.Name())
+		newFileName := filepath.Join(to, f.Name())
+		packageName := filepath.Base(to)
+		if strings.HasSuffix(f.Name(), ".go") {
+			if err := copyGoFile(oldFileName, newFileName, packageName); err != nil {
+				return fmt.Errorf("couldn't copy package: %s", err)
+			}
+		} else if strings.HasSuffix(f.Name(), ".proto") {
+			if err := copyProtoFile(oldFileName, newFileName, toPackage); err != nil {
+				return fmt.Errorf("couldn't copy package: %s", err)
+			}
+		} else {
+			if err := copyFile(oldFileName, newFileName); err != nil {
+				return fmt.Errorf("couldn't copy package: %s", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+var protoPackageDeclRe = regexp.MustCompile(`(package) [_\.a-z0-9]+`)
+var protoGoPackageDeclRe = regexp.MustCompile(`(option go_package =) "[_a-z0-9]+"`)
+
+func copyProtoFile(from, to, toPackage string) error {
+	b, err := ioutil.ReadFile(from)
+	if err != nil {
+		return err
+	}
+
+	newProtoPackageName := strings.Replace(toPackage, "/", ".", -1)
+	newProtoPackageName = strings.Replace(newProtoPackageName, "-", "_", -1)
+	newBytes := protoPackageDeclRe.ReplaceAll(b, []byte(fmt.Sprintf(`$1 %s`, newProtoPackageName)))
+
+	newProtoGoPackageName := path.Base(toPackage)
+	newBytes = protoGoPackageDeclRe.ReplaceAll(newBytes, []byte(fmt.Sprintf(`$1 "%s"`, newProtoGoPackageName)))
+
+	return ioutil.WriteFile(to, newBytes, 0644)
+}
+
+func copyGoFile(from, to, packageName string) error {
+	b, err := ioutil.ReadFile(from)
+	if err != nil {
+		return err
+	}
+	newBytes := packageDeclRe.ReplaceAll(b, []byte(fmt.Sprintf(`$1 %s`, packageName)))
+	return ioutil.WriteFile(to, newBytes, 0644)
+}
+
+func copyFile(from, to string) error {
+	b, err := ioutil.ReadFile(from)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(to, b, 0644)
+}
+
+func findPackageDir(path string) string {
+	return filepath.Join(build.Default.GOPATH, "src", path)
+}

--- a/internal/cmd/freeze-api/main.go
+++ b/internal/cmd/freeze-api/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+var (
+	fromPath = flag.String("from", "", "Package to freeze")
+	toPath   = flag.String("to", "", "Versioned package to create")
+)
+
+func main() {
+	flag.Parse()
+	if *fromPath == "" || *toPath == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+	if err := freezeAPI(*fromPath, *toPath); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func freezeAPI(from, to string) error {
+	if err := copyPackage(from, to); err != nil {
+		return fmt.Errorf("error copying packages: %s", err)
+	}
+	if err := createConverters(from, to); err != nil {
+		return fmt.Errorf("error creating converters: %s", err)
+	}
+	if err := registerTypes(to); err != nil {
+		return fmt.Errorf("error registering types: %s", err)
+	}
+	return nil
+}
+
+func createConverters(from, to string) error {
+	return nil
+}
+
+func registerTypes(to string) error {
+	return nil
+}

--- a/internal/cmd/freeze-api/main.go
+++ b/internal/cmd/freeze-api/main.go
@@ -21,25 +21,16 @@ func main() {
 	if err := freezeAPI(*fromPath, *toPath); err != nil {
 		log.Fatal(err)
 	}
+	successMessage := fmt.Sprintf("Froze API to %q. Now run: 'go generate github.com/sensu/sensu-go/runtime/registry'.")
+	fmt.Fprintln(flag.CommandLine.Output(), successMessage)
 }
 
 func freezeAPI(from, to string) error {
 	if err := copyPackage(from, to); err != nil {
 		return fmt.Errorf("error copying packages: %s", err)
 	}
-	if err := createConverters(from, to); err != nil {
+	if err := createConverters(to, from); err != nil {
 		return fmt.Errorf("error creating converters: %s", err)
 	}
-	if err := registerTypes(to); err != nil {
-		return fmt.Errorf("error registering types: %s", err)
-	}
-	return nil
-}
-
-func createConverters(from, to string) error {
-	return nil
-}
-
-func registerTypes(to string) error {
 	return nil
 }

--- a/internal/cmd/gen-register/main.go
+++ b/internal/cmd/gen-register/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type templateData []meta.TypeMeta
+
+var (
+	packagePath = flag.String("pkg", "", "Path to package to generate registry for")
+	tmplPath    = flag.String("t", "", "Path to template file")
+	outPath     = flag.String("o", "", "Output path")
+)
+
+const TypeMetaName = "TypeMeta"
+
+func main() {
+	log.SetFlags(log.Lshortfile)
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintf(w, "%s: Generate a type registry for sensu-go API types.\n", os.Args[0])
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -t register.go.tmpl -o register.go")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if *packagePath == "" {
+		log.Fatal("no package path supplied (-pkg)")
+	}
+	if *tmplPath == "" {
+		log.Fatal("no template path supplied (-t)")
+	}
+	if *outPath == "" {
+		log.Fatal("no output path supplied (-o)")
+	}
+
+	tmpl, err := template.ParseFiles(*tmplPath)
+	if err != nil {
+		log.Fatalf("couldn't read template: %s", err)
+	}
+
+	kinds, err := getPackageKinds(*packagePath)
+	if err != nil {
+		log.Fatalf("couldn't get package types: %s", err)
+	}
+
+	w, err := os.OpenFile(*outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalf("couldn't open output for writing: %s", err)
+	}
+
+	if err := tmpl.Execute(w, kinds); err != nil {
+		log.Fatalf("couldn't write registry: %s", err)
+	}
+}
+
+// getPackageKinds recursively traverses the package and all sub-packages for
+// sensu-go kinds (structs that embed meta.TypeMeta).
+func getPackageKinds(path string) (templateData, error) {
+	root := filepath.Join(build.Default.GOPATH, "src", path)
+	walker := &walker{
+		fset:     token.NewFileSet(),
+		packages: make(map[string]*ast.Package),
+	}
+	if err := filepath.Walk(root, walker.walk); err != nil {
+		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
+	}
+	td := scanPackages(walker.packages)
+	return td, nil
+}
+
+// scanPackages scans all of the collected packages for kinds and collects them
+// into a slice.
+func scanPackages(packages map[string]*ast.Package) templateData {
+	td := make(templateData, 0)
+	for _, pkg := range packages {
+		if strings.HasSuffix(pkg.Name, "_test") {
+			continue
+		}
+		kinds := getKinds(pkg)
+		for _, kind := range kinds {
+			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
+		}
+	}
+	return td
+}
+
+// getKinds finds all the sensu-go kinds in a package.
+func getKinds(pkg *ast.Package) (result []string) {
+	for _, f := range pkg.Files {
+		for _, decl := range f.Decls {
+			gendecl, ok := decl.(*ast.GenDecl)
+			if !ok || gendecl.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gendecl.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
+					continue
+				}
+				if isKind(ts.Type) {
+					result = append(result, ts.Name.Name)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// isKind returns true if the type is an *ast.StructType, and it embeds
+// meta.TypeMeta.
+func isKind(typ ast.Expr) bool {
+	strukt, ok := typ.(*ast.StructType)
+	if !ok {
+		return false
+	}
+	for _, field := range strukt.Fields.List {
+		if len(field.Names) != 0 {
+			// not embedded
+			continue
+		}
+		expr, ok := field.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if expr.Sel.Name == TypeMetaName {
+			return true
+		}
+	}
+	return false
+}
+
+// walker walks a filesystem recursively, looking for Go packages to parse.
+type walker struct {
+	packages map[string]*ast.Package
+	fset     *token.FileSet
+}
+
+func (w *walker) walk(path string, fi os.FileInfo, err error) error {
+	if fi == nil || !fi.IsDir() {
+		return nil
+	}
+	if strings.HasPrefix(fi.Name(), ".") {
+		return filepath.SkipDir
+	}
+	if fi.Name() == "vendor" {
+		return filepath.SkipDir
+	}
+	packages, err := parser.ParseDir(w.fset, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("couldn't parse directory: %s", err)
+	}
+	for k, v := range packages {
+		w.packages[k] = v
+	}
+	return nil
+}

--- a/internal/cmd/gen-register/main.go
+++ b/internal/cmd/gen-register/main.go
@@ -3,28 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
-	"go/ast"
-	"go/build"
-	"go/parser"
-	"go/token"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
-	"text/template"
 
-	"github.com/sensu/sensu-go/internal/apis/meta"
+	"github.com/sensu/sensu-go/internal/registry"
 )
-
-type templateData []meta.TypeMeta
 
 var (
 	packagePath = flag.String("pkg", "", "Path to package to generate registry for")
-	tmplPath    = flag.String("t", "", "Path to template file")
 	outPath     = flag.String("o", "", "Output path")
 )
-
-const TypeMetaName = "TypeMeta"
 
 func main() {
 	log.SetFlags(log.Lshortfile)
@@ -32,138 +20,17 @@ func main() {
 		w := flag.CommandLine.Output()
 		fmt.Fprintf(w, "%s: Generate a type registry for sensu-go API types.\n", os.Args[0])
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -t register.go.tmpl -o register.go")
+		fmt.Fprintln(w, "Example usage: gen-register -pkg github.com/sensu/sensu-go -o register.go")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
 	if *packagePath == "" {
 		log.Fatal("no package path supplied (-pkg)")
 	}
-	if *tmplPath == "" {
-		log.Fatal("no template path supplied (-t)")
-	}
 	if *outPath == "" {
 		log.Fatal("no output path supplied (-o)")
 	}
-
-	tmpl, err := template.ParseFiles(*tmplPath)
-	if err != nil {
-		log.Fatalf("couldn't read template: %s", err)
+	if err := registry.RegisterTypes(*packagePath, *outPath); err != nil {
+		log.Fatal(err)
 	}
-
-	kinds, err := getPackageKinds(*packagePath)
-	if err != nil {
-		log.Fatalf("couldn't get package types: %s", err)
-	}
-
-	w, err := os.OpenFile(*outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
-	if err != nil {
-		log.Fatalf("couldn't open output for writing: %s", err)
-	}
-
-	if err := tmpl.Execute(w, kinds); err != nil {
-		log.Fatalf("couldn't write registry: %s", err)
-	}
-}
-
-// getPackageKinds recursively traverses the package and all sub-packages for
-// sensu-go kinds (structs that embed meta.TypeMeta).
-func getPackageKinds(path string) (templateData, error) {
-	root := filepath.Join(build.Default.GOPATH, "src", path)
-	walker := &walker{
-		fset:     token.NewFileSet(),
-		packages: make(map[string]*ast.Package),
-	}
-	if err := filepath.Walk(root, walker.walk); err != nil {
-		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
-	}
-	td := scanPackages(walker.packages)
-	return td, nil
-}
-
-// scanPackages scans all of the collected packages for kinds and collects them
-// into a slice.
-func scanPackages(packages map[string]*ast.Package) templateData {
-	td := make(templateData, 0)
-	for _, pkg := range packages {
-		if strings.HasSuffix(pkg.Name, "_test") {
-			continue
-		}
-		kinds := getKinds(pkg)
-		for _, kind := range kinds {
-			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
-		}
-	}
-	return td
-}
-
-// getKinds finds all the sensu-go kinds in a package.
-func getKinds(pkg *ast.Package) (result []string) {
-	for _, f := range pkg.Files {
-		for _, decl := range f.Decls {
-			gendecl, ok := decl.(*ast.GenDecl)
-			if !ok || gendecl.Tok != token.TYPE {
-				continue
-			}
-			for _, spec := range gendecl.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !ts.Name.IsExported() {
-					continue
-				}
-				if isKind(ts.Type) {
-					result = append(result, ts.Name.Name)
-				}
-			}
-		}
-	}
-	return result
-}
-
-// isKind returns true if the type is an *ast.StructType, and it embeds
-// meta.TypeMeta.
-func isKind(typ ast.Expr) bool {
-	strukt, ok := typ.(*ast.StructType)
-	if !ok {
-		return false
-	}
-	for _, field := range strukt.Fields.List {
-		if len(field.Names) != 0 {
-			// not embedded
-			continue
-		}
-		expr, ok := field.Type.(*ast.SelectorExpr)
-		if !ok {
-			continue
-		}
-		if expr.Sel.Name == TypeMetaName {
-			return true
-		}
-	}
-	return false
-}
-
-// walker walks a filesystem recursively, looking for Go packages to parse.
-type walker struct {
-	packages map[string]*ast.Package
-	fset     *token.FileSet
-}
-
-func (w *walker) walk(path string, fi os.FileInfo, err error) error {
-	if fi == nil || !fi.IsDir() {
-		return nil
-	}
-	if strings.HasPrefix(fi.Name(), ".") {
-		return filepath.SkipDir
-	}
-	if fi.Name() == "vendor" {
-		return filepath.SkipDir
-	}
-	packages, err := parser.ParseDir(w.fset, path, nil, 0)
-	if err != nil {
-		return fmt.Errorf("couldn't parse directory: %s", err)
-	}
-	for k, v := range packages {
-		w.packages[k] = v
-	}
-	return nil
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,129 @@
+package registry
+
+import (
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sensu/sensu-go/internal/apis/meta"
+	"github.com/sensu/sensu-go/internal/astutil"
+)
+
+const templateText = `package registry
+
+// automatically generated file, do not edit!
+
+import (
+  "fmt"
+  "reflect"
+
+  "github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{ {{ range $index, $t := . }}
+  meta.TypeMeta{Kind: "{{ $t.Kind }}", APIVersion: "{{ $t.APIVersion }}"}: {{ $t.APIVersion }}.{{ $t.Kind }}{}, {{ end }}
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+  if !ok {
+    return nil, fmt.Errorf("type could not be found: %v", mt)
+  }
+  return t, nil
+}
+`
+
+var (
+	registryTmpl = template.Must(template.New("registry").Parse(templateText))
+)
+
+type templateData []meta.TypeMeta
+
+func RegisterTypes(packagePath, outPath string) error {
+	kinds, err := getPackageKinds(packagePath)
+	if err != nil {
+		return fmt.Errorf("couldn't get package types: %s", err)
+	}
+
+	w, err := os.OpenFile(outPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("couldn't open output for writing: %s", err)
+	}
+
+	if err := registryTmpl.Execute(w, kinds); err != nil {
+		return fmt.Errorf("couldn't write registry: %s", err)
+	}
+	return nil
+}
+
+// getPackageKinds recursively traverses the package and all sub-packages for
+// sensu-go kinds (structs that embed meta.TypeMeta).
+func getPackageKinds(path string) (templateData, error) {
+	root := filepath.Join(build.Default.GOPATH, "src", path)
+	walker := &walker{
+		fset:     token.NewFileSet(),
+		packages: make(map[string]*ast.Package),
+	}
+	if err := filepath.Walk(root, walker.walk); err != nil {
+		return nil, fmt.Errorf("couldn't walk filesystem: %s", err)
+	}
+	td := scanPackages(walker.packages)
+	return td, nil
+}
+
+// scanPackages scans all of the collected packages for kinds and collects them
+// into a slice.
+func scanPackages(packages map[string]*ast.Package) templateData {
+	td := make(templateData, 0)
+	for _, pkg := range packages {
+		if strings.HasSuffix(pkg.Name, "_test") {
+			continue
+		}
+		kinds := astutil.GetKindNames(pkg)
+		for _, kind := range kinds {
+			td = append(td, meta.TypeMeta{APIVersion: pkg.Name, Kind: kind})
+		}
+	}
+	return td
+}
+
+// walker walks a filesystem recursively, looking for Go packages to parse.
+type walker struct {
+	packages map[string]*ast.Package
+	fset     *token.FileSet
+}
+
+func (w *walker) walk(path string, fi os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+	if fi == nil || !fi.IsDir() {
+		return nil
+	}
+	if strings.HasPrefix(fi.Name(), ".") {
+		return filepath.SkipDir
+	}
+	// special case for vendor directory and types package
+	// we can eventually remove the special case for the types package
+	if fi.Name() == "vendor" || fi.Name() == "types" {
+		return filepath.SkipDir
+	}
+	packages, err := parser.ParseDir(w.fset, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("couldn't parse directory: %s", err)
+	}
+	for k, v := range packages {
+		w.packages[k] = v
+	}
+	return nil
+}

--- a/runtime/registry/registry.go
+++ b/runtime/registry/registry.go
@@ -1,0 +1,32 @@
+package registry
+
+// automatically generated file, do not edit!
+
+import (
+	"fmt"
+
+	"github.com/sensu/sensu-go/internal/apis/core"
+	"github.com/sensu/sensu-go/internal/apis/meta"
+	"github.com/sensu/sensu-go/internal/apis/rbac"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{
+	meta.TypeMeta{Kind: "Namespace", APIVersion: "core"}:          core.Namespace{},
+	meta.TypeMeta{Kind: "Role", APIVersion: "rbac"}:               rbac.Role{},
+	meta.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac"}:        rbac.ClusterRole{},
+	meta.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac"}: rbac.ClusterRoleBinding{},
+	meta.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac"}:        rbac.RoleBinding{},
+	meta.TypeMeta{Kind: "Subject", APIVersion: "rbac"}:            rbac.Subject{},
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+	if !ok {
+		return nil, fmt.Errorf("type could not be found: %v", mt)
+	}
+	return t, nil
+}

--- a/runtime/registry/registry.go.tmpl
+++ b/runtime/registry/registry.go.tmpl
@@ -1,0 +1,26 @@
+package registry
+
+// automatically generated file, do not edit!
+
+import (
+  "fmt"
+  "reflect"
+
+  "github.com/sensu/sensu-go/internal/apis/meta"
+)
+
+type registry map[meta.TypeMeta]meta.GroupVersionKind
+
+var typeRegistry = registry{ {{ range $index, $t := . }}
+  meta.TypeMeta{Kind: "{{ $t.Kind }}", APIVersion: "{{ $t.APIVersion }}"}: {{ $t.APIVersion }}.{{ $t.Kind }}{}, {{ end }}
+}
+
+// Resolve returns a zero-valued meta.GroupVersionKind, given a meta.TypeMeta.
+// If the type does not exist, then an error will be returned.
+func Resolve(mt meta.TypeMeta) (meta.GroupVersionKind, error) {
+	t, ok := typeRegistry[mt]
+  if !ok {
+    return nil, fmt.Errorf("type could not be found: %v", mt)
+  }
+  return t, nil
+}

--- a/runtime/registry/registry_gen.go
+++ b/runtime/registry/registry_gen.go
@@ -1,0 +1,5 @@
+package registry
+
+//go:generate go install github.com/sensu/sensu-go/internal/cmd/gen-register
+//go:generate gen-register -pkg github.com/sensu/sensu-go -t registry.go.tmpl -o registry.go
+//go:generate goimports -w registry.go

--- a/runtime/registry/registry_gen.go
+++ b/runtime/registry/registry_gen.go
@@ -1,5 +1,5 @@
 package registry
 
 //go:generate go install github.com/sensu/sensu-go/internal/cmd/gen-register
-//go:generate gen-register -pkg github.com/sensu/sensu-go -t registry.go.tmpl -o registry.go
+//go:generate gen-register -pkg github.com/sensu/sensu-go -o registry.go
 //go:generate goimports -w registry.go


### PR DESCRIPTION
## What is this change?

Add the freeze-api tool, which can be used to create a versioned API from an internal API. The tool includes a mechanism for copying a package to a new package, and converters to go between the types. There is also a type registration mechanism.

## Why is this change necessary?

We need a way to freeze internal APIs to versioned APIs.