### PR TITLE
Allow hook creation with sensuctl create -f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Silences List in web ui sorted by ascending order; defaults to descending
 - Reduces shuffling of items as events list updates
 - Fixed error in UI where status value could not be coerced
+- Fixed API endpoint used by the CLI to create hooks via the 'sensuctl create'
+  command. It's now possible to create objects of type 'Hook' with this command
+  again.
 
 ### [5.0.0] - 2018-11-30
 

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -146,5 +146,5 @@ func FixtureHookList(hookName string) *HookList {
 
 // URIPath returns the path component of a Hook URI.
 func (h *Hook) URIPath() string {
-	return fmt.Sprintf("/hooks/%s", url.PathEscape(h.Name))
+	return fmt.Sprintf("/api/core/v2/namespaces/%s/hooks/%s", url.PathEscape(h.Namespace), url.PathEscape(h.Name))
 }


### PR DESCRIPTION
Update `Hook.URIPath()` to reflect the recent API re-rooting and namespaces changes. This change, which was missed during that last API re-work, allows `sensuctl create -f` to work with objects of type `Hook`, instead of generating an error after trying to hit a non-existent endpoint.

### Why is this change necessary?

Closes #2510.

### Does your change need a Changelog entry?

Yes; changelog entry added.

### Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes are needed. This is how `sensuctl create -f` used to work all along.
