### PR TITLE
Use the get user endpoint to validate credentials

### DIFF
--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -47,6 +47,9 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Add the 'system:users' group to this user
+	user.Groups = append(user.Groups, "system:users")
+
 	// Create the token and a signed version
 	token, tokenString, err := jwt.AccessToken(user)
 	if err != nil {
@@ -193,6 +196,9 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
+
+	// Make sure to the 'system:users' group is present
+	user.Groups = append(user.Groups, "system:users")
 
 	// Remove the old access token from the access list
 	if err := a.store.DeleteTokens(accessClaims.Subject, []string{accessClaims.Id}); err != nil {

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -161,6 +161,7 @@ type UserAPIClient interface {
 	AddGroupToUser(string, string) error
 	CreateUser(*types.User) error
 	DisableUser(string) error
+	FetchUser(string) (*types.User, error)
 	ListUsers() ([]types.User, error)
 	ReinstateUser(string) error
 	RemoveGroupFromUser(string, string) error

--- a/cli/client/testing/mock_user_client.go
+++ b/cli/client/testing/mock_user_client.go
@@ -20,6 +20,12 @@ func (c *MockClient) DisableUser(username string) error {
 	return args.Error(0)
 }
 
+// FetchUser for use with mock lib
+func (c *MockClient) FetchUser(username string) (*types.User, error) {
+	args := c.Called(username)
+	return args.Get(0).(*types.User), args.Error(1)
+}
+
 // ListUsers for use with mock lib
 func (c *MockClient) ListUsers() ([]types.User, error) {
 	args := c.Called()

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -51,6 +51,23 @@ func (client *RestClient) DisableUser(username string) error {
 	return nil
 }
 
+// FetchUser retrieve the given user
+func (client *RestClient) FetchUser(username string) (*types.User, error) {
+	user := &types.User{}
+	res, err := client.R().Get("/rbac/users/" + url.PathEscape(username))
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode() >= 400 {
+		return nil, UnmarshalError(res)
+	}
+
+	err = json.Unmarshal(res.Body(), user)
+	return user, err
+}
+
 // ListUsers fetches all users from configured Sensu instance
 func (client *RestClient) ListUsers() ([]types.User, error) {
 	var users []types.User

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -97,7 +97,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				)
 			}
 
-			if _, err := cli.Client.FetchNamespace(answers.Namespace); err != nil {
+			if _, err := cli.Client.FetchUser(answers.Username); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/2321

Add the `system:users` group upon login and token renewal so all users can _view_ themselves, which is used to validate the users credentials.