### PR TITLE
Avoids configuration requirement while running version command in sen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Removed unused workflow `rel_build_and_test` in CircleCI config.
 
+### Fixed
+- Fixed a bug where `sensuctl version` required configuration files to exist.
+
 ## [5.1.1] - 2019-01-24
 
 ### Added

--- a/cli/commands/version/version.go
+++ b/cli/commands/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 
+	"github.com/sensu/sensu-go/cli/commands/hooks"
 	"github.com/sensu/sensu-go/version"
 	"github.com/spf13/cobra"
 )
@@ -18,6 +19,9 @@ func Command() *cobra.Command {
 				version.BuildSHA,
 				version.BuildDate,
 			)
+		},
+		Annotations: map[string]string{
+			hooks.ConfigurationRequirement: hooks.ConfigurationNotRequired,
 		},
 	}
 }


### PR DESCRIPTION
Avoids configuration requirement while running version command in sensuctl (##2532)

Signed-off-by: Arnaldo Mendonca <arnaldomf@user.noreply.github.com>

## What is this change?

This change fixes a bug where `sensuctl version` requires sensuctl to be configured.


## Why is this change necessary?

Closes [2532](https://github.com/sensu/sensu-go/issues/2532)

## Does your change need a Changelog entry?

Yes, done!

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required.

## Does this change require a new test case?

The unit tests passed either before or after the change. To validate, the tester should remove the `~/.config/sensu/sensuctl` directory before running `sensuctl version`.