### PR TITLE
[Web UI] Event Details keepalive improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed several resource leaks in the check scheduler.
 - Fixed a bug in the dashboard where entities could not be silenced.
 - Fixed interactive operations on entities in the CLI
+- Removed rerun and check links for keepalives on event details page.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -123,12 +123,13 @@ class EventDetailsCheckResult extends React.PureComponent {
                 <DictionaryEntry>
                   <DictionaryKey>Check</DictionaryKey>
                   <DictionaryValue>
-                    <NamespaceLink
-                      component={InlineLink}
-                      to={`/checks/${check.name}`}
-                    >
-                      {check.name}
-                    </NamespaceLink>
+                    {check.name !== "keepalive" ? (
+                      <InlineLink to={`/checks/${check.name}`}>
+                        {check.name}
+                      </InlineLink>
+                    ) : (
+                      check.name
+                    )}
                   </DictionaryValue>
                 </DictionaryEntry>
                 <DictionaryEntry>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -62,9 +62,13 @@ class EventDetailsSummary extends React.Component {
             <DictionaryEntry>
               <DictionaryKey>Check</DictionaryKey>
               <DictionaryValue>
-                <InlineLink to={`/${namespace}/checks/${check.name}`}>
-                  {check.name}
-                </InlineLink>
+                {check.name !== "keepalive" ? (
+                  <InlineLink to={`/${namespace}/checks/${check.name}`}>
+                    {check.name}
+                  </InlineLink>
+                ) : (
+                  check.name
+                )}
               </DictionaryValue>
             </DictionaryEntry>
             <DictionaryEntry>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsToolbar.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsToolbar.js
@@ -46,15 +46,17 @@ class EventDetailsToolbar extends React.Component {
               </ResolveAction>
             </ToolbarMenu.Item>
             <ToolbarMenu.Item id="re-run" visible="if-room">
-              <ReRunAction event={event}>
-                {run => (
-                  <QueueMenuItem
-                    title="Re-run Check"
-                    titleCondensed="Re-run"
-                    onClick={run}
-                  />
-                )}
-              </ReRunAction>
+              {event.check.name !== "keepalive" && (
+                <ReRunAction event={event}>
+                  {run => (
+                    <QueueMenuItem
+                      title="Re-run Check"
+                      titleCondensed="Re-run"
+                      onClick={run}
+                    />
+                  )}
+                </ReRunAction>
+              )}
             </ToolbarMenu.Item>
             <ToolbarMenu.Item id="delete" visible="never">
               <DeleteAction event={event}>


### PR DESCRIPTION
## What is this change?
Closes #2312 
- Removes re-run button from the event details page for keepalive events
- Removes links to keepalive check details page from the event details page because it would 404

## Why is this change necessary?
Stability

## Does your change need a Changelog entry?
Sure