### PR TITLE
Return the response status if body is empty in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ period of disconnection from the backend.
 - A panic in keepalive/check ttl monitors causing a panic.
 - Monitors are now properly namespaced in etcd.
 - Updating a users groups will no longer corrupt their password
+- Prevent empty error messages in sensuctl.
 
 ### Breaking Changes
 - The backend configuration attributes `api-host` & `api-port` have been

--- a/cli/client/error.go
+++ b/cli/client/error.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/go-resty/resty"
 )
@@ -21,7 +22,12 @@ func (a APIError) Error() string {
 func UnmarshalError(res *resty.Response) error {
 	var apiErr APIError
 	if err := json.Unmarshal(res.Body(), &apiErr); err != nil {
-		apiErr.Message = string(res.Body())
+		if len(res.Body()) > 0 {
+			apiErr.Message = string(res.Body())
+		} else {
+			apiErr.Message = fmt.Sprintf("the API returned: %s", res.Status())
+		}
 	}
+
 	return apiErr
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures an error message is always returned in sensuctl; if the response body is empty, return the HTTP status instead. Example:

```
$ sensuctl entity create foo -c proxy
Error: the API returned: 405 Method Not Allowed
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2469

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope