### PR TITLE
Namespace keepalive and check ttl monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ period of disconnection from the backend.
 - Fixed a bug where logging events without checks would cause a nil panic.
 - Removed the ability to rerun keepalives on the events list page
 - A panic in keepalive/check ttl monitors causing a panic.
+- Monitors are now properly namespaced in etcd.
 
 ## [2.0.0-beta.8-1] - 2018-11-15
 

--- a/backend/monitor/supervisor.go
+++ b/backend/monitor/supervisor.go
@@ -93,7 +93,7 @@ func NewEtcdSupervisor(client *clientv3.Client, h Handler) *EtcdSupervisor {
 // extended. If the monitor's ttl has changed, a new lease is created and the
 // key is updated with that new lease.
 func (m *EtcdSupervisor) Monitor(ctx context.Context, name string, event *types.Event, ttl int64) error {
-	key := monitorKeyBuilder.Build(name)
+	key := monitorKeyBuilder.WithNamespace(event.Entity.Namespace).Build(name)
 	// try to get the monitor from the store
 	mon, err := m.getMonitor(ctx, key)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Greg Poirier <greg.istehbest@gmail.com>

## What is this change?

This properly stores monitors in the entity namespace in etcd.

## Why is this change necessary?

closes #2432