### PR TITLE
Add backend environment to handler & mutator execution requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Copy local environment variables into execution context when running checks
 - Ensure environment variables are joined with a semicolon on Windows
 - Command arguments are no longer needlessly escaped on Windows
+- Backend environments are now included in handler & mutator execution requests.
 
 ### [5.0.0] - 2018-11-30
 


### PR DESCRIPTION
Fixes https://github.com/sensu/sensu-go/issues/2522.

Please review & merge https://github.com/sensu/sensu-go/pull/2519 before this PR.

## What is this change?

Adds the backend's environment to handler & mutator execution requests.

## Why is this change necessary?

While attempting to figure out why some checks were not executing on Windows agents, we found a regression in which backend's environments were not being included in handler & mutator execution requests.

## Does your change need a Changelog entry?

Yup!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required. This was supposed to be the expected behaviour.
