### PR TITLE
[Web UI] Network error improvements - offline and retry fields

### DIFF
--- a/dashboard/flow-typed/npm/react-apollo_v2.x.x.js
+++ b/dashboard/flow-typed/npm/react-apollo_v2.x.x.js
@@ -9,7 +9,9 @@ declare module "react-apollo" {
    * Copied types from Apollo Client libdef
    * Please update apollo-client libdef as well if updating these types
    */
-  declare export class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+  declare export class ObservableQuery<T> extends Observable<
+    ApolloQueryResult<T>,
+  > {
     options: WatchQueryOptions;
     queryId: string;
     variables: { [key: string]: any };
@@ -27,7 +29,7 @@ declare module "react-apollo" {
     constructor(data: {
       scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
-      shouldSubscribe?: boolean
+      shouldSubscribe?: boolean,
     }): this;
 
     result(): Promise<ApolloQueryResult<T>>;
@@ -37,19 +39,19 @@ declare module "react-apollo" {
     resetLastResults(): void;
     refetch(variables?: any): Promise<ApolloQueryResult<T>>;
     fetchMore(
-      fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
+      fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>,
     ): Promise<ApolloQueryResult<T>>;
     subscribeToMore(options: SubscribeToMoreOptions<any, any>): () => void;
     setOptions(
-      opts: ModifiableWatchQueryOptions
+      opts: ModifiableWatchQueryOptions,
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
       variables: any,
       tryFetch?: boolean,
-      fetchResults?: boolean
+      fetchResults?: boolean,
     ): Promise<ApolloQueryResult<T>>;
     updateQuery(
-      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed,
     ): void;
     stopPolling(): void;
     startPolling(pollInterval: number): void;
@@ -67,7 +69,7 @@ declare module "react-apollo" {
       queryDeduplication?: boolean,
       store: DataStore<TStore>,
       onBroadcast?: () => mixed,
-      ssrMode?: boolean
+      ssrMode?: boolean,
     }): this;
 
     mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
@@ -75,16 +77,16 @@ declare module "react-apollo" {
       queryId: string,
       options: WatchQueryOptions,
       fetchType?: FetchType,
-      fetchMoreForQueryId?: string
+      fetchMoreForQueryId?: string,
     ): Promise<FetchResult<T>>;
     queryListenerForObserver<T>(
       queryId: string,
       options: WatchQueryOptions,
-      observer: Observer<ApolloQueryResult<T>>
+      observer: Observer<ApolloQueryResult<T>>,
     ): QueryListener;
     watchQuery<T>(
       options: WatchQueryOptions,
-      shouldSubscribe?: boolean
+      shouldSubscribe?: boolean,
     ): ObservableQuery<T>;
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
     generateQueryId(): string;
@@ -93,18 +95,18 @@ declare module "react-apollo" {
     updateQueryWatch(
       queryId: string,
       document: DocumentNode,
-      options: WatchQueryOptions
+      options: WatchQueryOptions,
     ): void;
     addFetchQueryPromise<T>(
       requestId: number,
       promise: Promise<ApolloQueryResult<T>>,
       resolve: (result: ApolloQueryResult<T>) => void,
-      reject: (error: Error) => void
+      reject: (error: Error) => void,
     ): void;
     removeFetchQueryPromise(requestId: number): void;
     addObservableQuery<T>(
       queryId: string,
-      observableQuery: ObservableQuery<T>
+      observableQuery: ObservableQuery<T>,
     ): void;
     removeObservableQuery(queryId: string): void;
     clearStore(): Promise<void>;
@@ -122,17 +124,17 @@ declare module "react-apollo" {
       isPoll: boolean,
       isRefetch: boolean,
       metadata: any,
-      fetchMoreForQueryId: string | void
+      fetchMoreForQueryId: string | void,
     }): void;
     markQueryResult(
       queryId: string,
       result: ExecutionResult<>,
-      fetchMoreForQueryId: string | void
+      fetchMoreForQueryId: string | void,
     ): void;
     markQueryError(
       queryId: string,
       error: Error,
-      fetchMoreForQueryId: string | void
+      fetchMoreForQueryId: string | void,
     ): void;
     markQueryResultClient(queryId: string, complete: boolean): void;
     stopQuery(queryId: string): void;
@@ -146,27 +148,27 @@ declare module "react-apollo" {
     queryManager: QueryManager<TCacheShape>;
     constructor({
       queryManager: QueryManager<TCacheShape>,
-      ssrMode?: boolean
+      ssrMode?: boolean,
     }): this;
     checkInFlight(queryId: string): ?boolean;
     fetchQuery<T>(
       queryId: string,
       options: WatchQueryOptions,
-      fetchType: FetchType
+      fetchType: FetchType,
     ): Promise<FetchResult<T>>;
     startPollingQuery<T>(
       options: WatchQueryOptions,
       queryId: string,
-      listener?: QueryListener
+      listener?: QueryListener,
     ): string;
     stopPollingQuery(queryId: string): void;
     fetchQueriesOnInterval<T>(interval: number): void;
     addQueryOnInterval<T>(
       queryId: string,
-      queryOptions: WatchQueryOptions
+      queryOptions: WatchQueryOptions,
     ): void;
     registerPollingQuery<T>(
-      queryOptions: WatchQueryOptions
+      queryOptions: WatchQueryOptions,
     ): ObservableQuery<T>;
     markMutationError(mutationId: string, error: Error): void;
     reset(): void;
@@ -180,12 +182,12 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       fetchMoreForQueryId: string | void,
-      ignoreErrors?: boolean
+      ignoreErrors?: boolean,
     ): void;
     markSubscriptionResult(
       result: ExecutionResult<>,
       document: DocumentNode,
-      variables: any
+      variables: any,
     ): void;
     markMutationInit(mutation: {
       mutationId: string,
@@ -193,7 +195,7 @@ declare module "react-apollo" {
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
       update: ((proxy: DataProxy, mutationResult: Object) => mixed) | void,
-      optimisticResponse: Object | Function | void
+      optimisticResponse: Object | Function | void,
     }): void;
     markMutationResult(mutation: {
       mutationId: string,
@@ -201,23 +203,23 @@ declare module "react-apollo" {
       document: DocumentNode,
       variables: any,
       updateQueries: { [queryId: string]: QueryWithUpdater },
-      update: ((proxy: DataProxy, mutationResult: Object) => mixed) | void
+      update: ((proxy: DataProxy, mutationResult: Object) => mixed) | void,
     }): void;
     markMutationComplete({
       mutationId: string,
-      optimisticResponse?: any
+      optimisticResponse?: any,
     }): void;
     markUpdateQueryResult(
       document: DocumentNode,
       variables: any,
-      newResult: any
+      newResult: any,
     ): void;
     reset(): Promise<void>;
   }
 
   declare type QueryWithUpdater = {
     updater: MutationQueryReducer<Object>,
-    query: QueryStoreValue
+    query: QueryStoreValue,
   };
 
   declare interface MutationStoreValue {
@@ -233,7 +235,7 @@ declare module "react-apollo" {
     initMutation(
       mutationId: string,
       mutationString: string,
-      variables: Object | void
+      variables: Object | void,
     ): void;
   }
 
@@ -242,8 +244,8 @@ declare module "react-apollo" {
       previousQueryResult: TData,
       options: {
         fetchMoreResult?: TData,
-        variables: TVariables
-      }
+        variables: TVariables,
+      },
     ) => TData;
   }
 
@@ -257,7 +259,7 @@ declare module "react-apollo" {
     loading: boolean,
     networkStatus: NetworkStatus,
     error?: ApolloError,
-    partial?: boolean
+    partial?: boolean,
   };
 
   declare interface ModifiableWatchQueryOptions {
@@ -277,7 +279,7 @@ declare module "react-apollo" {
   }
 
   declare export type RefetchQueryDescription = $ReadOnlyArray<
-    string | PureQueryOptions
+    string | PureQueryOptions,
   >;
 
   declare interface MutationBaseOptions<T = { [key: string]: any }> {
@@ -321,7 +323,7 @@ declare module "react-apollo" {
   declare export type SubscribeToMoreOptions<
     TData,
     TSubscriptionData,
-    TSubscriptionVariables = void
+    TSubscriptionVariables = void,
   > = {
     document?: DocumentNode,
     variables?: TSubscriptionVariables,
@@ -329,22 +331,22 @@ declare module "react-apollo" {
       previousResult: TData,
       result: {
         subscriptionData: { data?: TSubscriptionData },
-        variables: TSubscriptionVariables
-      }
+        variables: TSubscriptionVariables,
+      },
     ) => TData,
-    onError?: (error: Error) => mixed
+    onError?: (error: Error) => mixed,
   };
 
   declare export type MutationUpdaterFn<T = OperationVariables> = (
     proxy: DataProxy,
-    mutationResult: FetchResult<T>
+    mutationResult: FetchResult<T>,
   ) => mixed;
 
   declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
   declare export type QueryListener = (
     queryStoreValue: QueryStoreValue,
-    newData?: any
+    newData?: any,
   ) => mixed;
 
   declare export type QueryStoreValue = {
@@ -354,12 +356,12 @@ declare module "react-apollo" {
     networkStatus: NetworkStatus,
     networkError: Error | null,
     graphQLErrors: GraphQLError[],
-    metadata: any
+    metadata: any,
   };
 
   declare export type PureQueryOptions = {
     query: DocumentNode,
-    variables?: { [key: string]: any }
+    variables?: { [key: string]: any },
   };
 
   declare export type ApolloQueryResult<T> = {
@@ -367,7 +369,7 @@ declare module "react-apollo" {
     errors?: Array<GraphQLError>,
     loading: boolean,
     networkStatus: NetworkStatus,
-    stale: boolean
+    stale: boolean,
   };
 
   declare export type FetchType = 1 | 2 | 3;
@@ -377,12 +379,12 @@ declare module "react-apollo" {
     options: {
       mutationResult: FetchResult<T>,
       queryName: string | void,
-      queryVariables: { [key: string]: any }
-    }
+      queryVariables: { [key: string]: any },
+    },
   ) => { [key: string]: any };
 
   declare export type MutationQueryReducersMap<T = { [key: string]: any }> = {
-    [queryName: string]: MutationQueryReducer<T>
+    [queryName: string]: MutationQueryReducer<T>,
   };
 
   declare export class ApolloError extends Error {
@@ -413,7 +415,7 @@ declare module "react-apollo" {
     ssrForceFetchDelay?: number,
     connectToDevTools?: boolean,
     queryDeduplication?: boolean,
-    defaultOptions?: DefaultOptions
+    defaultOptions?: DefaultOptions,
   };
 
   declare export class ApolloClient<TCacheShape> {
@@ -446,7 +448,7 @@ declare module "react-apollo" {
     resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
     onResetStore(cb: () => Promise<any>): () => void;
     reFetchObservableQueries(
-      includeStandby?: boolean
+      includeStandby?: boolean,
     ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
     extract(optimistic?: boolean): TCacheShape;
     restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
@@ -461,24 +463,24 @@ declare module "react-apollo" {
     static split(
       test: (op: Operation) => boolean,
       left: ApolloLink | RequestHandler,
-      right: ApolloLink | RequestHandler
+      right: ApolloLink | RequestHandler,
     ): ApolloLink;
     static execute(
       link: ApolloLink,
-      operation: GraphQLRequest
+      operation: GraphQLRequest,
     ): Observable<FetchResult<>>;
 
     split(
       test: (op: Operation) => boolean,
       left: ApolloLink | RequestHandler,
-      right: ApolloLink | RequestHandler
+      right: ApolloLink | RequestHandler,
     ): ApolloLink;
 
     concat(next: ApolloLink | RequestHandler): ApolloLink;
 
     request(
       operation: Operation,
-      forward?: NextLink
+      forward?: NextLink,
     ): Observable<FetchResult<>> | null;
   }
 
@@ -502,21 +504,21 @@ declare module "react-apollo" {
 
   declare export type FetchResult<
     C = { [key: string]: any },
-    E = { [key: string]: any }
+    E = { [key: string]: any },
   > = ExecutionResult<C> & { extension?: E, context?: C };
 
   declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
 
   declare type RequestHandler = (
     operation: Operation,
-    forward?: NextLink
+    forward?: NextLink,
   ) => Observable<FetchResult<>> | null;
 
   declare class Observable<T> {
     subscribe(
       observerOrNext: ((value: T) => mixed) | ZenObservableObserver<T>,
       error?: (error: any) => mixed,
-      complete?: () => mixed
+      complete?: () => mixed,
     ): ZenObservableSubscription;
 
     forEach(fn: (value: T) => mixed): Promise<void>;
@@ -527,13 +529,13 @@ declare module "react-apollo" {
 
     reduce<R>(
       fn: (previousValue: R | T, currentValue: T) => R | T,
-      initialValue?: R | T
+      initialValue?: R | T,
     ): Observable<R | T>;
 
     flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
 
     from<R>(
-      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
+      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>,
     ): Observable<R>;
 
     of<R>(...args: Array<R>): Observable<R>;
@@ -571,7 +573,7 @@ declare module "react-apollo" {
   }
 
   declare type ZenObservableSubscriber<T> = (
-    observer: ZenObservableSubscriptionObserver<T>
+    observer: ZenObservableSubscriptionObserver<T>,
   ) => mixed | (() => mixed) | SubscriptionLINK;
 
   declare interface ZenObservableObservableLike<T> {
@@ -580,7 +582,7 @@ declare module "react-apollo" {
   /* apollo-link types */
 
   /* apollo-cache types */
-  declare class ApolloCache<TSerialized> {
+  declare export class ApolloCache<TSerialized> {
     read<T>(query: CacheReadOptions): T | null;
     write(write: CacheWriteOptions): void;
     diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;
@@ -596,7 +598,7 @@ declare module "react-apollo" {
     performTransaction(transaction: Transaction<TSerialized>): void;
     recordOptimisticTransaction(
       transaction: Transaction<TSerialized>,
-      id: string
+      id: string,
     ): void;
 
     transformDocument(document: DocumentNode): DocumentNode;
@@ -604,11 +606,11 @@ declare module "react-apollo" {
 
     readQuery<QueryType>(
       options: DataProxyReadQueryOptions,
-      optimistic?: boolean
+      optimistic?: boolean,
     ): QueryType | null;
     readFragment<FragmentType>(
       options: DataProxyReadFragmentOptions,
-      optimistic?: boolean
+      optimistic?: boolean,
     ): FragmentType | null;
     writeQuery(options: CacheWriteQueryOptions): void;
     writeFragment(options: CacheWriteFragmentOptions): void;
@@ -685,17 +687,17 @@ declare module "react-apollo" {
 
   declare type DataProxyDiffResult<T> = {
     result?: T,
-    complete?: boolean
+    complete?: boolean,
   };
 
   declare export interface DataProxy {
     readQuery<QueryType>(
       options: DataProxyReadQueryOptions,
-      optimistic?: boolean
+      optimistic?: boolean,
     ): QueryType | null;
     readFragment<FragmentType>(
       options: DataProxyReadFragmentOptions,
-      optimistic?: boolean
+      optimistic?: boolean,
     ): FragmentType | null;
     writeQuery(options: DataProxyWriteQueryOptions): void;
     writeFragment(options: DataProxyWriteFragmentOptions): void;
@@ -713,7 +715,7 @@ declare module "react-apollo" {
   declare type ExecutionResult<T> = {
     data?: T,
     extensions?: { [string]: any },
-    errors?: any[]
+    errors?: any[],
   };
   declare type GraphQLError = any;
   declare type VariableDefinitionNode = any;
@@ -729,40 +731,40 @@ declare module "react-apollo" {
   }
 
   declare export class ApolloConsumer extends React$Component<
-    ApolloConsumerProps
+    ApolloConsumerProps,
   > {}
 
   declare export class ApolloProvider<TCache> extends React$Component<
-    ApolloProviderProps<TCache>
+    ApolloProviderProps<TCache>,
   > {
     childContextTypes: {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, { query: DocumentNode, variables: any }>,
     };
 
     getChildContext(): {
       client: ApolloClient<TCache>,
-      operations: Map<string, { query: DocumentNode, variables: any }>
+      operations: Map<string, { query: DocumentNode, variables: any }>,
     };
   }
 
   declare export type MutationFunc<TResult, TVariables> = (
-    opts: MutationOpts<TVariables>
+    opts: MutationOpts<TVariables>,
   ) => Promise<ApolloQueryResult<TResult>>;
 
   declare export type GraphqlData<TResult, TVariables> = TResult &
     GraphqlQueryControls<TVariables> & {
       variables: TVariables,
-      refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>
+      refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>,
     };
 
   declare export type ChildProps<
     TOwnProps,
     TResult,
-    TVariables: Object = {}
+    TVariables: Object = {},
   > = {
     data: GraphqlData<TResult, TVariables>,
-    mutate: MutationFunc<TResult, TVariables>
+    mutate: MutationFunc<TResult, TVariables>,
   } & TOwnProps;
 
   // back compat
@@ -777,7 +779,7 @@ declare module "react-apollo" {
     optimisticResponse?: Object,
     refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
     update?: MutationUpdaterFn<*>,
-    errorPolicy?: ErrorPolicy
+    errorPolicy?: ErrorPolicy,
   |};
 
   declare export type QueryOpts<TVariables> = {|
@@ -787,11 +789,11 @@ declare module "react-apollo" {
     pollInterval?: number,
     skip?: boolean,
     errorPolicy?: ErrorPolicy,
-    context?: { [key: string]: any }
+    context?: { [key: string]: any },
   |};
 
   declare export interface GraphqlQueryControls<
-    TGraphQLVariables = OperationVariables
+    TGraphQLVariables = OperationVariables,
   > {
     error?: ApolloError | any; // Added optional `any` to satisfy Flow < 0.62
     networkStatus: NetworkStatus;
@@ -799,14 +801,14 @@ declare module "react-apollo" {
     variables: TGraphQLVariables;
     fetchMore: (
       fetchMoreOptions: FetchMoreQueryOptions<TGraphQLVariables> &
-        FetchMoreOptions<any, TGraphQLVariables>
+        FetchMoreOptions<any, TGraphQLVariables>,
     ) => Promise<ApolloQueryResult<any>>;
     refetch: (variables?: TGraphQLVariables) => Promise<ApolloQueryResult<any>>;
     startPolling: (pollInterval: number) => void;
     stopPolling: () => void;
     subscribeToMore: (options: SubscribeToMoreOptions<any, any>) => () => void;
     updateQuery: (
-      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => mixed,
     ) => void;
   }
 
@@ -822,18 +824,18 @@ declare module "react-apollo" {
     | ((props: TProps) => QueryOpts<TVariables> | MutationOpts<TVariables>);
 
   declare export type NamedProps<P, R> = P & {
-    ownProps: R
+    ownProps: R,
   };
 
   declare export interface OperationOption<
     TResult: {},
     TProps: {},
     TChildProps: {},
-    TVariables: {}
+    TVariables: {},
   > {
     +options?: OptionDescription<TProps, TVariables>;
     props?: (
-      props: OptionProps<TProps, TResult, TVariables>
+      props: OptionProps<TProps, TResult, TVariables>,
     ) => TChildProps | ChildProps<TProps, TResult, TVariables>;
     +skip?: boolean | ((props: any) => boolean);
     name?: string;
@@ -846,23 +848,28 @@ declare module "react-apollo" {
     TResult: Object = {},
     TOwnProps: Object = {},
     TVariables: Object = {},
-    TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>
+    TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>,
   > {
     (component: ComponentType<TMergedProps>): ComponentType<TOwnProps>;
   }
 
   declare export function graphql<TResult, TProps, TVariables, TChildProps>(
     document: DocumentNode,
-    operationOptions?: OperationOption<TResult, TProps, TChildProps, TVariables>
+    operationOptions?: OperationOption<
+      TResult,
+      TProps,
+      TChildProps,
+      TVariables,
+    >,
   ): OperationComponent<TResult, TProps, TVariables, TChildProps>;
 
   declare type WithApolloOptions = {
-    withRef?: boolean
+    withRef?: boolean,
   };
 
   declare export function withApollo<TProps>(
     component: ComponentType<{ client: ApolloClient<any> } & TProps>,
-    operationOptions?: WithApolloOptions
+    operationOptions?: WithApolloOptions,
   ): ComponentType<TProps>;
 
   declare export interface IDocumentDefinition {
@@ -886,24 +893,24 @@ declare module "react-apollo" {
   declare export function walkTree(
     element: Node,
     context: Context,
-    visitor: (element: Node, instance: any, context: Context) => boolean | void
+    visitor: (element: Node, instance: any, context: Context) => boolean | void,
   ): void;
 
   declare export function getDataFromTree(
     rootElement: Element<*>,
     rootContext?: any,
-    fetchRoot?: boolean
+    fetchRoot?: boolean,
   ): Promise<void>;
 
   declare export function renderToStringWithData(
-    component: Element<*>
+    component: Element<*>,
   ): Promise<string>;
 
   declare export function cleanupApolloState(apolloState: any): void;
 
   declare export type QueryRenderProps<
     TData = any,
-    TVariables = OperationVariables
+    TVariables = OperationVariables,
   > = {
     data: $ObjMap<TData, MakeOptional> | void,
     loading: boolean,
@@ -913,29 +920,29 @@ declare module "react-apollo" {
     refetch: (variables?: TVariables) => Promise<ApolloQueryResult<TData>>,
     fetchMore: ((
       options: FetchMoreOptions<TData, TVariables> &
-        FetchMoreQueryOptions<TVariables>
+        FetchMoreQueryOptions<TVariables>,
     ) => Promise<ApolloQueryResult<TData>>) &
       (<TData2, TVariables2>(
         options: { query: DocumentNode } & FetchMoreQueryOptions<TVariables2> &
-          FetchMoreOptions<TData2, TVariables2>
+          FetchMoreOptions<TData2, TVariables2>,
       ) => Promise<ApolloQueryResult<TData2>>),
     load: () => void,
     startPolling: (interval: number) => void,
     stopPolling: () => void,
     subscribeToMore: (
-      options: SubscribeToMoreOptions<TData, any, any>
+      options: SubscribeToMoreOptions<TData, any, any>,
     ) => () => void,
     updateQuery: (
       mapFn: (
         previousResult: TData,
-        options: { variables: TVariables }
-      ) => TData
+        options: { variables: TVariables },
+      ) => TData,
     ) => mixed,
-    client: ApolloClient<any>
+    client: ApolloClient<any>,
   };
 
   declare export type QueryRenderPropFunction<TData, TVariables> = (
-    QueryRenderProps<TData, TVariables>
+    QueryRenderProps<TData, TVariables>,
   ) => Node;
 
   declare export class Query<TData, TVariables> extends React$Component<{
@@ -949,20 +956,20 @@ declare module "react-apollo" {
     ssr?: boolean,
     displayName?: string,
     delay?: boolean,
-    context?: { [string]: any }
+    context?: { [string]: any },
   }> {}
 
   declare export type SubscriptionResult<
     TData,
-    TVariables = OperationVariables
+    TVariables = OperationVariables,
   > = {
     loading: boolean,
     data?: TData | {||} | void,
-    error?: ApolloError
+    error?: ApolloError,
   };
 
   declare export type SubscriptionRenderPropFunction<TData, TVariables> = (
-    result: SubscriptionResult<TData, TVariables>
+    result: SubscriptionResult<TData, TVariables>,
   ) => Node;
 
   declare type SubscriptionProps<TData, TVariables = OperationVariables> = {
@@ -972,25 +979,25 @@ declare module "react-apollo" {
       | boolean
       | ((
           SubscriptionProps<TData, TVariables>,
-          SubscriptionProps<TData, TVariables>
+          SubscriptionProps<TData, TVariables>,
         ) => boolean),
-    children: SubscriptionRenderPropFunction<TData, TVariables>
+    children: SubscriptionRenderPropFunction<TData, TVariables>,
   };
 
   declare export class Subscription<TData, TVariables> extends React$Component<
-    SubscriptionProps<TData, TVariables>
+    SubscriptionProps<TData, TVariables>,
   > {}
 
   declare type OperationVariables = { [key: string]: any };
 
   declare export type MutationFunction<
     TData = any,
-    TVariables = OperationVariables
+    TVariables = OperationVariables,
   > = (options?: {
     variables?: TVariables,
     optimisticResponse?: Object,
     refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
-    update?: MutationUpdaterFn<TData>
+    update?: MutationUpdaterFn<TData>,
   }) => Promise<void | FetchResult<TData>>;
 
   declare export type MutationResult<TData = { [string]: any }> = {
@@ -998,17 +1005,17 @@ declare module "react-apollo" {
     error?: ApolloError,
     data?: TData,
     called: boolean,
-    client: ApolloClient<any>
+    client: ApolloClient<any>,
   };
 
   declare export type MutationRenderPropFunction<TData, TVariables> = (
     mutate: MutationFunction<TData, TVariables>,
-    result: MutationResult<TData>
+    result: MutationResult<TData>,
   ) => Node;
 
   declare export class Mutation<
     TData,
-    TVariables = void
+    TVariables = void,
   > extends React$Component<{
     mutation: DocumentNode,
     children: MutationRenderPropFunction<TData, TVariables>,
@@ -1019,7 +1026,7 @@ declare module "react-apollo" {
     refetchQueries?: RefetchQueryDescription | RefetchQueriesProviderFn,
     onCompleted?: (data: TData) => mixed,
     onError?: (error: ApolloError) => mixed,
-    context?: { [string]: any }
+    context?: { [string]: any },
   }> {}
 
   declare export var compose: $Compose;

--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -72,6 +72,18 @@ const createClient = () => {
     `,
   );
 
+  localStorageSync(
+    client,
+    gql`
+      query SynclocalNetworkQuery {
+        localNetwork @client {
+          offline
+          retry
+        }
+      }
+    `,
+  );
+
   return client;
 };
 

--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -40,7 +40,7 @@ const createClient = () => {
       introspectionLink(),
       stateLink({ cache }),
       authLink({ getClient }),
-      httpLink(),
+      httpLink({ getClient }),
     ]),
   });
 
@@ -75,9 +75,20 @@ const createClient = () => {
   localStorageSync(
     client,
     gql`
-      query SynclocalNetworkQuery {
+      query SyncLocalNetworkQuery {
         localNetwork @client {
           offline
+          retry
+        }
+      }
+    `,
+  );
+
+  localStorageSync(
+    client,
+    gql`
+      query SyncRetryQuery {
+        localNetwork @client {
           retry
         }
       }

--- a/dashboard/src/apollo/client.js
+++ b/dashboard/src/apollo/client.js
@@ -72,29 +72,6 @@ const createClient = () => {
     `,
   );
 
-  localStorageSync(
-    client,
-    gql`
-      query SyncLocalNetworkQuery {
-        localNetwork @client {
-          offline
-          retry
-        }
-      }
-    `,
-  );
-
-  localStorageSync(
-    client,
-    gql`
-      query SyncRetryQuery {
-        localNetwork @client {
-          retry
-        }
-      }
-    `,
-  );
-
   return client;
 };
 

--- a/dashboard/src/apollo/httpLink.js
+++ b/dashboard/src/apollo/httpLink.js
@@ -1,5 +1,6 @@
 import { BatchHttpLink as HttpLink } from "apollo-link-batch-http";
 import doFetch from "/utils/fetch";
+import { FailedError } from "/errors/FetchError";
 import gql from "graphql-tag";
 
 const mutation = gql`
@@ -23,7 +24,7 @@ const httpLink = ({ getClient }) =>
         error => {
           getClient().mutate({
             mutation,
-            variables: { offline: true },
+            variables: { offline: error.instanceOf(FailedError) },
           });
 
           throw error;

--- a/dashboard/src/apollo/httpLink.js
+++ b/dashboard/src/apollo/httpLink.js
@@ -8,8 +8,6 @@ const mutation = gql`
   }
 `;
 
-// TODO: Likely have some logic for when we would like to attempt retry?
-
 const httpLink = ({ getClient }) =>
   new HttpLink({
     uri: "/graphql",

--- a/dashboard/src/apollo/httpLink.js
+++ b/dashboard/src/apollo/httpLink.js
@@ -16,14 +16,14 @@ const httpLink = ({ getClient }) =>
         response => {
           getClient().mutate({
             mutation,
-            variables: { offline: true },
+            variables: { offline: false },
           });
           return response;
         },
         error => {
           getClient().mutate({
             mutation,
-            variables: { offline: false },
+            variables: { offline: true },
           });
 
           throw error;

--- a/dashboard/src/apollo/httpLink.js
+++ b/dashboard/src/apollo/httpLink.js
@@ -24,7 +24,7 @@ const httpLink = ({ getClient }) =>
         error => {
           getClient().mutate({
             mutation,
-            variables: { offline: error.instanceOf(FailedError) },
+            variables: { offline: error instanceof FailedError },
           });
 
           throw error;

--- a/dashboard/src/apollo/resolvers/localNetwork.js
+++ b/dashboard/src/apollo/resolvers/localNetwork.js
@@ -8,8 +8,27 @@ export default {
   },
   resolvers: {
     Mutation: {
-      retryLocalNetwork: () => null,
-      setLocalNetworkOffline: () => null,
+      retryLocalNetwork: () => (_, { cache }) => {
+        const data = {
+          localNetwork: {
+            __typename: "LocalNetwork",
+            retry: true,
+          },
+        };
+        cache.writeData(data);
+        return null;
+      },
+      setLocalNetworkOffline: (_, { offline }, { cache }) => {
+        const data = {
+          localNetwork: {
+            __typename: "LocalNetwork",
+            offline,
+            retry: false,
+          },
+        };
+        cache.writeData(data);
+        return null;
+      },
     },
   },
 };

--- a/dashboard/src/apollo/resolvers/localNetwork.js
+++ b/dashboard/src/apollo/resolvers/localNetwork.js
@@ -1,0 +1,15 @@
+export default {
+  defaults: {
+    localNetwork: {
+      __typename: "LocalNetwork",
+      offline: false,
+      retry: false,
+    },
+  },
+  resolvers: {
+    Mutation: {
+      retryLocalNetwork: () => null,
+      setLocalNetworkOffline: () => null,
+    },
+  },
+};

--- a/dashboard/src/apollo/resolvers/localNetwork.js
+++ b/dashboard/src/apollo/resolvers/localNetwork.js
@@ -1,3 +1,8 @@
+// @flow
+import type { ApolloCache } from "react-apollo";
+
+type Context = { cache: ApolloCache<mixed> };
+
 export default {
   defaults: {
     localNetwork: {
@@ -8,17 +13,21 @@ export default {
   },
   resolvers: {
     Mutation: {
-      retryLocalNetwork: () => (_, { cache }) => {
+      retryLocalNetwork: () => (_: mixed, args: mixed, { cache }: Context) => {
         const data = {
           localNetwork: {
             __typename: "LocalNetwork",
             retry: true,
           },
         };
-        cache.writeData(data);
+        cache.writeData({ data });
         return null;
       },
-      setLocalNetworkOffline: (_, { offline }, { cache }) => {
+      setLocalNetworkOffline: (
+        _: mixed,
+        { offline }: { offline: Boolean },
+        { cache }: Context,
+      ) => {
         const data = {
           localNetwork: {
             __typename: "LocalNetwork",
@@ -26,7 +35,7 @@ export default {
             retry: false,
           },
         };
-        cache.writeData(data);
+        cache.writeData({ data });
         return null;
       },
     },

--- a/dashboard/src/apollo/resolvers/localNetwork.js
+++ b/dashboard/src/apollo/resolvers/localNetwork.js
@@ -13,7 +13,7 @@ export default {
   },
   resolvers: {
     Mutation: {
-      retryLocalNetwork: () => (_: mixed, args: mixed, { cache }: Context) => {
+      retryLocalNetwork: (_: mixed, args: mixed, { cache }: Context) => {
         const data = {
           localNetwork: {
             __typename: "LocalNetwork",

--- a/dashboard/src/apollo/schema/client.graphql
+++ b/dashboard/src/apollo/schema/client.graphql
@@ -29,6 +29,17 @@ extend type Query {
 
   "The last namespace that the client accessed."
   lastNamespace: String!
+
+  "The networking state of the client"
+  localNetwork: LocalNetwork
+}
+
+type LocalNetwork {
+  "The current online state of the client."
+  offline: Boolean!
+
+  "If the client is offline and trying to retry the connection."
+  retry: Boolean!
 }
 
 extend type Mutation {

--- a/dashboard/src/apollo/schema/client.graphql
+++ b/dashboard/src/apollo/schema/client.graphql
@@ -63,6 +63,15 @@ extend type Mutation {
 
   "Stores given pair as user's last visited namespace."
   setLastNamespace(name: String!): Boolean
+
+  #
+  # LocalNetwork
+
+  "Flag to allow us to retry a connection"
+  retryLocalNetwork: Boolean
+
+  "Flags the client as being offline or online"
+  setLocalNetworkOffline(offline: Boolean!): Boolean
 }
 
 type Auth {

--- a/dashboard/src/apollo/schema/combined.graphql
+++ b/dashboard/src/apollo/schema/combined.graphql
@@ -419,6 +419,29 @@ enum CheckListOrder {
   NAME_DESC
 }
 
+"""ClusterRole applies to all namespaces within a cluster."""
+type ClusterRole {
+  rules: [Rule!]
+
+  """Name of the ClusterRole"""
+  name: String!
+}
+
+"""
+ClusterRoleBinding grants the permissions defined in a ClusterRole referenced
+to a user or a set of users
+"""
+type ClusterRoleBinding {
+  """Subjects holds references to the objects the ClusterRole applies to"""
+  subjects: [Subject!]
+
+  """RoleRef references a ClusterRole in the current namespace"""
+  roleRef: RoleRef
+
+  """Name of the ClusterRoleBinding"""
+  name: String!
+}
+
 input CreateCheckInput {
   """A unique identifier for the client performing the mutation."""
   clientMutationId: String
@@ -820,6 +843,14 @@ The JSON type describes any arbitrary JSON compatible data.
 """
 scalar JSON
 
+type LocalNetwork {
+  """The current online state of the client."""
+  offline: Boolean!
+
+  """If the client is offline and trying to retry the connection."""
+  retry: Boolean!
+}
+
 """The root query for implementing GraphQL mutations."""
 type Mutation {
   """Creates a new check."""
@@ -1116,6 +1147,9 @@ type Query {
 
   """The last namespace that the client accessed."""
   lastNamespace: String!
+
+  """The networking state of the client"""
+  localNetwork: LocalNetwork
 }
 
 type RefreshTokensPayload {
@@ -1141,43 +1175,65 @@ type ResolveEventPayload {
   event: Event!
 }
 
-"""Role describes set of rules"""
-type Role implements Node {
-  id: ID!
-  name: String!
-  rules: [Rule!]!
-}
+"""Role applies only to a single namespace."""
+type Role {
+  rules: [Rule!]
 
-"""Rule maps permissions to a given type"""
-type Rule implements Namespaced {
-  """namespace in which this record resides"""
+  """Namespace of the Role"""
   namespace: String!
 
-  """resource the permissions apply to"""
-  type: RuleResource!
-  permissions: [RulePermission!]!
+  """Name of the Role"""
+  name: String!
 }
 
-enum RulePermission {
-  ALL
-  CREATE
-  READ
-  UPDATE
-  DELETE
+"""
+RoleBinding grants the permissions defined in a Role referenced to a user or
+a set of users
+"""
+type RoleBinding {
+  """Subjects holds references to the objects the Role applies to"""
+  subjects: [Subject!]
+
+  """RoleRef references a Role in the current namespace"""
+  roleRef: RoleRef
+
+  """Namespace of the RoleBinding"""
+  namespace: String!
+
+  """Name of the RoleBinding"""
+  name: String!
 }
 
-enum RuleResource {
-  ALL
-  ASSETS
-  CHECKS
-  ENTITIES
-  HANDLERS
-  HOOKS
-  MUTATORS
-  ORGANIZATIONS
-  ROLES
-  SILENCED
-  USERS
+"""RoleRef maps groups to Roles or ClusterRoles."""
+type RoleRef {
+  """Type of role being referenced."""
+  type: String!
+
+  """Name of the resource being referenced"""
+  name: String!
+}
+
+"""Rule holds information that describes an action that can be taken"""
+type Rule {
+  """
+  Verbs is a list of verbs that apply to all of the listed resources for this
+  rule. These include "get", "list", "watch", "create", "update", "delete".
+  TODO: add support for "patch" (this is expensive and should be delayed
+  until a further release). TODO: add support for "watch" (via websockets)
+  """
+  verbs: [String!]!
+
+  """
+  Resources is a list of resources that this rule applies to. "*" represents
+  all resources.
+  """
+  resources: [String!]!
+
+  """
+  ResourceNames is an optional list of resource names that the rule applies
+  to.
+  """
+  resourceNames: [String!]!
 }
 
 """Silenced is the representation of a silence entry."""
@@ -1266,6 +1322,14 @@ type StandardError implements Error {
 
   """Message describing the error."""
   message: String!
+}
+
+type Subject {
+  """Kind of object referenced (user or group)"""
+  kind: String!
+
+  """Name of the referenced object"""
+  name: String!
 }
 
 """
@@ -1374,7 +1438,7 @@ type UpdateCheckPayload {
 """User describes an operator in the system"""
 type User {
   username: String!
-  roles: [Role!]!
+  groups: [String!]!
   disabled: Boolean!
   hasPassword: Boolean!
 }

--- a/dashboard/src/apollo/schema/combined.graphql
+++ b/dashboard/src/apollo/schema/combined.graphql
@@ -894,6 +894,12 @@ type Mutation {
 
   """Stores given pair as user's last visited namespace."""
   setLastNamespace(name: String!): Boolean
+
+  """Flag to allow us to retry a connection"""
+  retryLocalNetwork: Boolean
+
+  """Flags the client as being offline or online"""
+  setLocalNetworkOffline(offline: Boolean!): Boolean
 }
 
 """A Mutator is a mutator specification."""

--- a/dashboard/src/apollo/stateLink.js
+++ b/dashboard/src/apollo/stateLink.js
@@ -2,6 +2,7 @@ import merge from "deepmerge";
 import { withClientState } from "apollo-link-state";
 import auth from "./resolvers/auth";
 import lastNamespace from "./resolvers/lastNamespace";
+import localNetwork from "./resolvers/localNetwork";
 import addDeletedFieldTo from "./resolvers/deleted";
 
 const resolvers = merge.all([
@@ -13,6 +14,7 @@ const resolvers = merge.all([
   addDeletedFieldTo("Silenced"),
   addDeletedFieldTo("CheckConfig"),
   lastNamespace,
+  localNetwork,
 ]);
 
 const stateLink = ({ cache }) => withClientState({ ...resolvers, cache });


### PR DESCRIPTION
This is >probably< to be merged in after GA

## What is this change?
Closes #2423 and #2422
Adds LocalNetwork to the Query component. LocalNetwork contains fields for offline and retry. These fields do nothing at this point in time and are an initial step towards #2103

## Why is this change necessary?
This is to help track the state of the network better and add appropriate errors for the user.

## Does your change need a Changelog entry?
I don't think so, when this functionality is completed in it's entirety then it would make more sense to add an entry. As of now these fields do nothing.