### PR TITLE
Grepory/agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Improved event validation error messages.
 - Improved agent logging for statsd events.
 - Fixues issue with tooltip positioning.
+- The agent now reconnects to the backend if its first connection attempt
+  fails.
 
 ### Breaking Changes
 - Environments and organizations have been replaced with namespaces.

--- a/agent/api.go
+++ b/agent/api.go
@@ -34,14 +34,14 @@ func newServer(a *Agent) *http.Server {
 
 func registerRoutes(a *Agent, r *mux.Router) {
 	r.HandleFunc("/events", addEvent(a)).Methods(http.MethodPost)
-	r.HandleFunc("/healthz", healthz(a.conn)).Methods(http.MethodGet)
+	r.HandleFunc("/healthz", healthz(a.Connected)).Methods(http.MethodGet)
 }
 
 // healthz returns an OK status if the agent is up and connected to a backend.
 // If the backend connection is closed, it returns service unavailable.
-func healthz(conn transport.Transport) http.HandlerFunc {
+func healthz(connected func() bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if conn.Closed() {
+		if connected() {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_, _ = fmt.Fprint(w, "sensu backend unavailable")
 			return

--- a/agent/api_test.go
+++ b/agent/api_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/sensu/sensu-go/testing/mocktransport"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -69,31 +68,29 @@ func TestHealthz(t *testing.T) {
 	testCases := []struct {
 		desc             string
 		expectedResponse int
-		closeConn        bool
+		closeConn        int32
 	}{
 		{
 			"healthz returns success",
 			http.StatusOK,
-			false,
+			0,
 		},
 		{
 			"healthz returns failure",
 			http.StatusServiceUnavailable,
-			true,
+			1,
 		},
 	}
 
 	for _, tc := range testCases {
 		testName := fmt.Sprintf("test agent %s", tc.desc)
-		transport := &mocktransport.MockTransport{}
 
 		t.Run(testName, func(t *testing.T) {
 			// need to figure out how to pass the mock transport into the agent
 			config, cleanup := FixtureConfig()
 			defer cleanup()
 			agent := NewAgent(config)
-			agent.conn = transport
-			transport.On("Closed").Return(tc.closeConn)
+			agent.connected = tc.closeConn
 
 			r, err := http.NewRequest("GET", "/healthz", nil)
 			assert.NoError(t, err)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -4,11 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net/http"
 	"sync"
 
 	"github.com/gorilla/websocket"
-	"github.com/sensu/sensu-go/types"
 )
 
 var (
@@ -101,9 +99,6 @@ type Transport interface {
 	// Receive is used to receive a message from the transport. It takes a context
 	// and blocks until the next message is received from the transport.
 	Receive() (*Message, error)
-
-	// Reconnect ...
-	Reconnect(string, *types.TLSOptions, http.Header) error
 
 	// Send is used to send a message over the transport. It takes a message type
 	// hint and a serialized payload. Send will block until the message has been


### PR DESCRIPTION
## What is this change?

This reworks the reconnection / connection management path of the agent. Agents now reconnect if their initial connection attempt fails, and the transport is simplified so that it doesn't include any connection reuse logic. This also collapses the number of goroutines required for connection handling in the agent.

## Why is this change necessary?

The agent's connection handling logic was pretty difficult to follow and spread across a number of goroutines unnecessarily. This simplifies that workflow into two goroutines.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

I don't really need clarification, but I think if this approach to connection handling (sans reconnect logic) is satisfactory with people, then we should give the backend's agent session the same treatment. We could also then dramatically simplify the transport library.
