### PR TITLE
[Web UI] Display toast when re-running a check from events page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Added
-- Adds feedback when rerunning check[s] in the web app
-
 ### [5.0.0] - 2018-11-30
 
 ### Added
@@ -17,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Support for multiple API versions added to sensuctl create
 - Support for metadata added to wrapped resources (yaml, wrapped-json)
 - Added the backend configuration attributes `api-listen-address` & `api-url`.
+- Adds feedback when rerunning check[s] in the web app
 
 ### Removed
 - Check subdue functionality has been disabled. Users that have checks with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Adds feedback when rerunning check[s] in the web app
+
 ### [5.0.0] - 2018-11-30
 
 ### Added

--- a/dashboard/src/components/partials/EventsList/EventsList.js
+++ b/dashboard/src/components/partials/EventsList/EventsList.js
@@ -19,6 +19,7 @@ import ListController from "/components/controller/ListController";
 import Pagination from "/components/partials/Pagination";
 import SilenceEntryDialog from "/components/partials/SilenceEntryDialog";
 import ClearSilencesDialog from "/components/partials/ClearSilencedEntriesDialog";
+import ExecuteCheckStatusToast from "/components/relocation/ExecuteCheckStatusToast";
 
 import { TableListEmptyState } from "/components/TableList";
 
@@ -27,6 +28,7 @@ import EventsListItem from "./EventsListItem";
 
 class EventsContainer extends React.Component {
   static propTypes = {
+    addToast: PropTypes.func.isRequired,
     client: PropTypes.object.isRequired,
     editable: PropTypes.bool,
     namespace: PropTypes.shape({
@@ -125,10 +127,19 @@ class EventsContainer extends React.Component {
     const { client } = this.props;
 
     events.forEach(({ check, entity }) => {
-      executeCheck(client, {
+      const promise = executeCheck(client, {
         id: check.nodeId,
         subscriptions: [`entity:${entity.name}`],
       });
+
+      this.props.addToast(({ remove }) => (
+        <ExecuteCheckStatusToast
+          onClose={remove}
+          mutation={promise}
+          checkName={check.name}
+          namespace={check.namespace}
+        />
+      ));
     });
   };
 

--- a/dashboard/src/components/views/EnvironmentView/EventsContent.js
+++ b/dashboard/src/components/views/EnvironmentView/EventsContent.js
@@ -9,6 +9,7 @@ import ListToolbar from "/components/partials/EventsList/EventsListToolbar";
 import NotFound from "/components/partials/NotFound";
 import Query from "/components/util/Query";
 import { withQueryParams } from "/components/QueryParams";
+import ToastConnector from "/components/relocation/ToastConnector";
 import WithWidth from "/components/WithWidth";
 
 // If none given default expression is used.
@@ -80,19 +81,24 @@ class EventsContent extends React.Component {
         </Content>
 
         <AppLayout.MobileFullWidthContent>
-          <WithWidth>
-            {({ width }) => (
-              <EventsList
-                editable={width !== "xs"}
-                limit={limit}
-                offset={offset}
-                onChangeQuery={setQueryParams}
-                namespace={namespace}
-                loading={(loading && !namespace) || aborted}
-                refetch={refetch}
-              />
+          <ToastConnector>
+            {({ addToast }) => (
+              <WithWidth>
+                {({ width }) => (
+                  <EventsList
+                    addToast={addToast}
+                    editable={width !== "xs"}
+                    limit={limit}
+                    offset={offset}
+                    onChangeQuery={setQueryParams}
+                    namespace={namespace}
+                    loading={(loading && !namespace) || aborted}
+                    refetch={refetch}
+                  />
+                )}
+              </WithWidth>
             )}
-          </WithWidth>
+          </ToastConnector>
         </AppLayout.MobileFullWidthContent>
       </div>
     );


### PR DESCRIPTION
## What is this change?

Displays a toast when creating an adhoc check request from the events list.

![2018-12-03 11 52 38](https://user-images.githubusercontent.com/194892/49398029-07e88e80-f6f2-11e8-9f39-392e387526bb.gif)

## Why is this change necessary?

Without the toast the feedback is confusing.

## Does your change need a Changelog entry?

Probably.