### PR TITLE
Fix a deadlock in the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ uses the same facility as check subdue for handling time windows.
 - Web UI - Made silencing language more clear on Silences List page
 - Fixed a bug where resources from namespaces that share a common prefix, eg:
   "sensu" and "sensu-devel", could be listed together.
+- Fixed a bug in the agent where the agent would deadlock after a significant
+period of disconnection from the backend.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -365,7 +365,7 @@ func connectWithBackoff(url string, tlsOpts *types.TLSOptions, header http.Heade
 	var conn transport.Transport
 
 	backoff := retry.ExponentialBackoff{
-		InitialDelayInterval: time.Millisecond,
+		InitialDelayInterval: 10 * time.Millisecond,
 		MaxDelayInterval:     10 * time.Second,
 		Multiplier:           10,
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -237,6 +237,11 @@ func (a *Agent) receiveLoop(conn transport.Transport, done chan struct{}) {
 func (a *Agent) sendLoop(conn transport.Transport, done chan struct{}) {
 	keepalive := time.NewTicker(time.Duration(a.config.KeepaliveInterval) * time.Second)
 	defer keepalive.Stop()
+	logger.Info("sending keepalive")
+	if err := conn.Send(a.newKeepalive()); err != nil {
+		logger.WithError(err).Error("error sending message over websocket")
+		return
+	}
 	for {
 		select {
 		case <-done:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -49,6 +49,8 @@ func TestSendLoop(t *testing.T) {
 	cfg.API.Port = 0
 	cfg.Socket.Port = 0
 	ta := NewAgent(cfg)
+	mockTime.Start()
+	defer mockTime.Stop()
 	err := ta.Run()
 	require.NoError(t, err)
 	defer ta.Stop()
@@ -197,6 +199,8 @@ func TestKeepaliveLoggingRedaction(t *testing.T) {
 	cfg.API.Port = 0
 	cfg.Socket.Port = 0
 	ta := NewAgent(cfg)
+	mockTime.Start()
+	defer mockTime.Stop()
 	err := ta.Run()
 	require.NoError(t, err)
 	defer ta.Stop()

--- a/agent/timeproxy_test.go
+++ b/agent/timeproxy_test.go
@@ -13,6 +13,6 @@ func init() {
 	// advance the mock time by 500ms every 10ms of real time, giving us a
 	// precision of about 500ms for the mock time.
 	mockTime.Resolution = 10 * time.Millisecond
-	mockTime.Multiplier = 50
+	mockTime.Multiplier = 500
 	time.TimeProxy = mockTime
 }

--- a/agent/timeproxy_test.go
+++ b/agent/timeproxy_test.go
@@ -13,6 +13,6 @@ func init() {
 	// advance the mock time by 500ms every 10ms of real time, giving us a
 	// precision of about 500ms for the mock time.
 	mockTime.Resolution = 10 * time.Millisecond
-	mockTime.Multiplier = 500
+	mockTime.Multiplier = 50
 	time.TimeProxy = mockTime
 }

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -10,15 +10,19 @@ import (
 type ExponentialBackoff struct {
 	// InitialDelayInterval represents the initial amount of time of sleep
 	InitialDelayInterval time.Duration
+
 	// MaxDelayInterval represents the maximal amount of time of sleep between
 	// retries
 	MaxDelayInterval time.Duration
+
 	// MaxElapsedTime represents the maximal amount of time allowed to retry. A
 	// value of zero signifies no limit
 	MaxElapsedTime time.Duration
+
 	// MaxRetryAttempts is the maximal number of retries before exiting with
 	// an error. A value of zero signifies unlimited retry attemps
 	MaxRetryAttempts int
+
 	// Multiplier is used to increment the current interval by multiplying it with
 	// this multiplier
 	Multiplier float64
@@ -51,6 +55,9 @@ func (b *ExponentialBackoff) Retry(fn Func) error {
 			}
 
 			// Sleep for the determined duration
+			if b.MaxDelayInterval > 0 && wait > b.MaxDelayInterval {
+				wait = b.MaxDelayInterval
+			}
 			time.Sleep(wait)
 
 			// Exponentially increase that sleep duration


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in the agent where the send queue could
fill up with keepalives after a long period of disconnection. On
successful reconnection, the agent would try to send an immediate
keepalive, before returning control to the event loop responsible
for normal operation. This operation would block forever, resulting
in deadlock.

Agents will now only buffer a single keepalive; when the agent
reconnects, instead of sending multiple keepalives, it will send
only one, regardless of how much time has progressed.

This commit also fixes a bug in the retry library, where the
MaxDelayInterval parameter was not considered in computing the
amount of time to wait before retrying.

Finally, the agent's retry timeout has been adjusted. The agent
will retry on the following schedule:

10 ms, 100 ms, 1s, 10s

After reaching 10s, the agent will wait a maximum of 10s (with
jitter) before retrying.

## Why is this change necessary?

Closes #2367 

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

## Were there any complications while making this change?

I noticed that the retry library had a slight defect, which I corrected.