### PR TITLE
Use interval, not ttl, for keepalive event refresh

### DIFF
--- a/backend/monitor/monitor_test.go
+++ b/backend/monitor/monitor_test.go
@@ -153,7 +153,7 @@ func TestWatchMonDelete(t *testing.T) {
 
 	failWait := &sync.WaitGroup{}
 
-	testFailureHandler := func(context.Context, int64) {
+	testFailureHandler := func(context.Context) {
 		failWait.Done()
 	}
 


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in the monitor that causes failing events
to be emitted on a schedule determined by the final TTL before
failure, instead of the check or keepalive interval. This could
cause a panic to occur when a backend was started after a cold
period.

## Why is this change necessary?

Closes #2545 

## Does your change need a Changelog entry?

No, since this issue was caused by a commit in the same milestone.