### PR TITLE
[Web UI] Fix Relocation sink interface

### DIFF
--- a/dashboard/src/components/relocation/BannerSink.js
+++ b/dashboard/src/components/relocation/BannerSink.js
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Sink } from "/components/relocation/Relocation";
+import { BANNER } from "/components/relocation/types";
+
+class BannerSink extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  render() {
+    return <Sink>{{ render: () => this.props.children, type: BANNER }}</Sink>;
+  }
+}
+
+export default BannerSink;

--- a/dashboard/src/components/relocation/Relocation.js
+++ b/dashboard/src/components/relocation/Relocation.js
@@ -32,16 +32,17 @@ class SinkConnector extends React.PureComponent {
     addChild: PropTypes.func.isRequired,
     updateChild: PropTypes.func.isRequired,
     removeChild: PropTypes.func.isRequired,
+    children: PropTypes.any.isRequired,
   };
 
   id = uniqueId();
 
   componentDidMount() {
-    this.props.addChild(this.id, this.props);
+    this.props.addChild(this.id, this.props.children);
   }
 
   componentDidUpdate() {
-    this.props.updateChild(this.id, this.props);
+    this.props.updateChild(this.id, this.props.children);
   }
 
   componentWillUnmount() {
@@ -150,6 +151,10 @@ export class Provider extends React.PureComponent {
 }
 
 export class Sink extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.any.isRequired,
+  };
+
   render() {
     return (
       <Context.Consumer>
@@ -158,8 +163,9 @@ export class Sink extends React.PureComponent {
             addChild={addChild}
             updateChild={updateChild}
             removeChild={removeChild}
-            props={this.props}
-          />
+          >
+            {this.props.children}
+          </SinkConnector>
         )}
       </Context.Consumer>
     );

--- a/dashboard/src/components/relocation/ToastSink.js
+++ b/dashboard/src/components/relocation/ToastSink.js
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Sink } from "/components/relocation/Relocation";
+import { TOAST } from "/components/relocation/types";
+
+class ToastSink extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  render() {
+    return <Sink>{{ render: () => this.props.children, type: TOAST }}</Sink>;
+  }
+}
+
+export default ToastSink;


### PR DESCRIPTION
## What is this change?

The `Sink` feature of relocation enables declaratively defining components to be rendered elsewhere. Compared to the currently used imperative interface, where a new component instance is spawned and handed-off, a declaratively defined component using `Sink` is coupled to it's parent component's lifecycle - behaving in a manor very similar to `React.Portal`.

## Why is this change necessary?

This supports the upcoming offline alert banner.

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No