### PR TITLE
GraphQL service unauthorized err

### DIFF
--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -194,7 +194,10 @@ func registerGraphQLService(router *mux.Router, store store.Store, url string, t
 			router.NewRoute(),
 			middlewares.SimpleLogger{},
 			middlewares.LimitRequest{},
-			// Allow requests without an access token to continue
+			// TODO: Currently the web app relies on receiving a 401 to determine if
+			//       a user is not authenticated. However, in the future we should
+			//       allow requests without an access token to continue so that the
+			//       schema can be queried without authorization.
 			middlewares.Authentication{IgnoreUnauthorized: false},
 			middlewares.AllowList{Store: store, IgnoreMissingClaims: true},
 			middlewares.Edition{Name: version.Edition},

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -196,8 +196,12 @@ func registerGraphQLService(router *mux.Router, store store.Store, url string, t
 			middlewares.LimitRequest{},
 			// TODO: Currently the web app relies on receiving a 401 to determine if
 			//       a user is not authenticated. However, in the future we should
-			//       allow requests without an access token to continue so that the
-			//       schema can be queried without authorization.
+			//       allow requests without an access token to continue so that
+			//       unauthenticated clients can still fetch the schema. Useful for
+			//       implementing tools like GraphiQL.
+			//
+			//       https://github.com/graphql/graphiql
+			//       https://graphql.org/learn/introspection/
 			middlewares.Authentication{IgnoreUnauthorized: false},
 			middlewares.AllowList{Store: store, IgnoreMissingClaims: true},
 			middlewares.Edition{Name: version.Edition},

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -195,7 +195,7 @@ func registerGraphQLService(router *mux.Router, store store.Store, url string, t
 			middlewares.SimpleLogger{},
 			middlewares.LimitRequest{},
 			// Allow requests without an access token to continue
-			middlewares.Authentication{IgnoreUnauthorized: true},
+			middlewares.Authentication{IgnoreUnauthorized: false},
 			middlewares.AllowList{Store: store, IgnoreMissingClaims: true},
 			middlewares.Edition{Name: version.Edition},
 		),

--- a/backend/apid/graphql/fetch.go
+++ b/backend/apid/graphql/fetch.go
@@ -13,6 +13,8 @@ type assetPredicate func(*types.Asset) bool
 func fetchAssets(c client.APIClient, ns string, filter assetPredicate) ([]*types.Asset, error) {
 	records, err := c.ListAssets(ns)
 	relevant := make([]*types.Asset, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -38,6 +40,8 @@ type checkPredicate func(*types.CheckConfig) bool
 func fetchChecks(c client.APIClient, ns string, filter checkPredicate) ([]*types.CheckConfig, error) {
 	records, err := c.ListChecks(ns)
 	relevant := make([]*types.CheckConfig, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -63,6 +67,8 @@ type entityPredicate func(*types.Entity) bool
 func fetchEntities(c client.APIClient, ns string, filter entityPredicate) ([]*types.Entity, error) {
 	records, err := c.ListEntities(ns)
 	relevant := make([]*types.Entity, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -88,6 +94,8 @@ type eventPredicate func(*types.Event) bool
 func fetchEvents(c client.APIClient, ns string, filter eventPredicate) ([]*types.Event, error) {
 	records, err := c.ListEvents(ns)
 	relevant := make([]*types.Event, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -113,6 +121,8 @@ type handlerPredicate func(*types.Handler) bool
 func fetchHandlers(c client.APIClient, ns string, filter handlerPredicate) ([]*types.Handler, error) {
 	records, err := c.ListHandlers(ns)
 	relevant := make([]*types.Handler, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -138,6 +148,8 @@ type namespacePredicate func(*types.Namespace) bool
 func fetchNamespaces(c client.APIClient, filter namespacePredicate) ([]*types.Namespace, error) {
 	records, err := c.ListNamespaces()
 	relevant := make([]*types.Namespace, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -163,6 +175,8 @@ type silencePredicate func(*types.Silenced) bool
 func fetchSilenceds(c client.APIClient, ns string, filter silencePredicate) ([]*types.Silenced, error) {
 	records, err := c.ListSilenceds(ns, "", "")
 	relevant := make([]*types.Silenced, 0, len(records))
+
+	err = handleListErr(err)
 	if err != nil {
 		return relevant, err
 	}
@@ -194,4 +208,15 @@ func handleFetchResult(resource interface{}, err error) (interface{}, error) {
 		return nil, err
 	}
 	return resource, err
+}
+
+// When resolving a field, GraphQL does not consider the absence of a value an
+// error; as such we omit the error if the API client returns Permission denied.
+func handleListErr(err error) error {
+	if apiErr, ok := err.(client.APIError); ok {
+		if apiErr.Code == uint32(actions.PermissionDenied) {
+			return nil
+		}
+	}
+	return err
 }

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -230,7 +230,7 @@ func (r *namespaceImpl) CheckHistory(p schema.NamespaceCheckHistoryFieldResolver
 	ctx := contextWithNamespace(p.Context, nsp.Name)
 
 	client := r.factory.NewWithContext(ctx)
-	records, err := client.ListEvents(nsp.Name)
+	records, err := fetchEvents(client, nsp.Name, nil)
 	if err != nil {
 		return []types.CheckHistory{}, err
 	}
@@ -264,7 +264,7 @@ func (r *namespaceImpl) Subscriptions(p schema.NamespaceSubscriptionsFieldResolv
 	ctx := contextWithNamespace(p.Context, nsp.Name)
 
 	client := r.factory.NewWithContext(ctx)
-	entities, err := client.ListEntities(nsp.Name)
+	entities, err := fetchEntities(client, nsp.Name, nil)
 	if err != nil {
 		return set, err
 	}
@@ -274,7 +274,7 @@ func (r *namespaceImpl) Subscriptions(p schema.NamespaceSubscriptionsFieldResolv
 		set.Merge(newSet)
 	}
 
-	checks, err := client.ListChecks(nsp.Name)
+	checks, err := fetchChecks(client, nsp.Name, nil)
 	if err != nil {
 		return set, err
 	}

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -270,7 +270,7 @@ func (r *namespaceImpl) Subscriptions(p schema.NamespaceSubscriptionsFieldResolv
 	}
 	for i := range entities {
 		entity := entities[i]
-		newSet := occurrencesOfSubscriptions(&entity)
+		newSet := occurrencesOfSubscriptions(entity)
 		set.Merge(newSet)
 	}
 
@@ -280,7 +280,7 @@ func (r *namespaceImpl) Subscriptions(p schema.NamespaceSubscriptionsFieldResolv
 	}
 	for i := range checks {
 		check := checks[i]
-		newSet := occurrencesOfSubscriptions(&check)
+		newSet := occurrencesOfSubscriptions(check)
 		set.Merge(newSet)
 	}
 

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -18,7 +18,7 @@ func (client *RestClient) ListAssets(namespace string) ([]types.Asset, error) {
 	}
 
 	if res.StatusCode() >= 400 {
-		return assets, fmt.Errorf("%v", res.String())
+		return assets, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &assets)

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -39,7 +38,7 @@ func (client *RestClient) ListEntities(namespace string) ([]types.Entity, error)
 	}
 
 	if res.StatusCode() >= 400 {
-		return entities, fmt.Errorf("%v", res.String())
+		return entities, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &entities)

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -69,7 +69,7 @@ func (client *RestClient) ListFilters(namespace string) ([]types.EventFilter, er
 	}
 
 	if res.StatusCode() >= 400 {
-		return filters, fmt.Errorf("%v", res.String())
+		return filters, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &filters)

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -18,7 +18,7 @@ func (client *RestClient) ListHandlers(namespace string) ([]types.Handler, error
 	}
 
 	if res.StatusCode() >= 400 {
-		return handlers, fmt.Errorf("%v", res.String())
+		return handlers, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &handlers)


### PR DESCRIPTION
## What is this change?

Updates the GraphQL service to drop `PermissionDenied` errors when resolving fields that list resources. Selecting a field shouldn't result in an error unless something unrecoverable occurred.

In the future, we will need a method of retrieving permissions so that the UI can communicate lack of permission properly.

**NOTE** this should not be conflated with displaying resources despite lack of permission; we simply return an empty list in lieu of the error.
 
## Why is this change necessary?

Without this change the exception modal is displayed in the web application when a user navigates to a page with resources they do not have access to.

## Does your change need a Changelog entry?

unlikely.