### PR TITLE
Omit substituted values command & check hook values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ TLS hostname verification.
 in the presence cluster member failures and cluster restarts.
 - Fix snakeCase version of keys in typeMap for acronyms.
 - Pin childprocess to v0.9.0 in CircleCI so fpm can be installed.
+- Substitutions applied to command & hooks are now omitted from events.
 
 ## [5.1.1] - 2019-01-24
 

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -52,7 +52,9 @@ func (a *Agent) handleCheck(payload []byte) error {
 	}
 
 	logger.Info("scheduling check execution: ", checkConfig.Name)
-	go a.executeCheck(request)
+
+	entity := a.getAgentEntity()
+	go a.executeCheck(request, entity)
 
 	return nil
 }
@@ -72,7 +74,7 @@ func checkKey(request *v2.CheckRequest) string {
 	return strings.Join(parts, "/")
 }
 
-func (a *Agent) executeCheck(request *v2.CheckRequest) {
+func (a *Agent) executeCheck(request *v2.CheckRequest, entity *v2.Entity) {
 	a.inProgressMu.Lock()
 	a.inProgress[checkKey(request)] = request.Config
 	a.inProgressMu.Unlock()
@@ -103,7 +105,7 @@ func (a *Agent) executeCheck(request *v2.CheckRequest) {
 	}
 
 	// Prepare Check
-	err := prepareCheck(checkConfig, a.getAgentEntity())
+	err := prepareCheck(checkConfig, entity)
 	if err != nil {
 		a.sendFailure(createEvent(), fmt.Errorf("error preparing check: %s", err))
 		return

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -86,7 +86,7 @@ func (a *Agent) executeCheck(request *v2.CheckRequest) {
 	checkAssets := request.Assets
 	checkHooks := request.Hooks
 
-	// Before token subsitution we retain copies of command and hooks
+	// Before token subsitution we retain copy of the command
 	origCommand := checkConfig.Command
 	createEvent := func() *v2.Event {
 		event := &v2.Event{}

--- a/agent/check_handler_env_test_unix.go
+++ b/agent/check_handler_env_test_unix.go
@@ -25,7 +25,8 @@ func TestEnvVars(t *testing.T) {
 	ch := make(chan *transport.Message, 1)
 	agent.sendq = ch
 
-	agent.executeCheck(request)
+	entity := agent.getAgentEntity()
+	agent.executeCheck(request, entity)
 	msg := <-ch
 	event := &types.Event{}
 	assert.NoError(t, json.Unmarshal(msg.Payload, event))

--- a/agent/check_handler_env_test_windows.go
+++ b/agent/check_handler_env_test_windows.go
@@ -25,7 +25,8 @@ func TestEnvVars(t *testing.T) {
 	ch := make(chan *transport.Message, 1)
 	agent.sendq = ch
 
-	agent.executeCheck(request)
+	entity := agent.getAgentEntity()
+	agent.executeCheck(request, entity)
 	msg := <-ch
 	event := &types.Event{}
 	assert.NoError(t, json.Unmarshal(msg.Payload, event))

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -112,7 +112,8 @@ func TestExecuteCheck(t *testing.T) {
 	execution := command.FixtureExecutionResponse(0, "")
 	ex.Return(execution, nil)
 
-	agent.executeCheck(request)
+	entity := agent.getAgentEntity()
+	agent.executeCheck(request, entity)
 	msg := <-ch
 
 	event := &corev2.Event{}
@@ -122,7 +123,7 @@ func TestExecuteCheck(t *testing.T) {
 	assert.False(event.HasMetrics())
 
 	execution.Status = 1
-	agent.executeCheck(request)
+	agent.executeCheck(request, entity)
 	msg = <-ch
 
 	event = &corev2.Event{}
@@ -133,7 +134,7 @@ func TestExecuteCheck(t *testing.T) {
 
 	execution.Status = 127
 	execution.Output = "command not found"
-	agent.executeCheck(request)
+	agent.executeCheck(request, entity)
 	msg = <-ch
 
 	event = &corev2.Event{}
@@ -145,7 +146,7 @@ func TestExecuteCheck(t *testing.T) {
 
 	execution.Status = 2
 	execution.Output = ""
-	agent.executeCheck(request)
+	agent.executeCheck(request, entity)
 	msg = <-ch
 
 	event = &corev2.Event{}
@@ -158,7 +159,7 @@ func TestExecuteCheck(t *testing.T) {
 	execution.Status = 0
 	execution.Output = "metric.foo 1 123456789\nmetric.bar 2 987654321"
 	ex.Return(execution, nil)
-	agent.executeCheck(request)
+	agent.executeCheck(request, entity)
 	msg = <-ch
 
 	event = &corev2.Event{}
@@ -168,7 +169,7 @@ func TestExecuteCheck(t *testing.T) {
 
 	checkConfig.OutputMetricFormat = corev2.GraphiteOutputMetricFormat
 	ex.Return(execution, nil)
-	agent.executeCheck(request)
+	agent.executeCheck(request, entity)
 	msg = <-ch
 
 	event = &corev2.Event{}

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -265,7 +265,8 @@ func TestPrepareCheck(t *testing.T) {
 	entity.Labels = map[string]string{"foo": "bar"}
 	check := corev2.FixtureCheckConfig("check")
 	check.Command = "echo {{ .labels.foo }}"
-	prepareCheck(check, entity)
+	err := prepareCheck(check, entity)
+	require.NoError(t, err)
 	assert.Equal(t, check.Command, "echo bar")
 }
 

--- a/agent/hook.go
+++ b/agent/hook.go
@@ -22,6 +22,7 @@ func (a *Agent) ExecuteHooks(request *types.CheckRequest, status int) []*types.H
 			// run all the hooks of that type
 			for _, hookName := range hookList.Hooks {
 				hookConfig := getHookConfig(hookName, request.Hooks)
+				origCommand := hookConfig.Command
 				if ok := a.prepareHook(hookConfig); !ok {
 					// An error occured during the preparation of the hook and the error
 					// has been sent back to the server. At this point we should not
@@ -33,6 +34,9 @@ func (a *Agent) ExecuteHooks(request *types.CheckRequest, status int) []*types.H
 				in := hookInList(hookConfig.Name, executedHooks)
 				if !in {
 					hook := a.executeHook(hookConfig, request.Config.Name)
+					// To guard against publishing sensitive/redacted client attribute values
+					// the original command value is reinstated.
+					hook.Command = origCommand
 					executedHooks = append(executedHooks, hook)
 				}
 			}


### PR DESCRIPTION
## What is this change?

To guard against publishing sensitive/redacted client attribute values,
always use the original command and hook values.

Matches functionality in Sensu Classic, see [comment](https://github.com/sensu/sensu/blob/44f58ebdc6881161b34c67feaff572650d0b0ded/lib/sensu/client/process.rb#L172-L174) and [implementation](https://github.com/sensu/sensu/blob/44f58ebdc6881161b34c67feaff572650d0b0ded/lib/sensu/client/process.rb#L185-L186).

## Why is this change necessary?

Closes #2643 

## Does your change need a Changelog entry?

Yeah.

## Do you need clarification on anything?

Nada.

## Were there any complications while making this change?

Hubris.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## Does this change require a new test case?

Maybe!