### PR TITLE
Update backend state-dir to /var/lib/sensu/sensu-backend

### DIFF
--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// StateDir is the base path for Sensu's local storage.
-	StateDir = "/var/lib/sensu"
+	StateDir = "/var/lib/sensu/sensu-backend"
 	// ClusterStateNew specifies this is a new etcd cluster
 	ClusterStateNew = "new"
 	// EtcdStartupTimeout is the amount of time we give the embedded Etcd Server


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Update backend state-dir to `/var/lib/sensu/sensu-backend`.

## Why is this change necessary?

We've made this change to the default in packaging but never made a change to the default in sensu backend.

## Does your change need a Changelog entry?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
