### PR TITLE
Grepory/disable extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ found to have issues, and we are re-working the feature for a future release.
 'when' properties defined should delete and recreate the filter. Filter when
 uses the same facility as check subdue for handling time windows.
 - Removed event.Hooks and event.Silenced deprecated fields
+- Extensions have been removed until we have time to revisit the feature.
 
 ### Changed
 - Assets and checks environments are now merged, with a preference given to the

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/edit"
 	"github.com/sensu/sensu-go/cli/commands/entity"
 	"github.com/sensu/sensu-go/cli/commands/event"
-	"github.com/sensu/sensu-go/cli/commands/extension"
 	"github.com/sensu/sensu-go/cli/commands/filter"
 	"github.com/sensu/sensu-go/cli/commands/handler"
 	"github.com/sensu/sensu-go/cli/commands/hook"
@@ -53,7 +52,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		user.HelpCommand(cli),
 		silenced.HelpCommand(cli),
 		create.CreateCommand(cli),
-		extension.HelpCommand(cli),
+		//extension.HelpCommand(cli),
 		cluster.HelpCommand(cli),
 		edit.Command(cli),
 	)


### PR DESCRIPTION
## What is this change?

This disables extensions in sensuctl.


## Why is this change necessary?

Until we have a chance to revisit extensions, we want the omit the extensions command from sensuctl.

