### PR TITLE
Use package liveness in keepalived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
 - Fixed a bug where adhoc checks were not retrieving asset dependencies.
+- Fixed a bug where check updates would cause the check to immediately fire.
 
 ## [5.1.0] - 2018-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
 - Fixed a bug where adhoc checks were not retrieving asset dependencies.
 - Fixed a bug where check updates would cause the check to immediately fire.
+- Keepalive events will now continue to fire after cluster restarts.
 
 ## [5.1.0] - 2018-12-18
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -173,6 +173,9 @@ func (a *Agent) Run() error {
 	if err := v2.ValidateName(a.config.AgentName); err != nil {
 		return fmt.Errorf("invalid agent name: %v", err)
 	}
+	if timeout := a.config.KeepaliveTimeout; timeout > 0 && timeout < 5 {
+		return fmt.Errorf("bad keepalive timeout: %d (minimum value is 5 seconds)", timeout)
+	}
 
 	// Start the statsd listener only if the agent configuration has it enabled
 	if !a.config.StatsdServer.Disable {

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -104,6 +104,9 @@ func (c *Check) Validate() error {
 	if c.Ttl > 0 && c.Ttl <= int64(c.Interval) {
 		return errors.New("ttl must be greater than check interval")
 	}
+	if c.Ttl > 0 && c.Ttl < 5 {
+		return errors.New("minimum ttl is 5 seconds")
+	}
 
 	for _, assetName := range c.RuntimeAssets {
 		if err := ValidateAssetName(assetName); err != nil {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/eventd"
 	"github.com/sensu/sensu-go/backend/keepalived"
+	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/backend/pipelined"
@@ -190,9 +191,9 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:            bus,
-		Store:          store,
-		MonitorFactory: monitor.EtcdFactory(b.Client, "keepalived"),
+		Bus:             bus,
+		Store:           store,
+		LivenessFactory: liveness.EtcdFactory(context.TODO(), b.Client),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -157,9 +157,7 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	// Every 5 minutes, we will prune all values in etcd to only their latest
 	// revision.
 	cfg.AutoCompactionMode = "revision"
-	// This has to stay in ns until https://github.com/coreos/etcd/issues/9337
-	// is resolved.
-	cfg.AutoCompactionRetention = "1"
+	cfg.AutoCompactionRetention = "2"
 	// Default to 4G etcd size. TODO: make this configurable.
 	cfg.QuotaBackendBytes = int64(4 * 1024 * 1024 * 1024)
 

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -72,7 +72,7 @@ func TestEventdMonitor(t *testing.T) {
 
 	event := corev2.FixtureEvent("entity1", "check1")
 	event.Check.Interval = 1
-	event.Check.Ttl = 2
+	event.Check.Ttl = 5
 
 	if err := bus.Publish(messaging.TopicEventRaw, event); err != nil {
 		assert.FailNow(t, "failed to publish event to TopicEventRaw")

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -3,14 +3,16 @@
 package keepalived
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
-	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/backend/seeds"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
 	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +48,9 @@ func TestKeepaliveMonitor(t *testing.T) {
 	}
 	defer subscription.Cancel()
 
+	entity := corev2.FixtureEntity("entity1")
+	ctx := store.NamespaceContext(context.Background(), entity.Namespace)
+
 	store, err := testutil.NewStoreInstance()
 	if err != nil {
 		assert.FailNow(t, err.Error())
@@ -55,21 +60,34 @@ func TestKeepaliveMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	mFac := monitor.EtcdFactory(client, "TestKeepaliveMonitor")
+	if err := store.UpdateEntity(ctx, entity); err != nil {
+		t.Fatal(err)
+	}
 
-	k, err := New(Config{Store: store, Bus: bus, MonitorFactory: mFac})
+	keepalive := &corev2.Event{
+		Check: &corev2.Check{
+			ObjectMeta: corev2.ObjectMeta{
+				Name:      "keepalive",
+				Namespace: "default",
+			},
+			Interval: 1,
+			Timeout:  5,
+		},
+		Entity:    entity,
+		Timestamp: time.Now().Unix(),
+	}
+
+	if err := store.UpdateEvent(ctx, keepalive); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := liveness.EtcdFactory(context.Background(), client)
+
+	k, err := New(Config{Store: store, Bus: bus, LivenessFactory: factory})
 	require.NoError(t, err)
 
 	if err := k.Start(); err != nil {
 		assert.FailNow(t, err.Error())
-	}
-
-	entity := corev2.FixtureEntity("entity1")
-
-	keepalive := &corev2.Event{
-		Check:     &corev2.Check{Timeout: 1},
-		Entity:    entity,
-		Timestamp: time.Now().Unix(),
 	}
 
 	if err := bus.Publish(messaging.TopicKeepalive, keepalive); err != nil {

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
-	"github.com/sensu/sensu-go/backend/monitor"
 	"github.com/sensu/sensu-go/testing/mockring"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,19 +31,23 @@ func (k *keepalivedTest) Receiver() chan<- interface{} {
 	return k.receiver
 }
 
-type fakeMonitorSupervisor struct {
+type fakeLivenessInterface struct {
 }
 
-func (f fakeMonitorSupervisor) Monitor(context.Context, string, *types.Event, int64) error {
+func (f fakeLivenessInterface) Alive(context.Context, string, int64) error {
 	return nil
 }
 
-func fakeFactory(monitor.Handler) monitor.Supervisor {
-	return fakeMonitorSupervisor{}
+func (f fakeLivenessInterface) Dead(context.Context, string, int64) error {
+	return nil
 }
 
 // type assertion
-var _ monitor.Supervisor = fakeMonitorSupervisor{}
+var _ liveness.Interface = fakeLivenessInterface{}
+
+func fakeFactory(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
+	return fakeLivenessInterface{}
+}
 
 func newKeepalivedTest(t *testing.T) *keepalivedTest {
 	store := &mockstore.MockStore{}
@@ -51,7 +56,7 @@ func newKeepalivedTest(t *testing.T) *keepalivedTest {
 		RingGetter: &mockring.Getter{},
 	})
 	require.NoError(t, err)
-	k, err := New(Config{Store: store, Bus: bus, MonitorFactory: fakeFactory})
+	k, err := New(Config{Store: store, Bus: bus, LivenessFactory: fakeFactory})
 	require.NoError(t, err)
 	test := &keepalivedTest{
 		MessageBus:   bus,
@@ -235,7 +240,7 @@ func TestProcessRegistration(t *testing.T) {
 			subscription, err := messageBus.Subscribe(messaging.TopicEvent, "testSubscriber", tsub)
 			require.NoError(t, err)
 
-			keepalived, err := New(Config{Store: store, Bus: messageBus, MonitorFactory: fakeFactory})
+			keepalived, err := New(Config{Store: store, Bus: messageBus, LivenessFactory: fakeFactory})
 			require.NoError(t, err)
 
 			store.On("GetEntityByName", mock.Anything, "agent1").Return(tc.storeEntity, nil)

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -1,0 +1,299 @@
+package liveness
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/mvcc/mvccpb"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	switches = make(map[string]Interface)
+	switchMu sync.Mutex
+)
+
+// All switchset entities are tracked under path.Join(SwitchPrefix, toggleName, key)
+var SwitchPrefix = "/sensu.io/switchsets"
+
+type State int
+
+const (
+	// The system has discovered a toggle that did not store a TTL. Use the minimum
+	// supported etcd lease TTL as a fallback.
+	FallbackTTL = 5
+
+	// The Alive state is 0
+	Alive State = 0
+
+	// The Dead state is 1
+	Dead State = 1
+)
+
+func (s State) String() string {
+	switch s {
+	case Alive:
+		return "alive"
+	case Dead:
+		return "dead"
+	default:
+		return fmt.Sprintf("invalid<%d>", s)
+	}
+}
+
+// Interface specifies the interface for liveness
+type Interface interface {
+	// Alive is an assertion that an entity is alive.
+	Alive(ctx context.Context, key string, ttl int64) error
+
+	// Dead is an assertion that an entity is dead. Dead is useful for
+	// registering entities that are known to be dead, but not yet tracked.
+	Dead(ctx context.Context, key string, ttl int64) error
+}
+
+// Factory is a function that can deliver an Interface
+type Factory func(name string, dead, alive EventFunc, logger logrus.FieldLogger) Interface
+
+// EtcdFactory returns a Factory that uses an etcd client. The Interface is
+// cached after the first instantiation, and the EventFuncs and logger cannot
+// be changed later.
+func EtcdFactory(ctx context.Context, client *clientv3.Client) Factory {
+	return Factory(func(name string, dead, alive EventFunc, logger logrus.FieldLogger) Interface {
+		switchMu.Lock()
+		defer switchMu.Unlock()
+		_, ok := switches[name]
+		if !ok {
+			ss := NewSwitchSet(client, name, dead, alive, logger)
+			ss.monitor(ctx)
+			switches[name] = ss
+		}
+		return switches[name]
+	})
+}
+
+// SwitchSet is a set of switches that get flipped on life and death events
+// for entities. On life and death events, callback functions that are
+// registered on NewSwitchSet are started as new goroutines.
+//
+// The SwitchSet uses the Alive method to both register members of the set,
+// and to assert their liveness once registered. After its first call to
+// Alive, if a member does not assert its liveness, then it will be presumed
+// to be dead, and the callback for dead members will be called.
+//
+// When an entity in a SwitchSet dies, it gains a new life in the underworld.
+// In the underworld, a dead callback is issued for every TTL interval.
+// Entities can go from being dead to alive by calling Alive. When that
+// happens, an entity that lives in the underworld will be reborn.
+type SwitchSet struct {
+	client      *clientv3.Client
+	prefix      string
+	notifyDead  EventFunc
+	notifyAlive EventFunc
+	logger      logrus.FieldLogger
+
+	// This channel serializes events so that their execution ordering is
+	// as expected, without causing undue blocking in the main monitoring
+	// loop.
+	events chan func()
+}
+
+// EventFunc is a function that can be used by a SwitchSet to handle events.
+// The previous state of the switch will be passed to the function.
+//
+// For "dead" EventFuncs, the leader flag can be used to determine if the
+// client that flipped the switch is our client. For "alive" EventFuncs,
+// this parameter is always false.
+type EventFunc func(key string, prev State, leader bool)
+
+// NewSwitchSet creates a new SwitchSet. It will use an etcd prefix of
+// path.Join(SwitchPrefix, name). The dead and live callbacks will be called
+// on all life and death events.
+func NewSwitchSet(client *clientv3.Client, name string, dead, alive EventFunc, logger logrus.FieldLogger) *SwitchSet {
+	return &SwitchSet{
+		client:      client,
+		prefix:      path.Join(SwitchPrefix, name),
+		notifyDead:  dead,
+		notifyAlive: alive,
+		logger:      logger,
+		events:      make(chan func(), 512),
+	}
+}
+
+func (t *SwitchSet) ping(ctx context.Context, key string, ttl int64, alive bool) error {
+	if ttl < FallbackTTL {
+		return fmt.Errorf("bad ttl: %d is less than the minimum value of %d", ttl, FallbackTTL)
+	}
+	putVal := ttl
+	if !alive {
+		putVal = -putVal
+	}
+	key = path.Join(t.prefix, key)
+	val := fmt.Sprintf("%d", putVal)
+	lease, err := t.client.Grant(ctx, ttl)
+	if err != nil {
+		return err
+	}
+	_, err = t.client.Put(ctx, key, val, clientv3.WithLease(lease.ID), clientv3.WithPrevKV())
+	return err
+}
+
+// Alive is an assertion that an entity is alive.
+//
+// If the SwitchSet doesn't know about the entity yet, then it will be
+// registered, and the TTL countdown will start. Unless the entity continually
+// asserts its liveness with calls to Alive, it will be presumed dead.
+//
+// The ttl parameter is the time-to-live in seconds for the entity. The minimum
+// TTL value is 5. If a smaller value is passed, then an error will be returned
+// and no registration will occur.
+func (t *SwitchSet) Alive(ctx context.Context, key string, ttl int64) error {
+	return t.ping(ctx, key, ttl, true)
+}
+
+// Dead is an assertion that an entity is dead. Dead is useful for registering
+// entities that are known to be dead, but not yet tracked by the SwitchSet.
+//
+// If the SwitchSet doesn't know about the entity yet, then it will be
+// registered, and the TTL countdown will start. Until the entity
+// asserts its liveness, it will be presumed dead, and dead callbacks will
+// be issued.
+//
+// The ttl parameter is the time-to-live in seconds for the entity. The minimum
+// TTL value is 5. If a smaller value is passed, then an error will be returned
+// and no registration will occur.
+func (t *SwitchSet) Dead(ctx context.Context, key string, ttl int64) error {
+	return t.ping(ctx, key, ttl, false)
+}
+
+func (t *SwitchSet) getTTLFromEvent(event *clientv3.Event) (int64, State) {
+	var (
+		ttl, prev int64
+		prevState State
+	)
+	if event.PrevKv != nil && len(event.PrevKv.Value) > 0 {
+		fmt.Sscanf(string(event.PrevKv.Value), "%d", &prev)
+	}
+	if prev > 0 {
+		prevState = Alive
+	} else {
+		prevState = Dead
+	}
+	if len(event.Kv.Value) > 0 {
+		// A put has resulted in this event, and the TTL is stored here
+		fmt.Sscanf(string(event.Kv.Value), "%d", &ttl)
+		return ttl, prevState
+	}
+	if event.PrevKv != nil && len(event.PrevKv.Value) > 0 {
+		// The previous revision contains the TTL
+		fmt.Sscanf(string(event.PrevKv.Value), "%d", &ttl)
+		return ttl, prevState
+	}
+	t.logger.Errorf("using fallback TTL for %q", string(event.Kv.Key))
+	return -FallbackTTL, prevState
+}
+
+// monitor starts a goroutine that monitors the SwitchSet prefix for key PUT
+// and DELETE events.
+func (t *SwitchSet) monitor(ctx context.Context) {
+	wc := t.client.Watch(ctx, t.prefix, clientv3.WithPrefix(), clientv3.WithPrevKV())
+	go func() {
+		for event := range t.events {
+			event()
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(t.events)
+				return
+			case resp := <-wc:
+				if err := resp.Err(); err != nil {
+					t.logger.WithError(err).Error("error monitoring toggles")
+					continue
+				}
+				for _, event := range resp.Events {
+					t.handleEvent(ctx, event)
+				}
+			}
+		}
+	}()
+}
+
+// handleEvent handles a watch event, either DELETE or PUT.
+//
+// In the case of DELETE, an entity has expired, or an undead entity has been
+// replaced. Before any further action is taken, the handler is invoked as a
+// goroutine. After, the undead entity is replaced by another undead entity
+// with the same undead lifespan. (PUT) In concrete terms, the same key is PUT
+// with the same lease TTL as the previous key.
+//
+// In the case of PUT, the value associated with the event key is checked to
+// determine if it is a positive or negative value. If the value is a positive
+// value, the entity is either now alive, or still alive. If the value is a
+// negative value, then it is ignored, as it is only an undead entity being
+// replaced by another undead entity.
+func (t *SwitchSet) handleEvent(ctx context.Context, event *clientv3.Event) {
+	ttl, prevState := t.getTTLFromEvent(event)
+	key := string(event.Kv.Key)
+	switch event.Type {
+	case mvccpb.DELETE:
+		// The entity has expired. Replace it with a new entity
+		// to keep the events firing
+		t.logger.WithFields(logrus.Fields{"key": key, "ttl": ttl}).Debug("key expired")
+
+		// If the key doesn't exist, the version will be 0. This is done to
+		// prevent other clients from performing the same operation
+		// concurrently.
+		cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
+		var leaseTTL int64
+		if ttl < 0 {
+			// In this case, the entity was undead. A negative value is stored
+			// to indicate this to the PUT case.
+			leaseTTL = -ttl
+		} else {
+			// In this case, the entity was alive. Put a negative TTL for the
+			// value in order to indicate that the entity is now dead.
+			leaseTTL = ttl
+			ttl = -ttl
+		}
+
+		t.logger.Debugf("creating a lease for %s with TTL %d", key, leaseTTL)
+		lease, err := t.client.Grant(ctx, leaseTTL)
+		if err != nil {
+			t.logger.WithError(err).Errorf("error while granting lease for %s", key)
+			return
+		}
+
+		// Store a negative value for the TTL to indicate that the
+		// entity is not alive.
+		put := clientv3.OpPut(key, fmt.Sprintf("%d", ttl), clientv3.WithLease(lease.ID))
+		resp, err := t.client.Txn(ctx).If(cmp).Then(put).Commit()
+		if err != nil {
+			t.logger.WithError(err).Errorf("error commiting keepalive tx for %s", key)
+			return
+		}
+		t.events <- func() {
+			t.notifyDead(strings.TrimPrefix(key, t.prefix+"/"), prevState, resp.Succeeded)
+		}
+
+	case mvccpb.PUT:
+		// Watch PUTs to determine if we need to execute a handler for entity
+		// liveness.
+		if ttl == 0 {
+			t.logger.Errorf("bad PUT for %s: TTL is 0", key)
+			return
+		}
+		if ttl > 0 {
+			// A positive TTL indicates the entity is alive
+			t.logger.Debugf("%s alive: %d", key, ttl)
+			t.events <- func() {
+				t.notifyAlive(strings.TrimPrefix(key, t.prefix+"/"), prevState, false)
+			}
+		}
+	}
+}

--- a/backend/liveness/liveness_test.go
+++ b/backend/liveness/liveness_test.go
@@ -1,0 +1,131 @@
+// +build integration
+
+package liveness
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+var logger = logrus.New()
+
+func TestSwitchSet(t *testing.T) {
+	// This test sets up a SwitchSet and two callbacks that are used
+	// to verify that the SwitchSet is working as expected. It is
+	// expected to function deterministically, and is not dependent on timing
+	// or filesystem latency.
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	aliveC := make(chan struct{})
+	deadC := make(chan struct{})
+	results := make(map[string][]int)
+
+	// This callback gets executed when the entity dies
+	expired := func(key string, prev State, leader bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[key] = append(results[key], int(Dead))
+		deadC <- struct{}{}
+	}
+
+	// This callback gets executed when the entity asserts its liveness
+	alive := func(key string, prev State, leader bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[key] = append(results[key], int(Alive))
+		aliveC <- struct{}{}
+	}
+
+	toggle := NewSwitchSet(client, "test", expired, alive, logger)
+	go toggle.monitor(ctx)
+
+	// the [0, 0, 0, 1] sequences
+	for i := 0; i < 3; i++ {
+		if err := toggle.Alive(ctx, "entity1", 5); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		<-aliveC
+	}
+	<-deadC
+
+	// The subsequent [0, 1, 1, 1] sequence
+	if err := toggle.Alive(ctx, "entity1", 5); err != nil {
+		t.Fatal(err)
+	}
+	<-aliveC
+	for i := 0; i < 3; i++ {
+		<-deadC
+	}
+
+	mu.Lock()
+	if got, want := results["entity1"], []int{0, 0, 0, 1, 0, 1, 1, 1}; !reflect.DeepEqual(got, want) {
+		t.Errorf("bad results: got %v, want %v", got, want)
+	}
+	mu.Unlock()
+}
+
+func TestDead(t *testing.T) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var mu sync.Mutex
+	results := make(map[string][]int)
+	aliveC := make(chan struct{})
+	deadC := make(chan struct{})
+
+	// This callback gets executed when the entity dies
+	expired := func(key string, prev State, leader bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[key] = append(results[key], int(Dead))
+		deadC <- struct{}{}
+	}
+
+	// This callback gets executed when the entity asserts its liveness
+	alive := func(key string, prev State, leader bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		results[key] = append(results[key], int(Alive))
+		aliveC <- struct{}{}
+	}
+
+	toggle := NewSwitchSet(client, "test", expired, alive, logger)
+	go toggle.monitor(ctx)
+
+	if err := toggle.Dead(ctx, "entity1", 5); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		<-deadC
+	}
+
+	mu.Lock()
+	if got, want := results["entity1"], []int{1, 1, 1}; !reflect.DeepEqual(got, want) {
+		t.Errorf("bad results: got %v, want %v", got, want)
+	}
+	mu.Unlock()
+}

--- a/backend/schedulerd/check_scheduler.go
+++ b/backend/schedulerd/check_scheduler.go
@@ -2,6 +2,7 @@ package schedulerd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
@@ -18,29 +19,25 @@ const (
 
 // A CheckScheduler schedules checks to be executed on a timer
 type CheckScheduler struct {
-	checkName      string
-	checkNamespace string
-	checkInterval  uint32
-	checkCron      string
-	lastCronState  string
-	store          store.Store
-	bus            messaging.MessageBus
-	logger         *logrus.Entry
-	ctx            context.Context
-	cancel         context.CancelFunc
-	interrupt      chan struct{}
+	lastIntervalState uint32
+	lastCronState     string
+	check             *types.CheckConfig
+	store             store.Store
+	bus               messaging.MessageBus
+	logger            *logrus.Entry
+	ctx               context.Context
+	cancel            context.CancelFunc
+	interrupt         chan struct{}
 }
 
 func NewCheckScheduler(store store.Store, bus messaging.MessageBus, check *types.CheckConfig, ctx context.Context) *CheckScheduler {
 	sched := &CheckScheduler{
-		store:          store,
-		bus:            bus,
-		checkName:      check.Name,
-		checkNamespace: check.Namespace,
-		checkInterval:  check.Interval,
-		checkCron:      check.Cron,
-		lastCronState:  check.Cron,
-		interrupt:      make(chan struct{}),
+		store:             store,
+		bus:               bus,
+		check:             check,
+		lastIntervalState: check.Interval,
+		lastCronState:     check.Cron,
+		interrupt:         make(chan struct{}),
 		logger: logger.WithFields(logrus.Fields{
 			"name":      check.Name,
 			"namespace": check.Namespace,
@@ -51,72 +48,34 @@ func NewCheckScheduler(store store.Store, bus messaging.MessageBus, check *types
 	return sched
 }
 
-func (s *CheckScheduler) toggleCron(check *types.CheckConfig) (stateChanged bool) {
-	lastCron := s.lastCronState
-	cron := check.Cron
-	if (lastCron != "" && cron == "") || (lastCron == "" && cron != "") {
-		// Update the CheckScheduler with current check state and last cron state
-		s.lastCronState = cron
-		s.checkCron = cron
-		s.checkInterval = check.Interval
-		return true
-	}
-	return false
-}
-
-func (s *CheckScheduler) schedule(timer CheckTimer, executor *CheckExecutor) (restart bool) {
-	check, err := s.store.GetCheckConfigByName(s.ctx, s.checkName)
-	if err != nil {
+func (s *CheckScheduler) schedule(timer CheckTimer, executor *CheckExecutor) {
+	if err := s.refreshCheckFromStore(); err != nil {
 		s.logger.WithError(err).Error("unable to retrieve check in check scheduler")
-		return false
+		return
 	}
 
-	// The check has been deleted
-	if check == nil {
-		s.logger.Info("check is no longer in state")
-		return false
-	}
+	defer s.resetTimer(timer)
 
-	// Indicates a state change from cron to interval or interval to cron
-	if s.toggleCron(check) {
-		s.logger.Info("check schedule type has changed")
-		return true
-	}
-
-	// Update the CheckScheduler with the last cron state
-	s.lastCronState = check.Cron
-
-	if check.IsSubdued() {
+	if s.check.IsSubdued() {
 		s.logger.Debug("check is subdued")
-		// Reset the timer so the check is scheduled again for the next
-		// interval, since it might no longer be subdued
-		timer.SetDuration(check.Cron, uint(check.Interval))
-		timer.Next()
-		return false
+		return
 	}
 
 	s.logger.Debug("check is not subdued")
 
-	// Reset timer
-	timer.SetDuration(check.Cron, uint(check.Interval))
-	timer.Next()
-
-	if err := executor.processCheck(s.ctx, check); err != nil {
+	if err := executor.processCheck(s.ctx, s.check); err != nil {
 		logger.Error(err)
 	}
-
-	return false
 }
 
-// Start starts the CheckScheduler. It always returns nil error.
-func (s *CheckScheduler) Start() error {
+// Start starts the CheckScheduler.
+func (s *CheckScheduler) Start() {
 	go s.start()
-	return nil
 }
 
 func (s *CheckScheduler) mode() schedulerMode {
 	// cron scheduling mode
-	if s.checkCron != "" {
+	if s.check.Cron != "" {
 		return cronMode
 	}
 	return intervalMode
@@ -128,14 +87,14 @@ func (s *CheckScheduler) start() {
 	switch s.mode() {
 	case cronMode:
 		s.logger.Info("starting new cron scheduler")
-		timer = NewCronTimer(s.checkName, s.checkCron)
+		timer = NewCronTimer(s.check.Name, s.check.Cron)
 	default:
 		s.logger.Info("starting new interval scheduler")
-		timer = NewIntervalTimer(s.checkName, uint(s.checkInterval))
+		timer = NewIntervalTimer(s.check.Name, uint(s.check.Interval))
 	}
 
 	executor := NewCheckExecutor(
-		s.bus, newRoundRobinScheduler(s.ctx, s.bus), s.checkNamespace, s.store)
+		s.bus, newRoundRobinScheduler(s.ctx, s.bus), s.check.Namespace, s.store)
 
 	timer.Start()
 
@@ -145,18 +104,25 @@ func (s *CheckScheduler) start() {
 			timer.Stop()
 			return
 		case <-s.interrupt:
+			if err := s.refreshCheckFromStore(); err != nil {
+				s.logger.WithError(err).Error("unable to retrieve check in check scheduler")
+				return
+			}
+			// if a schedule change is detected, restart the timer
+			if s.toggleSchedule() {
+				timer.Stop()
+				defer s.Start()
+				return
+			}
+			continue
 		case <-timer.C():
 		}
-		restart := s.schedule(timer, executor)
-		if restart {
-			timer.Stop()
-			defer s.Start()
-			return
-		}
+		s.schedule(timer, executor)
 	}
 }
 
-// Interrupt causes the scheduler to immediately fire and ignore the timer.
+// Interrupt causes the scheduler to immediately fetch the check to determine if a timer reset is required.
+// It is called when the check watcher detects an update to the check.
 func (s *CheckScheduler) Interrupt() {
 	s.interrupt <- struct{}{}
 }
@@ -167,4 +133,40 @@ func (s *CheckScheduler) Stop() error {
 	s.cancel()
 
 	return nil
+}
+
+func (s *CheckScheduler) refreshCheckFromStore() error {
+	check, err := s.store.GetCheckConfigByName(s.ctx, s.check.Name)
+	if err != nil {
+		return err
+	}
+	if check == nil {
+		return fmt.Errorf("check %s is no longer in state", s.check.Name)
+	}
+	s.check = check
+	return nil
+}
+
+// Indicates a state change in the schedule, and if a timer needs to be reset.
+func (s *CheckScheduler) toggleSchedule() (stateChanged bool) {
+	defer s.setLastState()
+
+	if (s.lastIntervalState != s.check.Interval) || (s.lastCronState != s.check.Cron) {
+		s.logger.Info("check schedule has changed")
+		return true
+	}
+	s.logger.Info("check schedule has not changed")
+	return false
+}
+
+// Update the CheckScheduler with the last schedule states
+func (s *CheckScheduler) setLastState() {
+	s.lastCronState = s.check.Cron
+	s.lastIntervalState = s.check.Interval
+}
+
+// Reset timer
+func (s *CheckScheduler) resetTimer(timer CheckTimer) {
+	timer.SetDuration(s.check.Cron, uint(s.check.Interval))
+	timer.Next()
 }

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -101,7 +101,7 @@ func TestCheckSchedulerInterval(t *testing.T) {
 		wg.Done()
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Start()
 	wg.Wait()
 	mockTime.Stop()
@@ -149,7 +149,7 @@ func TestCheckSubdueInterval(t *testing.T) {
 		assert.NoError(scheduler.msgBus.Stop())
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Set(mockTime.Now().Add(2 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 
@@ -195,7 +195,7 @@ func TestCheckSchedulerCron(t *testing.T) {
 		wg.Done()
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Start()
 	wg.Wait()
 	mockTime.Stop()
@@ -244,7 +244,7 @@ func TestCheckSubdueCron(t *testing.T) {
 		assert.NoError(scheduler.msgBus.Stop())
 	}()
 
-	assert.NoError(scheduler.scheduler.Start())
+	scheduler.scheduler.Start()
 	mockTime.Set(mockTime.Now().Add(10 * time.Second))
 	assert.NoError(scheduler.scheduler.Stop())
 

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -49,9 +49,7 @@ func (c *CheckWatcher) startScheduler(check *types.CheckConfig) error {
 	scheduler := NewCheckScheduler(c.store, c.bus, check, c.ctx)
 
 	// Start scheduling check
-	if err := scheduler.Start(); err != nil {
-		return err
-	}
+	scheduler.Start()
 
 	// Register new check scheduler
 	c.items[key] = scheduler

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package schedulerd
 
 import (

--- a/backend/store/namespace.go
+++ b/backend/store/namespace.go
@@ -22,6 +22,11 @@ func NewNamespaceFromContext(ctx context.Context) string {
 	return ""
 }
 
+// NamespaceContext returns a context populated with the provided namespace.
+func NamespaceContext(ctx context.Context, namespace string) context.Context {
+	return context.WithValue(ctx, types.NamespaceKey, namespace)
+}
+
 // NewNamespaceFromResource creates a new Namespace from a MultitenantResource.
 func NewNamespaceFromResource(resource types.MultitenantResource) string {
 	return resource.GetNamespace()


### PR DESCRIPTION
## What is this change?

This commit makes use of package liveness in keepalived, in order
to achieve durable keepalives. With this change applied, failing
keepalives will continue firing even if one or more backends is
lost. (Assuming etcd quorum is intact)

## Why is this change necessary?

Closes #2530 

## Does your change need a Changelog entry?

Yes

## Testing Performed
Manual QA performed. Both agents and backends were removed, to ensure that keepalive failure events would be issued as expected. Keepalives continue to propagate even when the backend the agent was previously connected to is terminated. Also, keepalive events will continue to fire even after a cluster restart.