### PR TITLE
Identify the cause of a transaction failure in generic store methods

### DIFF
--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -218,7 +218,7 @@ func (s *Store) update(ctx context.Context, key, namespace string, object interf
 		}
 
 		// Check if the key was missing
-		if len(resp.Responses[1].GetResponseRange().Kvs) != 0 {
+		if len(resp.Responses[1].GetResponseRange().Kvs) == 0 {
 			return &store.ErrNotFound{Key: key}
 		}
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -49,6 +49,16 @@ func (e *ErrEncode) Error() string {
 	return fmt.Sprintf("could not encode the key %s: %s", e.Key, e.Err.Error())
 }
 
+// ErrNamespaceMissing is returned when the user tries to manipulate a resource
+// within a namespaces that does not exist
+type ErrNamespaceMissing struct {
+	Namespace string
+}
+
+func (e *ErrNamespaceMissing) Error() string {
+	return fmt.Sprintf("the namespace %s does not exist", e.Namespace)
+}
+
 // ErrNotFound is returned when a key is not found in the store
 type ErrNotFound struct {
 	Key string


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/2323

Upon failure of an etcd transaction, try to fetch the namespace and the key itself to determine why it failed and return the appropriate response. Example:

```
$ sensuctl role-binding create testing --role testing --user foo --group foo
Error: resource already exists
$ sensuctl role-binding create testing --role testing --user foo --group foo --namespace acme
Error: the namespace acme does not exist
$ sensuctl role-binding create testing2 --role testing --user foo --group foo
Created
```