### PR TITLE
Add list namespaces rule to system:user cluster role

### DIFF
--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -115,7 +115,7 @@ func setupClusterRoleBindings(store store.Store) error {
 	}
 
 	// The system:user ClusterRoleBinding grants permission found in the
-	// cluster-admin ClusterRole to any user belonging to the cluster-admins group
+	// system:user ClusterRole to any user belonging to the system:users group
 	systemUser := &types.ClusterRoleBinding{
 		Name: "system:user",
 		RoleRef: types.RoleRef{
@@ -243,6 +243,10 @@ func setupClusterRoles(store store.Store) error {
 			types.Rule{
 				Verbs:     []string{"get", "update"},
 				Resources: []string{types.LocalSelfUserResource},
+			},
+			types.Rule{
+				Verbs:     []string{"list"},
+				Resources: []string{"namespaces"},
 			},
 		},
 	}

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -245,8 +245,10 @@ func setupClusterRoles(store store.Store) error {
 				Resources: []string{types.LocalSelfUserResource},
 			},
 			types.Rule{
-				Verbs:     []string{"list"},
-				Resources: []string{"namespaces"},
+				Verbs: []string{"get", "list"},
+				Resources: []string{
+					"namespaces",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## What is this change?

This allows any user to implicitly list the namespaces and prevent
issues in the current implementation of the dashboard.

## Why is this change necessary?

Closes #2418 

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.
