### PR TITLE
Non-namespaced resources shouldn't return ErrNamespaceMissing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ in the presence cluster member failures and cluster restarts.
 - Fixed a bug in keepalive processing that could result in a crash.
 - Pin childprocess to v0.9.0 in CircleCI so fpm can be installed.
 - Substitutions applied to command & hooks are now omitted from events.
+- Fixes a bug where generic store methods assumed a namespace was provided for non-namespaced resources.
 
 ### Fixed
 - Fixed a bug where `sensuctl version` required configuration files to exist.

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -56,7 +56,7 @@ func Create(ctx context.Context, client *clientv3.Client, key, namespace string,
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
-		if len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
+		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
 			return &store.ErrNamespaceMissing{Namespace: namespace}
 		}
 
@@ -94,7 +94,15 @@ func CreateOrUpdate(ctx context.Context, client *clientv3.Client, key, namespace
 		return err
 	}
 	if !resp.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: namespace}
+		// Check if the namespace was missing
+		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
+			return &store.ErrNamespaceMissing{Namespace: namespace}
+		}
+
+		// Unknown error
+		return &store.ErrInternal{
+			Message: fmt.Sprintf("could not update the key %s", key),
+		}
 	}
 
 	return nil
@@ -202,7 +210,7 @@ func Update(ctx context.Context, client *clientv3.Client, key, namespace string,
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
-		if len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
+		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
 			return &store.ErrNamespaceMissing{Namespace: namespace}
 		}
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a bug where generic store methods assumed a namespace was provided for non-namespaced resources.

## Why is this change necessary?

Required by sensu-enterprise-go ticket.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## Does this change require a new test case?

We good.