### PR TITLE
Fix a bug in the check scheduler where a check would immediately fires if updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
 - Fixed a bug where adhoc checks were not retrieving asset dependencies.
+- Fixed a bug where check updates would cause the check to immediately fire.
 
 ## [5.1.0] - 2018-12-18
 

--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -68,10 +68,9 @@ func (s *CheckScheduler) schedule(timer CheckTimer, executor *CheckExecutor) {
 	}
 }
 
-// Start starts the CheckScheduler. It always returns nil error.
-func (s *CheckScheduler) Start() error {
+// Start starts the CheckScheduler.
+func (s *CheckScheduler) Start() {
 	go s.start()
-	return nil
 }
 
 func (s *CheckScheduler) mode() schedulerMode {
@@ -112,11 +111,8 @@ func (s *CheckScheduler) start() {
 			// if a schedule change is detected, restart the timer
 			if s.toggleSchedule() {
 				timer.Stop()
-				defer func() {
-					if err := s.Start(); err != nil {
-						s.logger.Error(err)
-					}
-				}()
+				defer s.Start()
+				return
 			}
 			continue
 		case <-timer.C():

--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -112,8 +112,12 @@ func (s *CheckScheduler) start() {
 			// if a schedule change is detected, restart the timer
 			if s.toggleSchedule() {
 				timer.Stop()
-				defer s.Start()
-				return
+				defer func() {
+					err := s.Start()
+					if err != nil {
+						s.logger.Error(err)
+					}
+				}()
 			}
 			continue
 		case <-timer.C():

--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -113,8 +113,7 @@ func (s *CheckScheduler) start() {
 			if s.toggleSchedule() {
 				timer.Stop()
 				defer func() {
-					err := s.Start()
-					if err != nil {
+					if err := s.Start(); err != nil {
 						s.logger.Error(err)
 					}
 				}()

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -101,7 +101,7 @@ func TestCheckSchedulerInterval(t *testing.T) {
 		wg.Done()
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Start()
 	wg.Wait()
 	mockTime.Stop()
@@ -149,7 +149,7 @@ func TestCheckSubdueInterval(t *testing.T) {
 		assert.NoError(scheduler.msgBus.Stop())
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Set(mockTime.Now().Add(2 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 
@@ -195,7 +195,7 @@ func TestCheckSchedulerCron(t *testing.T) {
 		wg.Done()
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Start()
 	wg.Wait()
 	mockTime.Stop()
@@ -244,7 +244,7 @@ func TestCheckSubdueCron(t *testing.T) {
 		assert.NoError(scheduler.msgBus.Stop())
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Set(mockTime.Now().Add(10 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -49,9 +49,7 @@ func (c *CheckWatcher) startScheduler(check *types.CheckConfig) error {
 	scheduler := NewCheckScheduler(c.store, c.bus, check, c.ctx)
 
 	// Start scheduling check
-	if err := scheduler.Start(); err != nil {
-		return err
-	}
+	scheduler.Start()
 
 	// Register new check scheduler
 	c.items[key] = scheduler

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package schedulerd
 
 import (


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Consolidates the `CheckScheduler` struct. Cleans up the check scheduler `schedule` function. Persists the check's timer if the schedule has not been updated (per 1.x parity). Special cases the interrupt issued by the check water to determine if the timer must be reset.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2550.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.