### PR TITLE
Keepalive bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Silences List in web ui sorted by ascending order
 - Sorting button now works properly
 - Fixed unresponsive silencing entry form begin date input.
+- Fixed a panic on the backend when handling keepalives from older agent versions.
+- Fixed a bug that would prevent some keepalive failures from occurring.
+- Improved event validation error messages.
 
 ## [2.0.0-beta.7-1] - 2018-10-26
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/backend/store"
@@ -251,10 +252,17 @@ func (k *Keepalived) handleEntityRegistration(entity *types.Entity) error {
 }
 
 func createKeepaliveEvent(rawEvent *types.Event) *types.Event {
+	check := rawEvent.Check
+	if check == nil {
+		check = &types.Check{
+			Interval: agent.DefaultKeepaliveInterval,
+			Timeout:  types.DefaultKeepaliveTimeout,
+		}
+	}
 	keepaliveCheck := &types.Check{
 		Name:         KeepaliveCheckName,
-		Interval:     rawEvent.Check.Interval,
-		Timeout:      rawEvent.Check.Timeout,
+		Interval:     check.Interval,
+		Timeout:      check.Timeout,
 		Handlers:     []string{KeepaliveHandlerName},
 		Environment:  rawEvent.Entity.Environment,
 		Organization: rawEvent.Entity.Organization,

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -248,4 +248,10 @@ func TestCreateKeepaliveEvent(t *testing.T) {
 	assert.Equal(t, []string{"keepalive"}, keepaliveEvent.Check.Handlers)
 	assert.Equal(t, uint32(0), keepaliveEvent.Check.Status)
 	assert.NotEqual(t, int64(0), keepaliveEvent.Check.Issued)
+
+	event.Check = nil
+	keepaliveEvent = createKeepaliveEvent(event)
+	assert.Equal(t, "keepalive", keepaliveEvent.Check.Name)
+	assert.Equal(t, uint32(20), keepaliveEvent.Check.Interval)
+	assert.Equal(t, uint32(120), keepaliveEvent.Check.Timeout)
 }

--- a/backend/monitor/supervisor.go
+++ b/backend/monitor/supervisor.go
@@ -74,9 +74,12 @@ func (m *EtcdSupervisor) Monitor(ctx context.Context, name string, event *types.
 	// if it exists and the ttl matches the original ttl of the lease, extend its
 	// lease with keep-alive.
 	if mon != nil && mon.ttl == ttl {
-		logger.Debugf("a lease for the key %s already exist, extending it", key)
+		logger.Debugf("a lease for the key %s already exists, extending lease %v", key, mon.leaseID)
 		_, kaerr := m.client.KeepAliveOnce(ctx, mon.leaseID)
-		return kaerr
+		if kaerr == nil {
+			return kaerr
+		}
+		logger.WithError(kaerr).Errorf("unable to extend lease %v, creating new lease for the key %s", mon.leaseID, key)
 	}
 
 	// If the ttls do not match or the monitor doesn't exist, create a new lease

--- a/types/event.go
+++ b/types/event.go
@@ -82,24 +82,24 @@ func (e *Event) Validate() error {
 	}
 
 	if err := e.Entity.Validate(); err != nil {
-		return errors.New("entity " + err.Error())
+		return errors.New("entity is invalid: " + err.Error())
 	}
 
 	if e.HasCheck() {
 		if err := e.Check.Validate(); err != nil {
-			return errors.New("check " + err.Error())
+			return errors.New("check is invalid: " + err.Error())
 		}
 	}
 
 	if e.HasMetrics() {
 		if err := e.Metrics.Validate(); err != nil {
-			return errors.New("metrics " + err.Error())
+			return errors.New("metrics are invalid: " + err.Error())
 		}
 	}
 
 	for _, hook := range e.Hooks {
 		if err := hook.Validate(); err != nil {
-			return errors.New("hook " + err.Error())
+			return errors.New("hook is invalid: " + err.Error())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a panic on the backend when handling keepalives from older agent versions., fixes a bug that would prevent some keepalive failures from occurring, and improves event validation error messages.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2153
Closes https://github.com/sensu/sensu-go/issues/2190
Fixes event validation error messages. For example:
```
{"component":"eventd","error":"check check interval must be greater than or equal to 1","level":"error","msg":"eventd - error handling event","time":"2018-10-30T10:47:05-07:00"}
```
becomes 
```
{"component":"eventd","error":"check is invalid: check interval must be greater than or equal to 1","level":"error","msg":"eventd - error handling event","time":"2018-10-30T10:47:05-07:00"}
```

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.