### PR TITLE
[Web UI] Remove global `react/no-danger` suppression

### DIFF
--- a/dashboard/.eslintrc.yml
+++ b/dashboard/.eslintrc.yml
@@ -47,9 +47,6 @@ rules:
 
   import/prefer-default-export: 0
 
-  # Code Highlighting requirees dangerously setting
-  react/no-danger: 0
-
   # https://github.com/apollographql/eslint-plugin-graphql
   graphql/template-strings:
     - error

--- a/dashboard/src/components/CodeHighlight/CodeHighlight.js
+++ b/dashboard/src/components/CodeHighlight/CodeHighlight.js
@@ -27,7 +27,11 @@ class CodeHighlight extends React.Component {
   static propTypes = {
     language: PropTypes.oneOf(["json", "bash", "properties"]).isRequired,
     code: PropTypes.string.isRequired,
-    children: PropTypes.func.isRequired,
+    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  };
+
+  static defaultProps = {
+    component: "code",
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -66,7 +70,10 @@ class CodeHighlight extends React.Component {
   };
 
   render() {
-    return this.props.children(this.state.result);
+    const { component: Component } = this.props;
+    return (
+      <Component dangerouslySetInnerHTML={{ __html: this.state.result }} />
+    );
   }
 }
 

--- a/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
+++ b/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
@@ -153,11 +153,11 @@ class CheckDetailsConfiguration extends React.PureComponent {
                 <DictionaryEntry>
                   <DictionaryKey>Command</DictionaryKey>
                   <DictionaryValue explicitRightMargin>
-                    <CodeHighlight language="bash" code={check.command}>
-                      {code => (
-                        <Code dangerouslySetInnerHTML={{ __html: code }} />
-                      )}
-                    </CodeHighlight>
+                    <CodeHighlight
+                      language="bash"
+                      code={check.command}
+                      component={Code}
+                    />
                   </DictionaryValue>
                 </DictionaryEntry>
 
@@ -272,11 +272,8 @@ class CheckDetailsConfiguration extends React.PureComponent {
                         <CodeHighlight
                           language="properties"
                           code={check.envVars.join("\n")}
-                        >
-                          {code => (
-                            <code dangerouslySetInnerHTML={{ __html: code }} />
-                          )}
-                        </CodeHighlight>
+                          component="code"
+                        />
                       </CodeBlock>
                     ) : (
                       "None"
@@ -364,9 +361,8 @@ class CheckDetailsConfiguration extends React.PureComponent {
                     null,
                     "\t",
                   )}`}
-                >
-                  {code => <code dangerouslySetInnerHTML={{ __html: code }} />}
-                </CodeHighlight>
+                  component="code"
+                />
               </CardContent>
             </CodeBlock>
           </React.Fragment>

--- a/dashboard/src/components/partials/ChecksList/ChecksListItem.js
+++ b/dashboard/src/components/partials/ChecksList/ChecksListItem.js
@@ -80,9 +80,11 @@ class CheckListItem extends React.Component {
             }
             details={
               <React.Fragment>
-                <CodeHighlight language="bash" code={check.command}>
-                  {code => <Code dangerouslySetInnerHTML={{ __html: code }} />}
-                </CodeHighlight>
+                <CodeHighlight
+                  language="bash"
+                  code={check.command}
+                  component={Code}
+                />
                 <br />
                 <CheckSchedule check={check} />
               </React.Fragment>

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
@@ -239,9 +239,8 @@ class EntityDetailsInformation extends React.PureComponent {
                 <CodeHighlight
                   language="json"
                   code={JSON.stringify(entity.extendedAttributes, null, "\t")}
-                >
-                  {code => <code dangerouslySetInnerHTML={{ __html: code }} />}
-                </CodeHighlight>
+                  component="code"
+                />
               </CardContent>
             </CodeBlock>
           </React.Fragment>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -124,9 +124,8 @@ class EventDetailsSummary extends React.Component {
                 <CodeHighlight
                   language="bash"
                   code={`# Executed command\n$ ${check.command}`}
-                >
-                  {code => <code dangerouslySetInnerHTML={{ __html: code }} />}
-                </CodeHighlight>
+                  component="code"
+                />
               </CardContent>
             </CodeBlock>
           </React.Fragment>


### PR DESCRIPTION
## What is this change?

Refactor the `<CodeHighlight>` component so that it does not require using the `dangerouslySetInnerHTML` prop at each instance.

## Why is this change necessary?

 This allows us to leave the `react/no-danger` lint rule enabled to catch other potential issues elsewhere.

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No