### PR TITLE
Add Authentication Providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added the notion of authentication providers.
+
+### Changed
+- Refactoring of the internal authentication mechanism into a `basic`
+authentication provider.
+
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
 - Fixed a bug where adhoc checks were not retrieving asset dependencies.

--- a/api/core/v2/token.go
+++ b/api/core/v2/token.go
@@ -5,5 +5,33 @@ import jwt "github.com/dgrijalva/jwt-go"
 // Claims represents the JWT claims
 type Claims struct {
 	jwt.StandardClaims
-	Groups []string
+
+	// Custom claims
+	Groups   []string       `json:"groups"`
+	Provider ProviderClaims `json:"provider"`
+}
+
+// ProviderClaims contains information from the authentication provider
+type ProviderClaims struct {
+	// ProviderID used to login the user
+	ProviderID string `json:"provider_id"`
+	// UserID assigned to the user by the provider
+	UserID string `json:"user_id"`
+}
+
+// FixtureClaims returns a testing fixture for a JWT claims
+func FixtureClaims(username string, groups []string) *Claims {
+	return &Claims{
+		StandardClaims: jwt.StandardClaims{Subject: username},
+		Groups:         groups,
+		Provider: ProviderClaims{
+			ProviderID: "basic/default",
+			UserID:     username,
+		},
+	}
+}
+
+// StandardClaims returns an initialized jwt.StandardClaims with the subject
+func StandardClaims(subject string) jwt.StandardClaims {
+	return jwt.StandardClaims{Subject: subject}
 }

--- a/api/core/v2/typemap.go
+++ b/api/core/v2/typemap.go
@@ -71,6 +71,8 @@ var typeMap = map[string]interface{}{
 	"network_interface":      &NetworkInterface{},
 	"ObjectMeta":             &ObjectMeta{},
 	"object_meta":            &ObjectMeta{},
+	"ProviderClaims":         &ProviderClaims{},
+	"provider_claims":        &ProviderClaims{},
 	"ProxyRequests":          &ProxyRequests{},
 	"proxy_requests":         &ProxyRequests{},
 	"Role":                   &Role{},

--- a/backend/apid/middlewares/allowlist.go
+++ b/backend/apid/middlewares/allowlist.go
@@ -34,8 +34,8 @@ func (m AllowList) Then(next http.Handler) http.Handler {
 		// Validate that the JWT is authorized
 		if _, err := m.Store.GetToken(claims.Subject, claims.Id); err != nil {
 			logger.WithFields(logrus.Fields{
-				"user":         claims.Subject,
-				"access token": claims.Id,
+				"token_id": claims.Id,
+				"user":     claims.Subject,
 			}).WithError(err).Error("access token is not authorized")
 			http.Error(w, "Request unauthorized", http.StatusUnauthorized)
 			return

--- a/backend/apid/middlewares/allowlist_test.go
+++ b/backend/apid/middlewares/allowlist_test.go
@@ -6,17 +6,16 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/testing/mockstore"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAllowList(t *testing.T) {
 	// Create a token
-	user := &types.User{Username: "foo"}
-	token, tokenString, _ := jwt.AccessToken(user)
-	claims, _ := jwt.GetClaims(token)
+	claims := v2.FixtureClaims("foo", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
 
 	store := &mockstore.MockStore{}
 	store.On("GetToken", claims.Subject, claims.Id).Return(claims, nil)
@@ -38,9 +37,8 @@ func TestAllowList(t *testing.T) {
 
 func TestMissingTokenFromAllowList(t *testing.T) {
 	// Create a token
-	user := &types.User{Username: "foo"}
-	token, tokenString, _ := jwt.AccessToken(user)
-	claims, _ := jwt.GetClaims(token)
+	claims := v2.FixtureClaims("bar", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
 
 	store := &mockstore.MockStore{}
 	store.On("GetToken", claims.Subject, claims.Id).Return(claims, fmt.Errorf("error"))

--- a/backend/apid/middlewares/authentication_test.go
+++ b/backend/apid/middlewares/authentication_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,8 +28,8 @@ func TestMiddlewareJWT(t *testing.T) {
 	defer server.Close()
 
 	// Valid JWT
-	user := &types.User{Username: "foo"}
-	_, tokenString, _ := jwt.AccessToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
 
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", server.URL, nil)

--- a/backend/apid/middlewares/refresh_token_test.go
+++ b/backend/apid/middlewares/refresh_token_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -44,8 +45,8 @@ func TestRefreshTokenNoRefreshToken(t *testing.T) {
 	server := httptest.NewServer(mware.Then(testHandler()))
 	defer server.Close()
 
-	user := &types.User{Username: "foo"}
-	_, tokenString, _ := jwt.AccessToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
 
 	req, _ := http.NewRequest(http.MethodPost, server.URL, nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenString))
@@ -67,8 +68,8 @@ func TestRefreshTokenInvalidRefreshToken(t *testing.T) {
 	server := httptest.NewServer(mware.Then(testHandler()))
 	defer server.Close()
 
-	user := &types.User{Username: "foo"}
-	_, tokenString, _ := jwt.AccessToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
 	refreshTokenString := "foobar"
 	body := &types.Tokens{Refresh: refreshTokenString}
 	payload, _ := json.Marshal(body)
@@ -86,10 +87,10 @@ func TestRefreshTokenMismatchingSub(t *testing.T) {
 	server := httptest.NewServer(mware.Then(testHandler()))
 	defer server.Close()
 
-	user1 := &types.User{Username: "foo"}
-	user2 := &types.User{Username: "bar"}
-	_, tokenString, _ := jwt.AccessToken(user1)
-	_, refreshTokenString, _ := jwt.RefreshToken(user2)
+	fooClaims := v2.FixtureClaims("foo", nil)
+	barClaims := v2.FixtureClaims("bar", nil)
+	_, tokenString, _ := jwt.AccessToken(fooClaims)
+	_, refreshTokenString, _ := jwt.RefreshToken(barClaims)
 
 	body := &types.Tokens{Refresh: refreshTokenString}
 	payload, _ := json.Marshal(body)
@@ -122,9 +123,9 @@ func TestRefreshTokenSuccess(t *testing.T) {
 	))
 	defer server.Close()
 
-	user := &types.User{Username: "foo"}
-	_, tokenString, _ := jwt.AccessToken(user)
-	_, refreshTokenString, _ := jwt.RefreshToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, tokenString, _ := jwt.AccessToken(claims)
+	_, refreshTokenString, _ := jwt.RefreshToken(claims)
 	body := &types.Tokens{Refresh: refreshTokenString}
 	payload, _ := json.Marshal(body)
 

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -44,7 +44,8 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// Authenticate against the provider
 	claims, err := a.authenticator.Authenticate(r.Context(), username, password)
 	if err != nil {
-		logger.WithField("user", username).Error("invalid username and/or password")
+		logger.WithError(err).WithField("user", username).
+			Error("invalid username and/or password")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -118,7 +118,7 @@ func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
 
 	// Remove the access & refresh tokens from the access list
 	if err := a.store.RevokeTokens(accessClaims, refreshClaims); err != nil {
-		logger.WithField("user", refreshClaims.Subject).Errorf(
+		logger.WithError(err).WithField("user", refreshClaims.Subject).Errorf(
 			"could not revoke tokens IDs %q & %q", accessClaims.Id, refreshClaims.Id,
 		)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -126,7 +126,6 @@ func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
 		"user", username,
 	).WithError(err).Info("invalid username and/or password")
 	http.Error(w, "Request unauthorized", http.StatusUnauthorized)
-	return
 }
 
 // logout handles the logout flow

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/providers"
+
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
@@ -13,12 +16,13 @@ import (
 
 // AuthenticationRouter handles authentication related requests
 type AuthenticationRouter struct {
-	store store.Store
+	store         store.Store
+	authenticator *providers.Authenticator
 }
 
 // NewAuthenticationRouter instantiates new router.
-func NewAuthenticationRouter(store store.Store) *AuthenticationRouter {
-	return &AuthenticationRouter{store: store}
+func NewAuthenticationRouter(store store.Store, authenticator *providers.Authenticator) *AuthenticationRouter {
+	return &AuthenticationRouter{store: store, authenticator: authenticator}
 }
 
 // Mount the authentication routes on given mux.Router.
@@ -33,69 +37,44 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// Check for credentials provided in the Authorization header
 	username, password, ok := r.BasicAuth()
 	if !ok {
-		http.Error(w, "Request unauthorized", http.StatusUnauthorized)
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 
 	// Authenticate against the provider
-	user, err := a.store.AuthenticateUser(r.Context(), username, password)
+	claims, err := a.authenticator.Authenticate(r.Context(), username, password)
 	if err != nil {
-		logger.WithField(
-			"user", username,
-		).WithError(err).Error("invalid username and/or password")
-		http.Error(w, "Request unauthorized", http.StatusUnauthorized)
+		logger.WithField("user", username).Error("invalid username and/or password")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
+
+	logger = logger.WithField("user", claims.Subject)
 
 	// Add the 'system:users' group to this user
-	user.Groups = append(user.Groups, "system:users")
+	claims.Groups = append(claims.Groups, "system:users")
 
-	// Create the token and a signed version
-	token, tokenString, err := jwt.AccessToken(user)
+	// Create an access token and its signed version
+	token, tokenString, err := jwt.AccessToken(claims)
 	if err != nil {
-		err = fmt.Errorf("could not issue an access token: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.WithError(err).Error("could not issue an access token")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	// Retrieve the claims because we later need the expiration
-	claims, err := jwt.GetClaims(token)
+	// Create a refresh token and its signed version
+	refreshClaims := &v2.Claims{StandardClaims: v2.StandardClaims(claims.Subject)}
+	refreshToken, refreshTokenString, err := jwt.RefreshToken(refreshClaims)
 	if err != nil {
-		err = fmt.Errorf("could not get the access token claims: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.WithError(err).Error("could not issue a refresh token")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	refreshToken, refreshTokenString, err := jwt.RefreshToken(user)
-	if err != nil {
-		err = fmt.Errorf("could not issue a refresh token: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	refreshClaims, err := jwt.GetClaims(refreshToken)
-	if err != nil {
-		err = fmt.Errorf("could not get the refresh token claims: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// store the access and refresh tokens in the access list
-	if err = a.store.CreateToken(claims); err != nil {
-		err = fmt.Errorf("could not add the access token to the access list: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err = a.store.CreateToken(refreshClaims); err != nil {
-		err = fmt.Errorf("could not add the refresh token to the access list: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	// Add the tokens in the access list
+	if err := a.store.AllowTokens(token, refreshToken); err != nil {
+		logger.WithError(err).Error("could not add tokens to the access list")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
@@ -108,9 +87,8 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 
 	resBytes, err := json.Marshal(response)
 	if err != nil {
-		err = fmt.Errorf("could not not marshal response: %s", err)
-		logger.WithField("user", username).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.WithError(err).Error("could not encode response body")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
@@ -124,113 +102,104 @@ func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
 
 	// Get the access token claims
 	if value := r.Context().Value(types.AccessTokenClaims); value != nil {
-		accessClaims = value.(*types.Claims)
+		accessClaims = value.(*v2.Claims)
 	} else {
-		http.Error(w, "could not retrieve the access token claims", http.StatusBadRequest)
+		http.Error(w, "invalid access token", http.StatusBadRequest)
 		return
 	}
 
 	// Get the refresh token claims
 	if value := r.Context().Value(types.RefreshTokenClaims); value != nil {
-		refreshClaims = value.(*types.Claims)
+		refreshClaims = value.(*v2.Claims)
 	} else {
-		http.Error(w, "could not retrieve the refresh token claims", http.StatusBadRequest)
+		http.Error(w, "invalid refresh token", http.StatusBadRequest)
 		return
 	}
 
 	// Remove the access & refresh tokens from the access list
-	tokensToRemove := []string{accessClaims.Id, refreshClaims.Id}
-	if err := a.store.DeleteTokens(refreshClaims.Subject, tokensToRemove); err != nil {
-		err = fmt.Errorf("could not remove the access and refresh tokens from the access list: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if err := a.store.RevokeTokens(accessClaims, refreshClaims); err != nil {
+		logger.WithField("user", refreshClaims.Subject).Errorf(
+			"could not revoke tokens IDs %q & %q", accessClaims.Id, refreshClaims.Id,
+		)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 }
 
 // token handles logic for issuing new access tokens
 func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
-	var accessClaims, refreshClaims *types.Claims
+	var accessClaims, refreshClaims *v2.Claims
 
 	// Get the access token claims
-	if value := r.Context().Value(types.AccessTokenClaims); value != nil {
-		accessClaims = value.(*types.Claims)
+	if value := r.Context().Value(v2.AccessTokenClaims); value != nil {
+		accessClaims = value.(*v2.Claims)
 	} else {
-		http.Error(w, "could not retrieve the access token claims", http.StatusBadRequest)
+		http.Error(w, "invalid access token", http.StatusBadRequest)
 		return
 	}
 
+	logger = logger.WithField("user", accessClaims.Subject)
+
 	// Get the refresh token claims
-	if value := r.Context().Value(types.RefreshTokenClaims); value != nil {
-		refreshClaims = value.(*types.Claims)
+	if value := r.Context().Value(v2.RefreshTokenClaims); value != nil {
+		refreshClaims = value.(*v2.Claims)
 	} else {
-		http.Error(w, "could not retrieve the refresh token claims", http.StatusBadRequest)
+		http.Error(w, "invalid refresh token", http.StatusBadRequest)
 		return
 	}
 
 	// Get the refresh token string
-	var refreshString string
-	if value := r.Context().Value(types.RefreshTokenString); value != nil {
-		refreshString = value.(string)
+	var refreshTokenString string
+	if value := r.Context().Value(v2.RefreshTokenString); value != nil {
+		refreshTokenString = value.(string)
 	} else {
-		http.Error(w, "could not retrieve the refresh token string", http.StatusBadRequest)
+		http.Error(w, "invalid refresh token", http.StatusBadRequest)
 		return
 	}
 
 	// Make sure the refresh token is authorized in the access list
 	if _, err := a.store.GetToken(refreshClaims.Subject, refreshClaims.Id); err != nil {
-		err = fmt.Errorf("the refresh token is not authorized: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Update the user claims from the authentication provider
-	// TODO: support external directories
-	user, err := a.store.GetUser(r.Context(), refreshClaims.Subject)
-	if err != nil {
-		http.Error(w, "could not find the user", http.StatusInternalServerError)
-		return
-	}
-	if user == nil {
+		logger.WithError(err).Infof("refresh token ID %q is unauthorized", refreshClaims.Id)
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 
-	// Make sure to the 'system:users' group is present
-	user.Groups = append(user.Groups, "system:users")
-
-	// Remove the old access token from the access list
-	if err := a.store.DeleteTokens(accessClaims.Subject, []string{accessClaims.Id}); err != nil {
-		err = fmt.Errorf("could not remove the access token from the access list: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	// Revoke the old access token from the access list
+	if err := a.store.RevokeTokens(accessClaims); err != nil {
+		logger.WithError(err).Errorf("could not revoke access token ID %q", accessClaims.Id)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
+
+	// Ensure backward compatibility by filling the provider claims if missing
+	if accessClaims.Provider.ProviderID == "" || accessClaims.Provider.UserID == "" {
+		accessClaims.Provider.ProviderID = "basic/default"
+		accessClaims.Provider.UserID = accessClaims.Subject
+	}
+
+	// Refresh the user claims
+	claims, err := a.authenticator.Refresh(r.Context(), accessClaims.Provider)
+	if err != nil {
+		logger.WithError(err).Error("could not refresh user claims")
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	// Ensure the 'system:users' group is present
+	claims.Groups = append(claims.Groups, "system:users")
 
 	// Issue a new access token
-	accessToken, accessTokenString, err := jwt.AccessToken(user)
+	accessToken, accessTokenString, err := jwt.AccessToken(claims)
 	if err != nil {
-		err = fmt.Errorf("could not issue a new access token: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Retrieve the claims because we later need the expiration
-	accessClaims, err = jwt.GetClaims(accessToken)
-	if err != nil {
-		err = fmt.Errorf("could not issue a new access token: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.WithError(err).Error("could not issue a new access token")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	// store the new access token in the access list
-	if err = a.store.CreateToken(accessClaims); err != nil {
-		err = fmt.Errorf("could not add the new access token to the access list: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if err = a.store.AllowTokens(accessToken); err != nil {
+		logger.WithError(err).Errorf("could not allow new access token %q", claims.Id)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
@@ -238,14 +207,13 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 	response := &types.Tokens{
 		Access:    accessTokenString,
 		ExpiresAt: accessClaims.ExpiresAt,
-		Refresh:   refreshString,
+		Refresh:   refreshTokenString,
 	}
 
 	resBytes, err := json.Marshal(response)
 	if err != nil {
-		err = fmt.Errorf("could not not marshal response: %s", err)
-		logger.WithField("user", refreshClaims.Subject).Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		logger.WithError(err).Error("could not encode response body")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 

--- a/backend/apid/routers/authentication_test.go
+++ b/backend/apid/routers/authentication_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/authentication/providers"
 	"github.com/sensu/sensu-go/backend/authentication/providers/basic"
-	"github.com/sensu/sensu-go/backend/store"
+	realStore "github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -76,7 +76,7 @@ func TestLoginSuccessful(t *testing.T) {
 
 func TestTestNoCredentials(t *testing.T) {
 	store := &mockstore.MockStore{}
-	a := &AuthenticationRouter{store}
+	a := authenticationRouter(store)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
 
@@ -86,7 +86,7 @@ func TestTestNoCredentials(t *testing.T) {
 
 func TestTestInvalidCredentials(t *testing.T) {
 	store := &mockstore.MockStore{}
-	a := &AuthenticationRouter{store}
+	a := authenticationRouter(store)
 
 	user := types.FixtureUser("foo")
 	store.
@@ -102,7 +102,7 @@ func TestTestInvalidCredentials(t *testing.T) {
 
 func TestTestSuccessful(t *testing.T) {
 	store := &mockstore.MockStore{}
-	a := &AuthenticationRouter{store}
+	a := authenticationRouter(store)
 
 	user := types.FixtureUser("foo")
 	store.
@@ -168,7 +168,7 @@ func TestTokenRefreshTokenNotWhitelisted(t *testing.T) {
 		"GetToken",
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
-	).Return(&types.Claims{}, fmt.Errorf("error"))
+	).Return(&types.Claims{}, &realStore.ErrNotFound{})
 	store.On("GetUser",
 		mock.AnythingOfType("*context.valueCtx"),
 		mock.AnythingOfType("string"),
@@ -257,7 +257,7 @@ func TestTokenSuccess(t *testing.T) {
 	assert.NotEmpty(t, response.Refresh)
 }
 
-func authenticationRouter(store store.Store) *AuthenticationRouter {
+func authenticationRouter(store realStore.Store) *AuthenticationRouter {
 	authenticator := &providers.Authenticator{}
 	provider := &basic.Provider{Store: store}
 	authenticator.AddProvider(provider)

--- a/backend/authentication/providers/LICENSE
+++ b/backend/authentication/providers/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/authentication/providers/LICENSE
+++ b/backend/authentication/providers/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Sensu Inc.
+Copyright (c) 2019 Sensu Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/backend/authentication/providers/basic/LICENSE
+++ b/backend/authentication/providers/basic/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/authentication/providers/basic/LICENSE
+++ b/backend/authentication/providers/basic/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Sensu Inc.
+Copyright (c) 2019 Sensu Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -1,0 +1,80 @@
+package basic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
+	"github.com/sensu/sensu-go/backend/authentication/providers"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+// Type represents the type of the basic authentication provider
+const Type = "basic"
+
+// Provider represents the basic internal authentication provider
+type Provider struct {
+	Store store.Store
+}
+
+// Authenticate a user, with the provided credentials, against the Sensu store
+func (p *Provider) Authenticate(ctx context.Context, username, password string) (*v2.Claims, error) {
+	if username == "" || password == "" {
+		return nil, errors.New("the username and the password must not be empty")
+	}
+
+	user, err := p.Store.AuthenticateUser(ctx, username, password)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, err := jwt.NewClaims(user)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the provider claims
+	claims.Provider = p.claims(user.Username)
+
+	return claims, nil
+}
+
+// Refresh the claims of a user
+func (p *Provider) Refresh(ctx context.Context, providerClaims v2.ProviderClaims) (*v2.Claims, error) {
+	user, err := p.Store.GetUser(ctx, providerClaims.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, fmt.Errorf("user %q does not exist", providerClaims.UserID)
+	}
+
+	claims, err := jwt.NewClaims(user)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the provider claims
+	claims.Provider = p.claims(user.Username)
+
+	return claims, nil
+}
+
+// GetName returns the provider name
+func (p *Provider) GetName() string {
+	return "default"
+}
+
+// Type returns the provider type
+func (p *Provider) Type() string {
+	return Type
+}
+
+func (p *Provider) claims(username string) v2.ProviderClaims {
+	return v2.ProviderClaims{
+		ProviderID: providers.ID(p),
+		UserID:     username,
+	}
+}

--- a/backend/authentication/providers/logger.go
+++ b/backend/authentication/providers/logger.go
@@ -1,0 +1,7 @@
+package providers
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "auth.providers",
+})

--- a/backend/authentication/providers/providers.go
+++ b/backend/authentication/providers/providers.go
@@ -1,0 +1,93 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/sensu/sensu-go/api/core/v2"
+)
+
+// Provider represents an abstracted authentication provider
+type Provider interface {
+	Authenticate(ctx context.Context, username, password string) (*v2.Claims, error)
+	GetName() string
+	Refresh(ctx context.Context, providerClaims v2.ProviderClaims) (*v2.Claims, error)
+	Type() string
+}
+
+// ID returns a unique identifier for a given provider
+func ID(p Provider) string {
+	return fmt.Sprintf("%s/%s", p.Type(), p.GetName())
+}
+
+// Authenticator contains the list of authentication providers
+type Authenticator struct {
+	mu        sync.RWMutex
+	providers map[string]Provider
+}
+
+// Authenticate with the configured authentication providers
+func (a *Authenticator) Authenticate(ctx context.Context, username, password string) (*v2.Claims, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	for _, provider := range a.providers {
+		claims, err := provider.Authenticate(ctx, username, password)
+		if err != nil {
+			logger.WithError(err).Debugf(
+				"could not authenticate with provider %q", provider.Type(),
+			)
+			continue
+		}
+
+		return claims, nil
+	}
+
+	return nil, errors.New("authentication failed")
+}
+
+// Refresh is called when a new access token is requested with a refresh token.
+// The provider should attempt to update the user identity to reflect any changes
+// since the access token was last refreshed
+func (a *Authenticator) Refresh(ctx context.Context, claims v2.ProviderClaims) (*v2.Claims, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if provider, ok := a.providers[claims.ProviderID]; ok {
+		user, err := provider.Refresh(ctx, claims)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"could not refresh user %q with provider %q: %s", claims.UserID, provider.Type(), err,
+			)
+		}
+
+		return user, nil
+	}
+
+	return nil, fmt.Errorf(
+		"could not refresh user %q with missing provider ID %q", claims.UserID, claims.ProviderID,
+	)
+}
+
+// AddProvider adds a provided provider to the list of configured providers
+func (a *Authenticator) AddProvider(provider Provider) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Make sure the providers map is not nil
+	if a.providers == nil {
+		a.providers = map[string]Provider{}
+	}
+
+	a.providers[ID(provider)] = provider
+}
+
+// Providers returns the configured providers
+func (a *Authenticator) Providers() map[string]Provider {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	return a.providers
+}

--- a/backend/authentication/providers/providers.go
+++ b/backend/authentication/providers/providers.go
@@ -35,7 +35,7 @@ func (a *Authenticator) Authenticate(ctx context.Context, username, password str
 
 	for _, provider := range a.providers {
 		claims, err := provider.Authenticate(ctx, username, password)
-		if err != nil {
+		if err != nil || claims == nil {
 			logger.WithError(err).Debugf(
 				"could not authenticate with provider %q", provider.Type(),
 			)

--- a/backend/daemon/daemon.go
+++ b/backend/daemon/daemon.go
@@ -18,3 +18,13 @@ type Daemon interface {
 	// Name returns the name of the daemon
 	Name() string
 }
+
+// Get returns the daemon with the provided name
+func Get(daemons []Daemon, name string) Daemon {
+	for _, daemon := range daemons {
+		if daemon.Name() == name {
+			return daemon
+		}
+	}
+	return nil
+}

--- a/backend/store/etcd/token_store.go
+++ b/backend/store/etcd/token_store.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -14,28 +16,28 @@ func getTokenPath(subject, id string) string {
 	return fmt.Sprintf("%s/tokens/%s/%s", EtcdRoot, subject, id)
 }
 
-// CreateToken creates a Claims.
-func (s *Store) CreateToken(claims *types.Claims) error {
-	bytes, err := json.Marshal(claims)
-	if err != nil {
-		return err
+// AllowTokens adds the provided tokens to the JWT access list
+func (s *Store) AllowTokens(tokens ...*jwt.Token) error {
+	claims := make([]*v2.Claims, len(tokens))
+
+	// Get the claims for each tokens
+	for i, token := range tokens {
+		if c, ok := token.Claims.(*v2.Claims); ok {
+			claims[i] = c
+			continue
+		}
+		return errors.New("could not parse all token claims")
 	}
 
-	_, err = s.client.Put(context.TODO(), getTokenPath(claims.Subject, claims.Id), string(bytes))
-	return err
-}
-
-// DeleteTokens deletes multiples tokens, belonging to the same subject, with
-// a transaction
-func (s *Store) DeleteTokens(subject string, ids []string) error {
-	if subject == "" || len(ids) == 0 {
-		return errors.New("must specify token subject and at least one ID")
-	}
-
-	// Construct the list of operations to make in the transaction
-	ops := make([]clientv3.Op, len(ids))
+	// Construct the list of operations for this transaction
+	ops := make([]clientv3.Op, len(tokens))
 	for i := range ops {
-		ops[i] = clientv3.OpDelete(getTokenPath(subject, ids[i]))
+		bytes, err := json.Marshal(claims[i])
+		if err != nil {
+			return err
+		}
+
+		ops[i] = clientv3.OpPut(getTokenPath(claims[i].Subject, claims[i].Id), string(bytes))
 	}
 
 	res, err := s.client.Txn(context.TODO()).Then(ops...).Commit()
@@ -43,7 +45,26 @@ func (s *Store) DeleteTokens(subject string, ids []string) error {
 		return err
 	}
 	if !res.Succeeded {
-		return fmt.Errorf("could not delete all tokens")
+		return fmt.Errorf("could not allow all tokens")
+	}
+
+	return nil
+}
+
+// RevokeTokens removes the provided tokens from the JWT access list
+func (s *Store) RevokeTokens(claims ...*v2.Claims) error {
+	// Construct the list of operations for this transaction
+	ops := make([]clientv3.Op, len(claims))
+	for i := range ops {
+		ops[i] = clientv3.OpDelete(getTokenPath(claims[i].Subject, claims[i].Id))
+	}
+
+	res, err := s.client.Txn(context.TODO()).Then(ops...).Commit()
+	if err != nil {
+		return err
+	}
+	if !res.Succeeded {
+		return fmt.Errorf("could not revoke all tokens")
 	}
 
 	return nil

--- a/backend/store/etcd/user_store.go
+++ b/backend/store/etcd/user_store.go
@@ -18,18 +18,18 @@ func getUserPath(id string) string {
 func (s *Store) AuthenticateUser(ctx context.Context, username, password string) (*types.User, error) {
 	user, err := s.GetUser(ctx, username)
 	if user == nil {
-		return nil, fmt.Errorf("User %s does not exist", username)
+		return nil, fmt.Errorf("user %s does not exist", username)
 	} else if err != nil {
 		return nil, err
 	}
 
 	if user.Disabled {
-		return nil, fmt.Errorf("User %s is disabled", username)
+		return nil, fmt.Errorf("user %s is disabled", username)
 	}
 
 	ok := bcrypt.CheckPassword(user.Password, password)
 	if !ok {
-		return nil, fmt.Errorf("Wrong password for user %s", username)
+		return nil, fmt.Errorf("wrong password for user %s", username)
 	}
 
 	return user, nil

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
@@ -75,13 +76,12 @@ func TestUserStorage(t *testing.T) {
 		assert.Equal(t, 2, len(users))
 
 		// Generate a token for the bar user
-		barUser := &types.User{Username: "bar"}
-		token, _, _ := jwt.AccessToken(barUser)
-		claims, _ := jwt.GetClaims(token)
-		err = store.CreateToken(claims)
+		claims := v2.FixtureClaims("bar", nil)
+		token, _, _ := jwt.AccessToken(claims)
+		err = store.AllowTokens(token)
 		assert.NoError(t, err)
 
-		// Disable a user a user that does not exist
+		// Disable a user that does not exist
 		err = store.DeleteUser(ctx, &types.User{Username: "Frankieie"})
 		assert.NoError(t, err)
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -547,12 +549,12 @@ type SilencedStore interface {
 
 // TokenStore provides methods for managing the JWT access list
 type TokenStore interface {
-	// CreateToken creates a new entry in the JWT access list with the given claims.
-	CreateToken(claims *types.Claims) error
+	// AllowTokens adds the provided tokens to the JWT access list
+	AllowTokens(tokens ...*jwt.Token) error
 
-	// DeleteTokens deletes one or multiple given tokens, belonging to the same
-	// given subject.
-	DeleteTokens(subject string, tokens []string) error
+	// RevokeTokens removes tokens using the provided claims from the JWT access
+	// list
+	RevokeTokens(claims ...*v2.Claims) error
 
 	// GetToken returns the claims of a given token ID, belonging to the given
 	// subject. An error is returned if no claims were found.

--- a/cli/commands/check/execute_test.go
+++ b/cli/commands/check/execute_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	clientmock "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
@@ -33,8 +34,8 @@ func TestExecuteCommandRunEClosureSuccess(t *testing.T) {
 	client.On("ExecuteCheck", mock.Anything).Return(nil)
 
 	config := cli.Config.(*clientmock.MockConfig)
-	user := &types.User{Username: "foo"}
-	_, accessToken, _ := jwt.AccessToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, accessToken, _ := jwt.AccessToken(claims)
 	config.On("Tokens").Return(&types.Tokens{Access: accessToken})
 
 	cmd := ExecuteCommand(cli)
@@ -54,8 +55,8 @@ func TestExecuteCommandRunEClosureServerErr(t *testing.T) {
 	client.On("ExecuteCheck", mock.Anything).Return(errors.New("whoops"))
 
 	config := cli.Config.(*clientmock.MockConfig)
-	user := &types.User{Username: "foo"}
-	_, accessToken, _ := jwt.AccessToken(user)
+	claims := v2.FixtureClaims("foo", nil)
+	_, accessToken, _ := jwt.AccessToken(claims)
 	config.On("Tokens").Return(&types.Tokens{Access: accessToken})
 
 	cmd := ExecuteCommand(cli)

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -97,10 +97,6 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				)
 			}
 
-			if _, err := cli.Client.FetchUser(answers.Username); err != nil {
-				return err
-			}
-
 			if err = cli.Config.SaveNamespace(answers.Namespace); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(

--- a/testing/mockstore/token.go
+++ b/testing/mockstore/token.go
@@ -1,16 +1,20 @@
 package mockstore
 
-import "github.com/sensu/sensu-go/types"
+import (
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
+)
 
 // CreateToken ...
-func (s *MockStore) CreateToken(claims *types.Claims) error {
-	args := s.Called(claims)
+func (s *MockStore) AllowTokens(tokens ...*jwt.Token) error {
+	args := s.Called(tokens)
 	return args.Error(0)
 }
 
-// DeleteTokens ...
-func (s *MockStore) DeleteTokens(subject string, ids []string) error {
-	args := s.Called(subject, ids)
+// RevokeTokens ...
+func (s *MockStore) RevokeTokens(claims ...*v2.Claims) error {
+	args := s.Called(claims)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## What is this change?

This change introduces the notion of authentication providers and move all the current authentication logic into a `basic` authentication provider.

In details:
- Authentication providers have two main methods; `Authenticate` & `Refresh`. The former is used to authenticate a user with a username/password combinaison and the latter is used to renew the user claims (mainly groups) without the password.
- The JWT claims now contain a `ProviderClaims` struct, which informs us of the provider used to authenticate the user and its username (which might differs from the username used by Sensu).
	- This is useful for renewing the user claims during the renewal of an access token
- Added the notion of an `Authenticator` to apid.
	- It has the knowledge of all enabled authentication providers and it contains the business logic to determine which providers should be used for authentication (e.g. use them in order or only use a specific one)
- Refactored the `Token` store and renamed some of its methods, so it can now accept a list of tokens/claims to allow or revoke.
- The authentication providers now return the user claims instead of a user struct; this struct is specific to the `basic` authentication provider, therefore we shouldn't have to use this "limiting" struct between the providers and the tokens.
- Refactored the error messages and log entries of the `AuthenticationRouter` so we don't leak information via the API about the reasons behind an unauthorized request, and instead provide the logs with all the required information.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/21

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!
