### PR TITLE
Return empty slice instead of nil for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Silences List in web ui sorted by ascending order; defaults to descending
 - Reduces shuffling of items as events list updates
 - Fixed error in UI where status value could not be coerced
+- Listing an empty set of assets now correctly returns [] instead of null.
 
 ### [5.0.0] - 2018-11-30
 

--- a/backend/store/etcd/asset_store.go
+++ b/backend/store/etcd/asset_store.go
@@ -46,7 +46,7 @@ func (s *Store) GetAssets(ctx context.Context) ([]*types.Asset, error) {
 		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
-		return nil, nil
+		return []*types.Asset{}, nil
 	}
 
 	assetArray := make([]*types.Asset, len(resp.Kvs))


### PR DESCRIPTION
When querying for a list of assets, instead of returning nil when there
are none to be returned, we return an empty slice of results instead.

This is to be in line with the behaviour of all the other object stores
and ensure a consistent behaviour across all the types.

## Why is this change necessary?

Closes #2509.
Ensure a more consistent behaviour across the different stores. 

## Does your change need a Changelog entry?

Yes.
Changelog entry added. 

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not needed.
