### PR TITLE
[Web UI] Sort order fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0-beta.7-1] - 2018-10-26
 
+### Fixed
+- Silences List in web ui sorted by ascending order
+- Sorting button now works properly
+
 ### Added
 - Asset functionality for mutators and handlers.
 - Web ui allows publishing and unpublishing on checks page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## [2.0.0-beta.7-1] - 2018-10-26
-
 ### Fixed
 - Silences List in web ui sorted by ascending order
 - Sorting button now works properly
+
+## [2.0.0-beta.7-1] - 2018-10-26
 
 ### Added
 - Asset functionality for mutators and handlers.

--- a/backend/apid/graphql/environment.go
+++ b/backend/apid/graphql/environment.go
@@ -170,9 +170,9 @@ func (r *envImpl) Silences(p schema.EnvironmentSilencesFieldResolverParams) (int
 		sort.Sort(sort.Reverse(types.SortSilencedByBegin(filteredSilences)))
 	case schema.SilencesListOrders.BEGIN:
 		sort.Sort(types.SortSilencedByBegin(filteredSilences))
-	case schema.SilencesListOrders.ID:
-		sort.Sort(sort.Reverse(types.SortSilencedByID(filteredSilences)))
 	case schema.SilencesListOrders.ID_DESC:
+		sort.Sort(sort.Reverse(types.SortSilencedByID(filteredSilences)))
+	case schema.SilencesListOrders.ID:
 	default:
 		sort.Sort(types.SortSilencedByID(filteredSilences))
 	}

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -872,7 +872,7 @@ var _InputTypeDeleteRecordInputDesc = graphql.InputDesc{Config: _InputTypeDelete
 type CheckConfigInputs struct {
 	// Command - command to run.
 	Command string
-	// Interval - interval is the time interval, in seconds, in which the check should be run. Defaults to 60.
+	// Interval - interval is the time interval, in seconds, in which the check should be run.
 	Interval int
 	/*
 	   LowFlapThreshold - lowFlapThreshold is the flap detection low threshold (% state change) for
@@ -922,7 +922,7 @@ func _InputTypeCheckConfigInputsConfigFn() graphql1.InputObjectConfig {
 				Type:        graphql1.Int,
 			},
 			"interval": &graphql1.InputObjectFieldConfig{
-				Description: "interval is the time interval, in seconds, in which the check should be run. Defaults to 60.",
+				Description: "interval is the time interval, in seconds, in which the check should be run.",
 				Type:        graphql1.Int,
 			},
 			"lowFlapThreshold": &graphql1.InputObjectFieldConfig{

--- a/dashboard/src/components/partials/ListSortSelector/Menu.js
+++ b/dashboard/src/components/partials/ListSortSelector/Menu.js
@@ -42,17 +42,14 @@ class Menu extends React.PureComponent {
     if (valueProp === value || valueProp === `${value}_DESC`) {
       icon = (
         <ListItemIcon style={{ transform: "scale(0.77)" }}>
-          {strEndsWith(valueProp, "_DESC") ? <ArrowDown /> : <ArrowUp />}
+          {strEndsWith(valueProp, "_DESC") ? <ArrowUp /> : <ArrowDown />}
         </ListItemIcon>
       );
     }
 
     const onClick = () => {
       onChangeQuery(query => {
-        query.set(
-          queryKey,
-          query.get(queryKey) === value ? `${value}_DESC` : value,
-        );
+        query.set(queryKey, valueProp === value ? `${value}_DESC` : value);
       });
       onClose();
     };


### PR DESCRIPTION
## What is this change?
Closes #2196 
Fixes the sort order implementation of Silences. Fixes the sort button not switching to descending on initial click. Changes the arrow to point the "direction" of the action to be taken on click (ascending is up, descending is down).

## Why is this change necessary?
It wasn't working optimally and was a little confusing from a user perspective.

## Does your change need a Changelog entry?
Added one.