### PR TITLE
Add keepalive check output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Changed keepalive event to include check.output
 
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -2,6 +2,7 @@ package keepalived
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -316,6 +317,7 @@ func (k *Keepalived) handleUpdate(e *types.Event) error {
 	}
 	event := createKeepaliveEvent(e)
 	event.Check.Status = 0
+	event.Check.Output = fmt.Sprintf("Keepalive last sent from %s at %s", entity.Name, time.Unix(entity.LastSeen, 0).String())
 
 	return k.bus.Publish(messaging.TopicEventRaw, event)
 }
@@ -340,6 +342,7 @@ func (k *Keepalived) HandleFailure(e *types.Event) error {
 	// this is a real keepalive event, emit it.
 	event := createKeepaliveEvent(e)
 	event.Check.Status = 1
+	event.Check.Output = fmt.Sprintf("No keepalive sent from %s for %v seconds (>= %v)", entity.Name, time.Now().Unix()-entity.LastSeen, event.Check.Timeout)
 
 	if err := k.bus.Publish(messaging.TopicEventRaw, event); err != nil {
 		return err


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->
Adds check.output for keepalive events.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
Closes #2585 
## Does your change need a Changelog entry?
Yes
<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?
One thing that might stand out is that for passing keepalives, I use the absolute (clock on the wall) time as opposed to using the relative time for failures.  This is because when viewing keepalive events (e.g. in the dashboard) if I used relative time it would report the last seen as zero seconds all the time, which is not useful information.  I use the relative time (including the configured timeout) in failures to match 1.x functionality.
<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?
No.
<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?
I didn't see any references to keepalive events in the documentation where this would need to be updated.  The only visible change would be to events output when surfaced through a handler or seen in the dashboard.
<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
