### PR TITLE
Fix API path used by entity create

### DIFF
--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -78,7 +78,7 @@ func (client *RestClient) CreateEntity(entity *types.Entity) (err error) {
 		return err
 	}
 
-	path := entitiesPath(entity.Namespace, entity.Name)
+	path := entitiesPath(entity.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What is this change?

Fix API path used by `sensuctl entity create`.

## Why is this change necessary?

Closes #2467 
