### PR TITLE
Use StringSlice for subscriptions flag in sensu-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Breaking Changes
 - Environments and organizations have been replaced with namespaces.
 - Removed unused asset metadata field.
+- Agent subscriptions are now specified in the config file as an array instead
+  instead of a comma-delimited list of strings.
 
 ## [2.0.0-beta.7-1] - 2018-10-26
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -161,12 +161,8 @@ func newStartCommand() *cobra.Command {
 			}
 
 			// Get a single or a list of subscriptions
-			subscriptions := viper.GetString(flagSubscriptions)
-			if subscriptions != "" {
-				cfg.Subscriptions = splitAndTrim(subscriptions)
-			} else {
-				cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
-			}
+			subscriptions := viper.GetStringSlice(flagSubscriptions)
+			cfg.Subscriptions = subscriptions
 
 			sensuAgent := agent.NewAgent(cfg)
 			if err := sensuAgent.Run(); err != nil {


### PR DESCRIPTION
## What is this change?

This moves us from using `pflag.String` and manual parsing for the `--subscriptions` flag to `pflag.StringSlice`.

## Why is this change necessary?

This allows users to specify subscriptions as an array while preserving the command-line argument as a comma-delimited list of strings.

closes #2291 