### PR TITLE
Support new RBAC types in sensuctl

### DIFF
--- a/cli/client/clusterrole.go
+++ b/cli/client/clusterrole.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"net/url"
+	"path"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+const clusterRolesBasePath = "/apis/rbac/v2/clusterroles"
+
+func clusterRolesPath(name string) string {
+	name = url.PathEscape(name)
+	return path.Join(clusterRolesBasePath, name)
+}
+
+// CreateClusterRole with the given cluster role
+func (client *RestClient) CreateClusterRole(clusterRole *types.ClusterRole) error {
+	return client.post(clusterRolesBasePath, clusterRole)
+}
+
+// DeleteClusterRole with the given name
+func (client *RestClient) DeleteClusterRole(name string) error {
+	return client.delete(clusterRolesPath(name))
+}
+
+// FetchClusterRole with the given name
+func (client *RestClient) FetchClusterRole(name string) (*types.ClusterRole, error) {
+	clusterRole := &types.ClusterRole{}
+	if err := client.get(clusterRolesPath(name), clusterRole); err != nil {
+		return nil, err
+	}
+	return clusterRole, nil
+}
+
+// ListClusterRoles within the namespace
+func (client *RestClient) ListClusterRoles() ([]types.ClusterRole, error) {
+	clusterRoles := []types.ClusterRole{}
+
+	if err := client.list(clusterRolesBasePath, &clusterRoles); err != nil {
+		return nil, err
+	}
+
+	return clusterRoles, nil
+}

--- a/cli/client/clusterrolebinding.go
+++ b/cli/client/clusterrolebinding.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"net/url"
+	"path"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+const clusterRoleBindingsBasePath = "/apis/rbac/v2/clusterrolebindings"
+
+func clusterRoleBindingsPath(name string) string {
+	name = url.PathEscape(name)
+	return path.Join(clusterRoleBindingsBasePath, name)
+}
+
+// CreateClusterRoleBinding with the given cluster role binding
+func (client *RestClient) CreateClusterRoleBinding(clusterRoleBinding *types.ClusterRoleBinding) error {
+	return client.post(clusterRoleBindingsBasePath, clusterRoleBinding)
+}
+
+// DeleteClusterRoleBinding with the given name
+func (client *RestClient) DeleteClusterRoleBinding(name string) error {
+	return client.delete(clusterRoleBindingsPath(name))
+}
+
+// FetchClusterRoleBinding with the given name
+func (client *RestClient) FetchClusterRoleBinding(name string) (*types.ClusterRoleBinding, error) {
+	clusterRoleBinding := &types.ClusterRoleBinding{}
+	if err := client.get(clusterRoleBindingsPath(name), clusterRoleBinding); err != nil {
+		return nil, err
+	}
+	return clusterRoleBinding, nil
+}
+
+// ListClusterRoleBinding in the cluster
+func (client *RestClient) ListClusterRoleBindings() ([]types.ClusterRoleBinding, error) {
+	clusterRoleBindings := []types.ClusterRoleBinding{}
+
+	if err := client.list(clusterRoleBindingsBasePath, &clusterRoleBindings); err != nil {
+		return nil, err
+	}
+
+	return clusterRoleBindings, nil
+}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -10,6 +10,8 @@ type APIClient interface {
 	AuthenticationAPIClient
 	AssetAPIClient
 	CheckAPIClient
+	ClusterRoleAPIClient
+	ClusterRoleBindingAPIClient
 	EntityAPIClient
 	EventAPIClient
 	ExtensionAPIClient
@@ -20,6 +22,7 @@ type APIClient interface {
 	MutatorAPIClient
 	NamespaceAPIClient
 	RoleAPIClient
+	RoleBindingAPIClient
 	UserAPIClient
 	SilencedAPIClient
 	GenericClient
@@ -59,6 +62,22 @@ type CheckAPIClient interface {
 
 	AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error
 	RemoveCheckHook(check *types.CheckConfig, checkHookType string, hookName string) error
+}
+
+// RoleAPIClient client methods for cluster roles
+type ClusterRoleAPIClient interface {
+	CreateClusterRole(*types.ClusterRole) error
+	DeleteClusterRole(string) error
+	FetchClusterRole(string) (*types.ClusterRole, error)
+	ListClusterRoles() ([]types.ClusterRole, error)
+}
+
+// ClusterRoleBindingAPIClient client methods for cluster role bindings
+type ClusterRoleBindingAPIClient interface {
+	CreateClusterRoleBinding(*types.ClusterRoleBinding) error
+	DeleteClusterRoleBinding(string) error
+	FetchClusterRoleBinding(string) (*types.ClusterRoleBinding, error)
+	ListClusterRoleBindings() ([]types.ClusterRoleBinding, error)
 }
 
 // EntityAPIClient client methods for entities
@@ -150,12 +169,20 @@ type UserAPIClient interface {
 	UpdatePassword(string, string) error
 }
 
-// RoleAPIClient client methods for role
+// RoleAPIClient client methods for roles
 type RoleAPIClient interface {
 	CreateRole(*types.Role) error
 	DeleteRole(string) error
 	FetchRole(string) (*types.Role, error)
 	ListRoles() ([]types.Role, error)
+}
+
+// RoleBindingAPIClient client methods for role bindings
+type RoleBindingAPIClient interface {
+	CreateRoleBinding(*types.RoleBinding) error
+	DeleteRoleBinding(string) error
+	FetchRoleBinding(string) (*types.RoleBinding, error)
+	ListRoleBindings() ([]types.RoleBinding, error)
 }
 
 // SilencedAPIClient client methods for silenced

--- a/cli/client/methods.go
+++ b/cli/client/methods.go
@@ -1,0 +1,55 @@
+package client
+
+import "encoding/json"
+
+func (client *RestClient) delete(path string) error {
+	res, err := client.R().Delete(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}
+
+func (client *RestClient) get(path string, obj interface{}) error {
+	res, err := client.R().SetResult(obj).Get(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}
+
+func (client *RestClient) list(path string, objs interface{}) error {
+	res, err := client.R().Get(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return json.Unmarshal(res.Body(), objs)
+}
+
+func (client *RestClient) post(path string, obj interface{}) error {
+	res, err := client.R().SetBody(obj).Post(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}

--- a/cli/client/namespaced.go
+++ b/cli/client/namespaced.go
@@ -1,1 +1,0 @@
-package client

--- a/cli/client/namespaced.go
+++ b/cli/client/namespaced.go
@@ -1,0 +1,1 @@
+package client

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -1,80 +1,47 @@
 package client
 
 import (
-	"encoding/json"
+	"fmt"
 	"net/url"
 	"path"
 
 	"github.com/sensu/sensu-go/types"
 )
 
-const rolesBasePath = "/rbac/roles"
+const rolesBasePath = "/apis/rbac/v2/namespaces/%s/roles"
 
-func rolesPath(ext ...string) string {
-	parts := ext
-	for i := range parts {
-		parts[i] = url.PathEscape(parts[i])
-	}
-	return path.Join(append([]string{rolesBasePath}, parts...)...)
+func rolesPath(namespace, name string) string {
+	name = url.PathEscape(name)
+	namespace = url.PathEscape(namespace)
+	return path.Join(fmt.Sprintf(rolesBasePath, namespace), name)
 }
 
-// CreateRole creates new role on configured Sensu instance
+// CreateRole with the given role
 func (client *RestClient) CreateRole(role *types.Role) error {
-	res, err := client.R().SetBody(role).Post(rolesBasePath)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode() >= 400 {
-		return UnmarshalError(res)
-	}
-
-	return nil
+	return client.post(rolesPath(role.Namespace, ""), role)
 }
 
-// DeleteRole deletes a role on configured Sensu instance
+// DeleteRole with the given name
 func (client *RestClient) DeleteRole(name string) error {
-	res, err := client.R().Delete(rolesPath(name))
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode() >= 400 {
-		return UnmarshalError(res)
-	}
-
-	return nil
+	return client.delete(rolesPath(client.config.Namespace(), name))
 }
 
-// FetchRole fetches role from configured Sensu instance
+// FetchRole with the given name
 func (client *RestClient) FetchRole(name string) (*types.Role, error) {
-	var role types.Role
-
-	res, cerr := client.R().SetResult(&role).Get(rolesPath(name))
-	if cerr != nil {
-		return nil, cerr
+	role := &types.Role{}
+	if err := client.get(rolesPath(client.config.Namespace(), name), role); err != nil {
+		return nil, err
 	}
-
-	if res.StatusCode() >= 400 {
-		return nil, UnmarshalError(res)
-	}
-
-	return &role, nil
+	return role, nil
 }
 
-// ListRoles fetches all roles from configured Sensu instance
+// ListRoles within the namespace
 func (client *RestClient) ListRoles() ([]types.Role, error) {
-	var roles []types.Role
+	roles := []types.Role{}
 
-	res, err := client.R().Get("/rbac/roles")
-	if err != nil {
-		return roles, err
+	if err := client.list(rolesPath(client.config.Namespace(), ""), &roles); err != nil {
+		return nil, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return roles, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &roles)
-	return roles, err
+	return roles, nil
 }

--- a/cli/client/rolebinding.go
+++ b/cli/client/rolebinding.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+const roleBindingsBasePath = "/apis/rbac/v2/namespaces/%s/rolebindings"
+
+func roleBindingsPath(namespace, name string) string {
+	name = url.PathEscape(name)
+	namespace = url.PathEscape(namespace)
+	return path.Join(fmt.Sprintf(rolesBasePath, namespace), name)
+}
+
+// CreateRoleBinding with the given role binding
+func (client *RestClient) CreateRoleBinding(roleBinding *types.RoleBinding) error {
+	return client.post(rolesPath(roleBinding.Namespace, ""), roleBinding)
+}
+
+// DeleteRoleBinding with the given name
+func (client *RestClient) DeleteRoleBinding(name string) error {
+	return client.delete(rolesPath(client.config.Namespace(), name))
+}
+
+// FetchRoleBinding with the given name
+func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, error) {
+	roleBinding := &types.RoleBinding{}
+	if err := client.get(rolesPath(client.config.Namespace(), name), roleBinding); err != nil {
+		return nil, err
+	}
+	return roleBinding, nil
+}
+
+// ListRoleBindings within the namespace
+func (client *RestClient) ListRoleBindings() ([]types.RoleBinding, error) {
+	roleBindings := []types.RoleBinding{}
+
+	if err := client.list(rolesPath(client.config.Namespace(), ""), &roleBindings); err != nil {
+		return nil, err
+	}
+
+	return roleBindings, nil
+}

--- a/cli/client/rolebinding.go
+++ b/cli/client/rolebinding.go
@@ -13,23 +13,23 @@ const roleBindingsBasePath = "/apis/rbac/v2/namespaces/%s/rolebindings"
 func roleBindingsPath(namespace, name string) string {
 	name = url.PathEscape(name)
 	namespace = url.PathEscape(namespace)
-	return path.Join(fmt.Sprintf(rolesBasePath, namespace), name)
+	return path.Join(fmt.Sprintf(roleBindingsBasePath, namespace), name)
 }
 
 // CreateRoleBinding with the given role binding
 func (client *RestClient) CreateRoleBinding(roleBinding *types.RoleBinding) error {
-	return client.post(rolesPath(roleBinding.Namespace, ""), roleBinding)
+	return client.post(roleBindingsPath(roleBinding.Namespace, ""), roleBinding)
 }
 
 // DeleteRoleBinding with the given name
 func (client *RestClient) DeleteRoleBinding(name string) error {
-	return client.delete(rolesPath(client.config.Namespace(), name))
+	return client.delete(roleBindingsPath(client.config.Namespace(), name))
 }
 
 // FetchRoleBinding with the given name
 func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, error) {
 	roleBinding := &types.RoleBinding{}
-	if err := client.get(rolesPath(client.config.Namespace(), name), roleBinding); err != nil {
+	if err := client.get(roleBindingsPath(client.config.Namespace(), name), roleBinding); err != nil {
 		return nil, err
 	}
 	return roleBinding, nil
@@ -39,7 +39,7 @@ func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, err
 func (client *RestClient) ListRoleBindings() ([]types.RoleBinding, error) {
 	roleBindings := []types.RoleBinding{}
 
-	if err := client.list(rolesPath(client.config.Namespace(), ""), &roleBindings); err != nil {
+	if err := client.list(roleBindingsPath(client.config.Namespace(), ""), &roleBindings); err != nil {
 		return nil, err
 	}
 

--- a/cli/client/testing/mock_clusterrole_client.go
+++ b/cli/client/testing/mock_clusterrole_client.go
@@ -1,0 +1,27 @@
+package testing
+
+import "github.com/sensu/sensu-go/types"
+
+// CreateClusterRole ...
+func (c *MockClient) CreateClusterRole(obj *types.ClusterRole) error {
+	args := c.Called(obj)
+	return args.Error(0)
+}
+
+// FetchClusterRole ...
+func (c *MockClient) FetchClusterRole(name string) (*types.ClusterRole, error) {
+	args := c.Called(name)
+	return args.Get(0).(*types.ClusterRole), args.Error(1)
+}
+
+// DeleteClusterRole ...
+func (c *MockClient) DeleteClusterRole(name string) error {
+	args := c.Called(name)
+	return args.Error(0)
+}
+
+// ListClusterRoles ...
+func (c *MockClient) ListClusterRoles() ([]types.ClusterRole, error) {
+	args := c.Called()
+	return args.Get(0).([]types.ClusterRole), args.Error(1)
+}

--- a/cli/client/testing/mock_clusterrolebinding_client.go
+++ b/cli/client/testing/mock_clusterrolebinding_client.go
@@ -1,0 +1,27 @@
+package testing
+
+import "github.com/sensu/sensu-go/types"
+
+// CreateClusterRoleBinding ...
+func (c *MockClient) CreateClusterRoleBinding(obj *types.ClusterRoleBinding) error {
+	args := c.Called(obj)
+	return args.Error(0)
+}
+
+// FetchClusterRoleBinding ...
+func (c *MockClient) FetchClusterRoleBinding(name string) (*types.ClusterRoleBinding, error) {
+	args := c.Called(name)
+	return args.Get(0).(*types.ClusterRoleBinding), args.Error(1)
+}
+
+// DeleteClusterRoleBinding ...
+func (c *MockClient) DeleteClusterRoleBinding(name string) error {
+	args := c.Called(name)
+	return args.Error(0)
+}
+
+// ListClusterRoleBindings ...
+func (c *MockClient) ListClusterRoleBindings() ([]types.ClusterRoleBinding, error) {
+	args := c.Called()
+	return args.Get(0).([]types.ClusterRoleBinding), args.Error(1)
+}

--- a/cli/client/testing/mock_role_client.go
+++ b/cli/client/testing/mock_role_client.go
@@ -2,25 +2,25 @@ package testing
 
 import "github.com/sensu/sensu-go/types"
 
-// CreateRole for use with mock lib
+// CreateRole ...
 func (c *MockClient) CreateRole(check *types.Role) error {
 	args := c.Called(check)
 	return args.Error(0)
 }
 
-// FetchRole for use with mock lib
+// FetchRole ...
 func (c *MockClient) FetchRole(name string) (*types.Role, error) {
 	args := c.Called(name)
 	return args.Get(0).(*types.Role), args.Error(1)
 }
 
-// DeleteRole for use with mock lib
+// DeleteRole ...
 func (c *MockClient) DeleteRole(name string) error {
 	args := c.Called(name)
 	return args.Error(0)
 }
 
-// ListRoles for use with mock lib
+// ListRoles ...
 func (c *MockClient) ListRoles() ([]types.Role, error) {
 	args := c.Called()
 	return args.Get(0).([]types.Role), args.Error(1)

--- a/cli/client/testing/mock_rolebinding_client.go
+++ b/cli/client/testing/mock_rolebinding_client.go
@@ -1,0 +1,27 @@
+package testing
+
+import "github.com/sensu/sensu-go/types"
+
+// CreateRoleBinding ...
+func (c *MockClient) CreateRoleBinding(obj *types.RoleBinding) error {
+	args := c.Called(obj)
+	return args.Error(0)
+}
+
+// FetchRoleBinding ...
+func (c *MockClient) FetchRoleBinding(name string) (*types.RoleBinding, error) {
+	args := c.Called(name)
+	return args.Get(0).(*types.RoleBinding), args.Error(1)
+}
+
+// DeleteRoleBinding ...
+func (c *MockClient) DeleteRoleBinding(name string) error {
+	args := c.Called(name)
+	return args.Error(0)
+}
+
+// ListRoleBindings ...
+func (c *MockClient) ListRoleBindings() ([]types.RoleBinding, error) {
+	args := c.Called()
+	return args.Get(0).([]types.RoleBinding), args.Error(1)
+}

--- a/cli/commands/clusterrole/LICENSE
+++ b/cli/commands/clusterrole/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) 2018 Sensu Inc. Permission is hereby granted, free of charge, to
+any person obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/cli/commands/clusterrole/create.go
+++ b/cli/commands/clusterrole/create.go
@@ -12,8 +12,8 @@ import (
 // CreateCommand defines new command to create a cluster role
 func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create [NAME]",
-		Short:        "create a new cluster role and assign a rule to it",
+		Use:          "create [NAME] --verb=VERBS --resource=RESOURCES [--resource-name=RESOURCE_NAMES]",
+		Short:        "create a new ClusterRole with a single rule",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -26,7 +26,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			// Retrieve the rule from the flags
 			rule := types.Rule{}
 
-			verbs, err := cmd.Flags().GetStringSlice("verbs")
+			verbs, err := cmd.Flags().GetStringSlice("verb")
 			if err != nil {
 				return err
 			}
@@ -35,7 +35,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			rule.Verbs = verbs
 
-			resources, err := cmd.Flags().GetStringSlice("resources")
+			resources, err := cmd.Flags().GetStringSlice("resource")
 			if err != nil {
 				return err
 			}
@@ -44,7 +44,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			rule.Resources = resources
 
-			resourceNames, err := cmd.Flags().GetStringSlice("resource-names")
+			resourceNames, err := cmd.Flags().GetStringSlice("resource-name")
 			if err != nil {
 				return err
 			}
@@ -64,14 +64,14 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	_ = cmd.Flags().StringSliceP("verbs", "v", []string{},
-		"list of verbs that apply to all of the listed resources for this rule",
+	_ = cmd.Flags().StringSliceP("verb", "v", []string{},
+		"verbs that apply to the resources contained in the rule",
 	)
-	_ = cmd.Flags().StringSliceP("resources", "r", []string{},
-		"list of resources that this rule applies to",
+	_ = cmd.Flags().StringSliceP("resource", "r", []string{},
+		"resources that the rule applies to",
 	)
-	_ = cmd.Flags().StringSliceP("resource-names", "n", []string{},
-		"optional list of resource names that the rule applies to",
+	_ = cmd.Flags().StringSliceP("resource-name", "n", []string{},
+		"optional resource names that the rule applies to",
 	)
 
 	return cmd

--- a/cli/commands/clusterrole/create.go
+++ b/cli/commands/clusterrole/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
@@ -16,9 +17,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "create a new ClusterRole with a single rule",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if err := helpers.VerifyName(args); err != nil {
 				_ = cmd.Help()
-				return errors.New("a name is required")
+				return err
 			}
 
 			clusterRole := &types.ClusterRole{Name: args[0]}

--- a/cli/commands/clusterrole/create.go
+++ b/cli/commands/clusterrole/create.go
@@ -1,20 +1,19 @@
-package role
+package clusterrole
 
 import (
 	"errors"
 	"fmt"
 
 	"github.com/sensu/sensu-go/cli"
-	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
-// CreateCommand defines new command to create roles
+// CreateCommand defines new command to create a cluster role
 func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "create [NAME]",
-		Short:        "create a new role and assign a rule to it",
+		Short:        "create a new cluster role and assign a rule to it",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -22,12 +21,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				return errors.New("a name is required")
 			}
 
-			role := &types.Role{Name: args[0]}
-			if namespace := helpers.GetChangedStringValueFlag("namespace", cmd.Flags()); namespace != "" {
-				role.Namespace = namespace
-			} else {
-				role.Namespace = cli.Config.Namespace()
-			}
+			clusterRole := &types.ClusterRole{Name: args[0]}
 
 			// Retrieve the rule from the flags
 			rule := types.Rule{}
@@ -56,13 +50,13 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			rule.ResourceNames = resourceNames
 
-			// Assign the rule to our role and validate it
-			role.Rules = []types.Rule{rule}
-			if err := role.Validate(); err != nil {
+			// Assign the rule to our cluster role and validate it
+			clusterRole.Rules = []types.Rule{rule}
+			if err := clusterRole.Validate(); err != nil {
 				return err
 			}
 
-			if err := cli.Client.CreateRole(role); err != nil {
+			if err := cli.Client.CreateClusterRole(clusterRole); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Created")

--- a/cli/commands/clusterrole/create_test.go
+++ b/cli/commands/clusterrole/create_test.go
@@ -16,7 +16,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("clusterrole", cmd.Short)
+	assert.Regexp("cluster role", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {

--- a/cli/commands/clusterrole/create_test.go
+++ b/cli/commands/clusterrole/create_test.go
@@ -1,0 +1,32 @@
+package clusterrole
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("create", cmd.Use)
+	assert.Regexp("clusterrole", cmd.Short)
+}
+
+func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	cmd := CreateCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	// Print help usage
+	assert.NotEmpty(out)
+	assert.Error(err)
+}

--- a/cli/commands/clusterrole/create_test.go
+++ b/cli/commands/clusterrole/create_test.go
@@ -16,7 +16,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("cluster role", cmd.Short)
+	assert.Regexp("ClusterRole", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {

--- a/cli/commands/clusterrole/delete.go
+++ b/cli/commands/clusterrole/delete.go
@@ -13,13 +13,13 @@ import (
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete a cluster role with the given name",
+		Short:        "delete a ClusterRole with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("a cluster role name is required")
+				return errors.New("a ClusterRole name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {

--- a/cli/commands/clusterrole/delete.go
+++ b/cli/commands/clusterrole/delete.go
@@ -1,4 +1,4 @@
-package role
+package clusterrole
 
 import (
 	"errors"
@@ -9,17 +9,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DeleteCommand defines new command to delete a role
+// DeleteCommand defines new command to delete a cluster role
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete a role with the given name",
+		Short:        "delete a cluster role with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("a role name is required")
+				return errors.New("a cluster role name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
@@ -28,7 +28,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 					return err
 				}
 			}
-			err := cli.Client.DeleteRole(name)
+			err := cli.Client.DeleteClusterRole(name)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrole/delete_test.go
+++ b/cli/commands/clusterrole/delete_test.go
@@ -1,0 +1,61 @@
+package clusterrole
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("delete", cmd.Use)
+	assert.Regexp("clusterrole", cmd.Short)
+}
+func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{})
+	assert.Regexp("Usage", out) // usage should print out
+	assert.Error(err)
+}
+func TestDeleteCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteClusterRole", "foo").Return(nil)
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo"})
+	assert.Regexp("Deleted", out)
+	assert.Nil(err)
+}
+func TestDeleteCommandRunEClosureWithServerErr(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteClusterRole", "bar").Return(errors.New("oh noes"))
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"bar"})
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("oh noes", err.Error())
+}
+func TestDeleteCommandRunEFailConfirm(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"bar"})
+	assert.Contains(out, "Canceled")
+	assert.NoError(err)
+}

--- a/cli/commands/clusterrole/delete_test.go
+++ b/cli/commands/clusterrole/delete_test.go
@@ -17,7 +17,7 @@ func TestDeleteCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("delete", cmd.Use)
-	assert.Regexp("clusterrole", cmd.Short)
+	assert.Regexp("cluster role", cmd.Short)
 }
 func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
 	assert := assert.New(t)

--- a/cli/commands/clusterrole/delete_test.go
+++ b/cli/commands/clusterrole/delete_test.go
@@ -17,7 +17,7 @@ func TestDeleteCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("delete", cmd.Use)
-	assert.Regexp("cluster role", cmd.Short)
+	assert.Regexp("ClusterRole", cmd.Short)
 }
 func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
 	assert := assert.New(t)

--- a/cli/commands/clusterrole/help.go
+++ b/cli/commands/clusterrole/help.go
@@ -8,8 +8,8 @@ import (
 // HelpCommand defines new parent
 func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clusterrole",
-		Short: "Manage cluster roles",
+		Use:   "cluster-role",
+		Short: "Manage ClusterRoles",
 	}
 
 	// Add sub-commands

--- a/cli/commands/clusterrole/help.go
+++ b/cli/commands/clusterrole/help.go
@@ -1,0 +1,24 @@
+package clusterrole
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new parent
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clusterrole",
+		Short: "Manage cluster roles",
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		CreateCommand(cli),
+		DeleteCommand(cli),
+		ListCommand(cli),
+		InfoCommand(cli),
+	)
+
+	return cmd
+}

--- a/cli/commands/clusterrole/info.go
+++ b/cli/commands/clusterrole/info.go
@@ -18,7 +18,7 @@ import (
 func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "info [NAME]",
-		Short:        "show detailed information about a cluster role",
+		Short:        "show detailed information about a ClusterRole",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cli/commands/clusterrole/info.go
+++ b/cli/commands/clusterrole/info.go
@@ -1,4 +1,4 @@
-package role
+package clusterrole
 
 import (
 	"errors"
@@ -13,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// InfoCommand defines new command to display detailed information about a role
+// InfoCommand defines new command to display detailed information about a
+// cluster role
 func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "info [NAME]",
-		Aliases:      []string{"list-rules"}, // backward compatibility
-		Short:        "show detailed information about a role",
+		Short:        "show detailed information about a cluster role",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -27,7 +27,7 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			r, err := cli.Client.FetchRole(args[0])
+			r, err := cli.Client.FetchClusterRole(args[0])
 			if err != nil {
 				return err
 			}
@@ -45,18 +45,11 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 }
 
 func printRulesToTable(v interface{}, io io.Writer) error {
-	queryResults, ok := v.(*types.Role)
+	queryResults, ok := v.(*types.ClusterRole)
 	if !ok {
-		return fmt.Errorf("%t is not a Role", v)
+		return fmt.Errorf("%t is not a cluster role", v)
 	}
 	table := table.New([]*table.Column{
-		{
-			Title:       "Namespace",
-			ColumnStyle: table.PrimaryTextStyle,
-			CellTransformer: func(data interface{}) string {
-				return queryResults.Namespace
-			},
-		},
 		{
 			Title: "Verbs",
 			CellTransformer: func(data interface{}) string {

--- a/cli/commands/clusterrole/info_test.go
+++ b/cli/commands/clusterrole/info_test.go
@@ -22,7 +22,7 @@ func TestInfoCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("info", cmd.Use)
-	assert.Regexp("cluster role", cmd.Short)
+	assert.Regexp("ClusterRole", cmd.Short)
 }
 
 func TestInfoCommandRunEWithError(t *testing.T) {

--- a/cli/commands/clusterrole/info_test.go
+++ b/cli/commands/clusterrole/info_test.go
@@ -22,7 +22,7 @@ func TestInfoCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("info", cmd.Use)
-	assert.Regexp("show detailed role information", cmd.Short)
+	assert.Regexp("cluster role", cmd.Short)
 }
 
 func TestInfoCommandRunEWithError(t *testing.T) {
@@ -33,8 +33,8 @@ func TestInfoCommandRunEWithError(t *testing.T) {
 	config.On("Format").Return("none")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("FetchRole", "abc").Return(
-		types.FixtureRole("abc", "default"),
+	client.On("FetchClusterRole", "abc").Return(
+		types.FixtureClusterRole("abc"),
 		errors.New("sadfa"),
 	)
 
@@ -53,8 +53,8 @@ func TestInfoCommandRunEClosure(t *testing.T) {
 	config.On("Format").Return("none")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("FetchRole", "abc").Return(
-		types.FixtureRole("abc", "default"),
+	client.On("FetchClusterRole", "abc").Return(
+		types.FixtureClusterRole("abc"),
 		nil,
 	)
 
@@ -70,8 +70,8 @@ func TestInfoCommandRunEJSON(t *testing.T) {
 	cli := test.NewCLI()
 
 	client := cli.Client.(*client.MockClient)
-	client.On("FetchRole", "abc").Return(
-		types.FixtureRole("abc", "default"),
+	client.On("FetchClusterRole", "abc").Return(
+		types.FixtureClusterRole("abc"),
 		nil,
 	)
 

--- a/cli/commands/clusterrole/info_test.go
+++ b/cli/commands/clusterrole/info_test.go
@@ -1,4 +1,4 @@
-package role
+package clusterrole
 
 import (
 	"errors"
@@ -22,7 +22,7 @@ func TestInfoCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("info", cmd.Use)
-	assert.Regexp("show detailed information about a role", cmd.Short)
+	assert.Regexp("show detailed role information", cmd.Short)
 }
 
 func TestInfoCommandRunEWithError(t *testing.T) {

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -15,7 +15,7 @@ import (
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
-		Short:        "list cluster roles",
+		Short:        "list ClusterRoles",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Fetch roles from API

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -1,4 +1,4 @@
-package role
+package clusterrole
 
 import (
 	"io"
@@ -11,15 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListCommand defines a command to list roles
+// ListCommand list all roles
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
-		Short:        "list roles",
+		Short:        "list cluster roles",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Fetch roles from API
-			results, err := cli.Client.ListRoles()
+			results, err := cli.Client.ListClusterRoles()
 			if err != nil {
 				return err
 			}
@@ -40,7 +40,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				role, ok := data.(types.ClusterRole)
 				if !ok {
 					return cli.TypeError
 				}
@@ -48,19 +48,9 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
-			Title: "Namespace",
-			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
-				if !ok {
-					return cli.TypeError
-				}
-				return role.Namespace
-			},
-		},
-		{
 			Title: "Rules",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				role, ok := data.(types.ClusterRole)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/clusterrole/list_test.go
+++ b/cli/commands/clusterrole/list_test.go
@@ -23,9 +23,9 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles").Return([]types.Role{
-		*types.FixtureRole("one", "*"),
-		*types.FixtureRole("two", "*"),
+	client.On("ListClusterRoles").Return([]types.ClusterRole{
+		*types.FixtureClusterRole("one"),
+		*types.FixtureClusterRole("two"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -38,9 +38,9 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("")
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles").Return([]types.Role{
-		*types.FixtureRole("one", "*"),
-		*types.FixtureRole("two", "*"),
+	client.On("ListClusterRoles").Return([]types.ClusterRole{
+		*types.FixtureClusterRole("one"),
+		*types.FixtureClusterRole("two"),
 	}, nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -54,7 +54,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles").Return([]types.Role{}, errors.New("fire"))
+	client.On("ListClusterRoles").Return([]types.ClusterRole{}, errors.New("fire"))
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Empty(out)

--- a/cli/commands/clusterrole/list_test.go
+++ b/cli/commands/clusterrole/list_test.go
@@ -1,0 +1,63 @@
+package clusterrole
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewCLI()
+	cmd := ListCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list", cmd.Use)
+	assert.Regexp("role", cmd.Short)
+}
+func TestListCommandRunEClosureJSONFormat(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("ListRoles").Return([]types.Role{
+		*types.FixtureRole("one", "*"),
+		*types.FixtureRole("two", "*"),
+	}, nil)
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Nil(err)
+}
+func TestListCommandRunEClosureTabularFormat(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("")
+	client := cli.Client.(*client.MockClient)
+	client.On("ListRoles").Return([]types.Role{
+		*types.FixtureRole("one", "*"),
+		*types.FixtureRole("two", "*"),
+	}, nil)
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Contains(out, "Name")
+	assert.Contains(out, "one")
+	assert.Contains(out, "two")
+	assert.Nil(err)
+}
+func TestListCommandRunEClosureWithErr(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("ListRoles").Return([]types.Role{}, errors.New("fire"))
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("fire", err.Error())
+}

--- a/cli/commands/clusterrole/list_test.go
+++ b/cli/commands/clusterrole/list_test.go
@@ -17,7 +17,7 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("list", cmd.Use)
-	assert.Regexp("role", cmd.Short)
+	assert.Regexp("ClusterRoles", cmd.Short)
 }
 func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)

--- a/cli/commands/clusterrolebinding/create.go
+++ b/cli/commands/clusterrolebinding/create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
@@ -16,9 +17,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "create a new ClusterRoleBinding for a particular ClusterRole",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if err := helpers.VerifyName(args); err != nil {
 				_ = cmd.Help()
-				return errors.New("a name is required")
+				return err
 			}
 
 			clusterRoleBinding := &types.ClusterRoleBinding{Name: args[0]}

--- a/cli/commands/clusterrolebinding/create.go
+++ b/cli/commands/clusterrolebinding/create.go
@@ -1,0 +1,40 @@
+package clusterrolebinding
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// CreateCommand defines a new command to create a cluster role binding
+func CreateCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create [NAME]",
+		Short:        "create a new cluster role binding",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("a name is required")
+			}
+
+			clusterRoleBinding := &types.ClusterRoleBinding{Name: args[0]}
+
+			// Assign the rule to our role and valiate it
+			if err := clusterRoleBinding.Validate(); err != nil {
+				return err
+			}
+
+			if err := cli.Client.CreateClusterRoleBinding(clusterRoleBinding); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Created")
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/clusterrolebinding/create_test.go
+++ b/cli/commands/clusterrolebinding/create_test.go
@@ -3,8 +3,11 @@ package clusterrolebinding
 import (
 	"testing"
 
+	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateCommand(t *testing.T) {
@@ -16,7 +19,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("cluster role binding", cmd.Short)
+	assert.Regexp("ClusterRoleBinding", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
@@ -29,4 +32,31 @@ func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
 	// Print help usage
 	assert.NotEmpty(out)
 	assert.Error(err)
+}
+
+func TestCreateCommandSubjects(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateClusterRoleBinding", mock.AnythingOfType("*types.ClusterRoleBinding")).Return(nil)
+
+	// No user or group provided
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("cluster-role", "admin"))
+	_, err := test.RunCmd(cmd, []string{"admin"})
+	assert.Error(err)
+
+	// A user was provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("cluster-role", "admin"))
+	require.NoError(t, cmd.Flags().Set("user", "foo"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.NoError(err)
+
+	// A group was provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("cluster-role", "admin"))
+	require.NoError(t, cmd.Flags().Set("group", "bar"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.NoError(err)
 }

--- a/cli/commands/clusterrolebinding/create_test.go
+++ b/cli/commands/clusterrolebinding/create_test.go
@@ -1,0 +1,32 @@
+package clusterrolebinding
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("create", cmd.Use)
+	assert.Regexp("cluster role binding", cmd.Short)
+}
+
+func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	cmd := CreateCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	// Print help usage
+	assert.NotEmpty(out)
+	assert.Error(err)
+}

--- a/cli/commands/clusterrolebinding/delete.go
+++ b/cli/commands/clusterrolebinding/delete.go
@@ -1,4 +1,4 @@
-package role
+package clusterrolebinding
 
 import (
 	"errors"
@@ -9,17 +9,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DeleteCommand defines new command to delete a role
+// DeleteCommand defines new command to delete a cluster role binding
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete a role with the given name",
+		Short:        "delete a cluster role binding with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("a role name is required")
+				return errors.New("a cluster role binding name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
@@ -28,7 +28,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 					return err
 				}
 			}
-			err := cli.Client.DeleteRole(name)
+			err := cli.Client.DeleteClusterRoleBinding(name)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrolebinding/delete_test.go
+++ b/cli/commands/clusterrolebinding/delete_test.go
@@ -1,0 +1,40 @@
+package clusterrolebinding
+
+import (
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("delete", cmd.Use)
+	assert.Regexp("cluster role binding", cmd.Short)
+}
+func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{})
+	assert.Regexp("Usage", out) // usage should print out
+	assert.Error(err)
+}
+func TestDeleteCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteClusterRoleBinding", "foo").Return(nil)
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo"})
+	assert.Regexp("Deleted", out)
+	assert.Nil(err)
+}

--- a/cli/commands/clusterrolebinding/help.go
+++ b/cli/commands/clusterrolebinding/help.go
@@ -8,7 +8,7 @@ import (
 // HelpCommand defines new parent
 func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "clusterrolebinding",
+		Use:   "cluster-role-binding",
 		Short: "Manage cluster role bindings",
 	}
 

--- a/cli/commands/clusterrolebinding/help.go
+++ b/cli/commands/clusterrolebinding/help.go
@@ -1,0 +1,24 @@
+package clusterrolebinding
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new parent
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clusterrolebinding",
+		Short: "Manage cluster role bindings",
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		CreateCommand(cli),
+		DeleteCommand(cli),
+		ListCommand(cli),
+		InfoCommand(cli),
+	)
+
+	return cmd
+}

--- a/cli/commands/clusterrolebinding/info.go
+++ b/cli/commands/clusterrolebinding/info.go
@@ -1,0 +1,73 @@
+package clusterrolebinding
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/list"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// InfoCommand defines new command to display detailed information about a
+// cluster role binding
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info [NAME]",
+		Short:        "show detailed information about a clustern role binding",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("a cluster role binding name is required")
+			}
+
+			// Fetch roles from API
+			r, err := cli.Client.FetchClusterRoleBinding(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Determine the format to use to output the data
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+
+	return cmd
+}
+
+func printToList(v interface{}, writer io.Writer) error {
+	clusterRoleBinding, ok := v.(*types.RoleBinding)
+	if !ok {
+		return fmt.Errorf("%t is not a ClusterRoleBinding", v)
+	}
+
+	cfg := &list.Config{
+		Title: clusterRoleBinding.Name,
+		Rows: []*list.Row{
+			{
+				Label: "Name",
+				Value: clusterRoleBinding.Name,
+			},
+			{
+				Label: "Role",
+				Value: fmt.Sprintf("%s (%s)", clusterRoleBinding.RoleRef.Name, clusterRoleBinding.RoleRef.Type),
+			},
+			// TODO (Simon) Create a row for each subject once the API is working
+			{
+				Label: "Subjects",
+				Value: strconv.Itoa(len(clusterRoleBinding.Subjects)),
+			},
+		},
+	}
+
+	return list.Print(writer, cfg)
+}

--- a/cli/commands/clusterrolebinding/info.go
+++ b/cli/commands/clusterrolebinding/info.go
@@ -18,7 +18,7 @@ import (
 func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "info [NAME]",
-		Short:        "show detailed information about a clustern role binding",
+		Short:        "show detailed information about a cluster role binding",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cli/commands/clusterrolebinding/info_test.go
+++ b/cli/commands/clusterrolebinding/info_test.go
@@ -1,0 +1,20 @@
+package clusterrolebinding
+
+import (
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfoCommand(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+	cmd := InfoCommand(cli)
+
+	assert.NotNil(t, cmd, "cmd should be returned")
+	assert.NotNil(t, cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp(t, "info", cmd.Use)
+	assert.Regexp(t, "cluster role binding", cmd.Short)
+}

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -1,6 +1,7 @@
-package role
+package clusterrolebinding
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 
@@ -11,15 +12,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListCommand defines a command to list roles
+// ListCommand defines a command to list cluster role bindings
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
-		Short:        "list roles",
+		Short:        "list cluster role bindings",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Fetch roles from API
-			results, err := cli.Client.ListRoles()
+			// Fetch role bindings from API
+			results, err := cli.Client.ListClusterRoleBindings()
 			if err != nil {
 				return err
 			}
@@ -40,31 +41,31 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return role.Name
+				return clusterRoleBinding.Name
 			},
 		},
 		{
-			Title: "Namespace",
+			Title: "Role",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return role.Namespace
+				return fmt.Sprintf("%s (%s)", clusterRoleBinding.RoleRef.Name, clusterRoleBinding.RoleRef.Type)
 			},
 		},
 		{
-			Title: "Rules",
+			Title: "Subjects",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return strconv.Itoa(len(role.Rules))
+				return strconv.Itoa(len(clusterRoleBinding.Subjects))
 			},
 		},
 	})

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -1,7 +1,6 @@
 package clusterrolebinding
 
 import (
-	"fmt"
 	"io"
 	"strconv"
 
@@ -49,13 +48,13 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
-			Title: "Role",
+			Title: "ClusterRole",
 			CellTransformer: func(data interface{}) string {
 				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return fmt.Sprintf("%s (%s)", clusterRoleBinding.RoleRef.Name, clusterRoleBinding.RoleRef.Type)
+				return clusterRoleBinding.RoleRef.Name
 			},
 		},
 		{

--- a/cli/commands/clusterrolebinding/list_test.go
+++ b/cli/commands/clusterrolebinding/list_test.go
@@ -1,0 +1,18 @@
+package clusterrolebinding
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewCLI()
+	cmd := ListCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list", cmd.Use)
+	assert.Regexp("role bindings", cmd.Short)
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -5,6 +5,8 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/asset"
 	"github.com/sensu/sensu-go/cli/commands/check"
 	"github.com/sensu/sensu-go/cli/commands/cluster"
+	"github.com/sensu/sensu-go/cli/commands/clusterrole"
+	"github.com/sensu/sensu-go/cli/commands/clusterrolebinding"
 	"github.com/sensu/sensu-go/cli/commands/completion"
 	"github.com/sensu/sensu-go/cli/commands/config"
 	"github.com/sensu/sensu-go/cli/commands/configure"
@@ -19,6 +21,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/mutator"
 	"github.com/sensu/sensu-go/cli/commands/namespace"
 	"github.com/sensu/sensu-go/cli/commands/role"
+	"github.com/sensu/sensu-go/cli/commands/rolebinding"
 	"github.com/sensu/sensu-go/cli/commands/silenced"
 	"github.com/sensu/sensu-go/cli/commands/user"
 	"github.com/spf13/cobra"
@@ -35,6 +38,8 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		asset.HelpCommand(cli),
 		check.HelpCommand(cli),
 		config.HelpCommand(cli),
+		clusterrole.HelpCommand(cli),
+		clusterrolebinding.HelpCommand(cli),
 		entity.HelpCommand(cli),
 		event.HelpCommand(cli),
 		filter.HelpCommand(cli),
@@ -43,6 +48,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		mutator.HelpCommand(cli),
 		namespace.HelpCommand(cli),
 		role.HelpCommand(cli),
+		rolebinding.HelpCommand(cli),
 		user.HelpCommand(cli),
 		silenced.HelpCommand(cli),
 		create.CreateCommand(cli),

--- a/cli/commands/helpers/args.go
+++ b/cli/commands/helpers/args.go
@@ -1,0 +1,18 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// VerifyName ensures that (only) a name was provided in the arguments
+func VerifyName(args []string) error {
+	if len(args) == 0 {
+		return errors.New("a name is required")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments supplied: %s", strings.Join(args, ", "))
+	}
+	return nil
+}

--- a/cli/commands/role/create.go
+++ b/cli/commands/role/create.go
@@ -14,12 +14,12 @@ import (
 func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "create [NAME]",
-		Short:        "create new role",
+		Short:        "create a new role and assign a rule to it",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("invalid argument(s) received")
+				return errors.New("a role name is required")
 			}
 
 			role := &types.Role{Name: args[0]}
@@ -29,10 +29,35 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				role.Namespace = cli.Config.Namespace()
 			}
 
-			role.Rules = []types.Rule{
-				types.FixtureRule(),
-			}
+			// Retrieve the rule from the flags
+			rule := types.Rule{}
 
+			verbs, err := cmd.Flags().GetStringSlice("verbs")
+			if err != nil {
+				return err
+			}
+			if len(verbs) == 0 {
+				return errors.New("at least one verb must be provided")
+			}
+			rule.Verbs = verbs
+
+			resources, err := cmd.Flags().GetStringSlice("resources")
+			if err != nil {
+				return err
+			}
+			if len(resources) == 0 {
+				return errors.New("at least one resource must be provided")
+			}
+			rule.Resources = resources
+
+			resourceNames, err := cmd.Flags().GetStringSlice("resource-names")
+			if err != nil {
+				return err
+			}
+			rule.ResourceNames = resourceNames
+
+			// Assign the rule to our role and valiate it
+			role.Rules = []types.Rule{rule}
 			if err := role.Validate(); err != nil {
 				return err
 			}
@@ -40,10 +65,20 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			if err := cli.Client.CreateRole(role); err != nil {
 				return err
 			}
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Created")
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Created")
 			return err
 		},
 	}
+
+	_ = cmd.Flags().StringSliceP("verbs", "v", []string{},
+		"list of verbs that apply to all of the listed resources for this rule",
+	)
+	_ = cmd.Flags().StringSliceP("resources", "r", []string{},
+		"list of resources that this rule applies to",
+	)
+	_ = cmd.Flags().StringSliceP("resource-names", "n", []string{},
+		"optional list of resource names that the rule applies to",
+	)
 
 	return cmd
 }

--- a/cli/commands/role/create.go
+++ b/cli/commands/role/create.go
@@ -17,9 +17,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "create a new Role with a single rule",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if err := helpers.VerifyName(args); err != nil {
 				_ = cmd.Help()
-				return errors.New("a name is required")
+				return err
 			}
 
 			role := &types.Role{Name: args[0]}

--- a/cli/commands/role/create.go
+++ b/cli/commands/role/create.go
@@ -13,8 +13,8 @@ import (
 // CreateCommand defines new command to create roles
 func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create [NAME]",
-		Short:        "create a new role and assign a rule to it",
+		Use:          "create [NAME] --verb=VERBS --resource=RESOURCES [--resource-name=RESOURCE_NAMES]",
+		Short:        "create a new Role with a single rule",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -32,7 +32,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			// Retrieve the rule from the flags
 			rule := types.Rule{}
 
-			verbs, err := cmd.Flags().GetStringSlice("verbs")
+			verbs, err := cmd.Flags().GetStringSlice("verb")
 			if err != nil {
 				return err
 			}
@@ -41,7 +41,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			rule.Verbs = verbs
 
-			resources, err := cmd.Flags().GetStringSlice("resources")
+			resources, err := cmd.Flags().GetStringSlice("resource")
 			if err != nil {
 				return err
 			}
@@ -50,7 +50,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			rule.Resources = resources
 
-			resourceNames, err := cmd.Flags().GetStringSlice("resource-names")
+			resourceNames, err := cmd.Flags().GetStringSlice("resource-name")
 			if err != nil {
 				return err
 			}
@@ -70,14 +70,14 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 
-	_ = cmd.Flags().StringSliceP("verbs", "v", []string{},
-		"list of verbs that apply to all of the listed resources for this rule",
+	_ = cmd.Flags().StringSliceP("verb", "v", []string{},
+		"verbs that apply to the resources contained in the rule",
 	)
-	_ = cmd.Flags().StringSliceP("resources", "r", []string{},
-		"list of resources that this rule applies to",
+	_ = cmd.Flags().StringSliceP("resource", "r", []string{},
+		"resources that the rule applies to",
 	)
-	_ = cmd.Flags().StringSliceP("resource-names", "n", []string{},
-		"optional list of resource names that the rule applies to",
+	_ = cmd.Flags().StringSliceP("resource-name", "n", []string{},
+		"optional resource names that the rule applies to",
 	)
 
 	return cmd

--- a/cli/commands/role/create_test.go
+++ b/cli/commands/role/create_test.go
@@ -16,7 +16,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("role", cmd.Short)
+	assert.Regexp("Role", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {

--- a/cli/commands/role/delete.go
+++ b/cli/commands/role/delete.go
@@ -13,13 +13,13 @@ import (
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete role given name",
+		Short:        "delete a role with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("invalid argument(s) received")
+				return errors.New("a role name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {

--- a/cli/commands/role/delete.go
+++ b/cli/commands/role/delete.go
@@ -13,13 +13,13 @@ import (
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete a role with the given name",
+		Short:        "delete a Role with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("a role name is required")
+				return errors.New("a Role name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {

--- a/cli/commands/role/delete_test.go
+++ b/cli/commands/role/delete_test.go
@@ -17,7 +17,7 @@ func TestDeleteCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("delete", cmd.Use)
-	assert.Regexp("role", cmd.Short)
+	assert.Regexp("Role", cmd.Short)
 }
 func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
 	assert := assert.New(t)

--- a/cli/commands/role/help.go
+++ b/cli/commands/role/help.go
@@ -9,7 +9,7 @@ import (
 func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "role",
-		Short: "Manage roles",
+		Short: "Manage Roles",
 	}
 
 	// Add sub-commands

--- a/cli/commands/role/info.go
+++ b/cli/commands/role/info.go
@@ -18,7 +18,7 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "info [NAME]",
 		Aliases:      []string{"list-rules"}, // backward compatibility
-		Short:        "show detailed information about a role",
+		Short:        "show detailed information about a Role",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cli/commands/role/info.go
+++ b/cli/commands/role/info.go
@@ -2,10 +2,14 @@ package role
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/table"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
@@ -41,5 +45,50 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 }
 
 func printRulesToTable(v interface{}, io io.Writer) error {
+	queryResults, ok := v.(*types.Role)
+	if !ok {
+		return fmt.Errorf("%t is not a Role", v)
+	}
+	table := table.New([]*table.Column{
+		{
+			Title:       "Namespace",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				return queryResults.Namespace
+			},
+		},
+		{
+			Title: "Verbs",
+			CellTransformer: func(data interface{}) string {
+				rule, ok := data.(types.Rule)
+				if !ok {
+					return cli.TypeError
+				}
+				return strings.Join(rule.Verbs, ",")
+			},
+		},
+		{
+			Title: "Resources",
+			CellTransformer: func(data interface{}) string {
+				rule, ok := data.(types.Rule)
+				if !ok {
+					return cli.TypeError
+				}
+				return strings.Join(rule.Resources, ",")
+			},
+		},
+		{
+			Title: "Resource Names",
+			CellTransformer: func(data interface{}) string {
+				rule, ok := data.(types.Rule)
+				if !ok {
+					return cli.TypeError
+				}
+				return strings.Join(rule.ResourceNames, ",")
+			},
+		},
+	})
+
+	table.Render(io, queryResults.Rules)
 	return nil
 }

--- a/cli/commands/role/info_test.go
+++ b/cli/commands/role/info_test.go
@@ -22,7 +22,7 @@ func TestInfoCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("info", cmd.Use)
-	assert.Regexp("show detailed information about a role", cmd.Short)
+	assert.Regexp("show detailed information about a Role", cmd.Short)
 }
 
 func TestInfoCommandRunEWithError(t *testing.T) {

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -15,7 +15,7 @@ import (
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
-		Short:        "list roles",
+		Short:        "list Roles",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Fetch roles from API

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -3,6 +3,7 @@ package role
 import (
 	"errors"
 	"io"
+	"strconv"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
@@ -49,6 +50,26 @@ func printToTable(results interface{}, writer io.Writer) {
 					return cli.TypeError
 				}
 				return role.Name
+			},
+		},
+		{
+			Title: "Namespace",
+			CellTransformer: func(data interface{}) string {
+				role, ok := data.(types.Role)
+				if !ok {
+					return cli.TypeError
+				}
+				return role.Namespace
+			},
+		},
+		{
+			Title: "Rules",
+			CellTransformer: func(data interface{}) string {
+				role, ok := data.(types.Role)
+				if !ok {
+					return cli.TypeError
+				}
+				return strconv.Itoa(len(role.Rules))
 			},
 		},
 	})

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -17,7 +17,7 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("list", cmd.Use)
-	assert.Regexp("role", cmd.Short)
+	assert.Regexp("Roles", cmd.Short)
 }
 func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)

--- a/cli/commands/rolebinding/create.go
+++ b/cli/commands/rolebinding/create.go
@@ -13,8 +13,8 @@ import (
 // CreateCommand defines a new command to create a role binding
 func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "create [NAME]",
-		Short:        "create a new role binding",
+		Use:          "create [NAME] --cluster-role=NAME|--role=NAME [--user=username] [--group=groupname]",
+		Short:        "create a new RoleBinding for a particular Role or ClusterRole",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -29,6 +29,61 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				roleBinding.Namespace = cli.Config.Namespace()
 			}
 
+			// Determine if a Role or ClusterRole was provided and assign it to our
+			// RoleBinding
+			role, err := cmd.Flags().GetString("role")
+			if err != nil {
+				return err
+			}
+			clusterRole, err := cmd.Flags().GetString("cluster-role")
+			if err != nil {
+				return err
+			}
+
+			if clusterRole != "" {
+				roleBinding.RoleRef = types.RoleRef{
+					Type: "ClusterRole",
+					Name: clusterRole,
+				}
+			} else if role != "" {
+				roleBinding.RoleRef = types.RoleRef{
+					Type: "Role",
+					Name: role,
+				}
+			} else {
+				return errors.New("a Role or ClusterRole must be provided")
+			}
+
+			groups, err := cmd.Flags().GetStringSlice("group")
+			if err != nil {
+				return err
+			}
+			users, err := cmd.Flags().GetStringSlice("user")
+			if err != nil {
+				return err
+			}
+			if len(groups) == 0 && len(users) == 0 {
+				return errors.New("at least one group or user must be provided")
+			}
+
+			// Create our subjects list
+			for _, group := range groups {
+				roleBinding.Subjects = append(roleBinding.Subjects,
+					types.Subject{
+						Kind: "Group",
+						Name: group,
+					},
+				)
+			}
+			for _, user := range users {
+				roleBinding.Subjects = append(roleBinding.Subjects,
+					types.Subject{
+						Kind: "User",
+						Name: user,
+					},
+				)
+			}
+
 			// Assign the rule to our role and valiate it
 			if err := roleBinding.Validate(); err != nil {
 				return err
@@ -37,10 +92,23 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			if err := cli.Client.CreateRoleBinding(roleBinding); err != nil {
 				return err
 			}
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Created")
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Created")
 			return err
 		},
 	}
+
+	_ = cmd.Flags().StringP("cluster-role", "c", "",
+		"the ClusterRole this RoleBinding should reference",
+	)
+	_ = cmd.Flags().StringP("role", "r", "",
+		"the Role this RoleBinding should reference",
+	)
+	_ = cmd.Flags().StringSliceP("group", "g", []string{},
+		"groups to bind to the Role",
+	)
+	_ = cmd.Flags().StringSliceP("user", "u", []string{},
+		"users to bind to the Role",
+	)
 
 	return cmd
 }

--- a/cli/commands/rolebinding/create.go
+++ b/cli/commands/rolebinding/create.go
@@ -17,9 +17,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "create a new RoleBinding for a particular Role or ClusterRole",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
+			if err := helpers.VerifyName(args); err != nil {
 				_ = cmd.Help()
-				return errors.New("a name is required")
+				return err
 			}
 
 			roleBinding := &types.RoleBinding{Name: args[0]}

--- a/cli/commands/rolebinding/create.go
+++ b/cli/commands/rolebinding/create.go
@@ -1,0 +1,46 @@
+package rolebinding
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// CreateCommand defines a new command to create a role binding
+func CreateCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "create [NAME]",
+		Short:        "create a new role binding",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("a name is required")
+			}
+
+			roleBinding := &types.RoleBinding{Name: args[0]}
+			if namespace := helpers.GetChangedStringValueFlag("namespace", cmd.Flags()); namespace != "" {
+				roleBinding.Namespace = namespace
+			} else {
+				roleBinding.Namespace = cli.Config.Namespace()
+			}
+
+			// Assign the rule to our role and valiate it
+			if err := roleBinding.Validate(); err != nil {
+				return err
+			}
+
+			if err := cli.Client.CreateRoleBinding(roleBinding); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Created")
+			return err
+		},
+	}
+
+	return cmd
+}

--- a/cli/commands/rolebinding/create_test.go
+++ b/cli/commands/rolebinding/create_test.go
@@ -3,8 +3,11 @@ package rolebinding
 import (
 	"testing"
 
+	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateCommand(t *testing.T) {
@@ -16,7 +19,7 @@ func TestCreateCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("create", cmd.Use)
-	assert.Regexp("role binding", cmd.Short)
+	assert.Regexp("RoleBinding", cmd.Short)
 }
 
 func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
@@ -29,4 +32,58 @@ func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
 	// Print help usage
 	assert.NotEmpty(out)
 	assert.Error(err)
+}
+
+func TestCreateCommandRoleRef(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateRoleBinding", mock.AnythingOfType("*types.RoleBinding")).Return(nil)
+
+	// No role or ClusterRole provided
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("user", "foo"))
+	_, err := test.RunCmd(cmd, []string{"admin"})
+	assert.Error(err)
+
+	// Role provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("role", "admin"))
+	require.NoError(t, cmd.Flags().Set("user", "foo"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.NoError(err)
+
+	// Role and ClusterRole both provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("role", "admin"))
+	require.NoError(t, cmd.Flags().Set("cluster-role", "admin"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.Error(err)
+}
+
+func TestCreateCommandSubjects(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateRoleBinding", mock.AnythingOfType("*types.RoleBinding")).Return(nil)
+
+	// No user or group provided
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("role", "admin"))
+	_, err := test.RunCmd(cmd, []string{"admin"})
+	assert.Error(err)
+
+	// A user was provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("role", "admin"))
+	require.NoError(t, cmd.Flags().Set("user", "foo"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.NoError(err)
+
+	// A group was provided
+	cmd = CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("role", "admin"))
+	require.NoError(t, cmd.Flags().Set("group", "bar"))
+	_, err = test.RunCmd(cmd, []string{"admin"})
+	assert.NoError(err)
 }

--- a/cli/commands/rolebinding/create_test.go
+++ b/cli/commands/rolebinding/create_test.go
@@ -1,0 +1,32 @@
+package rolebinding
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := CreateCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("create", cmd.Use)
+	assert.Regexp("role binding", cmd.Short)
+}
+
+func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	cmd := CreateCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	// Print help usage
+	assert.NotEmpty(out)
+	assert.Error(err)
+}

--- a/cli/commands/rolebinding/delete.go
+++ b/cli/commands/rolebinding/delete.go
@@ -1,4 +1,4 @@
-package role
+package rolebinding
 
 import (
 	"errors"
@@ -9,17 +9,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DeleteCommand defines new command to delete a role
+// DeleteCommand defines new command to delete a role binding
 func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "delete [NAME]",
-		Short:        "delete a role with the given name",
+		Short:        "delete a role binding with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no name is present print out usage
 			if len(args) != 1 {
 				_ = cmd.Help()
-				return errors.New("a role name is required")
+				return errors.New("a role binding name is required")
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
@@ -28,7 +28,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 					return err
 				}
 			}
-			err := cli.Client.DeleteRole(name)
+			err := cli.Client.DeleteRoleBinding(name)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/rolebinding/delete_test.go
+++ b/cli/commands/rolebinding/delete_test.go
@@ -1,0 +1,40 @@
+package rolebinding
+
+import (
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("delete", cmd.Use)
+	assert.Regexp("role binding", cmd.Short)
+}
+func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{})
+	assert.Regexp("Usage", out) // usage should print out
+	assert.Error(err)
+}
+func TestDeleteCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("DeleteRoleBinding", "foo").Return(nil)
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo"})
+	assert.Regexp("Deleted", out)
+	assert.Nil(err)
+}

--- a/cli/commands/rolebinding/help.go
+++ b/cli/commands/rolebinding/help.go
@@ -8,7 +8,7 @@ import (
 // HelpCommand defines new parent
 func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rolebinding",
+		Use:   "role-binding",
 		Short: "Manage role bindings",
 	}
 

--- a/cli/commands/rolebinding/help.go
+++ b/cli/commands/rolebinding/help.go
@@ -1,0 +1,24 @@
+package rolebinding
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new parent
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rolebinding",
+		Short: "Manage role bindings",
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(
+		CreateCommand(cli),
+		DeleteCommand(cli),
+		ListCommand(cli),
+		InfoCommand(cli),
+	)
+
+	return cmd
+}

--- a/cli/commands/rolebinding/info.go
+++ b/cli/commands/rolebinding/info.go
@@ -62,8 +62,8 @@ func printToList(v interface{}, writer io.Writer) error {
 				Value: roleBinding.Namespace,
 			},
 			{
-				Label: "Role",
-				Value: fmt.Sprintf("%s (%s)", roleBinding.RoleRef.Name, roleBinding.RoleRef.Type),
+				Label: roleBinding.RoleRef.Type,
+				Value: roleBinding.RoleRef.Name,
 			},
 			// TODO (Simon) Create a row for each subject once the API is working
 			{

--- a/cli/commands/rolebinding/info.go
+++ b/cli/commands/rolebinding/info.go
@@ -1,0 +1,77 @@
+package rolebinding
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/list"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+// InfoCommand defines new command to display detailed information about a role
+// binding
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info [NAME]",
+		Short:        "show detailed information about a role binding",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("a role binding name is required")
+			}
+
+			// Fetch roles from API
+			r, err := cli.Client.FetchRoleBinding(args[0])
+			if err != nil {
+				return err
+			}
+
+			// Determine the format to use to output the data
+			flag := helpers.GetChangedStringValueFlag("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, r, cmd.OutOrStdout(), printToList)
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+
+	return cmd
+}
+
+func printToList(v interface{}, writer io.Writer) error {
+	roleBinding, ok := v.(*types.RoleBinding)
+	if !ok {
+		return fmt.Errorf("%t is not a RoleBinding", v)
+	}
+
+	cfg := &list.Config{
+		Title: fmt.Sprintf("%s/%s", roleBinding.Namespace, roleBinding.Name),
+		Rows: []*list.Row{
+			{
+				Label: "Name",
+				Value: roleBinding.Name,
+			},
+			{
+				Label: "Namespace",
+				Value: roleBinding.Namespace,
+			},
+			{
+				Label: "Role",
+				Value: fmt.Sprintf("%s (%s)", roleBinding.RoleRef.Name, roleBinding.RoleRef.Type),
+			},
+			// TODO (Simon) Create a row for each subject once the API is working
+			{
+				Label: "Subjects",
+				Value: strconv.Itoa(len(roleBinding.Subjects)),
+			},
+		},
+	}
+
+	return list.Print(writer, cfg)
+}

--- a/cli/commands/rolebinding/info_test.go
+++ b/cli/commands/rolebinding/info_test.go
@@ -1,0 +1,20 @@
+package rolebinding
+
+import (
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInfoCommand(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+	cmd := InfoCommand(cli)
+
+	assert.NotNil(t, cmd, "cmd should be returned")
+	assert.NotNil(t, cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp(t, "info", cmd.Use)
+	assert.Regexp(t, "role binding", cmd.Short)
+}

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -1,6 +1,7 @@
-package role
+package rolebinding
 
 import (
+	"fmt"
 	"io"
 	"strconv"
 
@@ -11,15 +12,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListCommand defines a command to list roles
+// ListCommand defines a command to list role bindings
 func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
-		Short:        "list roles",
+		Short:        "list role bindings",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Fetch roles from API
-			results, err := cli.Client.ListRoles()
+			// Fetch role bindings from API
+			results, err := cli.Client.ListRoleBindings()
 			if err != nil {
 				return err
 			}
@@ -40,31 +41,41 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				roleBinding, ok := data.(types.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return role.Name
+				return roleBinding.Name
 			},
 		},
 		{
 			Title: "Namespace",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				roleBinding, ok := data.(types.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return role.Namespace
+				return roleBinding.Namespace
 			},
 		},
 		{
-			Title: "Rules",
+			Title: "Role",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				roleBinding, ok := data.(types.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return strconv.Itoa(len(role.Rules))
+				return fmt.Sprintf("%s (%s)", roleBinding.RoleRef.Name, roleBinding.RoleRef.Type)
+			},
+		},
+		{
+			Title: "Subjects",
+			CellTransformer: func(data interface{}) string {
+				roleBinding, ok := data.(types.RoleBinding)
+				if !ok {
+					return cli.TypeError
+				}
+				return strconv.Itoa(len(roleBinding.Subjects))
 			},
 		},
 	})

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -1,7 +1,6 @@
 package rolebinding
 
 import (
-	"fmt"
 	"io"
 	"strconv"
 
@@ -59,13 +58,29 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
+			Title: "ClusterRole",
+			CellTransformer: func(data interface{}) string {
+				roleBinding, ok := data.(types.RoleBinding)
+				if !ok {
+					return cli.TypeError
+				}
+				if roleBinding.RoleRef.Type == "ClusterRole" {
+					return roleBinding.RoleRef.Name
+				}
+				return ""
+			},
+		},
+		{
 			Title: "Role",
 			CellTransformer: func(data interface{}) string {
 				roleBinding, ok := data.(types.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
-				return fmt.Sprintf("%s (%s)", roleBinding.RoleRef.Name, roleBinding.RoleRef.Type)
+				if roleBinding.RoleRef.Type == "Role" {
+					return roleBinding.RoleRef.Name
+				}
+				return ""
 			},
 		},
 		{

--- a/cli/commands/rolebinding/list_test.go
+++ b/cli/commands/rolebinding/list_test.go
@@ -1,0 +1,18 @@
+package rolebinding
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewCLI()
+	cmd := ListCommand(cli)
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list", cmd.Use)
+	assert.Regexp("role bindings", cmd.Short)
+}

--- a/cli/commands/root/templates.go
+++ b/cli/commands/root/templates.go
@@ -55,6 +55,7 @@ Enterprise Commands:
 
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
+
 `
 
 func init() {


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/2258.

This PR adds _basic_ support for new roles. I didn't added any of the fancy subcommands because it would require an enormous amount of code (for each of these 4 commands) and complexity, because rules can't be easily identified (if you want to remove a specific rule). I propose we suggest users to use `sensuctl {command} info --format wrapped-json > file.json` & `sensuctl create -f file.json` when they want to manipulate these RBAC resources for now.

I couldn't test these commands since the API routes are not available yet so it will probably require some love once everything is put together!