### PR TITLE
[Web UI] Remove re-run keepalives on Events and Checks List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ uses the same facility as check subdue for handling time windows.
 - Fixed a bug in the agent where the agent would deadlock after a significant
 period of disconnection from the backend.
 - Fixed a bug where logging events without checks would cause a nil panic.
+- Removed the ability to rerun keepalives on the events list page
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/dashboard/src/components/partials/ChecksList/ChecksListHeader.js
+++ b/dashboard/src/components/partials/ChecksList/ChecksListHeader.js
@@ -96,12 +96,11 @@ class ChecksListHeader extends React.PureComponent {
     return (
       <ToolbarMenu>
         <ToolbarMenu.Item id="queue" visible="always">
-          {selectedKeepalives.length === 0 && (
-            <QueueMenuItem
-              onClick={this.props.onClickExecute}
-              description="Queue an adhoc execution of the selected checks."
-            />
-          )}
+          <QueueMenuItem
+            disabled={selectedKeepalives.length !== 0}
+            onClick={this.props.onClickExecute}
+            description="Queue an adhoc execution of the selected checks."
+          />
         </ToolbarMenu.Item>
         <ToolbarMenu.Item
           id="silence"

--- a/dashboard/src/components/partials/ChecksList/ChecksListHeader.js
+++ b/dashboard/src/components/partials/ChecksList/ChecksListHeader.js
@@ -89,14 +89,19 @@ class ChecksListHeader extends React.PureComponent {
     const allSelectedUnsilenced = selectedSilenced.length === 0;
     const selectedPublished = selectedItems.filter(ch => ch.publish === true);
     const published = selectedCount === selectedPublished.length;
+    const selectedKeepalives = selectedItems.filter(
+      ch => ch.name === "keepalive",
+    );
 
     return (
       <ToolbarMenu>
         <ToolbarMenu.Item id="queue" visible="always">
-          <QueueMenuItem
-            onClick={this.props.onClickExecute}
-            description="Queue an adhoc execution of the selected checks."
-          />
+          {selectedKeepalives.length === 0 && (
+            <QueueMenuItem
+              onClick={this.props.onClickExecute}
+              description="Queue an adhoc execution of the selected checks."
+            />
+          )}
         </ToolbarMenu.Item>
         <ToolbarMenu.Item
           id="silence"

--- a/dashboard/src/components/partials/ChecksList/ChecksListItem.js
+++ b/dashboard/src/components/partials/ChecksList/ChecksListItem.js
@@ -95,7 +95,9 @@ class CheckListItem extends React.Component {
         <TableCell padding="checkbox">
           <ToolbarMenu>
             <ToolbarMenu.Item id="queue" visible="never">
-              <QueueMenuItem onClick={this.props.onClickExecute} />
+              {check.name !== "keepalive" && (
+                <QueueMenuItem onClick={this.props.onClickExecute} />
+              )}
             </ToolbarMenu.Item>
             <ToolbarMenu.Item id="silence" visible="never">
               <SilenceMenuItem

--- a/dashboard/src/components/partials/EventsList/EventsListHeader.js
+++ b/dashboard/src/components/partials/EventsList/EventsListHeader.js
@@ -126,14 +126,13 @@ class EventsListHeader extends React.Component {
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item id="re-run" visible="if-room">
-          {selectedKeepalives.length === 0 && (
-            <ExecuteMenuItem
-              title="Re-run Checks"
-              titleCondensed="Re-run"
-              description="Queue adhoc check executions for selected event(s)."
-              onClick={this.props.onClickRerun}
-            />
-          )}
+          <ExecuteMenuItem
+            disabled={selectedKeepalives.length !== 0}
+            title="Re-run Checks"
+            titleCondensed="Re-run"
+            description="Queue adhoc check executions for selected event(s)."
+            onClick={this.props.onClickRerun}
+          />
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item

--- a/dashboard/src/components/partials/EventsList/EventsListHeader.js
+++ b/dashboard/src/components/partials/EventsList/EventsListHeader.js
@@ -112,6 +112,9 @@ class EventsListHeader extends React.Component {
 
     const allSelectedSilenced = selectedSilenced.length === selectedCount;
     const allSelectedUnsilenced = selectedSilenced.length === 0;
+    const selectedKeepalives = selectedItems.filter(
+      ev => ev.check.name === "keepalive",
+    );
 
     return (
       <ToolbarMenu>
@@ -123,12 +126,14 @@ class EventsListHeader extends React.Component {
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item id="re-run" visible="if-room">
-          <ExecuteMenuItem
-            title="Re-run Checks"
-            titleCondensed="Re-run"
-            description="Queue adhoc check executions for selected event(s)."
-            onClick={this.props.onClickRerun}
-          />
+          {selectedKeepalives.length === 0 && (
+            <ExecuteMenuItem
+              title="Re-run Checks"
+              titleCondensed="Re-run"
+              description="Queue adhoc check executions for selected event(s)."
+              onClick={this.props.onClickRerun}
+            />
+          )}
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item

--- a/dashboard/src/components/partials/EventsList/EventsListItem.js
+++ b/dashboard/src/components/partials/EventsList/EventsListItem.js
@@ -115,12 +115,14 @@ class EventListItem extends React.Component {
               <ResolveMenuItem onClick={this.props.onClickResolve} />
             </ToolbarMenu.Item>
             <ToolbarMenu.Item id="re-run" visible="never">
-              <QueueMenuItem
-                title="Re-run Check"
-                onClick={this.props.onClickRerun}
-              />
+              {event.check.name !== "keepalive" && (
+                <QueueMenuItem
+                  title="Re-run Check"
+                  onClick={this.props.onClickRerun}
+                />
+              )}
             </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="re-run" visible="never">
+            <ToolbarMenu.Item id="silence" visible="never">
               <Select
                 disabled={event.isSilenced}
                 icon={<SilenceIcon />}
@@ -140,13 +142,13 @@ class EventListItem extends React.Component {
                 <Option value="both">Both</Option>
               </Select>
             </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="re-run" visible="never">
+            <ToolbarMenu.Item id="unsilence" visible="never">
               <UnsilenceMenuItem
                 disabled={!event.isSilenced}
                 onClick={this.props.onClickClearSilences}
               />
             </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="re-run" visible="never">
+            <ToolbarMenu.Item id="delete" visible="never">
               {menu => (
                 <ConfirmDelete
                   onSubmit={() => {


### PR DESCRIPTION
## What is this change?
Closes #2410
Removes the ability to re-run keepalives from the events and checks list


## Why is this change necessary?
We don't have a way to do this at this point in time, so it causes an exception in the frontend.

## Does your change need a Changelog entry?
Added one

## Were there any complications while making this change?
Disabling the button instead of not rendering it solves this ~There's some weirdness if you are doing bulk actions, the list header icon for re-run is removed if you add a keepalive to the selected items. However, if you unselect that keepalive the re-run button does not return unless you deselect the whole list. I'm open to suggestions on how to correct this.~