### PR TITLE
Generic store functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Refactoring of the internal authentication mechanism into a `basic`
 authentication provider.
+- Modified private generic store methods as public functions.
 
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.

--- a/backend/store/etcd/clusterrole_store.go
+++ b/backend/store/etcd/clusterrole_store.go
@@ -25,7 +25,7 @@ func (s *Store) CreateClusterRole(ctx context.Context, clusterRole *types.Cluste
 	if err := clusterRole.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.create(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+	return Create(ctx, s.client, getClusterRolePath(clusterRole), "", clusterRole)
 }
 
 // CreateOrUpdateClusterRole ...
@@ -33,25 +33,25 @@ func (s *Store) CreateOrUpdateClusterRole(ctx context.Context, clusterRole *type
 	if err := clusterRole.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.createOrUpdate(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+	return CreateOrUpdate(ctx, s.client, getClusterRolePath(clusterRole), "", clusterRole)
 }
 
 // DeleteClusterRole ...
 func (s *Store) DeleteClusterRole(ctx context.Context, name string) error {
-	return s.delete(ctx, getClusterRolesPath(ctx, name))
+	return Delete(ctx, s.client, getClusterRolesPath(ctx, name))
 }
 
 // GetClusterRole ...
 func (s *Store) GetClusterRole(ctx context.Context, name string) (*types.ClusterRole, error) {
 	clusterRole := &types.ClusterRole{}
-	err := s.get(ctx, getClusterRolesPath(ctx, name), clusterRole)
+	err := Get(ctx, s.client, getClusterRolesPath(ctx, name), clusterRole)
 	return clusterRole, err
 }
 
 // ListClusterRoles ...
 func (s *Store) ListClusterRoles(ctx context.Context) ([]*types.ClusterRole, error) {
 	clusterRoles := []*types.ClusterRole{}
-	err := s.list(ctx, getClusterRolesPath, &clusterRoles)
+	err := List(ctx, s.client, getClusterRolesPath, &clusterRoles)
 	return clusterRoles, err
 }
 
@@ -60,5 +60,5 @@ func (s *Store) UpdateClusterRole(ctx context.Context, clusterRole *types.Cluste
 	if err := clusterRole.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.update(ctx, getClusterRolePath(clusterRole), "", clusterRole)
+	return Update(ctx, s.client, getClusterRolePath(clusterRole), "", clusterRole)
 }

--- a/backend/store/etcd/clusterrolebinding_store.go
+++ b/backend/store/etcd/clusterrolebinding_store.go
@@ -25,7 +25,7 @@ func (s *Store) CreateClusterRoleBinding(ctx context.Context, clusterRoleBinding
 	if err := clusterRoleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.create(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+	return Create(ctx, s.client, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
 }
 
 // CreateOrUpdateClusterRoleBinding ...
@@ -33,25 +33,25 @@ func (s *Store) CreateOrUpdateClusterRoleBinding(ctx context.Context, clusterRol
 	if err := clusterRoleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.createOrUpdate(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+	return CreateOrUpdate(ctx, s.client, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
 }
 
 // DeleteClusterRoleBinding ...
 func (s *Store) DeleteClusterRoleBinding(ctx context.Context, name string) error {
-	return s.delete(ctx, getClusterRoleBindingsPath(ctx, name))
+	return Delete(ctx, s.client, getClusterRoleBindingsPath(ctx, name))
 }
 
 // GetClusterRoleBinding ...
 func (s *Store) GetClusterRoleBinding(ctx context.Context, name string) (*types.ClusterRoleBinding, error) {
 	role := &types.ClusterRoleBinding{}
-	err := s.get(ctx, getClusterRoleBindingsPath(ctx, name), role)
+	err := Get(ctx, s.client, getClusterRoleBindingsPath(ctx, name), role)
 	return role, err
 }
 
 // ListClusterRoleBindings ...
 func (s *Store) ListClusterRoleBindings(ctx context.Context) ([]*types.ClusterRoleBinding, error) {
 	roles := []*types.ClusterRoleBinding{}
-	err := s.list(ctx, getClusterRoleBindingsPath, &roles)
+	err := List(ctx, s.client, getClusterRoleBindingsPath, &roles)
 	return roles, err
 }
 
@@ -60,5 +60,5 @@ func (s *Store) UpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding
 	if err := clusterRoleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.update(ctx, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
+	return Update(ctx, s.client, getClusterRoleBindingPath(clusterRoleBinding), "", clusterRoleBinding)
 }

--- a/backend/store/etcd/role_store.go
+++ b/backend/store/etcd/role_store.go
@@ -25,7 +25,7 @@ func (s *Store) CreateRole(ctx context.Context, role *types.Role) error {
 	if err := role.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.create(ctx, getRolePath(role), role.Namespace, role)
+	return Create(ctx, s.client, getRolePath(role), role.Namespace, role)
 }
 
 // CreateOrUpdateRole ...
@@ -33,25 +33,25 @@ func (s *Store) CreateOrUpdateRole(ctx context.Context, role *types.Role) error 
 	if err := role.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.createOrUpdate(ctx, getRolePath(role), role.Namespace, role)
+	return CreateOrUpdate(ctx, s.client, getRolePath(role), role.Namespace, role)
 }
 
 // DeleteRole ...
 func (s *Store) DeleteRole(ctx context.Context, name string) error {
-	return s.delete(ctx, getRolesPath(ctx, name))
+	return Delete(ctx, s.client, getRolesPath(ctx, name))
 }
 
 // GetRole ...
 func (s *Store) GetRole(ctx context.Context, name string) (*types.Role, error) {
 	role := &types.Role{}
-	err := s.get(ctx, getRolesPath(ctx, name), role)
+	err := Get(ctx, s.client, getRolesPath(ctx, name), role)
 	return role, err
 }
 
 // ListRoles ...
 func (s *Store) ListRoles(ctx context.Context) ([]*types.Role, error) {
 	roles := []*types.Role{}
-	err := s.list(ctx, getRolesPath, &roles)
+	err := List(ctx, s.client, getRolesPath, &roles)
 	return roles, err
 }
 
@@ -60,5 +60,5 @@ func (s *Store) UpdateRole(ctx context.Context, role *types.Role) error {
 	if err := role.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.update(ctx, getRolePath(role), role.Namespace, role)
+	return Update(ctx, s.client, getRolePath(role), role.Namespace, role)
 }

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -25,7 +25,7 @@ func (s *Store) CreateRoleBinding(ctx context.Context, roleBinding *types.RoleBi
 	if err := roleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.create(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+	return Create(ctx, s.client, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
 }
 
 // CreateOrUpdateRoleBinding ...
@@ -33,25 +33,25 @@ func (s *Store) CreateOrUpdateRoleBinding(ctx context.Context, roleBinding *type
 	if err := roleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.createOrUpdate(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+	return CreateOrUpdate(ctx, s.client, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
 }
 
 // DeleteRoleBinding ...
 func (s *Store) DeleteRoleBinding(ctx context.Context, name string) error {
-	return s.delete(ctx, getRoleBindingsPath(ctx, name))
+	return Delete(ctx, s.client, getRoleBindingsPath(ctx, name))
 }
 
 // GetRoleBinding ...
 func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBinding, error) {
 	role := &types.RoleBinding{}
-	err := s.get(ctx, getRoleBindingsPath(ctx, name), role)
+	err := Get(ctx, s.client, getRoleBindingsPath(ctx, name), role)
 	return role, err
 }
 
 // ListRoleBindings ...
 func (s *Store) ListRoleBindings(ctx context.Context) ([]*types.RoleBinding, error) {
 	roles := []*types.RoleBinding{}
-	err := s.list(ctx, getRoleBindingsPath, &roles)
+	err := List(ctx, s.client, getRoleBindingsPath, &roles)
 	return roles, err
 }
 
@@ -60,5 +60,5 @@ func (s *Store) UpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBi
 	if err := roleBinding.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	return s.update(ctx, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
+	return Update(ctx, s.client, getRoleBindingPath(roleBinding), roleBinding.Namespace, roleBinding)
 }

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -32,8 +32,8 @@ func NewStore(client *clientv3.Client, name string) *Store {
 	return store
 }
 
-// Create a key given with the serialized object.
-func (s *Store) create(ctx context.Context, key, namespace string, object interface{}) error {
+// Create the given key with the serialized object.
+func Create(ctx context.Context, client *clientv3.Client, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
 		return &store.ErrEncode{Key: key, Err: err}
@@ -48,7 +48,7 @@ func (s *Store) create(ctx context.Context, key, namespace string, object interf
 	comparisons = append(comparisons, keyNotFound(key))
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Else(
+	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Else(
 		getNamespace(namespace), getKey(key),
 	).Commit()
 	if err != nil {
@@ -76,7 +76,7 @@ func (s *Store) create(ctx context.Context, key, namespace string, object interf
 
 // CreateOrUpdate writes the given key with the serialized object, regarless of
 // its current existence
-func (s *Store) createOrUpdate(ctx context.Context, key, namespace string, object interface{}) error {
+func CreateOrUpdate(ctx context.Context, client *clientv3.Client, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
 		return &store.ErrEncode{Key: key, Err: err}
@@ -89,7 +89,7 @@ func (s *Store) createOrUpdate(ctx context.Context, key, namespace string, objec
 	}
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Commit()
+	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Commit()
 	if err != nil {
 		return err
 	}
@@ -100,9 +100,9 @@ func (s *Store) createOrUpdate(ctx context.Context, key, namespace string, objec
 	return nil
 }
 
-// delete the given key
-func (s *Store) delete(ctx context.Context, key string) error {
-	resp, err := s.client.Delete(ctx, key)
+// Delete the given key
+func Delete(ctx context.Context, client *clientv3.Client, key string) error {
+	resp, err := client.Delete(ctx, key)
 	if err != nil {
 		return err
 	}
@@ -117,10 +117,10 @@ func (s *Store) delete(ctx context.Context, key string) error {
 	return nil
 }
 
-// get retrieves an object with the given key
-func (s *Store) get(ctx context.Context, key string, object interface{}) error {
+// Get retrieves an object with the given key
+func Get(ctx context.Context, client *clientv3.Client, key string, object interface{}) error {
 	// Fetch the key from the store
-	resp, err := s.client.Get(ctx, key, clientv3.WithLimit(1))
+	resp, err := client.Get(ctx, key, clientv3.WithLimit(1))
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ type keyBuilderFn func(context.Context, string) string
 
 // list retrieves all keys from storage under the provided prefix key, while
 // supporting all namespaces, and deserialize it into objsPtr.
-func (s *Store) list(ctx context.Context, keyBuilder keyBuilderFn, objsPtr interface{}) error {
+func List(ctx context.Context, client *clientv3.Client, keyBuilder keyBuilderFn, objsPtr interface{}) error {
 	// Make sure the interface is a pointer, and that the element at this address
 	// is a slice.
 	v := reflect.ValueOf(objsPtr)
@@ -160,7 +160,7 @@ func (s *Store) list(ctx context.Context, keyBuilder keyBuilderFn, objsPtr inter
 	}
 
 	key := keyBuilder(ctx, "")
-	resp, err := s.client.Get(ctx, key, opts...)
+	resp, err := client.Get(ctx, key, opts...)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (s *Store) list(ctx context.Context, keyBuilder keyBuilderFn, objsPtr inter
 }
 
 // Update a key given with the serialized object.
-func (s *Store) update(ctx context.Context, key, namespace string, object interface{}) error {
+func Update(ctx context.Context, client *clientv3.Client, key, namespace string, object interface{}) error {
 	bytes, err := json.Marshal(object)
 	if err != nil {
 		return &store.ErrEncode{Key: key, Err: err}
@@ -194,7 +194,7 @@ func (s *Store) update(ctx context.Context, key, namespace string, object interf
 	comparisons = append(comparisons, keyFound(key))
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := s.client.Txn(ctx).If(comparisons...).Then(req).Else(
+	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Else(
 		getNamespace(namespace), getKey(key),
 	).Commit()
 	if err != nil {

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -75,15 +75,15 @@ func TestCreate(t *testing.T) {
 		// Creating a namespaced key that does not exist should work
 		obj := &genericObject{}
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		err := store.create(ctx, "/default/foo", "default", obj)
+		err := Create(ctx, store.client, "/default/foo", "default", obj)
 		assert.NoError(t, err)
 
 		// Creating this same key should return an error
-		err = store.create(ctx, "/default/foo", "default", obj)
+		err = Create(ctx, store.client, "/default/foo", "default", obj)
 		assert.Error(t, err)
 
 		// We should also be able to create a global object
-		err = store.create(ctx, "/foo", "", obj)
+		err = Create(ctx, store.client, "/foo", "", obj)
 		assert.NoError(t, err)
 	})
 }
@@ -93,22 +93,22 @@ func TestCreateOrUpdate(t *testing.T) {
 		// Creating a namespaced key that does not exist should work
 		obj := &genericObject{Revision: 1}
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		err := store.createOrUpdate(ctx, "/default/foo", "default", obj)
+		err := CreateOrUpdate(ctx, store.client, "/default/foo", "default", obj)
 		assert.NoError(t, err)
 
 		// Creating this same key should also work, but the revision should be
 		// different
 		obj2 := &genericObject{Revision: 2}
-		err = store.createOrUpdate(ctx, "/default/foo", "default", obj)
+		err = CreateOrUpdate(ctx, store.client, "/default/foo", "default", obj)
 		assert.NoError(t, err)
 		result := &genericObject{}
-		err = store.get(ctx, "/default/foo", obj2)
+		err = Get(ctx, store.client, "/default/foo", obj2)
 		assert.NoError(t, err)
 		assert.NotEqual(t, obj.Revision, result.Revision)
 
 		// We should also be able to create a global object
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "")
-		err = store.createOrUpdate(ctx, "/foo", "", obj)
+		err = CreateOrUpdate(ctx, store.client, "/foo", "", obj)
 		assert.NoError(t, err)
 	})
 }
@@ -117,16 +117,16 @@ func TestDelete(t *testing.T) {
 	testWithEtcdStore(t, func(store *Store) {
 		// Deleting a non-existant key should fail
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		require.Error(t, store.delete(ctx, "/default/foo"))
+		require.Error(t, Delete(ctx, store.client, "/default/foo"))
 
 		// Create it first
 		obj := &genericObject{}
-		require.NoError(t, store.create(ctx, "/default/foo", "default", obj))
+		require.NoError(t, Create(ctx, store.client, "/default/foo", "default", obj))
 
 		// Now make sure it gets properly deleted
-		require.NoError(t, store.delete(ctx, "/default/foo"))
+		require.NoError(t, Delete(ctx, store.client, "/default/foo"))
 		result := &genericObject{}
-		require.Error(t, store.get(ctx, "/default/foo", result))
+		require.Error(t, Get(ctx, store.client, "/default/foo", result))
 	})
 }
 func TestGet(t *testing.T) {
@@ -134,24 +134,24 @@ func TestGet(t *testing.T) {
 		// Create a namespaced key
 		obj := &genericObject{Revision: 1}
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		err := store.create(ctx, "/default/foo", "default", obj)
+		err := Create(ctx, store.client, "/default/foo", "default", obj)
 		assert.NoError(t, err)
 
 		// Retrieve the namespaced key and make sure it's the expected object
 		result := &genericObject{}
-		err = store.get(ctx, "/default/foo", result)
+		err = Get(ctx, store.client, "/default/foo", result)
 		assert.NoError(t, err)
 		assert.Equal(t, obj, result)
 
 		// Create a global key
 		obj2 := &genericObject{Revision: 2}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "")
-		err = store.create(ctx, "/foo", "", obj2)
+		err = Create(ctx, store.client, "/foo", "", obj2)
 		assert.NoError(t, err)
 
 		// Retrieve the global key and make sure it's the expected object
 		result2 := &genericObject{}
-		err = store.get(ctx, "/foo", result2)
+		err = Get(ctx, store.client, "/foo", result2)
 		assert.NoError(t, err)
 		assert.Equal(t, obj2, result2)
 	})
@@ -174,32 +174,32 @@ func TestList(t *testing.T) {
 		// Create a bunch of keys everywhere
 		obj1 := &genericObject{Name: "obj1", Namespace: "default"}
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		require.NoError(t, store.create(ctx, "/sensu.io/generic/default/obj1", "default", obj1))
+		require.NoError(t, Create(ctx, store.client, "/sensu.io/generic/default/obj1", "default", obj1))
 
 		obj2 := &genericObject{Name: "obj2", Namespace: "acme"}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
-		require.NoError(t, store.create(ctx, "/sensu.io/generic/acme/obj2", "acme", obj2))
+		require.NoError(t, Create(ctx, store.client, "/sensu.io/generic/acme/obj2", "acme", obj2))
 
 		obj3 := &genericObject{Name: "obj3", Namespace: "acme"}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
-		require.NoError(t, store.create(ctx, "/sensu.io/generic/acme/obj3", "acme", obj3))
+		require.NoError(t, Create(ctx, store.client, "/sensu.io/generic/acme/obj3", "acme", obj3))
 
 		// We should have 1 object when listing keys under the default namespace
 		list := []*genericObject{}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "default")
-		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		require.NoError(t, List(ctx, store.client, getGenericObjectsPath, &list))
 		assert.Len(t, list, 1)
 
 		// We should have 2 objects when listing keys under the acme namespace
 		list = []*genericObject{}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "acme")
-		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		require.NoError(t, List(ctx, store.client, getGenericObjectsPath, &list))
 		assert.Len(t, list, 2)
 
 		// We should have 3 objects when listing through all namespaces
 		list = []*genericObject{}
 		ctx = context.WithValue(context.Background(), types.NamespaceKey, "")
-		require.NoError(t, store.list(ctx, getGenericObjectsPath, &list))
+		require.NoError(t, List(ctx, store.client, getGenericObjectsPath, &list))
 		assert.Len(t, list, 3)
 	})
 }
@@ -209,16 +209,16 @@ func TestUpdate(t *testing.T) {
 		// Updating a non-existent object should fail
 		obj := &genericObject{Revision: 1}
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, "default")
-		require.Error(t, store.update(ctx, "/default/foo", "default", obj))
+		require.Error(t, Update(ctx, store.client, "/default/foo", "default", obj))
 
 		// Create it first
-		require.NoError(t, store.create(ctx, "/default/foo", "default", obj))
+		require.NoError(t, Create(ctx, store.client, "/default/foo", "default", obj))
 
 		// Now make sure it gets properly updated
 		obj.Revision = 2
-		require.NoError(t, store.update(ctx, "/default/foo", "default", obj))
+		require.NoError(t, Update(ctx, store.client, "/default/foo", "default", obj))
 		result := &genericObject{}
-		require.NoError(t, store.get(ctx, "/default/foo", result))
+		require.NoError(t, Get(ctx, store.client, "/default/foo", result))
 		assert.Equal(t, 2, obj.Revision)
 	})
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It modifies previously private generic store methods into public functions, so they can be used from the enterprise codebase.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/184.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## Does this change require a new test case?

Nope!
