### PR TITLE
Fix keepalive and check TTL bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ period of disconnection from the backend.
 - A panic in keepalive/check ttl monitors causing a panic.
 - Monitors are now properly namespaced in etcd.
 - Updating a users groups will no longer corrupt their password
+- Fixed a bug where keepalive failures could be influenced by check TTL
+successes, and vice versa.
+- Fixed a bug where check TTL events were not formed correctly.
 
 ### Breaking Changes
 - The backend configuration attributes `api-host` & `api-port` have been

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -154,7 +154,7 @@ func Initialize(config *Config) (*Backend, error) {
 	event, err := eventd.New(eventd.Config{
 		Store:          store,
 		Bus:            bus,
-		MonitorFactory: monitor.EtcdFactory(client),
+		MonitorFactory: monitor.EtcdFactory(client, "eventd"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", event.Name(), err)
@@ -190,7 +190,7 @@ func Initialize(config *Config) (*Backend, error) {
 		DeregistrationHandler: config.DeregistrationHandler,
 		Bus:            bus,
 		Store:          store,
-		MonitorFactory: monitor.EtcdFactory(client),
+		MonitorFactory: monitor.EtcdFactory(client, "keepalived"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -5,13 +5,13 @@ package eventd
 import (
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
 	"github.com/sensu/sensu-go/testing/mockring"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func TestEventdMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	monFac := monitor.EtcdFactory(client)
+	monFac := monitor.EtcdFactory(client, "TestEventdMonitor")
 
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
 		RingGetter: &mockring.Getter{},
@@ -70,7 +70,7 @@ func TestEventdMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	event := types.FixtureEvent("entity1", "check1")
+	event := corev2.FixtureEvent("entity1", "check1")
 	event.Check.Interval = 1
 	event.Check.Ttl = 2
 
@@ -83,7 +83,7 @@ func TestEventdMonitor(t *testing.T) {
 		assert.FailNow(t, "failed to pull message off eventChan")
 	}
 
-	okEvent, ok := msg.(*types.Event)
+	okEvent, ok := msg.(*corev2.Event)
 	if !ok {
 		assert.FailNow(t, "message type was not an event")
 	}
@@ -93,7 +93,7 @@ func TestEventdMonitor(t *testing.T) {
 	if !ok {
 		assert.FailNow(t, "failed to pull message off eventChan")
 	}
-	warnEvent, ok := msg.(*types.Event)
+	warnEvent, ok := msg.(*corev2.Event)
 	if !ok {
 		assert.FailNow(t, "message type was not an event")
 	}

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
 	"github.com/sensu/sensu-go/testing/mockring"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +55,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	mFac := monitor.EtcdFactory(client)
+	mFac := monitor.EtcdFactory(client, "TestKeepaliveMonitor")
 
 	k, err := New(Config{Store: store, Bus: bus, MonitorFactory: mFac})
 	require.NoError(t, err)
@@ -64,10 +64,10 @@ func TestKeepaliveMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	entity := types.FixtureEntity("entity1")
+	entity := corev2.FixtureEntity("entity1")
 
-	keepalive := &types.Event{
-		Check:     &types.Check{Timeout: 1},
+	keepalive := &corev2.Event{
+		Check:     &corev2.Check{Timeout: 1},
 		Entity:    entity,
 		Timestamp: time.Now().Unix(),
 	}
@@ -81,7 +81,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 		assert.FailNow(t, "failed to pull message off eventChan")
 	}
 
-	okEvent, ok := msg.(*types.Event)
+	okEvent, ok := msg.(*corev2.Event)
 	if !ok {
 		assert.FailNow(t, "message type was not an event")
 	}
@@ -91,7 +91,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 	if !ok {
 		assert.FailNow(t, "failed to pull message off eventChan")
 	}
-	warnEvent, ok := msg.(*types.Event)
+	warnEvent, ok := msg.(*corev2.Event)
 	if !ok {
 		assert.FailNow(t, "message type was not an event")
 	}

--- a/backend/monitor/monitor_test.go
+++ b/backend/monitor/monitor_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -199,4 +200,72 @@ func TestWatchMonPut(t *testing.T) {
 	_, err = client.Put(context.Background(), mon.key, "test value")
 	require.NoError(t, err)
 	shutdownWait.Wait()
+}
+
+func newBlockingHandler() *blockingHandler {
+	return &blockingHandler{
+		executed: make(chan struct{}, 1),
+	}
+}
+
+type blockingHandler struct {
+	executed chan struct{}
+}
+
+func (r *blockingHandler) HandleFailure(e *corev2.Event) error {
+	r.executed <- struct{}{}
+	return nil
+}
+
+func (r *blockingHandler) HandleError(err error) {
+	panic(err)
+}
+
+func TestWritesDoNotConflict_GH2470(t *testing.T) {
+	t.Parallel()
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+	client, err := e.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Create two supervisors with different prefixes
+	facA := EtcdFactory(client, "A")
+	facB := EtcdFactory(client, "B")
+
+	handlerA := newBlockingHandler()
+	handlerB := newBlockingHandler()
+
+	superA := facA(handlerA)
+	superB := facB(handlerB)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		// Refresh the monitor forever, it should never fail
+		for {
+			err := superA.Monitor(ctx, "key", corev2.FixtureEvent("foo", "bar"), 1)
+			if err != nil && ctx.Err() == nil {
+				panic(err)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// Monitor the same key with the other supervisor, but allow this monitor to fail
+	err = superB.Monitor(context.Background(), "key", corev2.FixtureEvent("foo", "bar"), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatal("test timed out")
+	case <-handlerA.executed:
+		t.Fatal("handler A should never execute")
+	case <-handlerB.executed:
+	}
 }

--- a/build.sh
+++ b/build.sh
@@ -206,6 +206,9 @@ docker_commands () {
 }
 
 docker_build() {
+    # install sensuctl to make sure it's current with the docker build
+    go install ./cmd/sensuctl
+
     local build_sha=$(git rev-parse HEAD)
     local ext=$@
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - "28081:8081"
   agent1:
     image: sensu/sensu:master
-    command: sensu-agent start --backend-url ws://backend1:8081 --subscriptions test --log-level debug
+    command: sensu-agent start --backend-url ws://backend1:8081 --subscriptions metrics,misc,roundrobin,proxy --log-level debug --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent1
     restart: always
     depends_on:
@@ -43,7 +43,7 @@ services:
       - backend3
   agent2:
     image: sensu/sensu:master
-    command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions test --log-level debug
+    command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions schedules,rbac,roundrobin,proxy --log-level debug --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent2
     restart: always
     depends_on:
@@ -52,7 +52,7 @@ services:
       - backend3
   agent3:
     image: sensu/sensu:master
-    command: sensu-agent start --backend-url ws://backend3:8081 --subscriptions test --log-level debug
+    command: sensu-agent start --backend-url ws://backend3:8081 --subscriptions rbac,roundrobin --log-level debug --namespace devops --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent3
     restart: always
     depends_on:


### PR DESCRIPTION
## What is this change?

This commit fixes a bug that caused check TTL monitors to be
aliased to keepalive monitors. The previous behaviour was that
passing keepalives would cancel out failing check TTLs, and
passing checks would cancel out failing keepalives, depending on
order of execution.

This commit also fixes a bug in check TTL where the failing check
event is not created properly.

Additionally, docker-compose has been modified so that the agents
involved use the subscriptions defined in the staging resources.

The build.sh script has been modified so that users who run
`./build.sh docker` get a newly installed sensuctl in $GOPATH/bin.

## Why is this change necessary?

Closes #2473 
Closes #2470 

## Testing performed

I did several test runs with docker-compose, with a set of checks that caused the problem to occur previously.