### PR TITLE
Add better error checking/handling to entity cli client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a bug where a bad line in check output would abort metric extraction.
 An error is now logged instead, and extraction continues after a bad line is encountered.
 - Fixed a panic in the dashboardd shutdown routine.
+- Fixed a bug where deleting a non-existent entity with sensuctl would not return an error.
 
 ### Changed
 - Improved logging for errors in proxy check requests.

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -11,8 +11,14 @@ var entitiesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "entities")
 // DeleteEntity deletes given entitiy from the configured sensu instance
 func (client *RestClient) DeleteEntity(entity *types.Entity) (err error) {
 	path := entitiesPath(client.config.Namespace(), entity.Name)
-	_, err = client.R().Delete(path)
-	return err
+	res, err := client.R().Delete(path)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+	return nil
 }
 
 // FetchEntity fetches a specific entity


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds error checking and handling to the entity rest client used by sensuctl.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2598.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## Does this change require a new test case?

https://github.com/sensu/sensu-go-qa-crucible/issues/5