### PR TITLE
[Web UI] Quick fix for FireFox resize event bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a web-ui bug causing the app to crash on window resize in FireFox
+
 ### [5.0.0] - 2018-11-30
 
 ### Added

--- a/dashboard/src/components/partials/ToolbarMenu/Menu.js
+++ b/dashboard/src/components/partials/ToolbarMenu/Menu.js
@@ -92,8 +92,8 @@ class ToolbarMenu extends React.PureComponent {
     });
   };
 
-  handleWindowResize = debounce(ev => {
-    const newWidth = ev.currentTarget.innerWidth;
+  handleWindowResize = debounce(currentTarget => {
+    const newWidth = currentTarget.innerWidth;
     const oldWidth = this.windowWidth || 0;
 
     // If the window grew in size and the toolbar menu isn't configured to fill
@@ -187,7 +187,10 @@ class ToolbarMenu extends React.PureComponent {
     if (!this.props.width) {
       return (
         <React.Fragment>
-          <EventListener target="window" onResize={this.handleWindowResize} />
+          <EventListener
+            target="window"
+            onResize={ev => this.handleWindowResize(ev.currentTarget)}
+          />
           {items}
         </React.Fragment>
       );

--- a/dashboard/src/components/partials/ToolbarMenu/Menu.js
+++ b/dashboard/src/components/partials/ToolbarMenu/Menu.js
@@ -69,7 +69,7 @@ class ToolbarMenu extends React.PureComponent {
   };
 
   componentWillUnmount() {
-    this.handleWindowResize.clear();
+    this.updateButtonsWidth.clear();
   }
 
   handleOverflowButtonResize = rect => {
@@ -92,7 +92,11 @@ class ToolbarMenu extends React.PureComponent {
     });
   };
 
-  handleWindowResize = debounce(currentTarget => {
+  handleWindowResize = event => {
+    this.updateButtonsWidth(event.currentTarget);
+  };
+
+  updateButtonsWidth = debounce(currentTarget => {
     const newWidth = currentTarget.innerWidth;
     const oldWidth = this.windowWidth || 0;
 
@@ -187,10 +191,7 @@ class ToolbarMenu extends React.PureComponent {
     if (!this.props.width) {
       return (
         <React.Fragment>
-          <EventListener
-            target="window"
-            onResize={ev => this.handleWindowResize(ev.currentTarget)}
-          />
+          <EventListener target="window" onResize={this.handleWindowResize} />
           {items}
         </React.Fragment>
       );


### PR DESCRIPTION
## What is this change?

Prevent unintended null reference at `event.currentTarget` by not passing the event object into the async debounce handler.

## Why is this change necessary?

Event objects in FireFox appear to get garbage collected sooner than in other browsers. 

## Does your change need a Changelog entry?

Updated.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No
