### PR TITLE
Change the entity's status field to use uint type

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -94,7 +94,7 @@ func (r *entityImpl) Related(p schema.EntityRelatedFieldResolverParams) (interfa
 }
 
 // Status implements response to request for 'status' field.
-func (r *entityImpl) Status(p graphql.ResolveParams) (int, error) {
+func (r *entityImpl) Status(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*types.Entity)
 	client := r.factory.NewWithContext(p.Context)
 
@@ -114,7 +114,7 @@ func (r *entityImpl) Status(p graphql.ResolveParams) (int, error) {
 		}
 		st = maxUint32(ev.Check.Status, st)
 	}
-	return int(st), nil
+	return st, nil
 }
 
 // IsSilenced implements response to request for 'isSilenced' field.

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -52,7 +52,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 	impl := &entityImpl{factory: factory}
 	st, err := impl.Status(params)
 	require.NoError(t, err)
-	assert.Equal(t, 0, st)
+	assert.EqualValues(t, 0, st)
 
 	// Add failing event
 	failingEv := types.FixtureEvent(entity.Name, "bad")
@@ -65,7 +65,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 	// exit status: 2
 	st, err = impl.Status(params)
 	require.NoError(t, err)
-	assert.Equal(t, 2, st)
+	assert.EqualValues(t, 2, st)
 }
 
 func TestEntityTypeLastSeenField(t *testing.T) {

--- a/backend/apid/graphql/schema/entity.gql.go
+++ b/backend/apid/graphql/schema/entity.gql.go
@@ -79,7 +79,7 @@ type EntityRedactFieldResolver interface {
 // EntityStatusFieldResolver implement to resolve requests for the Entity's status field.
 type EntityStatusFieldResolver interface {
 	// Status implements response to request for status field.
-	Status(p graphql.ResolveParams) (int, error)
+	Status(p graphql.ResolveParams) (interface{}, error)
 }
 
 // EntityRelatedFieldResolverArgs contains arguments provided to related when selected
@@ -392,16 +392,9 @@ func (_ EntityAliases) Redact(p graphql.ResolveParams) ([]string, error) {
 }
 
 // Status implements response to request for 'status' field.
-func (_ EntityAliases) Status(p graphql.ResolveParams) (int, error) {
+func (_ EntityAliases) Status(p graphql.ResolveParams) (interface{}, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
-	ret, ok := graphql1.Int.ParseValue(val).(int)
-	if err != nil {
-		return ret, err
-	}
-	if !ok {
-		return ret, errors.New("unable to coerce value for field 'status'")
-	}
-	return ret, err
+	return val, err
 }
 
 // Related implements response to request for 'related' field.
@@ -690,7 +683,7 @@ func _ObjectTypeEntityConfigFn() graphql1.ObjectConfig {
 				DeprecationReason: "",
 				Description:       "Status represents the MAX status of all events associated with the entity. If\nno events are present value is 0.",
 				Name:              "status",
-				Type:              graphql1.NewNonNull(graphql1.Int),
+				Type:              graphql1.NewNonNull(graphql.OutputType("Uint")),
 			},
 			"subscriptions": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},

--- a/backend/apid/graphql/schema/entity.graphql
+++ b/backend/apid/graphql/schema/entity.graphql
@@ -26,7 +26,7 @@ type Entity implements Node, Namespaced {
   Status represents the MAX status of all events associated with the entity. If
   no events are present value is 0.
   """
-  status: Int!
+  status: Uint!
 
   "Related returns a sorted list of like entities from the same environment."
   related(limit: Int = 10): [Entity]!


### PR DESCRIPTION
## What is this change?

Updates the GraphQL service's entity status field to use the uint type.

## Why is this change necessary?

* Windows exit codes are represented as unsigned 32bit integers.
* Discovered while attempting to replicate #2514 

## Does your change need a Changelog entry?

Likely covered by the last entry.