### PR TITLE
Removed unused workflow in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,19 +95,3 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-  rel_build_and_test:
-    jobs:
-      - build:
-          filters:
-            tags:
-              only: /^\d\.\d\.\d\-beta.\d+.+/
-            branches:
-              ignore: /.*/
-      - test:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^\d\.\d\.\d\-beta.\d+.+/
-            branches:
-              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added the notion of authentication providers.
 
 ### Changed
+- Improved logging for errors in proxy check requests.
+- Updated Go version from 1.10 to 1.11.4.
 - Refactoring of the internal authentication mechanism into a `basic`
 authentication provider.
 - Modified private generic store methods as public functions.
+- Removed unused workflow `rel_build_and_test` in CircleCI config.
 
 ### Fixed
 - Fixed a bug where `sensuctl edit` was not removing the temp file it created.
@@ -23,10 +26,6 @@ authentication provider.
 An error is now logged instead, and extraction continues after a bad line is encountered.
 - Fixed a panic in the dashboardd shutdown routine.
 - Fixed a bug where deleting a non-existent entity with sensuctl would not return an error.
-
-### Changed
-- Improved logging for errors in proxy check requests.
-- Updated Go version from 1.10 to 1.11.4.
 
 ## [5.1.0] - 2018-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## [5.1.1] - 2019-01-24
 ### Changed
+- Removed unused workflow `rel_build_and_test` in CircleCI config.
+
+## [5.1.1] - 2019-01-24
 
 ### Added
 - Added the notion of authentication providers.
@@ -19,7 +21,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Refactoring of the internal authentication mechanism into a `basic`
 authentication provider.
 - Modified private generic store methods as public functions.
-- Removed unused workflow `rel_build_and_test` in CircleCI config.
 - Improved logging for errors in proxy check requests.
 - Updated Go version from 1.10 to 1.11.4.
 - Changed keepalive event to include check.outputé


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes an used workflow named `rel_build_and_test`, which relies on `beta` tags.

## Why is this change necessary?

Simple cleanup.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## Does this change require a new test case?

Nope!
