### PR TITLE
[Web-UI] Fix date input bug surfaced by React 16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed unresponsive silencing entry form begin date input.
+
 ## [2.0.0-beta.7-1] - 2018-10-26
 
 ### Added

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "update-schema": "node scripts updateSchema"
   },
   "dependencies": {
-    "@10xjs/date-input-controller": "^0.1.5",
+    "@10xjs/date-input-controller": "0.1.6",
     "@10xjs/form": "^0.1.7",
     "@material-ui/core": "^1.4.0",
     "@material-ui/icons": "^2.0.0",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@10xjs/date-input-controller@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@10xjs/date-input-controller/-/date-input-controller-0.1.5.tgz#0532a68a46a7fdcc6990a0c05672750cbf4e8820"
+"@10xjs/date-input-controller@0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@10xjs/date-input-controller/-/date-input-controller-0.1.6.tgz#bd63235293cfb109c3d7f466c48257854e724a0d"
 
 "@10xjs/form@^0.1.7":
   version "0.1.7"


### PR DESCRIPTION
## What is this change?

Update to the latest version of `@10xjs/date-input-controller`.

## Why is this change necessary?

Fixes #2223 

React 16.4 included a change to the behavior of getDerivedStateFromProps which is now called after internal state updates in addition to received props. This surfaced as a bug prevent the begin date field in the silencing entry form from accepting changes.

See: https://github.com/10xjs/date-input-controller/pull/1

## Does your change need a Changelog entry?

Changelog updated.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No