### PR TITLE
Remove e2e tests from appveyor test matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,8 +25,6 @@ environment:
       TEST_SUITE: integration
     - GOARCH: amd64
       TEST_SUITE: integration
-    - GOARCH: amd64
-      TEST_SUITE: e2e
 
 install:
   - rmdir c:\go /s /q


### PR DESCRIPTION
## What is this change?

Remove e2e tests from AppVeyor test matrix.

## Why is this change necessary?

E2E suite was removed but AppVeyor is trying to run them.

## Does your change need a Changelog entry?

Unlikely.