### PR TITLE
Fix object listing in namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed issue filtering by status on the events page
 - Fixed interactive operations on entities in the CLI
 - Removed rerun and check links for keepalives on event details page.
+- Fixed a bug where resources from namespaces that share a common prefix, eg:
+  "sensu" and "sensu-devel", could be listed together.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/backend/store/etcd/check_store.go
+++ b/backend/store/etcd/check_store.go
@@ -38,7 +38,6 @@ func (s *Store) DeleteCheckConfigByName(ctx context.Context, name string) error 
 }
 
 // GetCheckConfigs returns check configurations for an (optional) namespace.
-// If org is the empty string, it returns all check configs.
 func (s *Store) GetCheckConfigs(ctx context.Context) ([]*types.CheckConfig, error) {
 	resp, err := query(ctx, s, getCheckConfigsPath)
 	if err != nil {

--- a/backend/store/key_builder.go
+++ b/backend/store/key_builder.go
@@ -81,7 +81,6 @@ func (b KeyBuilder) BuildPrefix(keys ...string) string {
 		if key == "" {
 			continue
 		}
-		//
 		out = out + keySeparator + key
 	}
 

--- a/backend/store/key_builder.go
+++ b/backend/store/key_builder.go
@@ -49,7 +49,20 @@ func (b KeyBuilder) Build(keys ...string) string {
 		},
 		keys...,
 	)
-	return path.Join(items...)
+
+	key := path.Join(items...)
+
+	// In order to not inadvertently build a key that could list across
+	// namespaces, we need to make sure that we terminate the key with the key
+	// separator when a namespace is involved without a specific object name
+	// within it.
+	if b.namespace.Namespace != "" {
+		if len(keys) == 0 || keys[len(keys)-1] == "" {
+			key += keySeparator
+		}
+	}
+
+	return key
 }
 
 // BuildPrefix can be used when building a key that will be used to retrieve a collection of
@@ -68,6 +81,7 @@ func (b KeyBuilder) BuildPrefix(keys ...string) string {
 		if key == "" {
 			continue
 		}
+		//
 		out = out + keySeparator + key
 	}
 

--- a/backend/store/key_builder_test.go
+++ b/backend/store/key_builder_test.go
@@ -22,4 +22,9 @@ func TestContextKeyBuilder(t *testing.T) {
 	ctx = context.WithValue(ctx, types.NamespaceKey, "acme")
 	builder := NewKeyBuilder("checks").WithContext(ctx)
 	assert.Equal(t, "/sensu.io/checks/acme/check_name", builder.Build("check_name"))
+
+	// Querying the content of a whole namespace uses etcd prefixes, so we want
+	// the key to end in '/' in order not to inadvertently retrieve objects from
+	// a different namespace that would have the same prefix, eg: acme-devel
+	assert.Equal(t, "/sensu.io/checks/acme/", builder.Build(""))
 }


### PR DESCRIPTION
## What is this change?
Resources from namespaces that share a common prefix, eg: "sensu" and
"sensu-devel", could be listed together.

This was due to a bug with key construction and key prefix usage in the
etcd client.

## Why is this change necessary?

Closes #2371.

## Does your change need a Changelog entry?

Yes, added.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.
