### PR TITLE
Fix a bug in proxy check execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ An error is now logged instead, and extraction continues after a bad line is enc
 - Fixed a bug where deleting a non-existent entity with sensuctl would not return an error.
 - Web UI - toolbar menu buttons now switch with dark theme.
 - Web UI - some buttons easier to see with dark theme.
+- Agents will now take proxy entity names into consideration when guarding
+against duplicate check requests.
 
 ### Changed
 - Improved logging for errors in proxy check requests.

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -30,7 +30,7 @@ func (a *Agent) handleCheck(payload []byte) error {
 	// only schedule check execution if its not already in progress
 	// ** check hooks are part of a checks execution
 	a.inProgressMu.Lock()
-	_, in := a.inProgress[request.Config.Name]
+	_, in := a.inProgress[checkKey(request)]
 	a.inProgressMu.Unlock()
 	if !in {
 		logger.Info("scheduling check execution: ", request.Config.Name)
@@ -50,9 +50,13 @@ func (a *Agent) handleCheck(payload []byte) error {
 	return nil
 }
 
+func checkKey(request *v2.CheckRequest) string {
+	return request.Config.Name
+}
+
 func (a *Agent) executeCheck(request *v2.CheckRequest) {
 	a.inProgressMu.Lock()
-	a.inProgress[request.Config.Name] = request.Config
+	a.inProgress[checkKey(request)] = request.Config
 	a.inProgressMu.Unlock()
 	defer func() {
 		a.inProgressMu.Lock()

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -11,7 +11,6 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +31,7 @@ func TestHandleCheck(t *testing.T) {
 	ex := &mockexecutor.MockExecutor{}
 	agent.executor = ex
 	execution := command.FixtureExecutionResponse(0, "")
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 	ch := make(chan *transport.Message, 5)
 	agent.sendq = ch
 
@@ -69,7 +68,7 @@ func TestHandleProxyCheck(t *testing.T) {
 	ex := &mockexecutor.MockExecutor{}
 	agent.executor = ex
 	execution := command.FixtureExecutionResponse(0, "")
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 	agent.sendq = make(chan *transport.Message, 5)
 
 	// simulate checkA executing
@@ -111,7 +110,7 @@ func TestExecuteCheck(t *testing.T) {
 	ex := &mockexecutor.MockExecutor{}
 	agent.executor = ex
 	execution := command.FixtureExecutionResponse(0, "")
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 
 	agent.executeCheck(request)
 	msg := <-ch
@@ -158,7 +157,7 @@ func TestExecuteCheck(t *testing.T) {
 	checkConfig.OutputMetricFormat = ""
 	execution.Status = 0
 	execution.Output = "metric.foo 1 123456789\nmetric.bar 2 987654321"
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 	agent.executeCheck(request)
 	msg = <-ch
 
@@ -168,7 +167,7 @@ func TestExecuteCheck(t *testing.T) {
 	assert.False(event.HasMetrics())
 
 	checkConfig.OutputMetricFormat = corev2.GraphiteOutputMetricFormat
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 	agent.executeCheck(request)
 	msg = <-ch
 

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestExecuteHook(t *testing.T) {
@@ -26,7 +25,7 @@ func TestExecuteHook(t *testing.T) {
 	ex := &mockexecutor.MockExecutor{}
 	agent.executor = ex
 	execution := command.FixtureExecutionResponse(0, "")
-	ex.On("Execute", mock.Anything, mock.Anything).Return(execution, nil)
+	ex.Return(execution, nil)
 
 	hook := agent.executeHook(hookConfig, "check")
 

--- a/testing/mockexecutor/executor.go
+++ b/testing/mockexecutor/executor.go
@@ -2,18 +2,31 @@ package mockexecutor
 
 import (
 	"context"
+	"sync"
 
 	"github.com/sensu/sensu-go/command"
-	"github.com/stretchr/testify/mock"
 )
 
 // MockExecutor ...
 type MockExecutor struct {
-	mock.Mock
+	// Note: this used to use the testify mock.Mock type, but I removed that,
+	// because it was causing race conditions to occur in tests, since the mock
+	// library wanted to inspect fields that were being guarded by mutexes.
+	response *command.ExecutionResponse
+	err      error
+	mu       sync.Mutex
+}
+
+func (e *MockExecutor) Return(r *command.ExecutionResponse, err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.response = r
+	e.err = err
 }
 
 // Execute ...
 func (e *MockExecutor) Execute(ctx context.Context, execution command.ExecutionRequest) (*command.ExecutionResponse, error) {
-	args := e.Called(ctx, execution)
-	return args.Get(0).(*command.ExecutionResponse), args.Error(1)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.response, e.err
 }


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where otherwise-identical proxy checks
would prevent each other from executing, due to a deduplication
check that involved only the check name.
    
The duplicate check execution guard now also takes proxy entity
name into consideration.

## Why is this change necessary?

Closes #2612 

## Does your change need a Changelog entry?

Included

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

These changes bring the proxy check feature in line with what the docs describe.

## Does this change require a new test case?

Added
