### PR TITLE
Do not build or test the backend for windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,16 +13,8 @@ environment:
   GOVERSION: 1.10.2
 
   matrix:
-    - GOARCH: 386
-      TEST_SUITE: unit
-      MSI_BUILDER: true
-      TIME_OUT_MINS: 30
-      APPVEYOR_API_TOKEN:
-        secure: 9DEZNCLW186SbfhAzXCPXh8TfOFysY56bW32dSpTWlQ=
     - GOARCH: amd64
       TEST_SUITE: unit
-    - GOARCH: 386
-      TEST_SUITE: integration
     - GOARCH: amd64
       TEST_SUITE: integration
 

--- a/build.ps1
+++ b/build.ps1
@@ -49,9 +49,6 @@ function cmd_name_map([string]$cmd)
 {
     switch ($cmd)
     {
-        "backend" {
-            return "sensu-backend"
-        }
         "agent" {
             return "sensu-agent"
         }
@@ -112,7 +109,7 @@ function build_commands
 {
     echo "Running build..."
 
-    ForEach ($bin in "agent","backend","cli") {
+    ForEach ($bin in "agent","cli") {
         build_command $bin
     }
 }
@@ -120,12 +117,6 @@ function build_commands
 function build_agent
 {
     build_command "agent"
-}
-
-function build_backend
-{
-    build_dashboard
-    build_command "backend"
 }
 
 function build_cli
@@ -178,7 +169,7 @@ function unit_test_commands
 {
     echo "Running unit tests..."
 
-    go test -timeout=60s $(go list ./... | Select-String -pattern "scripts", "testing", "vendor" -notMatch)
+    go test -timeout=60s $(go list ./... | Select-String -pattern "scripts", "testing", "vendor", "backend" -notMatch)
     If ($LASTEXITCODE -ne 0) {
         echo "Unit testing failed..."
         exit 1
@@ -189,7 +180,7 @@ function integration_test_commands
 {
     echo "Running integration tests..."
 
-    go test -timeout=200s -tags=integration $(go list ./... | Select-String -pattern "scripts", "testing", "vendor" -notMatch)
+    go test -timeout=200s -tags=integration github.com/sensu/sensu-go/agent/...
     If ($LASTEXITCODE -ne 0) {
         echo "Integration testing failed..."
         exit 1
@@ -257,9 +248,6 @@ If ($cmd -eq "build") {
 ElseIf ($cmd -eq "build_agent") {
     build_command "agent"
 }
-ElseIf ($cmd -eq "build_backend") {
-    build_command "backend"
-}
 ElseIf ($cmd -eq "build_cli") {
     build_command "cli"
 }
@@ -283,13 +271,9 @@ ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
         $env:GOARCH = "amd64"
         build_command "agent"
 
-        $env:GOARCH = "386"
-        build_command "agent"
-
         wait_for_appveyor_jobs
 
         build_package "agent" "x64"
-        build_package "agent" "x86"
     }
 }
 Else {


### PR DESCRIPTION
The backend is unsupported on Windows. Also disables 386 tests for
Windows.

Signed-off-by: Eric Chlebek <eric@sensu.io>