### PR TITLE
Fixes a bug where a bad line in check output would abort metric extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
 - Fixed a bug where adhoc checks were not retrieving asset dependencies.
 - Fixed a bug where check updates would cause the check to immediately fire.
+- Fixed a bug where a bad line in check output would abort metric extraction.
+An error is now logged instead, and extraction continues after a bad line is encountered.
 
 ## [5.1.0] - 2018-12-18
 

--- a/agent/transformers/logger.go
+++ b/agent/transformers/logger.go
@@ -1,0 +1,11 @@
+package transformers
+
+import "github.com/sirupsen/logrus"
+
+var logger *logrus.Entry
+
+func init() {
+	logger = logrus.WithFields(logrus.Fields{
+		"component": "agent",
+	})
+}

--- a/agent/transformers/opentsdb.go
+++ b/agent/transformers/opentsdb.go
@@ -1,11 +1,11 @@
 package transformers
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/sensu/sensu-go/types"
+	"github.com/sirupsen/logrus"
 )
 
 // OpenTSDBList contains a list of OpenTSDB metrics
@@ -35,20 +35,27 @@ func (o OpenTSDBList) Transform() []*types.MetricPoint {
 }
 
 // ParseOpenTSDB parses OpenTSDB metrics into a list of OpenTSDB structs
-func ParseOpenTSDB(output string) (OpenTSDBList, error) {
-	openTSDBList := OpenTSDBList{}
+func ParseOpenTSDB(event *types.Event) OpenTSDBList {
+	var openTSDBList OpenTSDBList
+	fields := logrus.Fields{
+		"namespace": event.Check.Namespace,
+		"check":     event.Check.Name,
+	}
 
 	// Split each line of the output into its own metric
-	output = strings.TrimSpace(output)
+	output := strings.TrimSpace(event.Check.Output)
 	metrics := strings.Split(output, "\n")
 
-	for _, metric := range metrics {
+OUTER:
+	for l, metric := range metrics {
+		fields["line"] = l
 		parts := strings.Split(metric, " ")
 
 		// Ensure we have all the required components. A single metric requires a
 		// name, timestamp, value and at least one tag.
 		if len(parts) < 4 {
-			return nil, fmt.Errorf("invalid opentsdb metric, at least 4 arguments are required: %s", metric)
+			logger.WithFields(fields).WithError(ErrMetricExtraction).Errorf("invalid opentsdb metric, at least 4 arguments are required: %s", metric)
+			continue
 		}
 
 		name := parts[0]
@@ -56,7 +63,8 @@ func ParseOpenTSDB(output string) (OpenTSDBList, error) {
 		// Convert the timestamp to a unix timestamp with second resolution
 		timestamp, err := strconv.ParseInt(parts[1], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid opentsdb metric timestamp, must be an integer: %s", parts[1])
+			logger.WithFields(fields).WithError(ErrMetricExtraction).Errorf("invalid opentsdb metric timestamp, must be an integer: %s", parts[1])
+			continue
 		}
 		if len(parts[1]) == 13 {
 			timestamp = timestamp / 1000
@@ -65,7 +73,8 @@ func ParseOpenTSDB(output string) (OpenTSDBList, error) {
 		// Parse the value as a float64
 		value, err := strconv.ParseFloat(parts[2], 64)
 		if err != nil {
-			return nil, fmt.Errorf("invalid opentsdb metric value, must be an integer or a floating point value: %s", parts[1])
+			logger.WithFields(fields).WithError(ErrMetricExtraction).Errorf("invalid opentsdb metric value, must be an integer or a floating point value: %s", parts[2])
+			continue
 		}
 
 		// Create a OpenTSDB metric with what we have so far
@@ -81,7 +90,8 @@ func ParseOpenTSDB(output string) (OpenTSDBList, error) {
 			t := strings.Split(parts[i], "=")
 
 			if len(t) != 2 {
-				return nil, fmt.Errorf("invalid opentsdb metric tag: %s", parts[i])
+				logger.WithFields(fields).WithError(ErrMetricExtraction).Errorf("invalid opentsdb metric tag: %s", parts[i])
+				continue OUTER
 			}
 
 			tag := &types.MetricTag{
@@ -97,5 +107,5 @@ func ParseOpenTSDB(output string) (OpenTSDBList, error) {
 		openTSDBList = append(openTSDBList, o)
 	}
 
-	return openTSDBList, nil
+	return openTSDBList
 }

--- a/agent/transformers/opentsdb_test.go
+++ b/agent/transformers/opentsdb_test.go
@@ -10,10 +10,9 @@ import (
 
 func TestParseOpenTSDB(t *testing.T) {
 	testCases := []struct {
-		name    string
-		output  string
-		want    OpenTSDBList
-		wantErr bool
+		name   string
+		output string
+		want   OpenTSDBList
 	}{
 		{
 			name:   "standard opentsdb metric",
@@ -31,7 +30,6 @@ func TestParseOpenTSDB(t *testing.T) {
 					Value:     42.5,
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name:   "standard opentsdb metric with whitespace",
@@ -53,7 +51,27 @@ func TestParseOpenTSDB(t *testing.T) {
 					Value:     42.5,
 				},
 			},
-			wantErr: false,
+		},
+		{
+			name:   "GH_2511",
+			output: "sys.cpu.user 1356998400 42.5 host=webserver01 cpu=0\nfoo",
+			want: OpenTSDBList{
+				OpenTSDB{
+					Name: "sys.cpu.user",
+					TagSet: []*types.MetricTag{
+						&types.MetricTag{
+							Name:  "host",
+							Value: "webserver01",
+						},
+						&types.MetricTag{
+							Name:  "cpu",
+							Value: "0",
+						},
+					},
+					Timestamp: 1356998400,
+					Value:     42.5,
+				},
+			},
 		},
 		{
 			name:   "timestamp with millisecond precision",
@@ -71,7 +89,6 @@ func TestParseOpenTSDB(t *testing.T) {
 					Value:     42.5,
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name:   "multiple tags",
@@ -93,41 +110,34 @@ func TestParseOpenTSDB(t *testing.T) {
 					Value:     42.5,
 				},
 			},
-			wantErr: false,
 		},
 		{
-			name:    "invalid format",
-			output:  "sys.cpu.user 1356998400000 42.5",
-			want:    OpenTSDBList(nil),
-			wantErr: true,
+			name:   "invalid format",
+			output: "sys.cpu.user 1356998400000 42.5",
+			want:   OpenTSDBList(nil),
 		},
 		{
-			name:    "invalid timestamp",
-			output:  "sys.cpu.user foo 42.5 host=webserver01",
-			want:    OpenTSDBList(nil),
-			wantErr: true,
+			name:   "invalid timestamp",
+			output: "sys.cpu.user foo 42.5 host=webserver01",
+			want:   OpenTSDBList(nil),
 		},
 		{
-			name:    "invalid value",
-			output:  "sys.cpu.user 1356998400 foo host=webserver01",
-			want:    OpenTSDBList(nil),
-			wantErr: true,
+			name:   "invalid value",
+			output: "sys.cpu.user 1356998400 foo host=webserver01",
+			want:   OpenTSDBList(nil),
 		},
 		{
-			name:    "invalid tag",
-			output:  "sys.cpu.user 1356998400 42.5 host",
-			want:    OpenTSDBList(nil),
-			wantErr: true,
+			name:   "invalid tag",
+			output: "sys.cpu.user 1356998400 42.5 host",
+			want:   OpenTSDBList(nil),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParseOpenTSDB(tc.output)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("ParseOpenTSDB() error = %v, wantErr %v", err, tc.wantErr)
-				return
-			}
+			event := types.FixtureEvent("test", "test")
+			event.Check.Output = tc.output
+			got := ParseOpenTSDB(event)
 			if !assert.Equal(t, got, tc.want) {
 				t.Errorf("ParseOpenTSDB() = %v, want %v", got, tc.want)
 			}
@@ -181,10 +191,9 @@ func TestTransformOpenTSDB(t *testing.T) {
 
 func TestParseAndTransformOpenTSDB(t *testing.T) {
 	testCases := []struct {
-		name    string
-		output  string
-		want    []*types.MetricPoint
-		wantErr bool
+		name   string
+		output string
+		want   []*types.MetricPoint
 	}{
 		{
 			name:   "happy path",
@@ -202,24 +211,36 @@ func TestParseAndTransformOpenTSDB(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
 		},
 		{
-			name:    "invalid metric",
-			output:  "sys.cpu.user 1356998400 42.5",
-			want:    []*types.MetricPoint(nil),
-			wantErr: true,
+			name:   "GH_2511",
+			output: "sys.cpu.user 1356998400 42.5 host=webserver01\nfoo",
+			want: []*types.MetricPoint{
+				{
+					Name:      "sys.cpu.user",
+					Value:     42.5,
+					Timestamp: 1356998400,
+					Tags: []*types.MetricTag{
+						&types.MetricTag{
+							Name:  "host",
+							Value: "webserver01",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "invalid metric",
+			output: "sys.cpu.user 1356998400 42.5",
+			want:   []*types.MetricPoint(nil),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			transformer, err := ParseOpenTSDB(tc.output)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("ParseOpenTSDB() error = %v, wantErr %v", err, tc.wantErr)
-				return
-			}
-
+			event := types.FixtureEvent("test", "test")
+			event.Check.Output = tc.output
+			transformer := ParseOpenTSDB(event)
 			got := transformer.Transform()
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("Transform() = %v, want %v", got, tc.want)

--- a/agent/transformers/transformer.go
+++ b/agent/transformers/transformer.go
@@ -1,5 +1,10 @@
 package transformers
 
+import "errors"
+
+// ErrMetricExtraction is a blanket error for when transformer fails to extract metrics from a single line protocol
+var ErrMetricExtraction = errors.New("unable to extract metric from check output")
+
 // Field is a key value pair representing a metric
 type Field struct {
 	Key   string


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

- Parse functions accept an Event as a parameter.
- Parse functions log errors rather than returning them.
- Transformers do not abort metric extraction when a bad line is encountered.
- Fixes bugs associated with https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2511

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.