### PR TITLE
Fix resource leaks in the monitor and ring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed several resource leaks in the check scheduler.
+
 ## [2.0.0-beta.8-1] - 2018-11-15
 
 ### Added

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -211,7 +211,7 @@ func newStartCommand() *cobra.Command {
 
 			if viper.GetBool(flagDebug) {
 				go func() {
-					log.Println(http.ListenAndServe("localhost:6060", nil))
+					log.Println(http.ListenAndServe(":6060", nil))
 				}()
 			}
 

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -3,6 +3,7 @@
 package messaging
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sensu/sensu-go/backend/daemon"
@@ -68,7 +69,7 @@ type MessageBus interface {
 	// PublishDirect routes a message to a single consumer of a topic.
 	// Implementations should make an effort for this to be fairly balanced
 	// between consumers.
-	PublishDirect(topic string, message interface{}) error
+	PublishDirect(ctx context.Context, topic string, message interface{}) error
 }
 
 // SubscriptionTopic is a helper to determine the proper topic name for a

--- a/backend/messaging/wizard_bus_test.go
+++ b/backend/messaging/wizard_bus_test.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -142,7 +143,7 @@ func TestPublishDirect(t *testing.T) {
 		_, err := bus.Subscribe("topic", id, ch)
 		require.NoError(t, err)
 	}
-	require.NoError(t, bus.PublishDirect("topic", "hello, world"))
+	require.NoError(t, bus.PublishDirect(context.TODO(), "topic", "hello, world"))
 	select {
 	case msg := <-subscribers["a"].Channel:
 		assert.Equal(t, msg, "hello, world")

--- a/backend/messaging/wizard_topic.go
+++ b/backend/messaging/wizard_topic.go
@@ -43,12 +43,12 @@ func (t *wizardTopic) Send(msg interface{}) {
 // ring. In a distributed environment, SendDirect may send a message, or it
 // may not, depending if the next subscriber in the round-robin is bound to
 // the backend.
-func (t *wizardTopic) SendRoundRobin(msg interface{}) error {
+func (t *wizardTopic) SendRoundRobin(ctx context.Context, msg interface{}) error {
 	if t.ring == nil {
 		return errors.New("no ring for topic: " + t.id)
 	}
 
-	id, err := t.ring.Next(context.Background())
+	id, err := t.ring.Next(ctx)
 	if err != nil {
 		if err == ring.ErrNotOwner || err == ring.ErrEmptyRing {
 			return nil

--- a/backend/monitor/monitor_test.go
+++ b/backend/monitor/monitor_test.go
@@ -124,7 +124,7 @@ func TestGetMonitorExisting(t *testing.T) {
 	testMon := &monitor{
 		key:     "testGetMonitorExisting",
 		leaseID: 0,
-		ttl:     0,
+		ttl:     3600,
 	}
 	monitorSupervisor := NewEtcdSupervisor(client, handler)
 	_, err = client.Put(context.Background(), testMon.key, fmt.Sprintf("%d", testMon.ttl))
@@ -153,7 +153,7 @@ func TestWatchMonDelete(t *testing.T) {
 	mon := &monitor{
 		key:     "monitorTestDelete",
 		leaseID: 0,
-		ttl:     0,
+		ttl:     3600,
 	}
 	_, err = client.Put(context.Background(), mon.key, "test value")
 	require.NoError(t, err)
@@ -182,7 +182,7 @@ func TestWatchMonPut(t *testing.T) {
 	mon := &monitor{
 		key:     "monitorTestPut",
 		leaseID: 0,
-		ttl:     0,
+		ttl:     3600,
 	}
 
 	_, err = client.Put(context.Background(), mon.key, "test value")

--- a/backend/monitor/supervisor.go
+++ b/backend/monitor/supervisor.go
@@ -2,11 +2,14 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -15,9 +18,32 @@ import (
 )
 
 var (
-	monitorPathPrefix = "monitors"
-	monitorKeyBuilder = store.NewKeyBuilder(monitorPathPrefix)
+	monitorPathPrefix     = "monitors"
+	monitorKeyBuilder     = store.NewKeyBuilder(monitorPathPrefix)
+	leasesToRevoke        = make(map[clientv3.LeaseID]struct{})
+	leasesMu              sync.Mutex
+	leasesOnce            sync.Once
+	packageClientDoNotUse *clientv3.Client
 )
+
+func init() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	// TODO:(echlebek) get rid of this when we fix all of this stuff :)
+	go func() {
+		<-sigs
+
+		leasesMu.Lock()
+		defer leasesMu.Unlock()
+
+		for id := range leasesToRevoke {
+			// There is nothing useful we can do with the error.
+			// If the lease can't be revoked, it will expire later on.
+			_, _ = packageClientDoNotUse.Lease.Revoke(context.TODO(), id)
+		}
+	}()
+}
 
 // Supervisor provides a way to refresh a named monitor. It is a proxy for all
 // of the running monitors in the system.
@@ -53,6 +79,9 @@ type Factory func(Handler) Supervisor
 
 // NewEtcdSupervisor returns a new Supervisor backed by Etcd.
 func NewEtcdSupervisor(client *clientv3.Client, h Handler) *EtcdSupervisor {
+	leasesOnce.Do(func() {
+		packageClientDoNotUse = client
+	})
 	return &EtcdSupervisor{
 		client:         client,
 		failureHandler: h,
@@ -65,6 +94,9 @@ func NewEtcdSupervisor(client *clientv3.Client, h Handler) *EtcdSupervisor {
 // extended. If the monitor's ttl has changed, a new lease is created and the
 // key is updated with that new lease.
 func (m *EtcdSupervisor) Monitor(ctx context.Context, name string, event *types.Event, ttl int64) error {
+	if ttl == 0 {
+		return errors.New("monitor ttl cannot be 0")
+	}
 	key := monitorKeyBuilder.Build(name)
 	// try to get the monitor from the store
 	mon, err := m.getMonitor(ctx, key)
@@ -146,38 +178,37 @@ func (m *EtcdSupervisor) getMonitor(ctx context.Context, key string) (*monitor, 
 // is witnessed, it calls the provided HandleFailure func. If a PUT event is
 // witnessed, the watcher is stopped.
 func watchMon(ctx context.Context, cli *clientv3.Client, mon *monitor, failureHandler func(), shutdownHandler func()) {
+	if mon.ttl == 0 {
+		panic("zero-duration ttl")
+	}
+	ctx, cancel := context.WithCancel(ctx)
 	responseChan := cli.Watch(ctx, mon.key)
+	timer := time.NewTimer(time.Duration(mon.ttl) * time.Second)
 	go func() {
-		for wresp := range responseChan {
-			for _, ev := range wresp.Events {
-				if ev.Type == mvccpb.DELETE {
-					failureHandler()
-					return
+		defer timer.Stop()
+		defer cancel()
+		for {
+			select {
+			case wresp := <-responseChan:
+				for _, ev := range wresp.Events {
+					if ev.Type == mvccpb.DELETE {
+						failureHandler()
+						return
+					}
+					// if there is a PUT on the key, the lease has been extended,
+					// and we want to kill this watcher to avoid duplicate watchers.
+					if ev.Type == mvccpb.PUT {
+						shutdownHandler()
+						return
+					}
 				}
-				// if there is a PUT on the key, the lease has been extended,
-				// and we want to kill this watcher to avoid duplicate watchers.
-				if ev.Type == mvccpb.PUT {
-					shutdownHandler()
-					return
-				}
+			case <-timer.C:
+				failureHandler()
+				return
 			}
 		}
 	}()
-
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-sigs
-
-		logger.Debugf("signal %s received, revoking lease for key %s",
-			sig.String(),
-			mon.key,
-		)
-
-		if _, err := cli.Lease.Revoke(ctx, mon.leaseID); err != nil {
-			logger.WithError(err).Warningf("could not revoke the lease %v for the key %s",
-				mon.leaseID, mon.key,
-			)
-		}
-	}()
+	leasesMu.Lock()
+	defer leasesMu.Unlock()
+	leasesToRevoke[mon.leaseID] = struct{}{}
 }

--- a/backend/monitor/supervisor.go
+++ b/backend/monitor/supervisor.go
@@ -209,6 +209,6 @@ func watchMon(ctx context.Context, cli *clientv3.Client, mon *monitor, failureHa
 		}
 	}()
 	leasesMu.Lock()
-	defer leasesMu.Unlock()
 	leasesToRevoke[mon.leaseID] = struct{}{}
+	leasesMu.Unlock()
 }

--- a/backend/ring/ring.go
+++ b/backend/ring/ring.go
@@ -318,7 +318,12 @@ func (r *Ring) Next(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("error initializing ring: %s", err)
 	}
 	r.wake()
-	watchResponse := <-r.watchChan
+	var watchResponse clientv3.WatchResponse
+	select {
+	case watchResponse = <-r.watchChan:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 	if watchResponse.Canceled {
 		r.initWatcher()
 		return r.Next(ctx)

--- a/backend/schedulerd/round_robin_scheduler.go
+++ b/backend/schedulerd/round_robin_scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	time "github.com/echlebek/timeproxy"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/types"
 )
@@ -53,7 +54,10 @@ func (r *roundRobinScheduler) loop() {
 // execute executes a round robin check request
 func (r *roundRobinScheduler) execute(msg *roundRobinMessage) {
 	defer msg.wg.Done()
-	if err := r.bus.PublishDirect(msg.subscription, msg.req); err != nil {
+	timeout := time.Second * time.Duration(msg.req.Config.Interval)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := r.bus.PublishDirect(ctx, msg.subscription, msg.req); err != nil {
 		r.logError(err, msg.req.Config.Name)
 	}
 }

--- a/backend/schedulerd/round_robin_scheduler_test.go
+++ b/backend/schedulerd/round_robin_scheduler_test.go
@@ -14,7 +14,7 @@ func TestRoundRobinScheduler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bus := mockbus.MockBus{}
-	bus.On("PublishDirect", "ramen-vending-machine", mock.Anything).Return(nil)
+	bus.On("PublishDirect", mock.Anything, "ramen-vending-machine", mock.Anything).Return(nil)
 	sched := newRoundRobinScheduler(ctx, &bus)
 	msg := &roundRobinMessage{
 		req:          types.FixtureCheckRequest("foo"),
@@ -23,5 +23,5 @@ func TestRoundRobinScheduler(t *testing.T) {
 	wg, err := sched.Schedule(msg)
 	require.NoError(t, err)
 	wg.Wait()
-	bus.AssertCalled(t, "PublishDirect", "ramen-vending-machine", msg.req)
+	bus.AssertCalled(t, "PublishDirect", mock.Anything, "ramen-vending-machine", msg.req)
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   backend1:
     image: sensu/sensu:master
-    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend1 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend1:2380 --state-dir /var/lib/sensu/etcd1 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug
+    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend1 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend1:2380 --state-dir /var/lib/sensu/etcd1 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug --debug
     hostname: backend1
     restart: always
     ports:
@@ -10,6 +10,7 @@ services:
       - "2380:2380"
       - "8080:8080"
       - "8081:8081"
+      - "6060:6060"
   backend2:
     image: sensu/sensu:master
     command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend2 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend2:2380 --state-dir /var/lib/sensu/etcd2 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug

--- a/testing/mockbus/mock.go
+++ b/testing/mockbus/mock.go
@@ -1,6 +1,8 @@
 package mockbus
 
 import (
+	"context"
+
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/stretchr/testify/mock"
 )
@@ -53,7 +55,7 @@ func (m *MockBus) Publish(topic string, message interface{}) error {
 }
 
 // PublishDirect ...
-func (m *MockBus) PublishDirect(topic string, message interface{}) error {
-	args := m.Called(topic, message)
+func (m *MockBus) PublishDirect(ctx context.Context, topic string, message interface{}) error {
+	args := m.Called(ctx, topic, message)
 	return args.Error(0)
 }

--- a/util/strings/strings.go
+++ b/util/strings/strings.go
@@ -1,10 +1,11 @@
 package strings
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 const (
-	numericStart    = 48
-	numericStop     = 57
 	lowerAlphaStart = 97
 	lowerAlphaStop  = 122
 )
@@ -25,17 +26,13 @@ func InArray(item string, array []string) bool {
 	return false
 }
 
-func isDigit(r rune) bool {
-	return r >= numericStart && r <= numericStop
-}
-
 func isAlpha(r rune) bool {
 	return r >= lowerAlphaStart && r <= lowerAlphaStop
 }
 
 func alphaNumeric(s string) bool {
 	for _, r := range s {
-		if !(isDigit(r) || isAlpha(r)) {
+		if !(unicode.IsDigit(r) || isAlpha(r)) {
 			return false
 		}
 	}

--- a/util/strings/strings.go
+++ b/util/strings/strings.go
@@ -1,8 +1,12 @@
 package strings
 
-import (
-	"regexp"
-	"strings"
+import "strings"
+
+const (
+	numericStart    = 48
+	numericStop     = 57
+	lowerAlphaStart = 97
+	lowerAlphaStop  = 122
 )
 
 // InArray searches 'array' for 'item' string
@@ -12,13 +16,56 @@ func InArray(item string, array []string) bool {
 		return false
 	}
 
-	for _, element := range array {
-		if element == item {
+	for i := range array {
+		if array[i] == item {
 			return true
 		}
 	}
 
 	return false
+}
+
+func isDigit(r rune) bool {
+	return r >= numericStart && r <= numericStop
+}
+
+func isAlpha(r rune) bool {
+	return r >= lowerAlphaStart && r <= lowerAlphaStop
+}
+
+func alphaNumeric(s string) bool {
+	for _, r := range s {
+		if !(isDigit(r) || isAlpha(r)) {
+			return false
+		}
+	}
+	return true
+}
+
+func isNormalized(array []string) bool {
+	for i := range array {
+		if !alphaNumeric(array[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalize(s string) string {
+	if alphaNumeric(s) {
+		return s
+	}
+	lowered := strings.ToLower(s)
+	if alphaNumeric(lowered) {
+		return lowered
+	}
+	trimmed := make([]rune, 0, len(lowered))
+	for _, r := range lowered {
+		if isAlpha(r) {
+			trimmed = append(trimmed, r)
+		}
+	}
+	return string(trimmed)
 }
 
 // FoundInArray searches array for item without distinguishing between uppercase
@@ -29,17 +76,10 @@ func FoundInArray(item string, array []string) bool {
 		return false
 	}
 
-	// Prepare our regex in order to remove all non-alphanumeric characters
-	r, err := regexp.Compile("[^a-zA-Z0-9]+")
-	if err != nil {
-		return false
-	}
+	item = normalize(item)
 
-	item = r.ReplaceAllString(strings.ToLower(item), "")
-
-	for _, element := range array {
-		element = r.ReplaceAllString(strings.ToLower(element), "")
-		if element == item {
+	for i := range array {
+		if normalize(array[i]) == item {
 			return true
 		}
 	}

--- a/util/strings/strings.go
+++ b/util/strings/strings.go
@@ -42,15 +42,6 @@ func alphaNumeric(s string) bool {
 	return true
 }
 
-func isNormalized(array []string) bool {
-	for i := range array {
-		if !alphaNumeric(array[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 func normalize(s string) string {
 	if alphaNumeric(s) {
 		return s

--- a/util/strings/strings_test.go
+++ b/util/strings/strings_test.go
@@ -76,3 +76,9 @@ func TestIntersect(t *testing.T) {
 	intr = Intersect(a, b)
 	assert.Equal(t, []string{}, intr)
 }
+
+func BenchmarkFoundInArray(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FoundInArray("foo!BAR   baz", []string{"foo", "foobar", "FOO BAR", "foo bar baz", "foobarbaz"})
+	}
+}


### PR DESCRIPTION
```
    Fix resource leaks in the monitor and ring.
    
    This commit fixes a goroutine leak in the supervisor, where each
    monitor would create a goroutine that would never terminate until
    the end of the program. It also adds some code that guards against
    watchers that are still waiting on events after the TTL has been
    reached.
    
    This commit also fixes a goroutine leak in the ring, where Next
    calls would build up over time. Now, Next calls will last no
    longer than the check interval duration they are associated with.
```

Closes #2314 