### PR TITLE
Fix a bug in keepalived that could result in a crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Check TTL failure events are now much more reliable, and will persist even
 in the presence cluster member failures and cluster restarts.
 - Fix snakeCase version of keys in typeMap for acronyms.
+- Fixed a bug in keepalive processing that could result in a crash.
 
 ## [5.1.1] - 2019-01-24
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -348,7 +348,7 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) {
 	}
 
 	if entity == nil {
-		lager.Error("entity could not be read")
+		lager.Error("entity not found")
 		return
 	}
 
@@ -371,6 +371,10 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) {
 	currentEvent, err := k.store.GetEventByEntityCheck(ctx, name, "keepalive")
 	if err != nil {
 		lager.WithError(err).Error("error while reading event")
+		return
+	}
+	if currentEvent == nil {
+		lager.Error("keepalive event not found")
 		return
 	}
 

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -279,6 +279,9 @@ func TestDeadCallbackNoEntity(t *testing.T) {
 	messageBus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
 		RingGetter: &mockring.Getter{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := messageBus.Start(); err != nil {
 		t.Fatal(err)
 	}
@@ -304,6 +307,9 @@ func TestDeadCallbackNoEvent(t *testing.T) {
 	messageBus, err := messaging.NewWizardBus(messaging.WizardBusConfig{
 		RingGetter: &mockring.Getter{},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := messageBus.Start(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What is this change?

This commit fixes a case in keepalived where the backend could
crash if the system was unable to find an event it expected to be
able to find. Now, if the backend is unable to find the event, an
error is logged and the keepalive processing terminates early.

## Why is this change necessary?

Closes #2638 

## Does this change require a new test case?

Added a unit test and also a testrails QA test.

## Additional information
I made sure the same problem did not exist in eventd for check TTL.
