### PR TITLE
Temporarily disable round-robin scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ uses the same facility as check subdue for handling time windows.
   values coming from the mutator's environment.
 - Metadata from wrappers and resources is now merged, with a preference given to
 the values coming from the wrapper. Labels and annotations are deep-merged.
+- Round-robin scheduling has been temporarily disabled.
 
 ### Fixed
 - Fixed several resource leaks in the check scheduler.

--- a/backend/schedulerd/round_robin_scheduler.go
+++ b/backend/schedulerd/round_robin_scheduler.go
@@ -2,6 +2,7 @@ package schedulerd
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	time "github.com/echlebek/timeproxy"
@@ -66,12 +67,15 @@ func (r *roundRobinScheduler) execute(msg *roundRobinMessage) {
 // Schedule returns a sync.WaitGroup that the caller can wait on to know
 // when scheduling is completed.
 func (r *roundRobinScheduler) Schedule(msg *roundRobinMessage) (*sync.WaitGroup, error) {
-	if err := r.ctx.Err(); err != nil {
-		return nil, err
-	}
-	msg.wg.Add(1)
-	r.messages <- msg
-	return &msg.wg, nil
+	/*
+		if err := r.ctx.Err(); err != nil {
+			return nil, err
+		}
+		msg.wg.Add(1)
+		r.messages <- msg
+		return &msg.wg, nil
+	*/
+	return nil, errors.New("roundrobin scheduling is currently unsupported, see https://github.com/sensu/sensu-go/issues/2444")
 }
 
 // logError logs errors and adds agentName and checkName as fields.

--- a/backend/schedulerd/round_robin_scheduler_test.go
+++ b/backend/schedulerd/round_robin_scheduler_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestRoundRobinScheduler(t *testing.T) {
+	// TODO: Revisit https://github.com/sensu/sensu-go/issues/2431 is resolved.
+	t.Skip()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bus := mockbus.MockBus{}


### PR DESCRIPTION
## What is this change?

Per https://github.com/sensu/sensu-go/issues/2444, we are temporarily
disabling round-robin scheduling. Issues with round-robin
scheduling, https://github.com/sensu/sensu-go/issues/2431 that made
us uncomfortable shipping this enabled as it can lead to a potential
deadlock in the scheduler.

## Why is this change necessary?

closes #2444 