### PR TITLE
Add check name and namespace fields to proxy check request logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 An error is now logged instead, and extraction continues after a bad line is encountered.
 - Fixed a panic in the dashboardd shutdown routine.
 
+### Changed
+- Improved logging for errors in proxy check requests.
+
 ## [5.1.0] - 2018-12-18
 
 ### Added

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -246,6 +246,10 @@ func publishProxyCheckRequests(e Executor, entities []*types.Entity, check *type
 }
 
 func processCheck(ctx context.Context, executor Executor, check *types.CheckConfig) error {
+	fields := logrus.Fields{
+		"check":     check.Name,
+		"namespace": check.Namespace,
+	}
 	if check.ProxyRequests != nil {
 		// get entities by namespace
 		entities, err := executor.getEntities(ctx)
@@ -255,10 +259,10 @@ func processCheck(ctx context.Context, executor Executor, check *types.CheckConf
 		// publish proxy requests on matching entities
 		if matchedEntities := matchEntities(entities, check.ProxyRequests); len(matchedEntities) != 0 {
 			if err := executor.publishProxyCheckRequests(matchedEntities, check); err != nil {
-				logger.Error(err)
+				logger.WithFields(fields).WithError(err).Error("error publishing proxy check requests")
 			}
 		} else {
-			logger.Info("no matching entities, check will not be published")
+			logger.WithFields(fields).Info("no matching entities, check will not be published")
 		}
 	} else {
 		return executor.execute(check)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds check name and namespace fields to proxy check request logs.
```
{"component":"schedulerd","level":"error","msg":"unmatched token: template: :1:149: executing \"\" at \u003c.labels.snmp_modules\u003e: map has no entry for key \"snmp_modules\"","time":"2019-01-16T14:48:47-08:00"}
```
becomes
```
{"check":"scrape_snmp","component":"schedulerd","error":"unmatched token: template: :1:149: executing \"\" at \u003c.labels.snmp_modules\u003e: map has no entry for key \"snmp_modules\"","level":"error","msg":"error publishing proxy check requests","namespace":"default","time":"2019-01-16T15:30:54-08:00"}
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2608.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.