### PR TITLE
Update to patched `react-resize-observer`

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -109,7 +109,7 @@
     "react-dom": "^16.4.2",
     "react-event-listener": "^0.6.3",
     "react-redux": "^5.0.6",
-    "react-resize-observer": "^0.2.2",
+    "react-resize-observer": "^1.1.0",
     "react-router-dom": "^4.2.2",
     "react-spring": "^5.6.10",
     "react-tap-event-plugin": "^3.0.2",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -6315,9 +6315,9 @@ react-redux@^5.0.6:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
-react-resize-observer@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/react-resize-observer/-/react-resize-observer-0.2.2.tgz#bd18e669c18a5adf65c18280ad79daa286af5118"
+react-resize-observer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-observer/-/react-resize-observer-1.1.0.tgz#ad1d4e23501fc0b753a39cc690004a1b5eb69b3d"
 
 react-router-dom@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
## What is this change?

Fixes exception thrown when browser window is resized.

## Why is this change necessary?

Closes #2161 

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No