### PR TITLE
Fix copy displayed when disabling users with sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ in the presence cluster member failures and cluster restarts.
 - Pin childprocess to v0.9.0 in CircleCI so fpm can be installed.
 - Substitutions applied to command & hooks are now omitted from events.
 - Fixes a bug where generic store methods assumed a namespace was provided for non-namespaced resources.
-
-### Fixed
 - Fixed a bug where `sensuctl version` required configuration files to exist.
+- Updates the copy on the confirm disable dialog to accurately reflect the
+operation.
 
 ## [5.1.1] - 2019-01-24
 

--- a/cli/commands/helpers/prompts.go
+++ b/cli/commands/helpers/prompts.go
@@ -1,23 +1,61 @@
 package helpers
 
 import (
+	"fmt"
+
 	"github.com/AlecAivazis/survey"
 	"github.com/sensu/sensu-go/cli/elements/globals"
 )
 
 // ConfirmDelete confirm a deletion operation before it is completed.
 func ConfirmDelete(name string) bool {
-	question := globals.TitleStyle("Are you sure you would like to ") + globals.CTATextStyle("delete") + globals.TitleStyle(" resource '") + globals.PrimaryTextStyle(name) + globals.TitleStyle("'?")
+	confirm := &ConfirmDestructiveOp{
+		Type: "resource",
+		Op:   "delete",
+	}
+	ok, _ := confirm.Ask(name)
+	return ok
+}
 
-	confirmation := false
-	prompt := &survey.Confirm{
+// ConfirmDestructiveOp presents prompt for a destructive operation.
+type ConfirmDestructiveOp struct {
+	Type string
+	Op   string
+}
+
+// Ask presents prompt confirming a destructive operation.
+func (c *ConfirmDestructiveOp) Ask(name string) (bool, error) {
+	question := globals.TitleStyle("Are you sure you would like to ") +
+		globals.CTATextStyle(c.Op) +
+		globals.TitleStyle(fmt.Sprintf(" %s '", c.Type)) +
+		globals.PrimaryTextStyle(name) +
+		globals.TitleStyle("'?")
+
+	confirm := &Confirm{
 		Message: question,
 		Default: false,
 	}
-	err := survey.AskOne(prompt, &confirmation, nil)
-	if err != nil {
-		return false
+	return confirm.Ask()
+}
+
+// Confirm an operation before it is completed
+type Confirm struct {
+	Message string
+	Default bool
+}
+
+// Ask executes confirmation of operation
+func (c *Confirm) Ask() (bool, error) {
+	prompt := &survey.Confirm{
+		Message: c.Message,
+		Default: c.Default,
 	}
 
-	return confirmation
+	confirmation := false
+	err := survey.AskOne(prompt, &confirmation, nil)
+	if err != nil {
+		return false, err
+	}
+
+	return confirmation, nil
 }

--- a/cli/commands/user/delete.go
+++ b/cli/commands/user/delete.go
@@ -24,7 +24,8 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 
 			username := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(username); !confirmed {
+				dialog := helpers.ConfirmDestructiveOp{Op: "disable", Type: "user"}
+				if ok, err := dialog.Ask(username); !ok || err != nil {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}


### PR DESCRIPTION
## What is this change?

Fixes copy displayed to user when attempting to disable another user with `sensuctl`.

## Why is this change necessary?

Closes #2677 

## Does your change need a Changelog entry?

Why not.

## Do you need clarification on anything?

no.

## Were there any complications while making this change?

not really.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

no changes required.

## Does this change require a new test case?

unlikely.