### PR TITLE
Fix a nil panic when logging non-check events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ uses the same facility as check subdue for handling time windows.
   "sensu" and "sensu-devel", could be listed together.
 - Fixed a bug in the agent where the agent would deadlock after a significant
 period of disconnection from the backend.
+- Fixed a bug where logging events without checks would cause a nil panic.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -28,10 +28,8 @@ func EventFields(event *types.Event, debug bool) map[string]interface{} {
 		if event.HasMetrics() {
 			fields["metrics"] = event.Metrics
 		}
-		if event.Check.Hooks != nil {
+		if event.HasCheck() {
 			fields["hooks"] = event.Check.Hooks
-		}
-		if event.Check.Silenced != nil {
 			fields["silenced"] = event.Check.Silenced
 		}
 	} else {


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Checks event.Check for nil before adding check fields

## Why is this change necessary?

Closes #2407

## Does your change need a Changelog entry?

Yes
