### PR TITLE
Grepory/monitor panic#2406

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ uses the same facility as check subdue for handling time windows.
 period of disconnection from the backend.
 - Fixed a bug where logging events without checks would cause a nil panic.
 - Removed the ability to rerun keepalives on the events list page
+- A panic in keepalive/check ttl monitors causing a panic.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 


### PR DESCRIPTION
## What is this change?

This allows monitor TTLs to be set to 0, which will cause a monitor to immediately fail and send a failing event on startup instead of panicking.

## Why is this change necessary?

closes #2406 

## Does your change need a Changelog entry?

Added.