### PR TITLE
Add support for wrapped resources storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,17 @@ TLS hostname verification.
 - Check output truncation support has been added. Check output can be truncated
 by adjusting the max_output_size and discard_output properties.
 - Added ability to silence/unsilence from the event details page.
+- Added support for wrapped resources in the API with `sensuctl create` &
+`sensuctl edit`.
 
 ### Changed
 - Removed unused workflow `rel_build_and_test` in CircleCI config.
 - Moved the `Provider` interface to `api/core/v2` package.
 - Moved the `Authenticator` interface to `backend/authentication` package.
-- Updated confirmation messages for sensuctl commands: `Created`, `Deleted` and `Updated` instead of `OK`.
+- Updated confirmation messages for sensuctl commands: `Created`, `Deleted` and
+`Updated` instead of `OK`.
 - Exported some functions and methods in the CLI client.
+- The API authenticator now identifies providers by their name only.
 
 ### Fixed
 - Check TTL failure events are now much more reliable, and will persist even

--- a/api/core/v2/provider.go
+++ b/api/core/v2/provider.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"context"
-	"fmt"
 )
 
 // AuthProvider represents an abstracted authentication provider
@@ -22,9 +21,4 @@ type AuthProvider interface {
 	URIPath() string
 	// Validate checks if the fields in the provider are valid
 	Validate() error
-}
-
-// AuthProviderID returns a unique identifier for a given auth provider
-func AuthProviderID(p AuthProvider) string {
-	return fmt.Sprintf("%s/%s", p.Type(), p.Name())
 }

--- a/backend/apid/routers/authentication_test.go
+++ b/backend/apid/routers/authentication_test.go
@@ -259,7 +259,7 @@ func TestTokenSuccess(t *testing.T) {
 
 func authenticationRouter(store realStore.Store) *AuthenticationRouter {
 	authenticator := &authentication.Authenticator{}
-	provider := &basic.Provider{Store: store, ObjectMeta: v2.ObjectMeta{Name: "default"}}
+	provider := &basic.Provider{Store: store, ObjectMeta: v2.ObjectMeta{Name: basic.Type}}
 	authenticator.AddProvider(provider)
 	return &AuthenticationRouter{store: store, authenticator: authenticator}
 }

--- a/backend/authentication/authenticator.go
+++ b/backend/authentication/authenticator.go
@@ -75,7 +75,7 @@ func (a *Authenticator) AddProvider(provider corev2.AuthProvider) {
 		a.providers = map[string]corev2.AuthProvider{}
 	}
 
-	a.providers[corev2.AuthProviderID(provider)] = provider
+	a.providers[provider.Name()] = provider
 }
 
 // Providers returns the configured providers
@@ -93,21 +93,21 @@ func (a *Authenticator) Providers() map[string]corev2.AuthProvider {
 	return providers
 }
 
-// RemoveProvider removes the provider with the given ID from the list of
+// RemoveProvider removes the provider with the given name from the list of
 // configued providers
-func (a *Authenticator) RemoveProvider(id string) error {
+func (a *Authenticator) RemoveProvider(name string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if _, ok := a.providers[id]; !ok {
-		return fmt.Errorf("provider %q is not configured, could not remove it", id)
+	if _, ok := a.providers[name]; !ok {
+		return fmt.Errorf("provider %q is not configured, could not remove it", name)
 	}
 
 	// Make sure at least two providers are enabled so there's still one remaining
 	if len(a.providers) == 1 {
-		return fmt.Errorf("provider %q is the only provider configured, could not remove it ", id)
+		return fmt.Errorf("provider %q is the only provider configured, could not remove it ", name)
 	}
 
-	delete(a.providers, id)
+	delete(a.providers, name)
 	return nil
 }

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
@@ -80,11 +79,9 @@ func (p *Provider) Type() string {
 	return Type
 }
 
-// URIPath returns the path component of the basic provider
+// URIPath returns the path component of the basic provider. Not implemented
 func (p *Provider) URIPath() string {
-	return fmt.Sprintf("/api/authentication/v2/auth-providers/%s",
-		url.PathEscape(p.Name()),
-	)
+	return ""
 }
 
 // Validate validates the basic provider configuration

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -82,21 +82,20 @@ func (p *Provider) Type() string {
 
 // URIPath returns the path component of the basic provider
 func (p *Provider) URIPath() string {
-	return fmt.Sprintf("/api/core/v2/auth-providers/%s/%s",
-		url.PathEscape(Type),
+	return fmt.Sprintf("/api/authentication/v2/auth-providers/%s",
 		url.PathEscape(p.Name()),
 	)
 }
 
 // Validate validates the basic provider configuration
 func (p *Provider) Validate() error {
-	//TODO(palourde): Implement this!
+	p.ObjectMeta.Name = Type
 	return nil
 }
 
 func (p *Provider) claims(username string) corev2.AuthProviderClaims {
 	return corev2.AuthProviderClaims{
-		ProviderID: corev2.AuthProviderID(p),
+		ProviderID: p.Name(),
 		UserID:     username,
 	}
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -211,7 +211,7 @@ func Initialize(config *Config) (*Backend, error) {
 	// Prepare the authentication providers
 	authenticator := &authentication.Authenticator{}
 	basic := &basic.Provider{
-		ObjectMeta: v2.ObjectMeta{Name: "default"},
+		ObjectMeta: v2.ObjectMeta{Name: basic.Type},
 		Store:      store,
 	}
 	authenticator.AddProvider(basic)

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -146,12 +146,12 @@ func Get(ctx context.Context, client *clientv3.Client, key string, object interf
 	return nil
 }
 
-// keyBuilderFn represents a generic key builder function
-type keyBuilderFn func(context.Context, string) string
+// KeyBuilderFn represents a generic key builder function
+type KeyBuilderFn func(context.Context, string) string
 
-// list retrieves all keys from storage under the provided prefix key, while
+// List retrieves all keys from storage under the provided prefix key, while
 // supporting all namespaces, and deserialize it into objsPtr.
-func List(ctx context.Context, client *clientv3.Client, keyBuilder keyBuilderFn, objsPtr interface{}) error {
+func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn, objsPtr interface{}) error {
 	// Make sure the interface is a pointer, and that the element at this address
 	// is a slice.
 	v := reflect.ValueOf(objsPtr)

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -71,10 +71,10 @@ func (client *RestClient) PutResource(r types.Wrapper) error {
 	// itself
 	var bytes []byte
 	var err error
-	if r.APIVersion == "enterprise/v2" {
-		bytes, err = json.Marshal(r)
-	} else {
+	if r.APIVersion == "core/v2" {
 		bytes, err = json.Marshal(r.Value)
+	} else {
+		bytes, err = json.Marshal(r)
 	}
 	if err != nil {
 		return err

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -64,13 +64,23 @@ func (client *RestClient) Post(path string, obj interface{}) error {
 }
 
 // PutResource ...
-func (client *RestClient) PutResource(r types.Resource) error {
-	path := r.URIPath()
-	b, err := json.Marshal(r)
+func (client *RestClient) PutResource(r types.Wrapper) error {
+	path := r.Value.URIPath()
+
+	// Determine if we should send the wrapped resource or only the resource
+	// itself
+	var bytes []byte
+	var err error
+	if r.APIVersion == "enterprise/v2" {
+		bytes, err = json.Marshal(r)
+	} else {
+		bytes, err = json.Marshal(r.Value)
+	}
 	if err != nil {
 		return err
 	}
-	res, err := client.R().SetBody(b).Put(path)
+
+	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return fmt.Errorf("PUT %q: %s", path, err)
 	}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -42,7 +42,7 @@ type GenericClient interface {
 	Post(path string, obj interface{}) error
 
 	// PutResource puts a resource according to its URIPath.
-	PutResource(types.Resource) error
+	PutResource(types.Wrapper) error
 }
 
 // AuthenticationAPIClient client methods for authenticating

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -27,7 +27,7 @@ func (c *MockClient) Post(path string, obj interface{}) error {
 }
 
 // PutResource ...
-func (c *MockClient) PutResource(r types.Resource) error {
+func (c *MockClient) PutResource(r types.Wrapper) error {
 	args := c.Called(r)
 	return args.Error(0)
 }

--- a/cli/commands/edit/edit.go
+++ b/cli/commands/edit/edit.go
@@ -102,7 +102,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			if err := create.PutResources(cli.Client, resources); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Updated %s\n", resources[0].URIPath())
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated %s\n", resources[0].Value.URIPath())
 			return nil
 		},
 	}


### PR DESCRIPTION
## What is this change?

This PR adds support for resources stored using the wrapper.

Specifically:
- The API authenticator now identifies providers using their name only
- `sensuctl create` & `sensuctl edit` have been modified so they send resources as `types.Wrapper` to the API for all API groups except `core/v2`, where it still sends `corev2.Resource`.
- It exports `KeyBuilderFn` so it can be re-used in the enterprise store

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/pull/201

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not required for now.

## Does this change require a new test case?

Not yet.
