### PR TITLE
Add new RBAC stores

### DIFF
--- a/backend/apid/actions/error.go
+++ b/backend/apid/actions/error.go
@@ -28,16 +28,6 @@ const (
 	// AlreadyExistsErr means that a create operation failed because the given
 	// resource already exists in the system.
 	AlreadyExistsErr
-
-	// PermissionDenied means that the viewer does not have permission to perform
-	// the action they are attempting. Is not used when user is unauthenticated.
-	// Eg. if the viewer is trying to list all events but doesn't not have the
-	// approriate roles for the operation.
-	PermissionDenied
-
-	// Unauthenticated used when viewer is not authenticated but action requires
-	// viewer to be authenticated.
-	Unauthenticated
 )
 
 // Default error messages if not message is provided.
@@ -46,8 +36,6 @@ var standardErrorMessages = map[ErrCode]string{
 	InvalidArgument:  "invalid argument(s) received",
 	NotFound:         "not found",
 	AlreadyExistsErr: "resource already exists",
-	PermissionDenied: "unauthorized to perform action",
-	Unauthenticated:  "unauthenticated",
 }
 
 // Error describes an issue that ocurred while performing the action.

--- a/backend/apid/actions/roles.go
+++ b/backend/apid/actions/roles.go
@@ -7,9 +7,6 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-// roleUpdateFields refers to fields a viewer may update
-var roleUpdateFields = []string{"Rules"}
-
 // RoleController exposes the Roles
 type RoleController struct {
 	Store store.RoleStore
@@ -22,8 +19,39 @@ func NewRoleController(store store.RoleStore) RoleController {
 	}
 }
 
-// Query returns resources available to the viewer filter by given params.
-func (a RoleController) Query(ctx context.Context) ([]*types.Role, error) {
+// Create creates a new role. It returns an error if the role already exists.
+func (a RoleController) Create(ctx context.Context, role types.Role) error {
+	if err := a.Store.CreateRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(AlreadyExistsErr)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// CreateOrReplace creates or replaces a role.
+func (a RoleController) CreateOrReplace(ctx context.Context, role types.Role) error {
+	return a.Store.CreateOrUpdateRole(ctx, &role)
+}
+
+// Destroy removes given role from the store.
+func (a RoleController) Destroy(ctx context.Context, name string) error {
+	return a.Store.DeleteRole(ctx, name)
+}
+
+// Get the role with the given name
+func (a RoleController) Get(ctx context.Context, name string) (*types.Role, error) {
+	return a.Store.GetRole(ctx, name)
+}
+
+// List returns all available resources
+func (a RoleController) List(ctx context.Context) ([]*types.Role, error) {
 	// Fetch from store
 	results, serr := a.Store.ListRoles(ctx)
 	if serr != nil {
@@ -33,110 +61,7 @@ func (a RoleController) Query(ctx context.Context) ([]*types.Role, error) {
 	return results, nil
 }
 
-// Find returns resource associated with given parameters if available to the
-// viewer.
-func (a RoleController) Find(ctx context.Context, name string) (*types.Role, error) {
-	// Fetch from store
-	result, serr := a.findRole(ctx, name)
-	if serr != nil {
-		return nil, serr
-	}
-
-	return result, nil
-}
-
-// Create creates a new role. It returns an error if the role already exists.
-func (a RoleController) Create(ctx context.Context, newRole types.Role) error {
-	// Role for existing
-	if e, err := a.Store.GetRole(ctx, newRole.Name); err != nil {
-		return NewError(InternalErr, err)
-	} else if e != nil {
-		return NewErrorf(AlreadyExistsErr)
-	}
-
-	// Validate
-	if err := newRole.Validate(); err != nil {
-		return NewError(InvalidArgument, err)
-	}
-
-	// Persist
-	if err := a.Store.UpdateRole(ctx, &newRole); err != nil {
-		return NewError(InternalErr, err)
-	}
-	return nil
-}
-
-// CreateOrReplace creates or replaces a role.
-func (a RoleController) CreateOrReplace(ctx context.Context, newRole types.Role) error {
-	// Validate
-	if err := newRole.Validate(); err != nil {
-		return NewError(InvalidArgument, err)
-	}
-
-	// Persist
-	if err := a.Store.UpdateRole(ctx, &newRole); err != nil {
-		return NewError(InternalErr, err)
-	}
-	return nil
-}
-
-// Update validates and persists changes to a resource if viewer has access.
-func (a RoleController) Update(ctx context.Context, given types.Role) error {
-	return a.findAndUpdateRole(ctx, given.Name, func(role *types.Role) error {
-		copyFields(role, &given, roleUpdateFields...)
-		return nil
-	})
-}
-
-// Destroy removes given role from the store.
-func (a RoleController) Destroy(ctx context.Context, name string) error {
-	// Fetch from store
-	_, err := a.findRole(ctx, name)
-	if err != nil {
-		return err
-	}
-	// Remove from store
-	if serr := a.Store.DeleteRole(ctx, name); serr != nil {
-		return NewError(InternalErr, serr)
-	}
-	return nil
-}
-
-func (a RoleController) findAndUpdateRole(
-	ctx context.Context,
-	name string,
-	configureFn func(*types.Role) error,
-) error {
-	// Find
-	role, serr := a.findRole(ctx, name)
-	if serr != nil {
-		return serr
-	}
-
-	// Configure
-	if err := configureFn(role); err != nil {
-		return err
-	}
-	// Update
-	return a.updateRole(ctx, role)
-}
-
-func (a RoleController) findRole(ctx context.Context, name string) (*types.Role, error) {
-	result, serr := a.Store.GetRole(ctx, name)
-	if serr != nil {
-		return nil, NewError(InternalErr, serr)
-	} else if result == nil {
-		return nil, NewErrorf(NotFound)
-	}
-	return result, nil
-}
-
-func (a RoleController) updateRole(ctx context.Context, role *types.Role) error {
-	if err := role.Validate(); err != nil {
-		return NewError(InvalidArgument, err)
-	}
-	if err := a.Store.UpdateRole(ctx, role); err != nil {
-		return NewError(InternalErr, err)
-	}
-	return nil
+// Update validates and persists changes to a resource
+func (a RoleController) Update(ctx context.Context, role types.Role) error {
+	return a.Store.UpdateRole(ctx, &role)
 }

--- a/backend/apid/actions/roles.go
+++ b/backend/apid/actions/roles.go
@@ -23,7 +23,7 @@ func NewRoleController(store store.RoleStore) RoleController {
 func (a RoleController) Create(ctx context.Context, role types.Role) error {
 	if err := a.Store.CreateRole(ctx, &role); err != nil {
 		switch err := err.(type) {
-		case *store.ErrNotFound:
+		case *store.ErrAlreadyExists:
 			return NewErrorf(AlreadyExistsErr)
 		case *store.ErrNotValid:
 			return NewErrorf(InvalidArgument)
@@ -37,25 +37,58 @@ func (a RoleController) Create(ctx context.Context, role types.Role) error {
 
 // CreateOrReplace creates or replaces a role.
 func (a RoleController) CreateOrReplace(ctx context.Context, role types.Role) error {
-	return a.Store.CreateOrUpdateRole(ctx, &role)
+	if err := a.Store.CreateOrUpdateRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
 }
 
 // Destroy removes given role from the store.
 func (a RoleController) Destroy(ctx context.Context, name string) error {
-	return a.Store.DeleteRole(ctx, name)
+	if err := a.Store.DeleteRole(ctx, name); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
 }
 
 // Get the role with the given name
 func (a RoleController) Get(ctx context.Context, name string) (*types.Role, error) {
-	return a.Store.GetRole(ctx, name)
+	role, err := a.Store.GetRole(ctx, name)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return role, nil
 }
 
 // List returns all available resources
 func (a RoleController) List(ctx context.Context) ([]*types.Role, error) {
 	// Fetch from store
-	results, serr := a.Store.ListRoles(ctx)
-	if serr != nil {
-		return nil, NewError(InternalErr, serr)
+	results, err := a.Store.ListRoles(ctx)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
 	}
 
 	return results, nil
@@ -63,5 +96,16 @@ func (a RoleController) List(ctx context.Context) ([]*types.Role, error) {
 
 // Update validates and persists changes to a resource
 func (a RoleController) Update(ctx context.Context, role types.Role) error {
-	return a.Store.UpdateRole(ctx, &role)
+	if err := a.Store.UpdateRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
 }

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -182,6 +182,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store, getter t
 		NewSubrouter(
 			router.NewRoute(),
 			middlewares.SimpleLogger{},
+			middlewares.Namespace{},
 			middlewares.Authentication{},
 			middlewares.AllowList{Store: store},
 			middlewares.LimitRequest{},

--- a/backend/apid/graphql/error.go
+++ b/backend/apid/graphql/error.go
@@ -32,8 +32,6 @@ func mapServiceErrCode(code actions.ErrCode) schema.ErrCode {
 		return schema.ErrCodes.ERR_NOT_FOUND
 	case actions.AlreadyExistsErr:
 		return schema.ErrCodes.ERR_ALREADY_EXISTS
-	case actions.PermissionDenied:
-		return schema.ErrCodes.ERR_PERMISSION_DENIED
 	case actions.InternalErr:
 		fallthrough
 	default:

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -224,7 +224,7 @@ func registerRoleNodeResolver(register relay.NodeRegister, store store.RoleStore
 
 func (f *roleNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
 	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.controller.Find(ctx, p.IDComponents.UniqueComponent())
+	record, err := f.controller.Get(ctx, p.IDComponents.UniqueComponent())
 	return handleControllerResults(record, err)
 }
 

--- a/backend/apid/graphql/schema/errors.gql.go
+++ b/backend/apid/graphql/schema/errors.gql.go
@@ -4,6 +4,7 @@ package schema
 
 import (
 	errors "errors"
+
 	graphql1 "github.com/graphql-go/graphql"
 	graphql "github.com/sensu/sensu-go/graphql"
 )
@@ -308,10 +309,9 @@ type ErrCode string
 
 // ErrCodes holds enum values
 var ErrCodes = _EnumTypeErrCodeValues{
-	ERR_ALREADY_EXISTS:    "ERR_ALREADY_EXISTS",
-	ERR_INTERNAL:          "ERR_INTERNAL",
-	ERR_NOT_FOUND:         "ERR_NOT_FOUND",
-	ERR_PERMISSION_DENIED: "ERR_PERMISSION_DENIED",
+	ERR_ALREADY_EXISTS: "ERR_ALREADY_EXISTS",
+	ERR_INTERNAL:       "ERR_INTERNAL",
+	ERR_NOT_FOUND:      "ERR_NOT_FOUND",
 }
 
 // ErrCodeType A terse description of an error.
@@ -366,9 +366,4 @@ type _EnumTypeErrCodeValues struct {
 	   completed.
 	*/
 	ERR_ALREADY_EXISTS ErrCode
-	/*
-	   ERR_PERMISSION_DENIED - Operation was canceled because the authorization token did not have sufficient
-	   permissions.
-	*/
-	ERR_PERMISSION_DENIED ErrCode
 }

--- a/backend/apid/middlewares/namespace.go
+++ b/backend/apid/middlewares/namespace.go
@@ -1,0 +1,30 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+const (
+	defaultNamespace = "default"
+)
+
+// Namespace retrieves the namespace passed as a query parameter and validate
+// its existence against the data store and then add them to the request context
+type Namespace struct {
+}
+
+// Then middleware
+func (n Namespace) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var namespace string
+		if namespace = r.URL.Query().Get("namespace"); namespace == "" {
+			namespace = defaultNamespace
+		}
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, types.NamespaceKey, namespace)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -32,21 +32,6 @@ func (r *RolesRouter) Mount(parent *mux.Router) {
 	routes.Put(r.createOrReplace)
 }
 
-func (r *RolesRouter) list(req *http.Request) (interface{}, error) {
-	records, err := r.controller.Query(req.Context())
-	return records, err
-}
-
-func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
-	params := mux.Vars(req)
-	id, err := url.PathUnescape(params["id"])
-	if err != nil {
-		return nil, err
-	}
-	record, err := r.controller.Find(req.Context(), id)
-	return record, err
-}
-
 func (r *RolesRouter) create(req *http.Request) (interface{}, error) {
 	cfg := types.Role{}
 	if err := UnmarshalBody(req, &cfg); err != nil {
@@ -75,4 +60,19 @@ func (r *RolesRouter) destroy(req *http.Request) (interface{}, error) {
 	}
 	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
+}
+
+func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+	record, err := r.controller.Get(req.Context(), id)
+	return record, err
+}
+
+func (r *RolesRouter) list(req *http.Request) (interface{}, error) {
+	records, err := r.controller.List(req.Context())
+	return records, err
 }

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -89,10 +89,6 @@ func HTTPStatusFromCode(code actions.ErrCode) int {
 		return http.StatusNotFound
 	case actions.AlreadyExistsErr:
 		return http.StatusConflict
-	case actions.PermissionDenied:
-		return http.StatusUnauthorized
-	case actions.Unauthenticated:
-		return http.StatusUnauthorized
 	}
 
 	logger.WithField("code", code).Error("unknown error code")

--- a/backend/store/etcd/clusterrole_store.go
+++ b/backend/store/etcd/clusterrole_store.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	clusterRolesPathPrefix = "rbac/clusterroles"
-	clusterRoleKeyBuilder  = store.NewKeyBuilder(clusterRolesPathPrefix)
 )
 
 func getClusterRolePath(clusterRole *types.ClusterRole) string {

--- a/backend/store/etcd/clusterrole_store.go
+++ b/backend/store/etcd/clusterrole_store.go
@@ -1,0 +1,65 @@
+package etcd
+
+import (
+	"context"
+	"path"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+var (
+	clusterRolesPathPrefix = "rbac/clusterroles"
+	clusterRoleKeyBuilder  = store.NewKeyBuilder(clusterRolesPathPrefix)
+)
+
+func getClusterRolePath(clusterRole *types.ClusterRole) string {
+	return path.Join(store.Root, clusterRolesPathPrefix, clusterRole.Name)
+}
+
+func getClusterRolesPath(ctx context.Context, name string) string {
+	return path.Join(store.Root, clusterRolesPathPrefix, name)
+}
+
+// CreateClusterRole ...
+func (s *Store) CreateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	if err := clusterRole.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.create(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+}
+
+// CreateOrUpdateClusterRole ...
+func (s *Store) CreateOrUpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	if err := clusterRole.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.createOrUpdate(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+}
+
+// DeleteClusterRole ...
+func (s *Store) DeleteClusterRole(ctx context.Context, name string) error {
+	return s.delete(ctx, getClusterRolesPath(ctx, name))
+}
+
+// GetClusterRole ...
+func (s *Store) GetClusterRole(ctx context.Context, name string) (*types.ClusterRole, error) {
+	clusterRole := &types.ClusterRole{}
+	err := s.get(ctx, getClusterRolesPath(ctx, name), clusterRole)
+	return clusterRole, err
+}
+
+// ListClusterRoles ...
+func (s *Store) ListClusterRoles(ctx context.Context) ([]*types.ClusterRole, error) {
+	clusterRoles := []*types.ClusterRole{}
+	err := s.list(ctx, getClusterRolesPath, &clusterRoles)
+	return clusterRoles, err
+}
+
+// UpdateClusterRole ...
+func (s *Store) UpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	if err := clusterRole.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.update(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+}

--- a/backend/store/etcd/clusterrolebinding_store.go
+++ b/backend/store/etcd/clusterrolebinding_store.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	clusterRoleBindingPathPrefix = "rbac/clusterrolebindings"
-	clusterRoleBindingKeyBuilder = store.NewKeyBuilder(clusterRoleBindingPathPrefix)
 )
 
 func getClusterRoleBindingPath(clusterRole *types.ClusterRoleBinding) string {

--- a/backend/store/etcd/clusterrolebinding_store.go
+++ b/backend/store/etcd/clusterrolebinding_store.go
@@ -1,0 +1,65 @@
+package etcd
+
+import (
+	"context"
+	"path"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+var (
+	clusterRoleBindingPathPrefix = "rbac/clusterrolebindings"
+	clusterRoleBindingKeyBuilder = store.NewKeyBuilder(clusterRoleBindingPathPrefix)
+)
+
+func getClusterRoleBindingPath(clusterRole *types.ClusterRoleBinding) string {
+	return path.Join(store.Root, clusterRoleBindingPathPrefix, clusterRole.Name)
+}
+
+func getClusterRoleBindingsPath(ctx context.Context, name string) string {
+	return path.Join(store.Root, clusterRoleBindingPathPrefix, name)
+}
+
+// CreateClusterRoleBinding ...
+func (s *Store) CreateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error {
+	if err := clusterRoleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.create(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+}
+
+// CreateOrUpdateClusterRoleBinding ...
+func (s *Store) CreateOrUpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error {
+	if err := clusterRoleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.createOrUpdate(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+}
+
+// DeleteClusterRoleBinding ...
+func (s *Store) DeleteClusterRoleBinding(ctx context.Context, name string) error {
+	return s.delete(ctx, getClusterRoleBindingsPath(ctx, name))
+}
+
+// GetClusterRoleBinding ...
+func (s *Store) GetClusterRoleBinding(ctx context.Context, name string) (*types.ClusterRoleBinding, error) {
+	role := &types.ClusterRoleBinding{}
+	err := s.get(ctx, getClusterRoleBindingsPath(ctx, name), role)
+	return role, err
+}
+
+// ListClusterRoleBindings ...
+func (s *Store) ListClusterRoleBindings(ctx context.Context) ([]*types.ClusterRoleBinding, error) {
+	roles := []*types.ClusterRoleBinding{}
+	err := s.list(ctx, getClusterRoleBindingsPath, &roles)
+	return roles, err
+}
+
+// UpdateClusterRoleBinding ...
+func (s *Store) UpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error {
+	if err := clusterRoleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.update(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+}

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -1,0 +1,64 @@
+package etcd
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+var (
+	roleBindingsPathPrefix = "rbac/rolebindings"
+	roleBindingKeyBuilder  = store.NewKeyBuilder(roleBindingsPathPrefix)
+)
+
+func getRoleBindingPath(roleBinding *types.RoleBinding) string {
+	return roleBindingKeyBuilder.WithResource(roleBinding).Build(roleBinding.Name)
+}
+
+func getRoleBindingsPath(ctx context.Context, name string) string {
+	return roleBindingKeyBuilder.WithContext(ctx).Build(name)
+}
+
+// CreateRoleBinding ...
+func (s *Store) CreateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error {
+	if err := roleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.create(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+}
+
+// CreateOrUpdateRoleBinding ...
+func (s *Store) CreateOrUpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error {
+	if err := roleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.createOrUpdate(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+}
+
+// DeleteRoleBinding ...
+func (s *Store) DeleteRoleBinding(ctx context.Context, name string) error {
+	return s.delete(ctx, getRoleBindingsPath(ctx, name))
+}
+
+// GetRoleBinding ...
+func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBinding, error) {
+	role := &types.RoleBinding{}
+	err := s.get(ctx, getRoleBindingsPath(ctx, name), role)
+	return role, err
+}
+
+// ListRolesBinding ...
+func (s *Store) ListRolesBindings(ctx context.Context) ([]*types.RoleBinding, error) {
+	roles := []*types.RoleBinding{}
+	err := s.list(ctx, getRoleBindingsPath, &roles)
+	return roles, err
+}
+
+// UpdateRoleBinding ...
+func (s *Store) UpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error {
+	if err := roleBinding.Validate(); err != nil {
+		return &store.ErrNotValid{Err: err}
+	}
+	return s.update(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+}

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -48,7 +48,7 @@ func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBin
 	return role, err
 }
 
-// ListRolesBinding ...
+// ListRolesBindings ...
 func (s *Store) ListRolesBindings(ctx context.Context) ([]*types.RoleBinding, error) {
 	roles := []*types.RoleBinding{}
 	err := s.list(ctx, getRoleBindingsPath, &roles)

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -54,7 +54,7 @@ func (s *Store) create(ctx context.Context, key, namespace string, object interf
 		return err
 	}
 	if !resp.Succeeded {
-		return fmt.Errorf("could not create the key %s", key)
+		return &store.ErrAlreadyExists{Key: key}
 	}
 
 	return nil

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -1,9 +1,15 @@
 package etcd
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"path"
+	"reflect"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
 )
 
 const (
@@ -25,4 +31,184 @@ func NewStore(client *clientv3.Client, name string) *Store {
 	}
 
 	return store
+}
+
+// Create a key given with the serialized object.
+func (s *Store) create(ctx context.Context, key, namespace string, object interface{}) error {
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return &store.ErrEncore{Key: key, Err: err}
+	}
+
+	comparisons := []clientv3.Cmp{}
+	// If we had a namespace provided, make sure it exists
+	if namespace != "" {
+		comparisons = append(comparisons, namespaceFound(namespace))
+	}
+	// Make sure the key does not exists
+	comparisons = append(comparisons, keyNotFound(key))
+
+	req := clientv3.OpPut(key, string(bytes))
+	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("could not create the key %s", key)
+	}
+
+	return nil
+}
+
+// CreateOrUpdate writes the given key with the serialized object, regarless of
+// its current existence
+func (s *Store) createOrUpdate(ctx context.Context, key, namespace string, object interface{}) error {
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return &store.ErrEncore{Key: key, Err: err}
+	}
+
+	comparisons := []clientv3.Cmp{}
+	// If we had a namespace provided, make sure it exists
+	if namespace != "" {
+		comparisons = append(comparisons, namespaceFound(namespace))
+	}
+
+	req := clientv3.OpPut(key, string(bytes))
+	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("could not create the key %s", key)
+	}
+
+	return nil
+}
+
+// delete the given key
+func (s *Store) delete(ctx context.Context, key string) error {
+	resp, err := s.client.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+	if resp.Deleted != 1 {
+		return fmt.Errorf("could not delete the key %s", key)
+	}
+
+	return nil
+}
+
+// get retrieves an object with the given key
+func (s *Store) get(ctx context.Context, key string, object interface{}) error {
+	// Fetch the key from the store
+	resp, err := s.client.Get(ctx, key, clientv3.WithLimit(1))
+	if err != nil {
+		return err
+	}
+
+	// Ensure we only received a single item
+	if len(resp.Kvs) == 0 {
+		return &store.ErrNotFound{Key: key}
+	}
+
+	// Deserialize the object to the given object
+	if err := json.Unmarshal(resp.Kvs[0].Value, object); err != nil {
+		return &store.ErrDecode{Key: key, Err: err}
+	}
+
+	return nil
+}
+
+// keyBuilderFn represents a generic key builder function
+type keyBuilderFn func(context.Context, string) string
+
+// list retrieves all keys from storage under the provided prefix key, while
+// supporting all namespaces, and deserialize it into objsPtr.
+func (s *Store) list(ctx context.Context, keyBuilder keyBuilderFn, objsPtr interface{}) error {
+	// Make sure the interface is a pointer, and that the element at this address
+	// is a slice.
+	v := reflect.ValueOf(objsPtr)
+	if v.Kind() != reflect.Ptr {
+		return fmt.Errorf("expected pointer, but got %v type", v.Type())
+	}
+	if v.Elem().Kind() != reflect.Slice {
+		return fmt.Errorf("expected slice, but got %s", v.Elem().Kind())
+	}
+	v = v.Elem()
+
+	// Support "*" as a wildcard for namespaces
+	if namespace := types.ContextNamespace(ctx); namespace == types.NamespaceTypeAll {
+		// Remove the namespace from the context if we had a wildcard
+		ctx = context.WithValue(ctx, types.NamespaceKey, "")
+	}
+
+	opts := []clientv3.OpOption{
+		clientv3.WithPrefix(),
+	}
+
+	key := keyBuilder(ctx, "")
+	resp, err := s.client.Get(ctx, key, opts...)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Kvs) == 0 {
+		return &store.ErrNotFound{Key: key}
+	}
+
+	for _, kv := range resp.Kvs {
+		// Decode and append the value to v, which must be a slice.
+		obj := reflect.New(v.Type().Elem()).Interface()
+		if err := json.Unmarshal(kv.Value, obj); err != nil {
+			return &store.ErrDecode{Key: key, Err: err}
+		}
+
+		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
+	}
+
+	return nil
+}
+
+// Update a key given with the serialized object.
+func (s *Store) update(ctx context.Context, key, namespace string, object interface{}) error {
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return &store.ErrEncore{Key: key, Err: err}
+	}
+
+	comparisons := []clientv3.Cmp{}
+	// If we had a namespace provided, make sure it exists
+	if namespace != "" {
+		comparisons = append(comparisons, namespaceFound(namespace))
+	}
+	// Make sure the key already exists
+	comparisons = append(comparisons, keyFound(key))
+
+	req := clientv3.OpPut(key, string(bytes))
+	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Commit()
+	if err != nil {
+		return err
+	}
+	if !resp.Succeeded {
+		return fmt.Errorf("could not update the key %s", key)
+	}
+
+	return nil
+}
+
+func keyFound(key string) clientv3.Cmp {
+	return clientv3.Compare(
+		clientv3.CreateRevision(key), ">", 0,
+	)
+}
+
+func keyNotFound(key string) clientv3.Cmp {
+	return clientv3.Compare(
+		clientv3.CreateRevision(key), "=", 0,
+	)
+}
+
+func namespaceFound(namespace string) clientv3.Cmp {
+	return keyFound(getNamespacePath(namespace))
 }

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -37,7 +37,7 @@ func NewStore(client *clientv3.Client, name string) *Store {
 func (s *Store) create(ctx context.Context, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
-		return &store.ErrEncore{Key: key, Err: err}
+		return &store.ErrEncode{Key: key, Err: err}
 	}
 
 	comparisons := []clientv3.Cmp{}
@@ -65,7 +65,7 @@ func (s *Store) create(ctx context.Context, key, namespace string, object interf
 func (s *Store) createOrUpdate(ctx context.Context, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
-		return &store.ErrEncore{Key: key, Err: err}
+		return &store.ErrEncode{Key: key, Err: err}
 	}
 
 	comparisons := []clientv3.Cmp{}
@@ -174,7 +174,7 @@ func (s *Store) list(ctx context.Context, keyBuilder keyBuilderFn, objsPtr inter
 func (s *Store) update(ctx context.Context, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
-		return &store.ErrEncore{Key: key, Err: err}
+		return &store.ErrEncode{Key: key, Err: err}
 	}
 
 	comparisons := []clientv3.Cmp{}

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -25,4 +27,182 @@ func testWithEtcd(t *testing.T, f func(store.Store)) {
 	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
 
 	f(s)
+}
+
+func testWithEtcdStore(t *testing.T, f func(*Store)) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+
+	s := NewStore(client, e.Name())
+
+	// Mock a default namespace
+	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
+
+	f(s)
+}
+
+type genericObject struct {
+	Namespace string
+	Name      string
+	Revision  int
+}
+
+func (g *genericObject) GetNamespace() string {
+	return g.Namespace
+}
+
+func TestCreate(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Creating a namespaced key that does not exist should work
+		obj := &genericObject{}
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		err := store.create(ctx, "/default/foo", "default", obj)
+		assert.NoError(t, err)
+
+		// Creating this same key should return an error
+		err = store.create(ctx, "/default/foo", "default", obj)
+		assert.Error(t, err)
+
+		// We should also be able to create a global object
+		err = store.create(ctx, "/foo", "", obj)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCreateOrUpdate(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Creating a namespaced key that does not exist should work
+		obj := &genericObject{Revision: 1}
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		err := store.createOrUpdate(ctx, "/default/foo", "default", obj)
+		assert.NoError(t, err)
+
+		// Creating this same key should also work, but the revision should be
+		// different
+		obj2 := &genericObject{Revision: 2}
+		err = store.createOrUpdate(ctx, "/default/foo", "default", obj)
+		assert.NoError(t, err)
+		result := &genericObject{}
+		err = store.get(ctx, "/default/foo", obj2)
+		assert.NoError(t, err)
+		assert.NotEqual(t, obj.Revision, result.Revision)
+
+		// We should also be able to create a global object
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "")
+		err = store.createOrUpdate(ctx, "/foo", "", obj)
+		assert.NoError(t, err)
+	})
+}
+
+func TestDelete(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Deleting a non-existant key should fail
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		require.Error(t, store.delete(ctx, "/default/foo"))
+
+		// Create it first
+		obj := &genericObject{}
+		require.NoError(t, store.create(ctx, "/default/foo", "default", obj))
+
+		// Now make sure it gets properly deleted
+		require.NoError(t, store.delete(ctx, "/default/foo"))
+		result := &genericObject{}
+		require.Error(t, store.get(ctx, "/default/foo", result))
+	})
+}
+func TestGet(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Create a namespaced key
+		obj := &genericObject{Revision: 1}
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		err := store.create(ctx, "/default/foo", "default", obj)
+		assert.NoError(t, err)
+
+		// Retrieve the namespaced key and make sure it's the expected object
+		result := &genericObject{}
+		err = store.get(ctx, "/default/foo", result)
+		assert.NoError(t, err)
+		assert.Equal(t, obj, result)
+
+		// Create a global key
+		obj2 := &genericObject{Revision: 2}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "")
+		err = store.create(ctx, "/foo", "", obj2)
+		assert.NoError(t, err)
+
+		// Retrieve the global key and make sure it's the expected object
+		result2 := &genericObject{}
+		err = store.get(ctx, "/foo", result2)
+		assert.NoError(t, err)
+		assert.Equal(t, obj2, result2)
+	})
+}
+
+var genericKeyBuilder = store.NewKeyBuilder("generic")
+
+func getGenericObjectPath(obj *genericObject) string {
+	return genericKeyBuilder.WithResource(obj).Build(obj.Name)
+}
+
+func getGenericObjectsPath(ctx context.Context, name string) string {
+	return genericKeyBuilder.WithContext(ctx).Build(name)
+}
+func TestList(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Create a second namespace
+		require.NoError(t, store.CreateNamespace(context.Background(), types.FixtureNamespace("acme")))
+
+		// Create a bunch of keys everywhere
+		obj1 := &genericObject{Name: "obj1", Namespace: "default"}
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		require.NoError(t, store.create(ctx, "/sensu.io/generic/default/obj1", "default", obj1))
+
+		obj2 := &genericObject{Name: "obj2", Namespace: "acme"}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
+		require.NoError(t, store.create(ctx, "/sensu.io/generic/acme/obj2", "acme", obj2))
+
+		obj3 := &genericObject{Name: "obj3", Namespace: "acme"}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
+		require.NoError(t, store.create(ctx, "/sensu.io/generic/acme/obj3", "acme", obj3))
+
+		// We should have 1 object when listing keys under the default namespace
+		list := []*genericObject{}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "default")
+		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		assert.Len(t, list, 1)
+
+		// We should have 2 objects when listing keys under the acme namespace
+		list = []*genericObject{}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
+		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		assert.Len(t, list, 2)
+
+		// We should have 3 objects when listing through all namespaces
+		list = []*genericObject{}
+		ctx = context.WithValue(context.Background(), types.NamespaceKey, "*")
+		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		assert.Len(t, list, 3)
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	testWithEtcdStore(t, func(store *Store) {
+		// Updating a non-existent object should fail
+		obj := &genericObject{Revision: 1}
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
+		require.Error(t, store.update(ctx, "/default/foo", "default", obj))
+
+		// Create it first
+		require.NoError(t, store.create(ctx, "/default/foo", "default", obj))
+
+		// Now make sure it gets properly updated
+		obj.Revision = 2
+		require.NoError(t, store.update(ctx, "/default/foo", "default", obj))
+		result := &genericObject{}
+		require.NoError(t, store.get(ctx, "/default/foo", result))
+		assert.Equal(t, 2, obj.Revision)
+	})
 }

--- a/backend/store/key_builder.go
+++ b/backend/store/key_builder.go
@@ -12,7 +12,7 @@ const keySeparator = "/"
 // KeyBuilder builds multi-tenant resource keys.
 type KeyBuilder struct {
 	resourceName string
-	namespace    Namespace
+	namespace    string
 }
 
 // NewKeyBuilder creates a new KeyBuilder.
@@ -23,7 +23,7 @@ func NewKeyBuilder(resourceName string) KeyBuilder {
 
 // WithNamespace adds a namespace to a key.
 func (b KeyBuilder) WithNamespace(namespace string) KeyBuilder {
-	b.namespace = Namespace{Namespace: namespace}
+	b.namespace = namespace
 	return b
 }
 
@@ -35,6 +35,8 @@ func (b KeyBuilder) WithResource(r types.MultitenantResource) KeyBuilder {
 
 // WithContext adds a namespace from a context.
 func (b KeyBuilder) WithContext(ctx context.Context) KeyBuilder {
+	// TODO (Simon): Use the authorization attributes to get the namespace and
+	// remove the "namespace" middleware
 	b.namespace = NewNamespaceFromContext(ctx)
 	return b
 }
@@ -45,7 +47,7 @@ func (b KeyBuilder) Build(keys ...string) string {
 		[]string{
 			Root,
 			b.resourceName,
-			b.namespace.Namespace,
+			b.namespace,
 		},
 		keys...,
 	)
@@ -58,7 +60,7 @@ func (b KeyBuilder) Build(keys ...string) string {
 func (b KeyBuilder) BuildPrefix(keys ...string) string {
 	out := Root + keySeparator + b.resourceName
 
-	keys = append([]string{b.namespace.Namespace}, keys...)
+	keys = append([]string{b.namespace}, keys...)
 	for _, key := range keys {
 		// If we encounter a wildcard stop and return key
 		if key == WildcardValue {

--- a/backend/store/namespace.go
+++ b/backend/store/namespace.go
@@ -14,34 +14,15 @@ const (
 	Root = "/sensu.io"
 )
 
-// Namespace describes the values in-which a Sensu resource may reside.
-type Namespace struct {
-	Namespace string
-}
-
 // NewNamespaceFromContext creates a new Namespace from a context.
-func NewNamespaceFromContext(ctx context.Context) Namespace {
-	return Namespace{
-		Namespace: namespace(ctx),
-	}
-}
-
-// NewNamespaceFromResource creates a new Namespace from a MultitenantResource.
-func NewNamespaceFromResource(resource types.MultitenantResource) Namespace {
-	return Namespace{
-		Namespace: resource.GetNamespace(),
-	}
-}
-
-// NamespaceIsWildcard returns true if the namespace is a wildcard.
-func (ns Namespace) NamespaceIsWildcard() bool {
-	return ns.Namespace == WildcardValue
-}
-
-// namespace returns the namespace name injected in the context
-func namespace(ctx context.Context) string {
+func NewNamespaceFromContext(ctx context.Context) string {
 	if value := ctx.Value(types.NamespaceKey); value != nil {
 		return value.(string)
 	}
 	return ""
+}
+
+// NewNamespaceFromResource creates a new Namespace from a MultitenantResource.
+func NewNamespaceFromResource(resource types.MultitenantResource) string {
+	return resource.GetNamespace()
 }

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -18,6 +19,44 @@ const (
 	// WatchDelete indicates that an object was deleted.
 	WatchDelete
 )
+
+// ErrDecode is returned when an object could not be decoded
+type ErrDecode struct {
+	Key string
+	Err error
+}
+
+func (e *ErrDecode) Error() string {
+	return fmt.Sprintf("could not decode the key %s: %s", e.Key, e.Err.Error())
+}
+
+// ErrEncore is returned when an object could not be decoded
+type ErrEncore struct {
+	Key string
+	Err error
+}
+
+func (e *ErrEncore) Error() string {
+	return fmt.Sprintf("could not encode the key %s: %s", e.Key, e.Err.Error())
+}
+
+// ErrNotFound is returned when a key is not found in the store
+type ErrNotFound struct {
+	Key string
+}
+
+func (e *ErrNotFound) Error() string {
+	return fmt.Sprintf("key %s not found", e.Key)
+}
+
+// ErrNotValid is returned when an object failed validation
+type ErrNotValid struct {
+	Err error
+}
+
+func (e *ErrNotValid) Error() string {
+	return fmt.Sprintf("resource is invalid: %s", e.Err.Error())
+}
 
 // WatchActionType indicates what type of change was made to an object in the store.
 type WatchActionType int
@@ -346,15 +385,20 @@ type NamespaceStore interface {
 
 // RoleStore provides methods for managing RBAC roles and rules
 type RoleStore interface {
+	// Create a given role
+	CreateRole(ctx context.Context, role *types.Role) error
+
+	// CreateOrUpdateRole overwrites the given role
+	CreateOrUpdateRole(ctx context.Context, role *types.Role) error
+
 	// DeleteRole deletes a role using the given name.
 	DeleteRole(ctx context.Context, name string) error
 
-	// GetRole returns a role using the given name. The result is nil if
-	// none was found.
+	// GetRole returns a role using the given name. An error is returned if no
+	// role was found
 	GetRole(ctx context.Context, name string) (*types.Role, error)
 
-	// ListRoles returns all roles. A nil slice with no error is returned if none
-	// were found.
+	// ListRoles returns all roles. An error is returned if no roles were found
 	ListRoles(context.Context) ([]*types.Role, error)
 
 	// UpdateRole creates or updates a given role.

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -221,6 +221,53 @@ type CheckConfigStore interface {
 	GetCheckConfigWatcher(ctx context.Context) <-chan WatchEventCheckConfig
 }
 
+// ClusterRoleBindingStore provides methods for managing RBAC cluster role
+// bindings
+type ClusterRoleBindingStore interface {
+	// Create a given cluster role binding
+	CreateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error
+
+	// CreateOrUpdateRole overwrites the given cluster role binding
+	CreateOrUpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error
+
+	// DeleteRole deletes a cluster role binding using the given name.
+	DeleteClusterRoleBinding(ctx context.Context, name string) error
+
+	// GetRole returns a cluster role binding using the given name. An error is
+	// returned if no binding was found
+	GetClusterRoleBinding(ctx context.Context, name string) (*types.ClusterRoleBinding, error)
+
+	// ListRoles returns all cluster role binding. An error is returned if no
+	// binding were found
+	ListClusterRoleBindings(context.Context) ([]*types.ClusterRoleBinding, error)
+
+	// UpdateRole creates or updates a given cluster role binding.
+	UpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error
+}
+
+// ClusterRoleStore provides methods for managing RBAC cluster roles and rules
+type ClusterRoleStore interface {
+	// Create a given cluster role
+	CreateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error
+
+	// CreateOrUpdateClusterRole overwrites the given cluster role
+	CreateOrUpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error
+
+	// DeleteClusterRole deletes a cluster role using the given name.
+	DeleteClusterRole(ctx context.Context, name string) error
+
+	// GetClusterRole returns a cluster role using the given name. An error is
+	// returned if no role was found
+	GetClusterRole(ctx context.Context, name string) (*types.ClusterRole, error)
+
+	// ListClusterRoles returns all cluster roles. An error is returned if no
+	// roles were found
+	ListClusterRoles(context.Context) ([]*types.ClusterRole, error)
+
+	// UpdateClusterRole creates or updates a given cluster role.
+	UpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error
+}
+
 // HookConfigStore provides methods for managing hooks configuration
 type HookConfigStore interface {
 	// DeleteHookConfigByName deletes a hook's configuration using the given name
@@ -381,6 +428,29 @@ type NamespaceStore interface {
 
 	// UpdateNamespace updates an existing namespace.
 	UpdateNamespace(ctx context.Context, org *types.Namespace) error
+}
+
+// RoleBindingStore provides methods for managing RBAC role bindings
+type RoleBindingStore interface {
+	// Create a given role binding
+	CreateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error
+
+	// CreateOrUpdateRole overwrites the given role binding
+	CreateOrUpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error
+
+	// DeleteRole deletes a role binding using the given name.
+	DeleteRoleBinding(ctx context.Context, name string) error
+
+	// GetRole returns a role binding using the given name. An error is returned
+	// if no binding was found
+	GetRoleBinding(ctx context.Context, name string) (*types.RoleBinding, error)
+
+	// ListRoles returns all role binding. An error is returned if no binding were
+	// found
+	ListRoleBindings(context.Context) ([]*types.RoleBinding, error)
+
+	// UpdateRole creates or updates a given role binding.
+	UpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error
 }
 
 // RoleStore provides methods for managing RBAC roles and rules

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -39,13 +39,13 @@ func (e *ErrDecode) Error() string {
 	return fmt.Sprintf("could not decode the key %s: %s", e.Key, e.Err.Error())
 }
 
-// ErrEncore is returned when an object could not be decoded
-type ErrEncore struct {
+// ErrEncode is returned when an object could not be decoded
+type ErrEncode struct {
 	Key string
 	Err error
 }
 
-func (e *ErrEncore) Error() string {
+func (e *ErrEncode) Error() string {
 	return fmt.Sprintf("could not encode the key %s: %s", e.Key, e.Err.Error())
 }
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -20,6 +20,15 @@ const (
 	WatchDelete
 )
 
+// ErrAlreadyExists is returned when an object already exists
+type ErrAlreadyExists struct {
+	Key string
+}
+
+func (e *ErrAlreadyExists) Error() string {
+	return fmt.Sprintf("could not create the key %s", e.Key)
+}
+
 // ErrDecode is returned when an object could not be decoded
 type ErrDecode struct {
 	Key string

--- a/cli/commands/role/create.go
+++ b/cli/commands/role/create.go
@@ -29,6 +29,10 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				role.Namespace = cli.Config.Namespace()
 			}
 
+			role.Rules = []types.Rule{
+				types.FixtureRule(),
+			}
+
 			if err := role.Validate(); err != nil {
 				return err
 			}

--- a/cli/commands/role/create_test.go
+++ b/cli/commands/role/create_test.go
@@ -16,7 +16,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("roles", cmd.Short)
+	assert.Regexp("role", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -24,8 +24,8 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{
-		types.FixtureRole("one", "*"),
-		types.FixtureRole("two", "*"),
+		*types.FixtureRole("one", "*"),
+		*types.FixtureRole("two", "*"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -39,8 +39,8 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	config.On("Format").Return("")
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{
-		types.FixtureRole("one", "*"),
-		types.FixtureRole("two", "*"),
+		*types.FixtureRole("one", "*"),
+		*types.FixtureRole("two", "*"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -24,8 +24,8 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{
-		*types.FixtureRole("one", "*"),
-		*types.FixtureRole("two", "*"),
+		types.FixtureRole("one", "*"),
+		types.FixtureRole("two", "*"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -39,8 +39,8 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	config.On("Format").Return("")
 	client := cli.Client.(*client.MockClient)
 	client.On("ListRoles").Return([]types.Role{
-		*types.FixtureRole("one", "*"),
-		*types.FixtureRole("two", "*"),
+		types.FixtureRole("one", "*"),
+		types.FixtureRole("two", "*"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/testing/mockstore/clusterrole.go
+++ b/testing/mockstore/clusterrole.go
@@ -1,0 +1,48 @@
+package mockstore
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// CreateClusterRole ...
+func (s *MockStore) CreateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	args := s.Called(ctx, clusterRole)
+	return args.Error(0)
+}
+
+// CreateOrUpdateClusterRole ...
+func (s *MockStore) CreateOrUpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	args := s.Called(ctx, clusterRole)
+	return args.Error(0)
+}
+
+// DeleteClusterRole ...
+func (s *MockStore) DeleteClusterRole(ctx context.Context, name string) error {
+	args := s.Called(ctx, name)
+	return args.Error(0)
+}
+
+// GetClusterRole ...
+func (s *MockStore) GetClusterRole(ctx context.Context, name string) (*types.ClusterRole, error) {
+	args := s.Called(ctx, name)
+	err := args.Error(1)
+
+	if clusterRole, ok := args.Get(0).(*types.ClusterRole); ok {
+		return clusterRole, err
+	}
+	return nil, err
+}
+
+// ListClusterRoles ...
+func (s *MockStore) ListClusterRoles(ctx context.Context) ([]*types.ClusterRole, error) {
+	args := s.Called(ctx)
+	return args.Get(0).([]*types.ClusterRole), args.Error(1)
+}
+
+// UpdateClusterRole ...
+func (s *MockStore) UpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error {
+	args := s.Called(ctx, clusterRole)
+	return args.Error(0)
+}

--- a/testing/mockstore/clusterrolebinding.go
+++ b/testing/mockstore/clusterrolebinding.go
@@ -1,0 +1,48 @@
+package mockstore
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// CreateClusterRoleBinding ...
+func (s *MockStore) CreateClusterRoleBinding(ctx context.Context, ClusterRoleBinding *types.ClusterRoleBinding) error {
+	args := s.Called(ctx, ClusterRoleBinding)
+	return args.Error(0)
+}
+
+// CreateOrUpdateClusterRoleBinding ...
+func (s *MockStore) CreateOrUpdateClusterRoleBinding(ctx context.Context, ClusterRoleBinding *types.ClusterRoleBinding) error {
+	args := s.Called(ctx, ClusterRoleBinding)
+	return args.Error(0)
+}
+
+// DeleteClusterRoleBinding ...
+func (s *MockStore) DeleteClusterRoleBinding(ctx context.Context, name string) error {
+	args := s.Called(ctx, name)
+	return args.Error(0)
+}
+
+// GetClusterRoleBinding ...
+func (s *MockStore) GetClusterRoleBinding(ctx context.Context, name string) (*types.ClusterRoleBinding, error) {
+	args := s.Called(ctx, name)
+	err := args.Error(1)
+
+	if clusterRoleBinding, ok := args.Get(0).(*types.ClusterRoleBinding); ok {
+		return clusterRoleBinding, err
+	}
+	return nil, err
+}
+
+// ListClusterRoleBindings ...
+func (s *MockStore) ListClusterRoleBindings(ctx context.Context) ([]*types.ClusterRoleBinding, error) {
+	args := s.Called(ctx)
+	return args.Get(0).([]*types.ClusterRoleBinding), args.Error(1)
+}
+
+// UpdateClusterRoleBinding ...
+func (s *MockStore) UpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error {
+	args := s.Called(ctx, clusterRoleBinding)
+	return args.Error(0)
+}

--- a/testing/mockstore/role.go
+++ b/testing/mockstore/role.go
@@ -6,6 +6,18 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+// CreateRole ...
+func (s *MockStore) CreateRole(ctx context.Context, role *types.Role) error {
+	args := s.Called(ctx, role)
+	return args.Error(0)
+}
+
+// CreateOrUpdateRole ...
+func (s *MockStore) CreateOrUpdateRole(ctx context.Context, role *types.Role) error {
+	args := s.Called(ctx, role)
+	return args.Error(0)
+}
+
 // DeleteRole ...
 func (s *MockStore) DeleteRole(ctx context.Context, name string) error {
 	args := s.Called(ctx, name)

--- a/testing/mockstore/rolebinding.go
+++ b/testing/mockstore/rolebinding.go
@@ -1,0 +1,48 @@
+package mockstore
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+// CreateRoleBinding ...
+func (s *MockStore) CreateRoleBinding(ctx context.Context, RoleBinding *types.RoleBinding) error {
+	args := s.Called(ctx, RoleBinding)
+	return args.Error(0)
+}
+
+// CreateOrUpdateRoleBinding ...
+func (s *MockStore) CreateOrUpdateRoleBinding(ctx context.Context, RoleBinding *types.RoleBinding) error {
+	args := s.Called(ctx, RoleBinding)
+	return args.Error(0)
+}
+
+// DeleteRoleBinding ...
+func (s *MockStore) DeleteRoleBinding(ctx context.Context, name string) error {
+	args := s.Called(ctx, name)
+	return args.Error(0)
+}
+
+// GetRoleBinding ...
+func (s *MockStore) GetRoleBinding(ctx context.Context, name string) (*types.RoleBinding, error) {
+	args := s.Called(ctx, name)
+	err := args.Error(1)
+
+	if roleBinding, ok := args.Get(0).(*types.RoleBinding); ok {
+		return roleBinding, err
+	}
+	return nil, err
+}
+
+// ListRoleBindings ...
+func (s *MockStore) ListRoleBindings(ctx context.Context) ([]*types.RoleBinding, error) {
+	args := s.Called(ctx)
+	return args.Get(0).([]*types.RoleBinding), args.Error(1)
+}
+
+// UpdateRoleBinding ...
+func (s *MockStore) UpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error {
+	args := s.Called(ctx, roleBinding)
+	return args.Error(0)
+}

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -19,8 +19,8 @@ const (
 )
 
 // FixtureRule returns a partial rule
-func FixtureRule() *Rule {
-	return &Rule{
+func FixtureRule() Rule {
+	return Rule{
 		Verbs:     []string{VerbAll},
 		Resources: []string{ResourceAll},
 	}
@@ -32,7 +32,7 @@ func FixtureRole(name, namespace string) *Role {
 		Name:      name,
 		Namespace: namespace,
 		Rules: []Rule{
-			*FixtureRule(),
+			FixtureRule(),
 		},
 	}
 }
@@ -42,7 +42,7 @@ func FixtureClusterRole(name string) *ClusterRole {
 	return &ClusterRole{
 		Name: name,
 		Rules: []Rule{
-			*FixtureRule(),
+			FixtureRule(),
 		},
 	}
 }


### PR DESCRIPTION
It adds stores for `clusterroles`, `clusterrolebindings`, `roles` & `rolebindings`.

I also made a small refactoring to `roles` in order to standardize how we deal with validation/errors/empty responses, so most of the logic in now in generic methods (see `backend/store/etcd/store.go`).

Closes https://github.com/sensu/sensu-go/issues/2280