### PR TITLE
[Web UI]  Refetch query when api connection resumes

### DIFF
--- a/dashboard/.flowconfig
+++ b/dashboard/.flowconfig
@@ -7,6 +7,10 @@ all=error
 [libs]
 flow-typed
 
+[ignore]
+.*/node_modules/graphql/.*/.*\.js\.flow$
+.*/node_modules/graphql-tag/.*\.flow\.js$
+
 [options]
 emoji=true
 include_warnings=true

--- a/dashboard/src/components/util/Query.js
+++ b/dashboard/src/components/util/Query.js
@@ -13,16 +13,17 @@ import type {
   ApolloQueryResult,
 } from "react-apollo";
 import shallowEqual from "fbjs/lib/shallowEqual";
+import gql from "graphql-tag";
 
 import QueryAbortedError from "/errors/QueryAbortedError";
 
 type ObservableMethods = {
-  fetchMore: () => void,
-  refetch: () => void,
-  startPolling: () => void,
-  stopPolling: () => void,
-  subscribeToMore: () => void,
-  updateQuery: () => void,
+  fetchMore: $PropertyType<ObservableQuery<mixed>, "fetchMore">,
+  refetch: $PropertyType<ObservableQuery<mixed>, "refetch">,
+  startPolling: $PropertyType<ObservableQuery<mixed>, "startPolling">,
+  stopPolling: $PropertyType<ObservableQuery<mixed>, "stopPolling">,
+  subscribeToMore: $PropertyType<ObservableQuery<mixed>, "subscribeToMore">,
+  updateQuery: $PropertyType<ObservableQuery<mixed>, "updateQuery">,
 };
 
 type Props = {
@@ -32,6 +33,8 @@ type Props = {
   onError: Error => void,
 } & WatchQueryOptions;
 
+type LocalData = { localNetwork: { offline: boolean, retry: boolean } };
+
 type State = {
   aborted: boolean,
   data: mixed | null, // TODO: Infer data type from query
@@ -39,6 +42,10 @@ type State = {
   loading: boolean,
   networkStatus: NetworkStatus,
   observable: ObservableQuery<mixed>,
+  localQuery: {
+    observable: ObservableQuery<LocalData>,
+    data: LocalData,
+  },
   props: Props,
 } & ObservableMethods;
 
@@ -64,6 +71,37 @@ const extractQueryOptions = (
   notifyOnNetworkStatusChange: props.notifyOnNetworkStatusChange,
 });
 
+const localQuery = gql`
+  query LocalNetworkStatusQuery {
+    localNetwork @client {
+      offline
+      retry
+    }
+  }
+`;
+
+const createQueryObservable = (props: Props) => {
+  const observable: ObservableQuery<mixed> = props.client.watchQuery(
+    extractQueryOptions(props),
+  );
+
+  // retrieve the result of the query from the local cache
+  const { data, loading, networkStatus } = observable.currentResult();
+
+  return {
+    observable,
+    data,
+    loading,
+    networkStatus,
+    refetch: observable.refetch.bind(observable),
+    fetchMore: observable.fetchMore.bind(observable),
+    updateQuery: observable.updateQuery.bind(observable),
+    startPolling: observable.startPolling.bind(observable),
+    stopPolling: observable.stopPolling.bind(observable),
+    subscribeToMore: observable.subscribeToMore.bind(observable),
+  };
+};
+
 class Query extends React.PureComponent<Props, State> {
   static defaultProps = {
     variables: {},
@@ -75,10 +113,30 @@ class Query extends React.PureComponent<Props, State> {
   };
 
   subscription: { unsubscribe(): void } | null = null;
+  localSubscription: { unsubscribe(): void } | null = null;
 
   static getDerivedStateFromProps(props: Props, state: State | null) {
     if (state !== null && state.props === props) {
       return null;
+    }
+
+    let nextState: $Shape<State> = { props };
+
+    if (state === null || state.props.client !== props.client) {
+      const observable: ObservableQuery<LocalData> = props.client.watchQuery({
+        query: localQuery,
+      });
+
+      const { data } = observable.currentResult();
+
+      nextState = {
+        ...nextState,
+        localQuery: {
+          observable,
+          // flowlint-next-line unclear-type: off
+          data: ((data: any): LocalData),
+        },
+      };
     }
 
     if (
@@ -86,35 +144,20 @@ class Query extends React.PureComponent<Props, State> {
       state.props.client !== props.client ||
       state.props.query !== props.query
     ) {
-      const observable: ObservableQuery<mixed> = props.client.watchQuery(
-        extractQueryOptions(props),
-      );
-
-      // retrieve the result of the query from the local cache
-      const { data, loading, networkStatus } = observable.currentResult();
-
-      return {
-        props,
-        observable,
-        data,
-        loading,
-        networkStatus,
-        refetch: observable.refetch.bind(observable),
-        fetchMore: observable.fetchMore.bind(observable),
-        updateQuery: observable.updateQuery.bind(observable),
-        startPolling: observable.startPolling.bind(observable),
-        stopPolling: observable.stopPolling.bind(observable),
-        subscribeToMore: observable.subscribeToMore.bind(observable),
+      nextState = {
+        ...nextState,
+        ...createQueryObservable(props),
       };
-    }
-
-    if (state && modifiableWatchQueryOptionsHaveChanged(state.props, props)) {
+    } else if (
+      state !== null &&
+      modifiableWatchQueryOptionsHaveChanged(state.props, props)
+    ) {
       state.observable.setOptions(extractQueryOptions(props));
     }
 
     // Changes to `metadata` and `context` props are ignored.
 
-    return { props };
+    return nextState;
   }
 
   subscribe() {
@@ -128,6 +171,17 @@ class Query extends React.PureComponent<Props, State> {
     });
   }
 
+  subscribeLocal() {
+    if (this.localSubscription) {
+      throw new Error("Cannot subscribe. Currently subscribed.");
+    }
+
+    this.localSubscription = this.state.localQuery.observable.subscribe({
+      next: this.onNextLocal,
+      error: this.onErrorLocal,
+    });
+  }
+
   unsubscribe() {
     if (!this.subscription) {
       throw new Error("Cannot unsubscribe. Not currently subscribed");
@@ -135,6 +189,15 @@ class Query extends React.PureComponent<Props, State> {
 
     this.subscription.unsubscribe();
     this.subscription = null;
+  }
+
+  unsubscribeLocal() {
+    if (!this.localSubscription) {
+      throw new Error("Cannot unsubscribe. Not currently subscribed");
+    }
+
+    this.localSubscription.unsubscribe();
+    this.localSubscription = null;
   }
 
   onNext = ({
@@ -149,18 +212,41 @@ class Query extends React.PureComponent<Props, State> {
       error = new ApolloError({ graphQLErrors: errors });
     }
 
-    this.setState((state: State) => ({
-      ...state,
+    this.setState({
       aborted: false,
       error,
       data,
       loading,
       networkStatus,
-    }));
+    });
 
     if (error) {
       this.props.onError(error);
     }
+  };
+
+  onNextLocal = ({ data }: ApolloQueryResult<LocalData>) => {
+    this.setState((state: State, props: Props) => {
+      let nextState = {
+        localQuery: {
+          ...state.localQuery,
+          data,
+        },
+      };
+
+      if (
+        state.localQuery.data.localNetwork.offline &&
+        (!nextState.localQuery.data.localNetwork.offline ||
+          nextState.localQuery.data.localNetwork.retry)
+      ) {
+        nextState = {
+          ...nextState,
+          ...createQueryObservable(props),
+        };
+      }
+
+      return nextState;
+    });
   };
 
   onError = (error: Error) => {
@@ -173,8 +259,13 @@ class Query extends React.PureComponent<Props, State> {
     }
   };
 
+  onErrorLocal = (error: Error) => {
+    throw error;
+  };
+
   componentDidMount() {
     this.subscribe();
+    this.subscribeLocal();
   }
 
   componentDidUpdate(previousProps: Props, previousState: State) {
@@ -182,10 +273,18 @@ class Query extends React.PureComponent<Props, State> {
       this.unsubscribe();
       this.subscribe();
     }
+
+    if (
+      this.state.localQuery.observable !== previousState.localQuery.observable
+    ) {
+      this.unsubscribeLocal();
+      this.subscribeLocal();
+    }
   }
 
   componentWillUnmount() {
     this.unsubscribe();
+    this.unsubscribeLocal();
   }
 
   render() {

--- a/dashboard/src/components/util/Query.js
+++ b/dashboard/src/components/util/Query.js
@@ -251,11 +251,11 @@ class Query extends React.PureComponent<Props, State> {
 
   onError = (error: Error) => {
     // flowlint-next-line unclear-type: off
-    if (!((error: Object).networkError instanceof QueryAbortedError)) {
+    if ((error: Object).networkError instanceof QueryAbortedError) {
+      this.setState({ aborted: true, error: null });
+    } else {
       this.setState({ error });
       this.props.onError(error);
-    } else {
-      this.setState({ aborted: true, error: null });
     }
   };
 

--- a/dashboard/src/components/views/EnvironmentView/CheckDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/CheckDetailsContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import Query from "/components/util/Query";
 import NotFound from "/components/partials/NotFound";
 import CheckDetailsContainer from "/components/partials/CheckDetailsContainer";
@@ -32,6 +34,13 @@ class CheckDetailsContent extends React.PureComponent {
         pollInterval={pollInterval}
         fetchPolicy="cache-and-network"
         variables={this.props.match.params}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {({
           aborted,

--- a/dashboard/src/components/views/EnvironmentView/ChecksContent.js
+++ b/dashboard/src/components/views/EnvironmentView/ChecksContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import AppLayout from "/components/AppLayout";
 import ChecksList from "/components/partials/ChecksList";
 import Content from "/components/Content";
@@ -106,6 +108,13 @@ class ChecksContent extends React.Component {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={variables}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {this.renderContent}
       </Query>

--- a/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntitiesContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import AppLayout from "/components/AppLayout";
 import Content from "/components/Content";
 import EntitiesList from "/components/partials/EntitiesList";
@@ -100,6 +102,13 @@ class EntitiesContent extends React.PureComponent {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={variables}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {this.renderContent}
       </Query>

--- a/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EntityDetailsContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import EntityDetailsContainer from "/components/partials/EntityDetailsContainer";
 import Loader from "/components/util/Loader";
 import NotFound from "/components/partials/NotFound";
@@ -34,6 +36,13 @@ class EntityDetailsContent extends React.PureComponent {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={this.props.match.params}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {({ data: { entity } = {}, networkStatus, aborted, refetch }) => {
           // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts

--- a/dashboard/src/components/views/EnvironmentView/EnvironmentView.js
+++ b/dashboard/src/components/views/EnvironmentView/EnvironmentView.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import { Switch, Route, Redirect } from "react-router-dom";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import AppBar from "/components/AppBar";
 import AppLayout from "/components/AppLayout";
 import QuickNav from "/components/QuickNav";
@@ -48,6 +50,13 @@ class EnvironmentView extends React.PureComponent {
         <Query
           query={EnvironmentView.query}
           variables={{ namespace: namespaceParam }}
+          onError={error => {
+            if (error.networkError instanceof FailedError) {
+              return;
+            }
+
+            throw error;
+          }}
         >
           {({ data: { viewer, namespace } = {}, loading, aborted }) => (
             <Loader loading={loading}>

--- a/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventDetailsContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import Query from "/components/util/Query";
 
 import NotFound from "/components/partials/NotFound";
@@ -38,6 +40,13 @@ class EventDetailsContent extends React.PureComponent {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={this.props.match.params}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {({ data: { event } = {}, networkStatus, aborted }) => {
           // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
 
+import { FailedError } from "/errors/FetchError";
+
 import AppLayout from "/components/AppLayout";
 import Content from "/components/Content";
 import EventsList from "/components/partials/EventsList";
@@ -108,6 +110,13 @@ class EventsContent extends React.Component {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={variables}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {this.renderContent}
       </Query>

--- a/dashboard/src/components/views/EnvironmentView/SilencesContent.js
+++ b/dashboard/src/components/views/EnvironmentView/SilencesContent.js
@@ -4,6 +4,8 @@ import gql from "graphql-tag";
 import withStateHandlers from "recompose/withStateHandlers";
 import toRenderProps from "recompose/toRenderProps";
 
+import { FailedError } from "/errors/FetchError";
+
 import AppLayout from "/components/AppLayout";
 import Content from "/components/Content";
 import NotFound from "/components/partials/NotFound";
@@ -134,6 +136,13 @@ class SilencesContent extends React.Component {
         fetchPolicy="cache-and-network"
         pollInterval={pollInterval}
         variables={variables}
+        onError={error => {
+          if (error.networkError instanceof FailedError) {
+            return;
+          }
+
+          throw error;
+        }}
       >
         {this.renderContent}
       </Query>


### PR DESCRIPTION
## What is this change?

Update the `Query` component to observe the `localNetwork` status (from #2437) and automatically restart the query subscription when online status resumes or the user requests a retry attempt.

## Why is this change necessary?

This provides a much more polished experience for users experiencing network connection issues.

## Does your change need a Changelog entry?

Not yet. The changelog will be updated the banner is implemented.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.