### PR TITLE
New RBAC Endpoints

### DIFF
--- a/backend/apid/actions/clusterrolebindings.go
+++ b/backend/apid/actions/clusterrolebindings.go
@@ -1,0 +1,112 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// ClusterRoleBindingController exposes the ClusterRoleBindings.
+type ClusterRoleBindingController struct {
+	Store store.ClusterRoleBindingStore
+}
+
+// NewClusterRoleBindingController creates a new ClusterRoleBindingController.
+func NewClusterRoleBindingController(store store.ClusterRoleBindingStore) ClusterRoleBindingController {
+	return ClusterRoleBindingController{
+		Store: store,
+	}
+}
+
+// Create creates a new cluster role binding.
+// Returns an error if the cluster role binding already exists.
+func (a ClusterRoleBindingController) Create(ctx context.Context, role types.ClusterRoleBinding) error {
+	if err := a.Store.CreateClusterRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrAlreadyExists:
+			return NewErrorf(AlreadyExistsErr)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// CreateOrReplace creates or replaces a cluster role binding.
+func (a ClusterRoleBindingController) CreateOrReplace(ctx context.Context, role types.ClusterRoleBinding) error {
+	if err := a.Store.CreateOrUpdateClusterRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Destroy removes the given cluster role binding from the store.
+func (a ClusterRoleBindingController) Destroy(ctx context.Context, name string) error {
+	if err := a.Store.DeleteClusterRoleBinding(ctx, name); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Get retrieves the cluster role binding with the given name.
+func (a ClusterRoleBindingController) Get(ctx context.Context, name string) (*types.ClusterRoleBinding, error) {
+	role, err := a.Store.GetClusterRoleBinding(ctx, name)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return role, nil
+}
+
+// List returns all available cluster role bindings.
+func (a ClusterRoleBindingController) List(ctx context.Context) ([]*types.ClusterRoleBinding, error) {
+	// Fetch from store
+	results, err := a.Store.ListClusterRoleBindings(ctx)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return results, nil
+}
+
+// Update validates and persists changes to a cluster role binding.
+func (a ClusterRoleBindingController) Update(ctx context.Context, role types.ClusterRoleBinding) error {
+	if err := a.Store.UpdateClusterRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}

--- a/backend/apid/actions/clusterrolebindings_test.go
+++ b/backend/apid/actions/clusterrolebindings_test.go
@@ -1,0 +1,406 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewClusterRoleBindingController(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &mockstore.MockStore{}
+	actions := NewClusterRoleBindingController(store)
+
+	assert.NotNil(actions)
+	assert.Equal(store, actions.Store)
+}
+
+func TestClusterRoleBindingCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRoleBinding("read-write"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Already existing",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        &store.ErrAlreadyExists{},
+			expectedErr:     true,
+			expectedErrCode: AlreadyExistsErr,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateClusterRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Create(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingCreateOrReplace(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create or update",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRoleBinding("read-write"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateOrUpdateClusterRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.CreateOrReplace(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingDestroy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Delete",
+			ctx:      context.Background(),
+			argument: "read-write",
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("DeleteClusterRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Destroy(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingGet(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedResult  *types.ClusterRoleBinding
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:           "Get",
+			ctx:            context.Background(),
+			argument:       "read-write",
+			expectedResult: types.FixtureClusterRoleBinding("read-write"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("GetClusterRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.Get(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingList(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		storeErr        error
+		expectedResult  []*types.ClusterRoleBinding
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name: "List",
+			ctx:  context.Background(),
+			expectedResult: []*types.ClusterRoleBinding{
+				types.FixtureClusterRoleBinding("read-write"),
+				types.FixtureClusterRoleBinding("read-only"),
+				types.FixtureClusterRoleBinding("sysadmin"),
+			},
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("ListClusterRoleBindings", mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.List(tc.ctx)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingUpdate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Update",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRoleBinding("read-write"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRoleBinding("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("UpdateClusterRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Update(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/backend/apid/actions/clusterroles.go
+++ b/backend/apid/actions/clusterroles.go
@@ -1,0 +1,112 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// ClusterRoleController exposes the ClusterRoles.
+type ClusterRoleController struct {
+	Store store.ClusterRoleStore
+}
+
+// NewClusterRoleController creates a new ClusterRoleController.
+func NewClusterRoleController(store store.ClusterRoleStore) ClusterRoleController {
+	return ClusterRoleController{
+		Store: store,
+	}
+}
+
+// Create creates a new cluster role.
+// Returns an error if the cluster role already exists.
+func (a ClusterRoleController) Create(ctx context.Context, role types.ClusterRole) error {
+	if err := a.Store.CreateClusterRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrAlreadyExists:
+			return NewErrorf(AlreadyExistsErr)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// CreateOrReplace creates or replaces a cluster role.
+func (a ClusterRoleController) CreateOrReplace(ctx context.Context, role types.ClusterRole) error {
+	if err := a.Store.CreateOrUpdateClusterRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Destroy removes the given cluster role from the store.
+func (a ClusterRoleController) Destroy(ctx context.Context, name string) error {
+	if err := a.Store.DeleteClusterRole(ctx, name); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Get retrieves the cluster role with the given name.
+func (a ClusterRoleController) Get(ctx context.Context, name string) (*types.ClusterRole, error) {
+	role, err := a.Store.GetClusterRole(ctx, name)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return role, nil
+}
+
+// List returns all available cluster roles.
+func (a ClusterRoleController) List(ctx context.Context) ([]*types.ClusterRole, error) {
+	// Fetch from store
+	results, err := a.Store.ListClusterRoles(ctx)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return results, nil
+}
+
+// Update validates and persists changes to a cluster role.
+func (a ClusterRoleController) Update(ctx context.Context, role types.ClusterRole) error {
+	if err := a.Store.UpdateClusterRole(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}

--- a/backend/apid/actions/clusterroles_test.go
+++ b/backend/apid/actions/clusterroles_test.go
@@ -1,0 +1,406 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewClusterRoleController(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &mockstore.MockStore{}
+	actions := NewClusterRoleController(store)
+
+	assert.NotNil(actions)
+	assert.Equal(store, actions.Store)
+}
+
+func TestClusterRoleCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRole
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRole("read-write"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Already existing",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        &store.ErrAlreadyExists{},
+			expectedErr:     true,
+			expectedErrCode: AlreadyExistsErr,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateClusterRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Create(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleCreateOrReplace(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRole
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create or update",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRole("read-write"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateOrUpdateClusterRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.CreateOrReplace(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleDestroy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Delete",
+			ctx:      context.Background(),
+			argument: "read-write",
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("DeleteClusterRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Destroy(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestClusterRoleGet(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedResult  *types.ClusterRole
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:           "Get",
+			ctx:            context.Background(),
+			argument:       "read-write",
+			expectedResult: types.FixtureClusterRole("read-write"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("GetClusterRole", mock.Anything, mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.Get(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestClusterRoleList(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		storeErr        error
+		expectedResult  []*types.ClusterRole
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name: "List",
+			ctx:  context.Background(),
+			expectedResult: []*types.ClusterRole{
+				types.FixtureClusterRole("read-write"),
+				types.FixtureClusterRole("read-only"),
+				types.FixtureClusterRole("sysadmin"),
+			},
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("ListClusterRoles", mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.List(tc.ctx)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestClusterRoleUpdate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.ClusterRole
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Update",
+			ctx:      context.Background(),
+			argument: types.FixtureClusterRole("read-write"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureClusterRole("read-write"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewClusterRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("UpdateClusterRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Update(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/backend/apid/actions/rolebindings.go
+++ b/backend/apid/actions/rolebindings.go
@@ -1,0 +1,112 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// RoleBindingController exposes the Roles.
+type RoleBindingController struct {
+	Store store.RoleBindingStore
+}
+
+// NewRoleBindingController creates a new RoleBindingController.
+func NewRoleBindingController(store store.RoleBindingStore) RoleBindingController {
+	return RoleBindingController{
+		Store: store,
+	}
+}
+
+// Create creates a new role binding.
+// Returns an error if the role binding already exists.
+func (a RoleBindingController) Create(ctx context.Context, role types.RoleBinding) error {
+	if err := a.Store.CreateRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrAlreadyExists:
+			return NewErrorf(AlreadyExistsErr)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// CreateOrReplace creates or replaces a role binding.
+func (a RoleBindingController) CreateOrReplace(ctx context.Context, role types.RoleBinding) error {
+	if err := a.Store.CreateOrUpdateRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Destroy removes the given role binding from the store.
+func (a RoleBindingController) Destroy(ctx context.Context, name string) error {
+	if err := a.Store.DeleteRoleBinding(ctx, name); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}
+
+// Get retrieves the role binding with the given name.
+func (a RoleBindingController) Get(ctx context.Context, name string) (*types.RoleBinding, error) {
+	role, err := a.Store.GetRoleBinding(ctx, name)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return role, nil
+}
+
+// List returns all available role bindings.
+func (a RoleBindingController) List(ctx context.Context) ([]*types.RoleBinding, error) {
+	// Fetch from store
+	results, err := a.Store.ListRoleBindings(ctx)
+	if err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, NewErrorf(NotFound)
+		default:
+			return nil, NewError(InternalErr, err)
+		}
+	}
+
+	return results, nil
+}
+
+// Update validates and persists changes to a role binding.
+func (a RoleBindingController) Update(ctx context.Context, role types.RoleBinding) error {
+	if err := a.Store.UpdateRoleBinding(ctx, &role); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return NewErrorf(NotFound)
+		case *store.ErrNotValid:
+			return NewErrorf(InvalidArgument)
+		default:
+			return NewError(InternalErr, err)
+		}
+	}
+
+	return nil
+}

--- a/backend/apid/actions/rolebindings_test.go
+++ b/backend/apid/actions/rolebindings_test.go
@@ -1,0 +1,406 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewRoleBindingController(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &mockstore.MockStore{}
+	actions := NewRoleBindingController(store)
+
+	assert.NotNil(actions)
+	assert.Equal(store, actions.Store)
+}
+
+func TestRoleBindingCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.RoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create",
+			ctx:      context.Background(),
+			argument: types.FixtureRoleBinding("read-write", "default"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Already existing",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        &store.ErrAlreadyExists{},
+			expectedErr:     true,
+			expectedErrCode: AlreadyExistsErr,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Create(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleBindingCreateOrReplace(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.RoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create or update",
+			ctx:      context.Background(),
+			argument: types.FixtureRoleBinding("read-write", "default"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateOrUpdateRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.CreateOrReplace(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleBindingDestroy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Delete",
+			ctx:      context.Background(),
+			argument: "read-write",
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("DeleteRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Destroy(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleBindingGet(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedResult  *types.RoleBinding
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:           "Get",
+			ctx:            context.Background(),
+			argument:       "read-write",
+			expectedResult: types.FixtureRoleBinding("read-write", "default"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("GetRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.Get(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestRoleBindingList(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		storeErr        error
+		expectedResult  []*types.RoleBinding
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name: "List",
+			ctx:  context.Background(),
+			expectedResult: []*types.RoleBinding{
+				types.FixtureRoleBinding("read-write", "default"),
+				types.FixtureRoleBinding("read-only", "default"),
+				types.FixtureRoleBinding("sysadmin", "IT"),
+			},
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("ListRoleBindings", mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.List(tc.ctx)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestRoleBindingUpdate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.RoleBinding
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Update",
+			ctx:      context.Background(),
+			argument: types.FixtureRoleBinding("read-write", "default"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRoleBinding("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleBindingController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("UpdateRoleBinding", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Update(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/backend/apid/actions/roles.go
+++ b/backend/apid/actions/roles.go
@@ -7,19 +7,20 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-// RoleController exposes the Roles
+// RoleController exposes the Roles.
 type RoleController struct {
 	Store store.RoleStore
 }
 
-// NewRoleController initializes a RoleController
+// NewRoleController creates a new RolesController.
 func NewRoleController(store store.RoleStore) RoleController {
 	return RoleController{
 		Store: store,
 	}
 }
 
-// Create creates a new role. It returns an error if the role already exists.
+// Create creates a new role.
+// Returns an error if the role already exists.
 func (a RoleController) Create(ctx context.Context, role types.Role) error {
 	if err := a.Store.CreateRole(ctx, &role); err != nil {
 		switch err := err.(type) {
@@ -49,7 +50,7 @@ func (a RoleController) CreateOrReplace(ctx context.Context, role types.Role) er
 	return nil
 }
 
-// Destroy removes given role from the store.
+// Destroy removes the given role from the store.
 func (a RoleController) Destroy(ctx context.Context, name string) error {
 	if err := a.Store.DeleteRole(ctx, name); err != nil {
 		switch err := err.(type) {
@@ -63,7 +64,7 @@ func (a RoleController) Destroy(ctx context.Context, name string) error {
 	return nil
 }
 
-// Get the role with the given name
+// Get retrieves the role with the given name.
 func (a RoleController) Get(ctx context.Context, name string) (*types.Role, error) {
 	role, err := a.Store.GetRole(ctx, name)
 	if err != nil {
@@ -78,7 +79,7 @@ func (a RoleController) Get(ctx context.Context, name string) (*types.Role, erro
 	return role, nil
 }
 
-// List returns all available resources
+// List returns all available roles.
 func (a RoleController) List(ctx context.Context) ([]*types.Role, error) {
 	// Fetch from store
 	results, err := a.Store.ListRoles(ctx)
@@ -94,7 +95,7 @@ func (a RoleController) List(ctx context.Context) ([]*types.Role, error) {
 	return results, nil
 }
 
-// Update validates and persists changes to a resource
+// Update validates and persists changes to a role.
 func (a RoleController) Update(ctx context.Context, role types.Role) error {
 	if err := a.Store.UpdateRole(ctx, &role); err != nil {
 		switch err := err.(type) {

--- a/backend/apid/actions/roles_test.go
+++ b/backend/apid/actions/roles_test.go
@@ -1,0 +1,406 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNewRoleController(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &mockstore.MockStore{}
+	actions := NewRoleController(store)
+
+	assert.NotNil(actions)
+	assert.Equal(store, actions.Store)
+}
+
+func TestRoleCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.Role
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create",
+			ctx:      context.Background(),
+			argument: types.FixtureRole("read-write", "default"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Already existing",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        &store.ErrAlreadyExists{},
+			expectedErr:     true,
+			expectedErrCode: AlreadyExistsErr,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Create(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleCreateOrReplace(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.Role
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Create or update",
+			ctx:      context.Background(),
+			argument: types.FixtureRole("read-write", "default"),
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("CreateOrUpdateRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.CreateOrReplace(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleDestroy(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Delete",
+			ctx:      context.Background(),
+			argument: "read-write",
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("DeleteRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Destroy(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestRoleGet(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        string
+		storeErr        error
+		expectedResult  *types.Role
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:           "Get",
+			ctx:            context.Background(),
+			argument:       "read-write",
+			expectedResult: types.FixtureRole("read-write", "default"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        "read-write",
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("GetRole", mock.Anything, mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.Get(tc.ctx, tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestRoleList(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		storeErr        error
+		expectedResult  []*types.Role
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name: "List",
+			ctx:  context.Background(),
+			expectedResult: []*types.Role{
+				types.FixtureRole("read-write", "default"),
+				types.FixtureRole("read-only", "default"),
+				types.FixtureRole("sysadmin", "IT"),
+			},
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("ListRoles", mock.Anything).
+				Return(tc.expectedResult, tc.storeErr)
+
+			result, err := actions.List(tc.ctx)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestRoleUpdate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		ctx             context.Context
+		argument        *types.Role
+		storeErr        error
+		expectedErr     bool
+		expectedErrCode ErrCode
+	}{
+		{
+			name:     "Update",
+			ctx:      context.Background(),
+			argument: types.FixtureRole("read-write", "default"),
+		},
+		{
+			name:            "Not found",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        &store.ErrNotFound{},
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+		},
+		{
+			name:            "Invalid input",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        &store.ErrNotValid{},
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
+		},
+		{
+			name:            "Store error",
+			ctx:             context.Background(),
+			argument:        types.FixtureRole("read-write", "default"),
+			storeErr:        errors.New("some error"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		store := &mockstore.MockStore{}
+		actions := NewRoleController(store)
+
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			store.
+				On("UpdateRole", mock.Anything, mock.Anything).
+				Return(tc.storeErr)
+
+			err := actions.Update(tc.ctx, *tc.argument)
+
+			if tc.expectedErr {
+				inferErr, ok := err.(Error)
+				if ok {
+					assert.Equal(tc.expectedErrCode, inferErr.Code)
+				} else {
+					assert.Error(err)
+					assert.FailNow("Return value was not of type 'Error'")
+				}
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -219,6 +219,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store) {
 			middlewares.Edition{Name: version.Edition},
 		),
 		routers.NewRolesRouter(store),
+		routers.NewRoleBindingsRouter(store),
 	)
 }
 

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -219,6 +219,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store) {
 			middlewares.Edition{Name: version.Edition},
 		),
 		routers.NewClusterRolesRouter(store),
+		routers.NewClusterRoleBindingsRouter(store),
 		routers.NewRolesRouter(store),
 		routers.NewRoleBindingsRouter(store),
 	)

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -218,6 +218,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store) {
 			middlewares.LimitRequest{},
 			middlewares.Edition{Name: version.Edition},
 		),
+		routers.NewClusterRolesRouter(store),
 		routers.NewRolesRouter(store),
 		routers.NewRoleBindingsRouter(store),
 	)

--- a/backend/apid/graphql/globalid/clusterrolebindings.go
+++ b/backend/apid/graphql/globalid/clusterrolebindings.go
@@ -1,0 +1,22 @@
+package globalid
+
+import "github.com/sensu/sensu-go/types"
+
+//
+// Cluster Role Bindings
+//
+var clusterRoleBindingName = "clusterrolebindings"
+
+// ClusterRoleBindingTranslator global ID resource
+var ClusterRoleBindingTranslator = commonTranslator{
+	name:       clusterRoleBindingName,
+	encodeFunc: standardEncoder(clusterRoleBindingName, "Name"),
+	decodeFunc: standardDecoder,
+	isResponsibleFunc: func(record interface{}) bool {
+		_, ok := record.(*types.ClusterRoleBinding)
+		return ok
+	},
+}
+
+// Register entity encoder/decoder
+func init() { registerTranslator(ClusterRoleBindingTranslator) }

--- a/backend/apid/graphql/globalid/clusterroles.go
+++ b/backend/apid/graphql/globalid/clusterroles.go
@@ -1,0 +1,22 @@
+package globalid
+
+import "github.com/sensu/sensu-go/types"
+
+//
+// Cluster Roles
+//
+var clusterRoleName = "clusterroles"
+
+// ClusterRoleTranslator global ID resource
+var ClusterRoleTranslator = commonTranslator{
+	name:       clusterRoleName,
+	encodeFunc: standardEncoder(clusterRoleName, "Name"),
+	decodeFunc: standardDecoder,
+	isResponsibleFunc: func(record interface{}) bool {
+		_, ok := record.(*types.ClusterRole)
+		return ok
+	},
+}
+
+// Register entity encoder/decoder
+func init() { registerTranslator(ClusterRoleTranslator) }

--- a/backend/apid/graphql/globalid/rolebindings.go
+++ b/backend/apid/graphql/globalid/rolebindings.go
@@ -1,0 +1,22 @@
+package globalid
+
+import "github.com/sensu/sensu-go/types"
+
+//
+// Role Bindings
+//
+var roleBindingName = "rolebindings"
+
+// RoleBindingTranslator global ID resource
+var RoleBindingTranslator = commonTranslator{
+	name:       roleBindingName,
+	encodeFunc: standardEncoder(roleBindingName, "Name"),
+	decodeFunc: standardDecoder,
+	isResponsibleFunc: func(record interface{}) bool {
+		_, ok := record.(*types.RoleBinding)
+		return ok
+	},
+}
+
+// Register entity encoder/decoder
+func init() { registerTranslator(RoleBindingTranslator) }

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -30,7 +30,10 @@ func newNodeResolver(store store.Store, getter types.QueueGetter) *nodeResolver 
 	registerHandlerNodeResolver(register, store)
 	registerHookNodeResolver(register, store)
 	registerMutatorNodeResolver(register, store)
+	registerClusterRoleNodeResolver(register, store)
+	registerClusterRoleBindingNodeResolver(register, store)
 	registerRoleNodeResolver(register, store)
+	registerRoleBindingNodeResolver(register, store)
 	registerUserNodeResolver(register, store)
 	registerEventNodeResolver(register, store)
 	registerNamespaceNodeResolver(register, store)
@@ -206,6 +209,50 @@ func (f *mutatorNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, er
 	return handleControllerResults(record, err)
 }
 
+// cluster roles
+
+type clusterRoleNodeResolver struct {
+	controller actions.ClusterRoleController
+}
+
+func registerClusterRoleNodeResolver(register relay.NodeRegister, store store.ClusterRoleStore) {
+	controller := actions.NewClusterRoleController(store)
+	resolver := &clusterRoleNodeResolver{controller}
+	register.RegisterResolver(relay.NodeResolver{
+		ObjectType: schema.ClusterRoleType,
+		Translator: globalid.ClusterRoleTranslator,
+		Resolve:    resolver.fetch,
+	})
+}
+
+func (f *clusterRoleNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
+	ctx := setContextFromComponents(p.Context, p.IDComponents)
+	record, err := f.controller.Get(ctx, p.IDComponents.UniqueComponent())
+	return handleControllerResults(record, err)
+}
+
+// cluster role bindings
+
+type clusterRoleBindingNodeResolver struct {
+	controller actions.ClusterRoleBindingController
+}
+
+func registerClusterRoleBindingNodeResolver(register relay.NodeRegister, store store.ClusterRoleBindingStore) {
+	controller := actions.NewClusterRoleBindingController(store)
+	resolver := &clusterRoleBindingNodeResolver{controller}
+	register.RegisterResolver(relay.NodeResolver{
+		ObjectType: schema.ClusterRoleBindingType,
+		Translator: globalid.ClusterRoleBindingTranslator,
+		Resolve:    resolver.fetch,
+	})
+}
+
+func (f *clusterRoleBindingNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
+	ctx := setContextFromComponents(p.Context, p.IDComponents)
+	record, err := f.controller.Get(ctx, p.IDComponents.UniqueComponent())
+	return handleControllerResults(record, err)
+}
+
 // roles
 
 type roleNodeResolver struct {
@@ -223,6 +270,28 @@ func registerRoleNodeResolver(register relay.NodeRegister, store store.RoleStore
 }
 
 func (f *roleNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
+	ctx := setContextFromComponents(p.Context, p.IDComponents)
+	record, err := f.controller.Get(ctx, p.IDComponents.UniqueComponent())
+	return handleControllerResults(record, err)
+}
+
+// role bindings
+
+type roleBindingNodeResolver struct {
+	controller actions.RoleBindingController
+}
+
+func registerRoleBindingNodeResolver(register relay.NodeRegister, store store.RoleBindingStore) {
+	controller := actions.NewRoleBindingController(store)
+	resolver := &roleBindingNodeResolver{controller}
+	register.RegisterResolver(relay.NodeResolver{
+		ObjectType: schema.RoleBindingType,
+		Translator: globalid.RoleBindingTranslator,
+		Resolve:    resolver.fetch,
+	})
+}
+
+func (f *roleBindingNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
 	ctx := setContextFromComponents(p.Context, p.IDComponents)
 	record, err := f.controller.Get(ctx, p.IDComponents.UniqueComponent())
 	return handleControllerResults(record, err)

--- a/backend/apid/graphql/schema/errors.gql.go
+++ b/backend/apid/graphql/schema/errors.gql.go
@@ -4,7 +4,6 @@ package schema
 
 import (
 	errors "errors"
-
 	graphql1 "github.com/graphql-go/graphql"
 	graphql "github.com/sensu/sensu-go/graphql"
 )
@@ -309,9 +308,10 @@ type ErrCode string
 
 // ErrCodes holds enum values
 var ErrCodes = _EnumTypeErrCodeValues{
-	ERR_ALREADY_EXISTS: "ERR_ALREADY_EXISTS",
-	ERR_INTERNAL:       "ERR_INTERNAL",
-	ERR_NOT_FOUND:      "ERR_NOT_FOUND",
+	ERR_ALREADY_EXISTS:    "ERR_ALREADY_EXISTS",
+	ERR_INTERNAL:          "ERR_INTERNAL",
+	ERR_NOT_FOUND:         "ERR_NOT_FOUND",
+	ERR_PERMISSION_DENIED: "ERR_PERMISSION_DENIED",
 }
 
 // ErrCodeType A terse description of an error.
@@ -366,4 +366,9 @@ type _EnumTypeErrCodeValues struct {
 	   completed.
 	*/
 	ERR_ALREADY_EXISTS ErrCode
+	/*
+	   ERR_PERMISSION_DENIED - Operation was canceled because the authorization token did not have sufficient
+	   permissions.
+	*/
+	ERR_PERMISSION_DENIED ErrCode
 }

--- a/backend/apid/graphql/schema/rbac.gql.go
+++ b/backend/apid/graphql/schema/rbac.gql.go
@@ -8,22 +8,22 @@ import (
 	graphql "github.com/sensu/sensu-go/graphql"
 )
 
-// RuleNamespaceFieldResolver implement to resolve requests for the Rule's namespace field.
-type RuleNamespaceFieldResolver interface {
-	// Namespace implements response to request for namespace field.
-	Namespace(p graphql.ResolveParams) (string, error)
+// RuleVerbsFieldResolver implement to resolve requests for the Rule's verbs field.
+type RuleVerbsFieldResolver interface {
+	// Verbs implements response to request for verbs field.
+	Verbs(p graphql.ResolveParams) ([]string, error)
 }
 
-// RuleTypeFieldResolver implement to resolve requests for the Rule's type field.
-type RuleTypeFieldResolver interface {
-	// Type implements response to request for type field.
-	Type(p graphql.ResolveParams) (RuleResource, error)
+// RuleResourcesFieldResolver implement to resolve requests for the Rule's resources field.
+type RuleResourcesFieldResolver interface {
+	// Resources implements response to request for resources field.
+	Resources(p graphql.ResolveParams) ([]string, error)
 }
 
-// RulePermissionsFieldResolver implement to resolve requests for the Rule's permissions field.
-type RulePermissionsFieldResolver interface {
-	// Permissions implements response to request for permissions field.
-	Permissions(p graphql.ResolveParams) (interface{}, error)
+// RuleResourceNamesFieldResolver implement to resolve requests for the Rule's resourceNames field.
+type RuleResourceNamesFieldResolver interface {
+	// ResourceNames implements response to request for resourceNames field.
+	ResourceNames(p graphql.ResolveParams) ([]string, error)
 }
 
 //
@@ -88,9 +88,9 @@ type RulePermissionsFieldResolver interface {
 //   }
 //
 type RuleFieldResolvers interface {
-	RuleNamespaceFieldResolver
-	RuleTypeFieldResolver
-	RulePermissionsFieldResolver
+	RuleVerbsFieldResolver
+	RuleResourcesFieldResolver
+	RuleResourceNamesFieldResolver
 }
 
 // RuleAliases implements all methods on RuleFieldResolvers interface by using reflection to
@@ -140,96 +140,100 @@ type RuleFieldResolvers interface {
 //
 type RuleAliases struct{}
 
-// Namespace implements response to request for 'namespace' field.
-func (_ RuleAliases) Namespace(p graphql.ResolveParams) (string, error) {
+// Verbs implements response to request for 'verbs' field.
+func (_ RuleAliases) Verbs(p graphql.ResolveParams) ([]string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	ret, ok := val.(string)
+	ret, ok := val.([]string)
 	if err != nil {
 		return ret, err
 	}
 	if !ok {
-		return ret, errors.New("unable to coerce value for field 'namespace'")
+		return ret, errors.New("unable to coerce value for field 'verbs'")
 	}
 	return ret, err
 }
 
-// Type implements response to request for 'type' field.
-func (_ RuleAliases) Type(p graphql.ResolveParams) (RuleResource, error) {
+// Resources implements response to request for 'resources' field.
+func (_ RuleAliases) Resources(p graphql.ResolveParams) ([]string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	ret, ok := RuleResource(val.(string)), true
+	ret, ok := val.([]string)
 	if err != nil {
 		return ret, err
 	}
 	if !ok {
-		return ret, errors.New("unable to coerce value for field 'type'")
+		return ret, errors.New("unable to coerce value for field 'resources'")
 	}
 	return ret, err
 }
 
-// Permissions implements response to request for 'permissions' field.
-func (_ RuleAliases) Permissions(p graphql.ResolveParams) (interface{}, error) {
+// ResourceNames implements response to request for 'resourceNames' field.
+func (_ RuleAliases) ResourceNames(p graphql.ResolveParams) ([]string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
+	ret, ok := val.([]string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'resourceNames'")
+	}
+	return ret, err
 }
 
-// RuleType Rule maps permissions to a given type
+// RuleType Rule holds information that describes an action that can be taken
 var RuleType = graphql.NewType("Rule", graphql.ObjectKind)
 
 // RegisterRule registers Rule object type with given service.
 func RegisterRule(svc *graphql.Service, impl RuleFieldResolvers) {
 	svc.RegisterObject(_ObjectTypeRuleDesc, impl)
 }
-func _ObjTypeRuleNamespaceHandler(impl interface{}) graphql1.FieldResolveFn {
-	resolver := impl.(RuleNamespaceFieldResolver)
+func _ObjTypeRuleVerbsHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RuleVerbsFieldResolver)
 	return func(frp graphql1.ResolveParams) (interface{}, error) {
-		return resolver.Namespace(frp)
+		return resolver.Verbs(frp)
 	}
 }
 
-func _ObjTypeRuleTypeHandler(impl interface{}) graphql1.FieldResolveFn {
-	resolver := impl.(RuleTypeFieldResolver)
+func _ObjTypeRuleResourcesHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RuleResourcesFieldResolver)
 	return func(frp graphql1.ResolveParams) (interface{}, error) {
-
-		val, err := resolver.Type(frp)
-		return string(val), err
+		return resolver.Resources(frp)
 	}
 }
 
-func _ObjTypeRulePermissionsHandler(impl interface{}) graphql1.FieldResolveFn {
-	resolver := impl.(RulePermissionsFieldResolver)
+func _ObjTypeRuleResourceNamesHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RuleResourceNamesFieldResolver)
 	return func(frp graphql1.ResolveParams) (interface{}, error) {
-		return resolver.Permissions(frp)
+		return resolver.ResourceNames(frp)
 	}
 }
 
 func _ObjectTypeRuleConfigFn() graphql1.ObjectConfig {
 	return graphql1.ObjectConfig{
-		Description: "Rule maps permissions to a given type",
+		Description: "Rule holds information that describes an action that can be taken",
 		Fields: graphql1.Fields{
-			"namespace": &graphql1.Field{
+			"resourceNames": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
-				Description:       "namespace in which this record resides",
-				Name:              "namespace",
-				Type:              graphql1.NewNonNull(graphql1.String),
+				Description:       "ResourceNames is an optional list of resource names that the rule applies\nto.",
+				Name:              "resourceNames",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql1.String))),
 			},
-			"permissions": &graphql1.Field{
+			"resources": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
-				Description:       "self descriptive",
-				Name:              "permissions",
-				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("RulePermission")))),
+				Description:       "Resources is a list of resources that this rule applies to. \"*\" represents\nall resources.",
+				Name:              "resources",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql1.String))),
 			},
-			"type": &graphql1.Field{
+			"verbs": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
-				Description:       "resource the permissions apply to",
-				Name:              "type",
-				Type:              graphql1.NewNonNull(graphql.OutputType("RuleResource")),
+				Description:       "Verbs is a list of verbs that apply to all of the listed resources for this\nrule. These include \"get\", \"list\", \"watch\", \"create\", \"update\", \"delete\".\nTODO: add support for \"patch\" (this is expensive and should be delayed\nuntil a further release). TODO: add support for \"watch\" (via websockets)",
+				Name:              "verbs",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql1.String))),
 			},
 		},
-		Interfaces: []*graphql1.Interface{
-			graphql.Interface("Namespaced")},
+		Interfaces: []*graphql1.Interface{},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of
@@ -246,28 +250,234 @@ func _ObjectTypeRuleConfigFn() graphql1.ObjectConfig {
 var _ObjectTypeRuleDesc = graphql.ObjectDesc{
 	Config: _ObjectTypeRuleConfigFn,
 	FieldHandlers: map[string]graphql.FieldHandler{
-		"namespace":   _ObjTypeRuleNamespaceHandler,
-		"permissions": _ObjTypeRulePermissionsHandler,
-		"type":        _ObjTypeRuleTypeHandler,
+		"resourceNames": _ObjTypeRuleResourceNamesHandler,
+		"resources":     _ObjTypeRuleResourcesHandler,
+		"verbs":         _ObjTypeRuleVerbsHandler,
 	},
 }
 
-// RoleIDFieldResolver implement to resolve requests for the Role's id field.
-type RoleIDFieldResolver interface {
-	// ID implements response to request for id field.
-	ID(p graphql.ResolveParams) (string, error)
+// ClusterRoleRulesFieldResolver implement to resolve requests for the ClusterRole's rules field.
+type ClusterRoleRulesFieldResolver interface {
+	// Rules implements response to request for rules field.
+	Rules(p graphql.ResolveParams) (interface{}, error)
 }
 
-// RoleNameFieldResolver implement to resolve requests for the Role's name field.
-type RoleNameFieldResolver interface {
+// ClusterRoleNameFieldResolver implement to resolve requests for the ClusterRole's name field.
+type ClusterRoleNameFieldResolver interface {
 	// Name implements response to request for name field.
 	Name(p graphql.ResolveParams) (string, error)
+}
+
+//
+// ClusterRoleFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'ClusterRole' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type ClusterRoleFieldResolvers interface {
+	ClusterRoleRulesFieldResolver
+	ClusterRoleNameFieldResolver
+}
+
+// ClusterRoleAliases implements all methods on ClusterRoleFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type ClusterRoleAliases struct{}
+
+// Rules implements response to request for 'rules' field.
+func (_ ClusterRoleAliases) Rules(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Name implements response to request for 'name' field.
+func (_ ClusterRoleAliases) Name(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'name'")
+	}
+	return ret, err
+}
+
+// ClusterRoleType ClusterRole applies to all namespaces within a cluster.
+var ClusterRoleType = graphql.NewType("ClusterRole", graphql.ObjectKind)
+
+// RegisterClusterRole registers ClusterRole object type with given service.
+func RegisterClusterRole(svc *graphql.Service, impl ClusterRoleFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeClusterRoleDesc, impl)
+}
+func _ObjTypeClusterRoleRulesHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(ClusterRoleRulesFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Rules(frp)
+	}
+}
+
+func _ObjTypeClusterRoleNameHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(ClusterRoleNameFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Name(frp)
+	}
+}
+
+func _ObjectTypeClusterRoleConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "ClusterRole applies to all namespaces within a cluster.",
+		Fields: graphql1.Fields{
+			"name": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Name of the ClusterRole",
+				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"rules": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Name:              "rules",
+				Type:              graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Rule"))),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see ClusterRoleFieldResolvers.")
+		},
+		Name: "ClusterRole",
+	}
+}
+
+// describe ClusterRole's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeClusterRoleDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeClusterRoleConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"name":  _ObjTypeClusterRoleNameHandler,
+		"rules": _ObjTypeClusterRoleRulesHandler,
+	},
 }
 
 // RoleRulesFieldResolver implement to resolve requests for the Role's rules field.
 type RoleRulesFieldResolver interface {
 	// Rules implements response to request for rules field.
 	Rules(p graphql.ResolveParams) (interface{}, error)
+}
+
+// RoleNamespaceFieldResolver implement to resolve requests for the Role's namespace field.
+type RoleNamespaceFieldResolver interface {
+	// Namespace implements response to request for namespace field.
+	Namespace(p graphql.ResolveParams) (string, error)
+}
+
+// RoleNameFieldResolver implement to resolve requests for the Role's name field.
+type RoleNameFieldResolver interface {
+	// Name implements response to request for name field.
+	Name(p graphql.ResolveParams) (string, error)
 }
 
 //
@@ -332,9 +542,9 @@ type RoleRulesFieldResolver interface {
 //   }
 //
 type RoleFieldResolvers interface {
-	RoleIDFieldResolver
-	RoleNameFieldResolver
 	RoleRulesFieldResolver
+	RoleNamespaceFieldResolver
+	RoleNameFieldResolver
 }
 
 // RoleAliases implements all methods on RoleFieldResolvers interface by using reflection to
@@ -384,15 +594,21 @@ type RoleFieldResolvers interface {
 //
 type RoleAliases struct{}
 
-// ID implements response to request for 'id' field.
-func (_ RoleAliases) ID(p graphql.ResolveParams) (string, error) {
+// Rules implements response to request for 'rules' field.
+func (_ RoleAliases) Rules(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Namespace implements response to request for 'namespace' field.
+func (_ RoleAliases) Namespace(p graphql.ResolveParams) (string, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
 	ret, ok := val.(string)
 	if err != nil {
 		return ret, err
 	}
 	if !ok {
-		return ret, errors.New("unable to coerce value for field 'id'")
+		return ret, errors.New("unable to coerce value for field 'namespace'")
 	}
 	return ret, err
 }
@@ -410,23 +626,24 @@ func (_ RoleAliases) Name(p graphql.ResolveParams) (string, error) {
 	return ret, err
 }
 
-// Rules implements response to request for 'rules' field.
-func (_ RoleAliases) Rules(p graphql.ResolveParams) (interface{}, error) {
-	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	return val, err
-}
-
-// RoleType Role describes set of rules
+// RoleType Role applies only to a single namespace.
 var RoleType = graphql.NewType("Role", graphql.ObjectKind)
 
 // RegisterRole registers Role object type with given service.
 func RegisterRole(svc *graphql.Service, impl RoleFieldResolvers) {
 	svc.RegisterObject(_ObjectTypeRoleDesc, impl)
 }
-func _ObjTypeRoleIDHandler(impl interface{}) graphql1.FieldResolveFn {
-	resolver := impl.(RoleIDFieldResolver)
+func _ObjTypeRoleRulesHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleRulesFieldResolver)
 	return func(frp graphql1.ResolveParams) (interface{}, error) {
-		return resolver.ID(frp)
+		return resolver.Rules(frp)
+	}
+}
+
+func _ObjTypeRoleNamespaceHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleNamespaceFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Namespace(frp)
 	}
 }
 
@@ -437,29 +654,22 @@ func _ObjTypeRoleNameHandler(impl interface{}) graphql1.FieldResolveFn {
 	}
 }
 
-func _ObjTypeRoleRulesHandler(impl interface{}) graphql1.FieldResolveFn {
-	resolver := impl.(RoleRulesFieldResolver)
-	return func(frp graphql1.ResolveParams) (interface{}, error) {
-		return resolver.Rules(frp)
-	}
-}
-
 func _ObjectTypeRoleConfigFn() graphql1.ObjectConfig {
 	return graphql1.ObjectConfig{
-		Description: "Role describes set of rules",
+		Description: "Role applies only to a single namespace.",
 		Fields: graphql1.Fields{
-			"id": &graphql1.Field{
-				Args:              graphql1.FieldConfigArgument{},
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Name:              "id",
-				Type:              graphql1.NewNonNull(graphql1.ID),
-			},
 			"name": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
 				DeprecationReason: "",
-				Description:       "self descriptive",
+				Description:       "Name of the Role",
 				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"namespace": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Namespace of the Role",
+				Name:              "namespace",
 				Type:              graphql1.NewNonNull(graphql1.String),
 			},
 			"rules": &graphql1.Field{
@@ -467,11 +677,10 @@ func _ObjectTypeRoleConfigFn() graphql1.ObjectConfig {
 				DeprecationReason: "",
 				Description:       "self descriptive",
 				Name:              "rules",
-				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Rule")))),
+				Type:              graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Rule"))),
 			},
 		},
-		Interfaces: []*graphql1.Interface{
-			graphql.Interface("Node")},
+		Interfaces: []*graphql1.Interface{},
 		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
 			// NOTE:
 			// Panic by default. Intent is that when Service is invoked, values of
@@ -488,194 +697,943 @@ func _ObjectTypeRoleConfigFn() graphql1.ObjectConfig {
 var _ObjectTypeRoleDesc = graphql.ObjectDesc{
 	Config: _ObjectTypeRoleConfigFn,
 	FieldHandlers: map[string]graphql.FieldHandler{
-		"id":    _ObjTypeRoleIDHandler,
-		"name":  _ObjTypeRoleNameHandler,
-		"rules": _ObjTypeRoleRulesHandler,
+		"name":      _ObjTypeRoleNameHandler,
+		"namespace": _ObjTypeRoleNamespaceHandler,
+		"rules":     _ObjTypeRoleRulesHandler,
 	},
 }
 
-// RuleResource self descriptive
-type RuleResource string
-
-// RuleResources holds enum values
-var RuleResources = _EnumTypeRuleResourceValues{
-	ALL:           "ALL",
-	ASSETS:        "ASSETS",
-	CHECKS:        "CHECKS",
-	ENTITIES:      "ENTITIES",
-	HANDLERS:      "HANDLERS",
-	HOOKS:         "HOOKS",
-	MUTATORS:      "MUTATORS",
-	ORGANIZATIONS: "ORGANIZATIONS",
-	ROLES:         "ROLES",
-	SILENCED:      "SILENCED",
-	USERS:         "USERS",
+// RoleRefTypeFieldResolver implement to resolve requests for the RoleRef's type field.
+type RoleRefTypeFieldResolver interface {
+	// Type implements response to request for type field.
+	Type(p graphql.ResolveParams) (string, error)
 }
 
-// RuleResourceType self descriptive
-var RuleResourceType = graphql.NewType("RuleResource", graphql.EnumKind)
-
-// RegisterRuleResource registers RuleResource object type with given service.
-func RegisterRuleResource(svc *graphql.Service) {
-	svc.RegisterEnum(_EnumTypeRuleResourceDesc)
+// RoleRefNameFieldResolver implement to resolve requests for the RoleRef's name field.
+type RoleRefNameFieldResolver interface {
+	// Name implements response to request for name field.
+	Name(p graphql.ResolveParams) (string, error)
 }
-func _EnumTypeRuleResourceConfigFn() graphql1.EnumConfig {
-	return graphql1.EnumConfig{
-		Description: "self descriptive",
-		Name:        "RuleResource",
-		Values: graphql1.EnumValueConfigMap{
-			"ALL": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ALL",
-			},
-			"ASSETS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ASSETS",
-			},
-			"CHECKS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "CHECKS",
-			},
-			"ENTITIES": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ENTITIES",
-			},
-			"HANDLERS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "HANDLERS",
-			},
-			"HOOKS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "HOOKS",
-			},
-			"MUTATORS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "MUTATORS",
-			},
-			"ORGANIZATIONS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ORGANIZATIONS",
-			},
-			"ROLES": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ROLES",
-			},
-			"SILENCED": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "SILENCED",
-			},
-			"USERS": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "USERS",
-			},
-		},
+
+//
+// RoleRefFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'RoleRef' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type RoleRefFieldResolvers interface {
+	RoleRefTypeFieldResolver
+	RoleRefNameFieldResolver
+}
+
+// RoleRefAliases implements all methods on RoleRefFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type RoleRefAliases struct{}
+
+// Type implements response to request for 'type' field.
+func (_ RoleRefAliases) Type(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'type'")
+	}
+	return ret, err
+}
+
+// Name implements response to request for 'name' field.
+func (_ RoleRefAliases) Name(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'name'")
+	}
+	return ret, err
+}
+
+// RoleRefType RoleRef maps groups to Roles or ClusterRoles.
+var RoleRefType = graphql.NewType("RoleRef", graphql.ObjectKind)
+
+// RegisterRoleRef registers RoleRef object type with given service.
+func RegisterRoleRef(svc *graphql.Service, impl RoleRefFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeRoleRefDesc, impl)
+}
+func _ObjTypeRoleRefTypeHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleRefTypeFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Type(frp)
 	}
 }
 
-// describe RuleResource's configuration; kept private to avoid unintentional tampering of configuration at runtime.
-var _EnumTypeRuleResourceDesc = graphql.EnumDesc{Config: _EnumTypeRuleResourceConfigFn}
-
-type _EnumTypeRuleResourceValues struct {
-	// ALL - self descriptive
-	ALL RuleResource
-	// ASSETS - self descriptive
-	ASSETS RuleResource
-	// CHECKS - self descriptive
-	CHECKS RuleResource
-	// ENTITIES - self descriptive
-	ENTITIES RuleResource
-	// HANDLERS - self descriptive
-	HANDLERS RuleResource
-	// HOOKS - self descriptive
-	HOOKS RuleResource
-	// MUTATORS - self descriptive
-	MUTATORS RuleResource
-	// ORGANIZATIONS - self descriptive
-	ORGANIZATIONS RuleResource
-	// ROLES - self descriptive
-	ROLES RuleResource
-	// SILENCED - self descriptive
-	SILENCED RuleResource
-	// USERS - self descriptive
-	USERS RuleResource
-}
-
-// RulePermission self descriptive
-type RulePermission string
-
-// RulePermissions holds enum values
-var RulePermissions = _EnumTypeRulePermissionValues{
-	ALL:    "ALL",
-	CREATE: "CREATE",
-	DELETE: "DELETE",
-	READ:   "READ",
-	UPDATE: "UPDATE",
-}
-
-// RulePermissionType self descriptive
-var RulePermissionType = graphql.NewType("RulePermission", graphql.EnumKind)
-
-// RegisterRulePermission registers RulePermission object type with given service.
-func RegisterRulePermission(svc *graphql.Service) {
-	svc.RegisterEnum(_EnumTypeRulePermissionDesc)
-}
-func _EnumTypeRulePermissionConfigFn() graphql1.EnumConfig {
-	return graphql1.EnumConfig{
-		Description: "self descriptive",
-		Name:        "RulePermission",
-		Values: graphql1.EnumValueConfigMap{
-			"ALL": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "ALL",
-			},
-			"CREATE": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "CREATE",
-			},
-			"DELETE": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "DELETE",
-			},
-			"READ": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "READ",
-			},
-			"UPDATE": &graphql1.EnumValueConfig{
-				DeprecationReason: "",
-				Description:       "self descriptive",
-				Value:             "UPDATE",
-			},
-		},
+func _ObjTypeRoleRefNameHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleRefNameFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Name(frp)
 	}
 }
 
-// describe RulePermission's configuration; kept private to avoid unintentional tampering of configuration at runtime.
-var _EnumTypeRulePermissionDesc = graphql.EnumDesc{Config: _EnumTypeRulePermissionConfigFn}
+func _ObjectTypeRoleRefConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "RoleRef maps groups to Roles or ClusterRoles.",
+		Fields: graphql1.Fields{
+			"name": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Name of the resource being referenced",
+				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"type": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Type of role being referenced.",
+				Name:              "type",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see RoleRefFieldResolvers.")
+		},
+		Name: "RoleRef",
+	}
+}
 
-type _EnumTypeRulePermissionValues struct {
-	// ALL - self descriptive
-	ALL RulePermission
-	// CREATE - self descriptive
-	CREATE RulePermission
-	// READ - self descriptive
-	READ RulePermission
-	// UPDATE - self descriptive
-	UPDATE RulePermission
-	// DELETE - self descriptive
-	DELETE RulePermission
+// describe RoleRef's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeRoleRefDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeRoleRefConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"name": _ObjTypeRoleRefNameHandler,
+		"type": _ObjTypeRoleRefTypeHandler,
+	},
+}
+
+// SubjectKindFieldResolver implement to resolve requests for the Subject's kind field.
+type SubjectKindFieldResolver interface {
+	// Kind implements response to request for kind field.
+	Kind(p graphql.ResolveParams) (string, error)
+}
+
+// SubjectNameFieldResolver implement to resolve requests for the Subject's name field.
+type SubjectNameFieldResolver interface {
+	// Name implements response to request for name field.
+	Name(p graphql.ResolveParams) (string, error)
+}
+
+//
+// SubjectFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'Subject' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type SubjectFieldResolvers interface {
+	SubjectKindFieldResolver
+	SubjectNameFieldResolver
+}
+
+// SubjectAliases implements all methods on SubjectFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type SubjectAliases struct{}
+
+// Kind implements response to request for 'kind' field.
+func (_ SubjectAliases) Kind(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'kind'")
+	}
+	return ret, err
+}
+
+// Name implements response to request for 'name' field.
+func (_ SubjectAliases) Name(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'name'")
+	}
+	return ret, err
+}
+
+// SubjectType self descriptive
+var SubjectType = graphql.NewType("Subject", graphql.ObjectKind)
+
+// RegisterSubject registers Subject object type with given service.
+func RegisterSubject(svc *graphql.Service, impl SubjectFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeSubjectDesc, impl)
+}
+func _ObjTypeSubjectKindHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(SubjectKindFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Kind(frp)
+	}
+}
+
+func _ObjTypeSubjectNameHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(SubjectNameFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Name(frp)
+	}
+}
+
+func _ObjectTypeSubjectConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "self descriptive",
+		Fields: graphql1.Fields{
+			"kind": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Kind of object referenced (user or group)",
+				Name:              "kind",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"name": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Name of the referenced object",
+				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see SubjectFieldResolvers.")
+		},
+		Name: "Subject",
+	}
+}
+
+// describe Subject's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeSubjectDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeSubjectConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"kind": _ObjTypeSubjectKindHandler,
+		"name": _ObjTypeSubjectNameHandler,
+	},
+}
+
+// ClusterRoleBindingSubjectsFieldResolver implement to resolve requests for the ClusterRoleBinding's subjects field.
+type ClusterRoleBindingSubjectsFieldResolver interface {
+	// Subjects implements response to request for subjects field.
+	Subjects(p graphql.ResolveParams) (interface{}, error)
+}
+
+// ClusterRoleBindingRoleRefFieldResolver implement to resolve requests for the ClusterRoleBinding's roleRef field.
+type ClusterRoleBindingRoleRefFieldResolver interface {
+	// RoleRef implements response to request for roleRef field.
+	RoleRef(p graphql.ResolveParams) (interface{}, error)
+}
+
+// ClusterRoleBindingNameFieldResolver implement to resolve requests for the ClusterRoleBinding's name field.
+type ClusterRoleBindingNameFieldResolver interface {
+	// Name implements response to request for name field.
+	Name(p graphql.ResolveParams) (string, error)
+}
+
+//
+// ClusterRoleBindingFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'ClusterRoleBinding' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type ClusterRoleBindingFieldResolvers interface {
+	ClusterRoleBindingSubjectsFieldResolver
+	ClusterRoleBindingRoleRefFieldResolver
+	ClusterRoleBindingNameFieldResolver
+}
+
+// ClusterRoleBindingAliases implements all methods on ClusterRoleBindingFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type ClusterRoleBindingAliases struct{}
+
+// Subjects implements response to request for 'subjects' field.
+func (_ ClusterRoleBindingAliases) Subjects(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// RoleRef implements response to request for 'roleRef' field.
+func (_ ClusterRoleBindingAliases) RoleRef(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Name implements response to request for 'name' field.
+func (_ ClusterRoleBindingAliases) Name(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'name'")
+	}
+	return ret, err
+}
+
+/*
+ClusterRoleBindingType ClusterRoleBinding grants the permissions defined in a ClusterRole referenced
+to a user or a set of users
+*/
+var ClusterRoleBindingType = graphql.NewType("ClusterRoleBinding", graphql.ObjectKind)
+
+// RegisterClusterRoleBinding registers ClusterRoleBinding object type with given service.
+func RegisterClusterRoleBinding(svc *graphql.Service, impl ClusterRoleBindingFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeClusterRoleBindingDesc, impl)
+}
+func _ObjTypeClusterRoleBindingSubjectsHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(ClusterRoleBindingSubjectsFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Subjects(frp)
+	}
+}
+
+func _ObjTypeClusterRoleBindingRoleRefHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(ClusterRoleBindingRoleRefFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.RoleRef(frp)
+	}
+}
+
+func _ObjTypeClusterRoleBindingNameHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(ClusterRoleBindingNameFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Name(frp)
+	}
+}
+
+func _ObjectTypeClusterRoleBindingConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "ClusterRoleBinding grants the permissions defined in a ClusterRole referenced\nto a user or a set of users",
+		Fields: graphql1.Fields{
+			"name": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Name of the ClusterRoleBinding",
+				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"roleRef": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "RoleRef references a ClusterRole in the current namespace",
+				Name:              "roleRef",
+				Type:              graphql.OutputType("RoleRef"),
+			},
+			"subjects": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Subjects holds references to the objects the ClusterRole applies to",
+				Name:              "subjects",
+				Type:              graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Subject"))),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see ClusterRoleBindingFieldResolvers.")
+		},
+		Name: "ClusterRoleBinding",
+	}
+}
+
+// describe ClusterRoleBinding's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeClusterRoleBindingDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeClusterRoleBindingConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"name":     _ObjTypeClusterRoleBindingNameHandler,
+		"roleRef":  _ObjTypeClusterRoleBindingRoleRefHandler,
+		"subjects": _ObjTypeClusterRoleBindingSubjectsHandler,
+	},
+}
+
+// RoleBindingSubjectsFieldResolver implement to resolve requests for the RoleBinding's subjects field.
+type RoleBindingSubjectsFieldResolver interface {
+	// Subjects implements response to request for subjects field.
+	Subjects(p graphql.ResolveParams) (interface{}, error)
+}
+
+// RoleBindingRoleRefFieldResolver implement to resolve requests for the RoleBinding's roleRef field.
+type RoleBindingRoleRefFieldResolver interface {
+	// RoleRef implements response to request for roleRef field.
+	RoleRef(p graphql.ResolveParams) (interface{}, error)
+}
+
+// RoleBindingNamespaceFieldResolver implement to resolve requests for the RoleBinding's namespace field.
+type RoleBindingNamespaceFieldResolver interface {
+	// Namespace implements response to request for namespace field.
+	Namespace(p graphql.ResolveParams) (string, error)
+}
+
+// RoleBindingNameFieldResolver implement to resolve requests for the RoleBinding's name field.
+type RoleBindingNameFieldResolver interface {
+	// Name implements response to request for name field.
+	Name(p graphql.ResolveParams) (string, error)
+}
+
+//
+// RoleBindingFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'RoleBinding' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type RoleBindingFieldResolvers interface {
+	RoleBindingSubjectsFieldResolver
+	RoleBindingRoleRefFieldResolver
+	RoleBindingNamespaceFieldResolver
+	RoleBindingNameFieldResolver
+}
+
+// RoleBindingAliases implements all methods on RoleBindingFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type RoleBindingAliases struct{}
+
+// Subjects implements response to request for 'subjects' field.
+func (_ RoleBindingAliases) Subjects(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// RoleRef implements response to request for 'roleRef' field.
+func (_ RoleBindingAliases) RoleRef(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Namespace implements response to request for 'namespace' field.
+func (_ RoleBindingAliases) Namespace(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'namespace'")
+	}
+	return ret, err
+}
+
+// Name implements response to request for 'name' field.
+func (_ RoleBindingAliases) Name(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'name'")
+	}
+	return ret, err
+}
+
+/*
+RoleBindingType RoleBinding grants the permissions defined in a Role referenced to a user or
+a set of users
+*/
+var RoleBindingType = graphql.NewType("RoleBinding", graphql.ObjectKind)
+
+// RegisterRoleBinding registers RoleBinding object type with given service.
+func RegisterRoleBinding(svc *graphql.Service, impl RoleBindingFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeRoleBindingDesc, impl)
+}
+func _ObjTypeRoleBindingSubjectsHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleBindingSubjectsFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Subjects(frp)
+	}
+}
+
+func _ObjTypeRoleBindingRoleRefHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleBindingRoleRefFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.RoleRef(frp)
+	}
+}
+
+func _ObjTypeRoleBindingNamespaceHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleBindingNamespaceFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Namespace(frp)
+	}
+}
+
+func _ObjTypeRoleBindingNameHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(RoleBindingNameFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Name(frp)
+	}
+}
+
+func _ObjectTypeRoleBindingConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "RoleBinding grants the permissions defined in a Role referenced to a user or\na set of users",
+		Fields: graphql1.Fields{
+			"name": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Name of the RoleBinding",
+				Name:              "name",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"namespace": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Namespace of the RoleBinding",
+				Name:              "namespace",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"roleRef": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "RoleRef references a Role in the current namespace",
+				Name:              "roleRef",
+				Type:              graphql.OutputType("RoleRef"),
+			},
+			"subjects": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Subjects holds references to the objects the Role applies to",
+				Name:              "subjects",
+				Type:              graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Subject"))),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see RoleBindingFieldResolvers.")
+		},
+		Name: "RoleBinding",
+	}
+}
+
+// describe RoleBinding's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeRoleBindingDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeRoleBindingConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"name":      _ObjTypeRoleBindingNameHandler,
+		"namespace": _ObjTypeRoleBindingNamespaceHandler,
+		"roleRef":   _ObjTypeRoleBindingRoleRefHandler,
+		"subjects":  _ObjTypeRoleBindingSubjectsHandler,
+	},
 }

--- a/backend/apid/graphql/schema/rbac.graphql
+++ b/backend/apid/graphql/schema/rbac.graphql
@@ -1,42 +1,88 @@
 """
-Rule maps permissions to a given type
+Rule holds information that describes an action that can be taken
 """
-type Rule implements Namespaced {
-  "namespace in which this record resides"
-  namespace: String!
-
-  "resource the permissions apply to"
-  type: RuleResource!
-  permissions: [RulePermission!]!
+type Rule {
+  """
+  Verbs is a list of verbs that apply to all of the listed resources for this
+  rule. These include "get", "list", "watch", "create", "update", "delete".
+  TODO: add support for "patch" (this is expensive and should be delayed
+  until a further release). TODO: add support for "watch" (via websockets)
+  """
+  verbs: [String!]!
+  """
+  Resources is a list of resources that this rule applies to. "*" represents
+  all resources.
+  """
+  resources: [String!]!
+  """
+  ResourceNames is an optional list of resource names that the rule applies
+  to.
+  """
+  resourceNames: [String!]!
 }
 
 """
-Role describes set of rules
+ClusterRole applies to all namespaces within a cluster.
 """
-type Role implements Node {
-  id: ID!
+type ClusterRole {
+  rules: [Rule!]
+  "Name of the ClusterRole"
   name: String!
-  rules: [Rule!]!
 }
 
-enum RuleResource {
-  ALL
-  ASSETS
-  CHECKS
-  ENTITIES
-  HANDLERS
-  HOOKS
-  MUTATORS
-  ORGANIZATIONS
-  ROLES
-  SILENCED
-  USERS
+"""
+Role applies only to a single namespace.
+"""
+type Role {
+  rules: [Rule!]
+  "Namespace of the Role"
+  namespace: String!
+  "Name of the Role"
+  name: String!
 }
 
-enum RulePermission {
-  ALL
-  CREATE
-  READ
-  UPDATE
-  DELETE
+"""
+RoleRef maps groups to Roles or ClusterRoles.
+"""
+type RoleRef {
+  "Type of role being referenced."
+  type: String!
+  "Name of the resource being referenced"
+  name: String!
 }
+
+type Subject {
+  "Kind of object referenced (user or group)"
+  kind: String!
+  "Name of the referenced object"
+  name: String!
+}
+
+"""
+ClusterRoleBinding grants the permissions defined in a ClusterRole referenced
+to a user or a set of users
+"""
+type ClusterRoleBinding {
+  "Subjects holds references to the objects the ClusterRole applies to"
+  subjects: [Subject!]
+  "RoleRef references a ClusterRole in the current namespace"
+  roleRef: RoleRef
+  "Name of the ClusterRoleBinding"
+  name: String!
+}
+
+"""
+RoleBinding grants the permissions defined in a Role referenced to a user or
+a set of users
+"""
+type RoleBinding {
+  "Subjects holds references to the objects the Role applies to"
+  subjects: [Subject!]
+  "RoleRef references a Role in the current namespace"
+  roleRef: RoleRef
+  "Namespace of the RoleBinding"
+  namespace: String!
+  "Name of the RoleBinding"
+  name: String!
+}
+

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -80,11 +80,16 @@ func NewService(cfg ServiceConfig) (*graphql.Service, error) {
 	schema.RegisterTimeWindowWhen(svc, &schema.TimeWindowWhenAliases{})
 	schema.RegisterTimeWindowTimeRange(svc, &schema.TimeWindowTimeRangeAliases{})
 
+	// Register RBAC types
+	schema.RegisterClusterRole(svc, &schema.ClusterRoleAliases{})
+	schema.RegisterClusterRoleBinding(svc, &schema.ClusterRoleBindingAliases{})
+	schema.RegisterRole(svc, &schema.RoleAliases{})
+	schema.RegisterRoleBinding(svc, &schema.RoleBindingAliases{})
+	schema.RegisterRoleRef(svc, &schema.RoleRefAliases{})
+	schema.RegisterRule(svc, &schema.RuleAliases{})
+	schema.RegisterSubject(svc, &schema.SubjectAliases{})
+
 	// Register user types
-	schema.RegisterRole(svc, &roleImpl{})
-	schema.RegisterRule(svc, &ruleImpl{})
-	schema.RegisterRuleResource(svc)
-	schema.RegisterRulePermission(svc)
 	schema.RegisterUser(svc, &userImpl{})
 
 	// Register mutations

--- a/backend/apid/routers/clusterrolebindings.go
+++ b/backend/apid/routers/clusterrolebindings.go
@@ -1,0 +1,84 @@
+package routers
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// ClusterRoleBindingsRouter handles requests for ClusterRoleBindings.
+type ClusterRoleBindingsRouter struct {
+	controller actions.ClusterRoleBindingController
+}
+
+// NewClusterRoleBindingsRouter instantiates a new router for ClusterRoleBindings.
+func NewClusterRoleBindingsRouter(store store.ClusterRoleBindingStore) *ClusterRoleBindingsRouter {
+	return &ClusterRoleBindingsRouter{
+		controller: actions.NewClusterRoleBindingController(store),
+	}
+}
+
+// Mount the ClusterRoleBindingsRouter on the given parent Router
+func (r *ClusterRoleBindingsRouter) Mount(parent *mux.Router) {
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/clusterrolebindings"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
+}
+
+func (r *ClusterRoleBindingsRouter) create(req *http.Request) (interface{}, error) {
+	obj := types.ClusterRoleBinding{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.Create(req.Context(), obj)
+	return obj, err
+}
+
+func (r *ClusterRoleBindingsRouter) createOrReplace(req *http.Request) (interface{}, error) {
+	obj := types.ClusterRoleBinding{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.CreateOrReplace(req.Context(), obj)
+	return obj, err
+}
+
+func (r *ClusterRoleBindingsRouter) destroy(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.controller.Destroy(req.Context(), id)
+	return nil, err
+}
+
+func (r *ClusterRoleBindingsRouter) find(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := r.controller.Get(req.Context(), id)
+	return obj, err
+}
+
+func (r *ClusterRoleBindingsRouter) list(req *http.Request) (interface{}, error) {
+	objs, err := r.controller.List(req.Context())
+	return objs, err
+}

--- a/backend/apid/routers/clusterroles.go
+++ b/backend/apid/routers/clusterroles.go
@@ -1,0 +1,84 @@
+package routers
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// ClusterRolesRouter handles requests for ClusterRoles.
+type ClusterRolesRouter struct {
+	controller actions.ClusterRoleController
+}
+
+// NewClusterRolesRouter instantiates a new router for ClusterRoles.
+func NewClusterRolesRouter(store store.ClusterRoleStore) *ClusterRolesRouter {
+	return &ClusterRolesRouter{
+		controller: actions.NewClusterRoleController(store),
+	}
+}
+
+// Mount the ClusterRolesRouter on the given parent Router
+func (r *ClusterRolesRouter) Mount(parent *mux.Router) {
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/clusterroles"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
+}
+
+func (r *ClusterRolesRouter) create(req *http.Request) (interface{}, error) {
+	obj := types.ClusterRole{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.Create(req.Context(), obj)
+	return obj, err
+}
+
+func (r *ClusterRolesRouter) createOrReplace(req *http.Request) (interface{}, error) {
+	obj := types.ClusterRole{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.CreateOrReplace(req.Context(), obj)
+	return obj, err
+}
+
+func (r *ClusterRolesRouter) destroy(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.controller.Destroy(req.Context(), id)
+	return nil, err
+}
+
+func (r *ClusterRolesRouter) find(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := r.controller.Get(req.Context(), id)
+	return obj, err
+}
+
+func (r *ClusterRolesRouter) list(req *http.Request) (interface{}, error) {
+	objs, err := r.controller.List(req.Context())
+	return objs, err
+}

--- a/backend/apid/routers/rolebindings.go
+++ b/backend/apid/routers/rolebindings.go
@@ -24,7 +24,7 @@ func NewRoleBindingsRouter(store store.RoleBindingStore) *RoleBindingsRouter {
 
 // Mount the RoleBindingsRouter on the given parent Router
 func (r *RoleBindingsRouter) Mount(parent *mux.Router) {
-	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/rolebindings"}
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/namespaces/{namespace}/rolebindings"}
 	routes.GetAll(r.list)
 	routes.Get(r.find)
 	routes.Post(r.create)

--- a/backend/apid/routers/rolebindings.go
+++ b/backend/apid/routers/rolebindings.go
@@ -1,0 +1,84 @@
+package routers
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// RoleBindingsRouter handles requests for RoleBindings.
+type RoleBindingsRouter struct {
+	controller actions.RoleBindingController
+}
+
+// NewRoleBindingsRouter instantiates a new router for RoleBindings.
+func NewRoleBindingsRouter(store store.RoleBindingStore) *RoleBindingsRouter {
+	return &RoleBindingsRouter{
+		controller: actions.NewRoleBindingController(store),
+	}
+}
+
+// Mount the RoleBindingsRouter on the given parent Router
+func (r *RoleBindingsRouter) Mount(parent *mux.Router) {
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/rolebindings"}
+	routes.GetAll(r.list)
+	routes.Get(r.find)
+	routes.Post(r.create)
+	routes.Del(r.destroy)
+	routes.Put(r.createOrReplace)
+}
+
+func (r *RoleBindingsRouter) create(req *http.Request) (interface{}, error) {
+	obj := types.RoleBinding{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.Create(req.Context(), obj)
+	return obj, err
+}
+
+func (r *RoleBindingsRouter) createOrReplace(req *http.Request) (interface{}, error) {
+	obj := types.RoleBinding{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
+		return nil, err
+	}
+
+	err := r.controller.CreateOrReplace(req.Context(), obj)
+	return obj, err
+}
+
+func (r *RoleBindingsRouter) destroy(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.controller.Destroy(req.Context(), id)
+	return nil, err
+}
+
+func (r *RoleBindingsRouter) find(req *http.Request) (interface{}, error) {
+	params := mux.Vars(req)
+
+	id, err := url.PathUnescape(params["id"])
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := r.controller.Get(req.Context(), id)
+	return obj, err
+}
+
+func (r *RoleBindingsRouter) list(req *http.Request) (interface{}, error) {
+	objs, err := r.controller.List(req.Context())
+	return objs, err
+}

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -24,7 +24,7 @@ func NewRolesRouter(store store.RoleStore) *RolesRouter {
 
 // Mount the RolesRouter on the given parent Router
 func (r *RolesRouter) Mount(parent *mux.Router) {
-	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/roles"}
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/namespaces/{namespace}/roles"}
 	routes.GetAll(r.list)
 	routes.Get(r.find)
 	routes.Post(r.create)

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -10,21 +10,21 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-// RolesRouter handles requests for /checks
+// RolesRouter handles requests for Roles.
 type RolesRouter struct {
 	controller actions.RoleController
 }
 
-// NewRolesRouter instantiates new router for controlling check resources
+// NewRolesRouter instantiates a new router for Roles.
 func NewRolesRouter(store store.RoleStore) *RolesRouter {
 	return &RolesRouter{
 		controller: actions.NewRoleController(store),
 	}
 }
 
-// Mount the RolesRouter to a parent Router
+// Mount the RolesRouter on the given parent Router
 func (r *RolesRouter) Mount(parent *mux.Router) {
-	routes := ResourceRoute{Router: parent, PathPrefix: "/rbac/roles"}
+	routes := ResourceRoute{Router: parent, PathPrefix: "/apis/rbac/v2/roles"}
 	routes.GetAll(r.list)
 	routes.Get(r.find)
 	routes.Post(r.create)
@@ -33,46 +33,52 @@ func (r *RolesRouter) Mount(parent *mux.Router) {
 }
 
 func (r *RolesRouter) create(req *http.Request) (interface{}, error) {
-	cfg := types.Role{}
-	if err := UnmarshalBody(req, &cfg); err != nil {
+	obj := types.Role{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
 		return nil, err
 	}
 
-	err := r.controller.Create(req.Context(), cfg)
-	return cfg, err
+	err := r.controller.Create(req.Context(), obj)
+	return obj, err
 }
 
 func (r *RolesRouter) createOrReplace(req *http.Request) (interface{}, error) {
-	cfg := types.Role{}
-	if err := UnmarshalBody(req, &cfg); err != nil {
+	obj := types.Role{}
+
+	if err := UnmarshalBody(req, &obj); err != nil {
 		return nil, err
 	}
 
-	err := r.controller.CreateOrReplace(req.Context(), cfg)
-	return cfg, err
+	err := r.controller.CreateOrReplace(req.Context(), obj)
+	return obj, err
 }
 
 func (r *RolesRouter) destroy(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
+
 	id, err := url.PathUnescape(params["id"])
 	if err != nil {
 		return nil, err
 	}
+
 	err = r.controller.Destroy(req.Context(), id)
 	return nil, err
 }
 
 func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
 	params := mux.Vars(req)
+
 	id, err := url.PathUnescape(params["id"])
 	if err != nil {
 		return nil, err
 	}
-	record, err := r.controller.Get(req.Context(), id)
-	return record, err
+
+	obj, err := r.controller.Get(req.Context(), id)
+	return obj, err
 }
 
 func (r *RolesRouter) list(req *http.Request) (interface{}, error) {
-	records, err := r.controller.List(req.Context())
-	return records, err
+	objs, err := r.controller.List(req.Context())
+	return objs, err
 }

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -49,7 +49,7 @@ func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBin
 }
 
 // ListRolesBindings ...
-func (s *Store) ListRolesBindings(ctx context.Context) ([]*types.RoleBinding, error) {
+func (s *Store) ListRoleBindings(ctx context.Context) ([]*types.RoleBinding, error) {
 	roles := []*types.RoleBinding{}
 	err := s.list(ctx, getRoleBindingsPath, &roles)
 	return roles, err

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -149,6 +149,9 @@ type Store interface {
 	// RoleStore provides an interface for managing roles
 	RoleStore
 
+	// RoleBindingStore provides an interface for managing role bindings
+	RoleBindingStore
+
 	// SilencedStore provides an interface for managing silenced entries,
 	// consisting of entities, subscriptions and/or checks
 	SilencedStore

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -149,6 +149,9 @@ type Store interface {
 	// ClusterRoleStore provides an interface for managing cluster roles
 	ClusterRoleStore
 
+	// ClusterRoleBindingStore provides an interface for managing cluster role bindings
+	ClusterRoleBindingStore
+
 	// RoleStore provides an interface for managing roles
 	RoleStore
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -146,6 +146,9 @@ type Store interface {
 	// NamespaceStore provides an interface for managing namespaces
 	NamespaceStore
 
+	// ClusterRoleStore provides an interface for managing cluster roles
+	ClusterRoleStore
+
 	// RoleStore provides an interface for managing roles
 	RoleStore
 

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -73,6 +73,15 @@ func FixtureClusterRole(name string) *ClusterRole {
 	}
 }
 
+// FixtureClusterRoleBinding creates a ClusterRoleBinding for testing
+func FixtureClusterRoleBinding(name string) *ClusterRoleBinding {
+	return &ClusterRoleBinding{
+		Name:     name,
+		Subjects: []Subject{FixtureSubject(UserKind, "username")},
+		RoleRef:  FixtureRoleRef("ClusterRole", "read-write"),
+	}
+}
+
 // Validate a ClusterRole
 func (r *ClusterRole) Validate() error {
 	if err := ValidateName(r.Name); err != nil {

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -18,6 +18,14 @@ const (
 	UserKind = "User"
 )
 
+// FixtureSubject creates a Subject for testing
+func FixtureSubject(kind, name string) Subject {
+	return Subject{
+		Kind: kind,
+		Name: name,
+	}
+}
+
 // FixtureRule returns a partial rule
 func FixtureRule() Rule {
 	return Rule{
@@ -34,6 +42,24 @@ func FixtureRole(name, namespace string) *Role {
 		Rules: []Rule{
 			FixtureRule(),
 		},
+	}
+}
+
+// FixtureRoleRef creates a RoleRef for testing
+func FixtureRoleRef(kind, name string) RoleRef {
+	return RoleRef{
+		Type: kind,
+		Name: name,
+	}
+}
+
+// FixtureRoleBinding creates a RoleBinding for testing
+func FixtureRoleBinding(name, namespace string) *RoleBinding {
+	return &RoleBinding{
+		Name:      name,
+		Namespace: namespace,
+		Subjects:  []Subject{FixtureSubject(UserKind, "username")},
+		RoleRef:   FixtureRoleRef("Role", "read-write"),
 	}
 }
 


### PR DESCRIPTION
Introduce the following endpoints in `apid` to manipulate the corresponding objects:
- `/apis/rbac/v2/namespaces/{namespace}/roles`
- `/apis/rbac/v2/namespaces/{namespace}/rolebindings`
- `/apis/rbac/v2/clusterroles`
- `/apis/rbac/v2/clusterrolebindings`

Closes #2281.