### PR TITLE
Add the etcd client to the backend struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Prevent a panic when using an external etcd cluster.
+
 ### [5.0.0] - 2018-11-30
 
 ### Added

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -35,6 +35,7 @@ import (
 // Backend represents the backend server, which is used to hold the datastore
 // and coordinating the daemons
 type Backend struct {
+	Client  *clientv3.Client
 	Daemons []daemon.Daemon
 	Etcd    *etcd.Etcd
 	Store   store.Store
@@ -94,35 +95,36 @@ func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 // backend. The daemons will later be started according to their position in the
 // b.Daemons list, and stopped in reverse order
 func Initialize(config *Config) (*Backend, error) {
+	var err error
 	// Initialize a Backend struct
 	b := &Backend{}
 
 	b.done = make(chan struct{})
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 
-	client, err := newClient(config, b)
+	b.Client, err = newClient(config, b)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize the store, which lives on top of etcd
 	logger.Debug("Initializing store...")
-	store := etcdstore.NewStore(client, config.EtcdName)
+	store := etcdstore.NewStore(b.Client, config.EtcdName)
 	if err = seeds.SeedInitialData(store); err != nil {
 		return nil, fmt.Errorf("error initializing the store: %s", err)
 	}
 	logger.Debug("Done initializing store")
 
 	logger.Debug("Registering backend...")
-	backendID := etcd.NewBackendIDGetter(b.ctx, client)
+	backendID := etcd.NewBackendIDGetter(b.ctx, b.Client)
 	logger.Debug("Done registering backend.")
 
 	// Initialize an etcd getter
-	queueGetter := queue.EtcdGetter{Client: client, BackendIDGetter: backendID}
+	queueGetter := queue.EtcdGetter{Client: b.Client, BackendIDGetter: backendID}
 
 	// Initialize the bus
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
-		RingGetter: ring.EtcdGetter{Client: client, BackendID: fmt.Sprintf("%x", backendID.GetBackendID())},
+		RingGetter: ring.EtcdGetter{Client: b.Client, BackendID: fmt.Sprintf("%x", backendID.GetBackendID())},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", bus.Name(), err)
@@ -154,7 +156,7 @@ func Initialize(config *Config) (*Backend, error) {
 	event, err := eventd.New(eventd.Config{
 		Store:          store,
 		Bus:            bus,
-		MonitorFactory: monitor.EtcdFactory(client, "eventd"),
+		MonitorFactory: monitor.EtcdFactory(b.Client, "eventd"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", event.Name(), err)
@@ -190,7 +192,7 @@ func Initialize(config *Config) (*Backend, error) {
 		DeregistrationHandler: config.DeregistrationHandler,
 		Bus:            bus,
 		Store:          store,
-		MonitorFactory: monitor.EtcdFactory(client, "keepalived"),
+		MonitorFactory: monitor.EtcdFactory(b.Client, "keepalived"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)
@@ -212,7 +214,7 @@ func Initialize(config *Config) (*Backend, error) {
 		Store:               store,
 		QueueGetter:         queueGetter,
 		TLS:                 config.TLS,
-		Cluster:             clientv3.NewCluster(client),
+		Cluster:             clientv3.NewCluster(b.Client),
 		EtcdClientTLSConfig: etcdClientTLSConfig,
 	})
 	if err != nil {


### PR DESCRIPTION
## What is this change?

It adds the etcd client generated by the `newClient` function to the `Backend` struct so it can be reused by the enterprise edition.

## Why is this change necessary?

Related to https://github.com/sensu/sensu-go/issues/2499.
Required by https://github.com/sensu/sensu-enterprise-go/issues/151.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

There's a couple of ways we could have fixed this issue, for example the `Initialize` function could also return the etcd client or we could make the `newClient` function public. I don't have any strong opinion.

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope