### PR TITLE
API authentication credential test endpoint

### DIFF
--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -24,6 +24,7 @@ func NewAuthenticationRouter(store store.Store) *AuthenticationRouter {
 // Mount the authentication routes on given mux.Router.
 func (a *AuthenticationRouter) Mount(r *mux.Router) {
 	r.HandleFunc("/auth", a.login).Methods(http.MethodGet)
+	r.HandleFunc("/auth/test", a.test).Methods(http.MethodGet)
 	r.HandleFunc("/auth/token", a.token).Methods(http.MethodPost)
 	r.HandleFunc("/auth/logout", a.logout).Methods(http.MethodPost)
 }
@@ -113,6 +114,26 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = fmt.Fprint(w, string(resBytes))
+}
+
+// test provides minimal username and password validation
+func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
+	// Check for credentials provided in the Authorization header
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		http.Error(w, "Request unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Authenticate against the provider
+	_, err := a.store.AuthenticateUser(r.Context(), username, password)
+	if err != nil {
+		logger.WithField(
+			"user", username,
+		).WithError(err).Error("invalid username and/or password")
+		http.Error(w, "Request unauthorized", http.StatusUnauthorized)
+		return
+	}
 }
 
 // logout handles the logout flow

--- a/backend/apid/routers/authentication_test.go
+++ b/backend/apid/routers/authentication_test.go
@@ -70,6 +70,48 @@ func TestLoginSuccessful(t *testing.T) {
 	assert.NotEmpty(t, response.Refresh)
 }
 
+func TestTestNoCredentials(t *testing.T) {
+	store := &mockstore.MockStore{}
+	a := &AuthenticationRouter{store}
+
+	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
+
+	res := processRequest(a, req)
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestTestInvalidCredentials(t *testing.T) {
+	store := &mockstore.MockStore{}
+	a := &AuthenticationRouter{store}
+
+	user := types.FixtureUser("foo")
+	store.
+		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
+		Return(user, fmt.Errorf("error"))
+
+	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
+	req.SetBasicAuth("foo", "P@ssw0rd!")
+
+	res := processRequest(a, req)
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestTestSuccessful(t *testing.T) {
+	store := &mockstore.MockStore{}
+	a := &AuthenticationRouter{store}
+
+	user := types.FixtureUser("foo")
+	store.
+		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
+		Return(user, nil)
+
+	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
+	req.SetBasicAuth("foo", "P@ssw0rd!")
+
+	res := processRequest(a, req)
+	assert.Equal(t, http.StatusOK, res.Code)
+}
+
 func TestLogoutNotWhitelisted(t *testing.T) {
 	store := &mockstore.MockStore{}
 	a := &AuthenticationRouter{store}

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -35,6 +35,24 @@ func (client *RestClient) CreateAccessToken(url, userid, password string) (*type
 	return &tokens, err
 }
 
+// TestCreds checks if the provided User credentials are valid
+func (client *RestClient) TestCreds(userid, password string) error {
+	client.ClearAuthToken()
+
+	res, err := client.R().SetBasicAuth(userid, password).Get("/auth/test")
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() == 401 {
+		return errors.New(string(res.Body()))
+	} else if res.StatusCode() >= 400 {
+		return errors.New("Received an unexpected response from the API")
+	}
+
+	return nil
+}
+
 // Logout performs a logout of the configured user
 func (client *RestClient) Logout(token string) error {
 	res, err := client.R().

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -36,6 +36,7 @@ type GenericClient interface {
 // AuthenticationAPIClient client methods for authenticating
 type AuthenticationAPIClient interface {
 	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, error)
+	TestCreds(userid string, secret string) error
 	Logout(token string) error
 	RefreshAccessToken(refreshToken string) (*types.Tokens, error)
 }

--- a/cli/client/testing/mock_authentication_client.go
+++ b/cli/client/testing/mock_authentication_client.go
@@ -8,6 +8,12 @@ func (c *MockClient) CreateAccessToken(url, u, p string) (*types.Tokens, error) 
 	return args.Get(0).(*types.Tokens), args.Error(1)
 }
 
+// TestCreds for use with mock lib
+func (c *MockClient) TestCreds(u, p string) error {
+	args := c.Called(u, p)
+	return args.Error(0)
+}
+
 // Logout for use with mock lib
 func (c *MockClient) Logout(token string) error {
 	args := c.Called(token)

--- a/cli/commands/user/help.go
+++ b/cli/commands/user/help.go
@@ -21,6 +21,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		ReinstateCommand(cli),
 		RemoveRoleCommand(cli),
 		SetPasswordCommand(cli),
+		TestCredsCommand(cli),
 	)
 
 	return cmd

--- a/cli/commands/user/test-creds.go
+++ b/cli/commands/user/test-creds.go
@@ -1,0 +1,93 @@
+package user
+
+import (
+	"errors"
+
+	"github.com/AlecAivazis/survey"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type testCredsOpts struct {
+	Username string `survey:"username"`
+	Password string `survey:"password"`
+}
+
+// TestCredsCommand adds a command that allows user to test other
+// user's credentials.
+func TestCredsCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "test-creds [NAME]",
+		Short:        "test user credentials",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+			if !isInteractive {
+				// Mark flags are required for bash-completions
+				_ = cmd.MarkFlagRequired("password")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			isInteractive, _ := cmd.Flags().GetBool(flags.Interactive)
+			opts := &testCredsOpts{}
+
+			if len(args) > 0 {
+				opts.Username = args[0]
+			}
+
+			if isInteractive {
+				if err := opts.administerQuestionnaire(); err != nil {
+					return err
+				}
+			} else {
+				opts.withFlags(cmd.Flags())
+			}
+
+			err := cli.Client.TestCreds(opts.Username, opts.Password)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	_ = cmd.Flags().StringP("password", "p", "", "Password")
+
+	helpers.AddInteractiveFlag(cmd.Flags())
+	return cmd
+}
+
+func (opts *testCredsOpts) withFlags(flags *pflag.FlagSet) {
+	opts.Password, _ = flags.GetString("password")
+}
+
+func (opts *testCredsOpts) administerQuestionnaire() error {
+	var qs = []*survey.Question{
+		{
+			Name: "username",
+			Prompt: &survey.Input{
+				Message: "Username:",
+				Default: opts.Username,
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "password",
+			Prompt: &survey.Password{
+				Message: "Password:",
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	return survey.Ask(qs, opts)
+}

--- a/cli/commands/user/test-creds_test.go
+++ b/cli/commands/user/test-creds_test.go
@@ -1,0 +1,23 @@
+package user
+
+import (
+	"testing"
+
+	//	clientmock "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	//	"github.com/stretchr/testify/mock"
+	//	"github.com/stretchr/testify/require"
+)
+
+func TestTestCredsCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := TestCredsCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("test-creds", cmd.Use)
+	assert.Regexp("test user credentials", cmd.Short)
+}

--- a/cli/commands/user/test-creds_test.go
+++ b/cli/commands/user/test-creds_test.go
@@ -3,11 +3,8 @@ package user
 import (
 	"testing"
 
-	//	clientmock "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
-	//	"github.com/stretchr/testify/mock"
-	//	"github.com/stretchr/testify/require"
 )
 
 func TestTestCredsCommand(t *testing.T) {


### PR DESCRIPTION
Provide a Backend API endpoint for testing User credentials (username & password). This pull-request allows automation tooling to check if user credentials it has on record are still valid and manage the user accordingly (e.g. reset or rotate the user password).

A possible solution for https://github.com/sensu/sensu-go/issues/1437

Signed-off-by: Sean Porter <portertech@gmail.com>

closes #1437