### PR TITLE
Don't pass a nil context to http Server.Shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where check updates would cause the check to immediately fire.
 - Fixed a bug where a bad line in check output would abort metric extraction.
 An error is now logged instead, and extraction continues after a bad line is encountered.
+- Fixed a panic in the dashboardd shutdown routine.
 
 ## [5.1.0] - 2018-12-18
 


### PR DESCRIPTION
This commit fixes a bug in the dashboardd Stop method by passing
a context with a timeout, instead of nil. Additionally, the
conditional call to Server.Close has been removed.

The result of calling Server.Shutdown is returned.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #2586 

## Does your change need a Changelog entry?

Included