### PR TITLE
[Web UI] Add platform version to entity details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ TLS hostname verification.
 - Added a generic watcher in the store.
 - Added `RemoveProvider` method to authenticator.
 - Added ability to silence/unsilence from the event details page.
+- Web UI - platform version displays on the entity details page.
 
 ### Changed
 - Removed unused workflow `rel_build_and_test` in CircleCI config.

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
@@ -173,7 +173,10 @@ class EntityDetailsInformation extends React.PureComponent {
                   <DictionaryValue>
                     <Maybe value={system.platform} fallback="n/a">
                       {() =>
-                        [system.platform, system.platformFamily]
+                        [
+                          `${system.platform} ${system.platformVersion}`,
+                          system.platformFamily,
+                        ]
                           .reduce(
                             (memo, val) => (val ? [...memo, val] : memo),
                             [],


### PR DESCRIPTION
## What is this change?
Closes #2651 
Adds the platform version to the entity details page. 
<img width="1085" alt="screen shot 2019-01-30 at 1 40 08 pm" src="https://user-images.githubusercontent.com/1707663/52014589-c9bedf80-2494-11e9-9800-e4b4c741feef.png">

## Why is this change necessary?
We should show this value. It's also listed on the entity list page.

## Does your change need a Changelog entry?
Added one