### PR TITLE
Re-introduce the namespace middleware for now

### DIFF
--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -182,6 +182,7 @@ func registerRestrictedResources(router *mux.Router, store store.Store, getter t
 		NewSubrouter(
 			router.NewRoute(),
 			middlewares.SimpleLogger{},
+			middlewares.Namespace{},
 			middlewares.Authentication{},
 			middlewares.AllowList{Store: store},
 			middlewares.Authorization{Store: store},

--- a/backend/apid/middlewares/namespace.go
+++ b/backend/apid/middlewares/namespace.go
@@ -11,8 +11,8 @@ const (
 	defaultNamespace = "default"
 )
 
-// Namespace retrieves the namespace passed as a query parameter and validate
-// its existence against the data store and then add them to the request context
+// Namespace retrieves the namespace passed as a query parameter and add it into
+// the context of the request
 type Namespace struct {
 }
 

--- a/backend/apid/middlewares/namespace.go
+++ b/backend/apid/middlewares/namespace.go
@@ -1,0 +1,30 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sensu/sensu-go/types"
+)
+
+const (
+	defaultNamespace = "default"
+)
+
+// Namespace retrieves the namespace passed as a query parameter and validate
+// its existence against the data store and then add them to the request context
+type Namespace struct {
+}
+
+// Then middleware
+func (n Namespace) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var namespace string
+		if namespace = r.URL.Query().Get("namespace"); namespace == "" {
+			namespace = defaultNamespace
+		}
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, types.NamespaceKey, namespace)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It re-adds the namespace middleware so the namespace is added into context of the request, which is later used by the store.

## Why is this change necessary?

Bug reported by Eric

## Does your change need a Changelog entry?

Nope, it fixes a bug introduced is an unreleased feature.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope