### PR TITLE
Improve agent statsd log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a panic on the backend when handling keepalives from older agent versions.
 - Fixed a bug that would prevent some keepalive failures from occurring.
 - Improved event validation error messages.
+- Improved agent logging for statsd events.
 
 ## [2.0.0-beta.7-1] - 2018-10-26
 

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/atlassian/gostatsd/pkg/statsd"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"
 )
@@ -157,6 +158,10 @@ func (c Client) sendMetrics(points []*types.MetricPoint) (retErr error) {
 		return err
 	}
 
+	logger.WithFields(logrus.Fields{
+		"metrics": event.Metrics,
+		"entity":  event.Entity.ID,
+	}).Debug("sending statsd metrics")
 	c.agent.sendMessage(transport.MessageTypeEvent, msg)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a debug log message on the agent side when it sends a statsd event.
```
{"component":"agent","entity":"Nikkis-MacBook-Pro","level":"debug","metrics":{"handlers":["statsd-log"],"points":[{"name":"Nikkis-MacBook-Pro.cpu.value","value":41,"timestamp":1541005037755019464,"tags":[{"name":"s","value":"127.0.0.1"}]},{"name":"Nikkis-MacBook-Pro.cpu.per_second","value":4.100051771763727,"timestamp":1541005037755019464,"tags":[{"name":"s","value":"127.0.0.1"}]}]},"msg":"sending statsd metrics","time":"2018-10-31T09:57:17-07:00"}
```
Logs already exist on the backend
```
{"component":"pipelined","entity":"Nikkis-MacBook-Pro","environment":"default","level":"debug","metrics":{"handlers":[],"points":[{"name":"Nikkis-MacBook-Pro.cpu.value","value":41,"timestamp":1541003827600649006,"tags":[{"name":"s","value":"127.0.0.1"}]},{"name":"Nikkis-MacBook-Pro.cpu.per_second","value":4.0996124357590835,"timestamp":1541003827600649006,"tags":[{"name":"s","value":"127.0.0.1"}]}]},"msg":"received event","organization":"default","time":"2018-10-31T09:37:07-07:00","timestamp":1541003827}
{"component":"pipelined","entity":"Nikkis-MacBook-Pro","environment":"default","first_metric_name":"Nikkis-MacBook-Pro.cpu.value","first_metric_value":41,"level":"info","metric_count":2,"msg":"no handlers available","organization":"default","time":"2018-10-31T09:37:07-07:00"}
```
We've already improved how we validate this in QA but this log is still useful.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2197.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.