### PR TITLE
Add --all-namespaces flag to extension list subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add filter query support for labels.
 - Add support for setting labels on agents with the command line.
 - The sensuctl tool now supports yaml.
+- Add support for `--all-namespaces` flag in `sensuctl extension list`
+subcommand.
 
 ### Fixed
 - Display appropriate fallback when an entity's lastSeen field is empty.

--- a/cli/client/extension.go
+++ b/cli/client/extension.go
@@ -12,7 +12,7 @@ import (
 func (client *RestClient) ListExtensions(namespace string) ([]types.Extension, error) {
 	var extensions []types.Extension
 
-	res, err := client.R().Get("/extensions?namespace=" + namespace)
+	res, err := client.R().SetQueryParam("namespace", namespace).Get("/extensions")
 	if err != nil {
 		return extensions, err
 	}

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
+	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
 	"github.com/sensu/sensu-go/types"
@@ -22,7 +23,10 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short: "list extensions",
 		RunE:  runList(cli.Config.Format(), cli.Client, cli.Config.Namespace(), cli.Config.Format()),
 	}
+
+	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFormatFlag(cmd.Flags())
+
 	return cmd
 }
 
@@ -32,6 +36,10 @@ func runList(config string, client client.APIClient, namespace, format string) f
 			_ = cmd.Help()
 			return errors.New("invalid arguments received")
 		}
+		if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
+			namespace = types.NamespaceTypeAll
+		}
+
 		extensions, err := client.ListExtensions(namespace)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds the `--all-namespaces` flag to the `sensuctl extension list` subcommand

```
$ sensuctl extension list
  Name         URL
 ────── ──────────────────
  foo    //127.0.0.1/.../
$ sensuctl extension list --namespace acme
  Name         URL
 ────── ──────────────────
  bar    //127.0.0.1/.../
$ sensuctl extension list --all-namespaces
  Name         URL
 ────── ──────────────────
  bar    //127.0.0.1/.../
  foo    //127.0.0.1/.../
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1767

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope