### PR TITLE
[Web UI] Fix firefox rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Ensure environment variables are joined with a semicolon on Windows
 - Command arguments are no longer needlessly escaped on Windows
 - Backend environments are now included in handler & mutator execution requests.
+- Firefox status icons not fully rendering 
 
 ### [5.0.0] - 2018-11-30
 

--- a/dashboard/src/icons/Error.js
+++ b/dashboard/src/icons/Error.js
@@ -19,7 +19,11 @@ class Icon extends React.PureComponent {
       <SvgIcon {...props}>
         <IconGap disabled={!withGap}>
           {({ maskId }) => (
-            <g fill="none" fillRule="evenodd" mask={`url(#${maskId})`}>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              mask={maskId && `url(#${maskId})`}
+            >
               <path d="M0 0h24v24H0z" />
               <path
                 d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"

--- a/dashboard/src/icons/OK.js
+++ b/dashboard/src/icons/OK.js
@@ -19,7 +19,7 @@ class Icon extends React.PureComponent {
       <SvgIcon {...props}>
         <IconGap disabled={!withGap}>
           {({ maskId }) => (
-            <g mask={`url(#${maskId})`}>
+            <g mask={maskId && `url(#${maskId})`}>
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
             </g>
           )}

--- a/dashboard/src/icons/Unknown.js
+++ b/dashboard/src/icons/Unknown.js
@@ -19,7 +19,7 @@ class Icon extends React.PureComponent {
       <SvgIcon {...props}>
         <IconGap disabled={!withGap}>
           {({ maskId }) => (
-            <g mask={`url(#${maskId})`}>
+            <g mask={maskId && `url(#${maskId})`}>
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
             </g>
           )}

--- a/dashboard/src/icons/Warn.js
+++ b/dashboard/src/icons/Warn.js
@@ -19,7 +19,7 @@ class Icon extends React.PureComponent {
       <SvgIcon {...props}>
         <IconGap disabled={!withGap}>
           {({ maskId }) => (
-            <g fill="currentColor" mask={`url(#${maskId})`}>
+            <g fill="currentColor" mask={maskId && `url(#${maskId})`}>
               <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
             </g>
           )}


### PR DESCRIPTION
## What is this change?
Fixes a bug where Firefox wouldn't properly render the entire status icon. The mask is used to apply the silence icon. However when there was no silence it would apply an empty mask and cause the side to be clipped.

## Why is this change necessary?
The icons were messed up and didn't look good.

## Does your change need a Changelog entry?
Added one