### PR TITLE
Fix CI failure due to fpm installation

### DIFF
--- a/build/ci/circle-ci-setup.sh
+++ b/build/ci/circle-ci-setup.sh
@@ -10,7 +10,7 @@ set -e
 set -x
 
 apt-get update
-apt-get install -y ruby ruby-dev build-essential rpm rpmlint wget git curl
+apt-get install -y ruby ruby-dev build-essential rpm rpmlint wget git curl gcc
 curl -sL https://deb.nodesource.com/setup_8.x | bash -
 apt-get install -y nodejs
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/build/ci/circle-ci-setup.sh
+++ b/build/ci/circle-ci-setup.sh
@@ -17,5 +17,6 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 apt-get update
 apt-get install yarn
+gem install childprocess -v 0.9.0
 gem install --no-ri --no-rdoc fpm
 apt-get clean

--- a/build/ci/circle-ci-setup.sh
+++ b/build/ci/circle-ci-setup.sh
@@ -17,6 +17,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 apt-get update
 apt-get install yarn
+# See https://github.com/jordansissel/fpm/issues/1592
 gem install childprocess -v 0.9.0
 gem install --no-ri --no-rdoc fpm
 apt-get clean


### PR DESCRIPTION
## What is this change?

It pins childprocess to v0.9.0, due to https://github.com/jordansissel/fpm/issues/1592.

## Why is this change necessary?

So CI does not fail.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## Does this change require a new test case?

Nope!
