### PR TITLE
[Web UI] Reflect deregistration configuration on entity details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ by adjusting the max_output_size and discard_output properties.
 - Added support for wrapped resources in the API with `sensuctl create` &
 `sensuctl edit`.
 - Web UI - platform version displays on the entity details page.
+- Web UI - display deregistration config on the entity details page.
 
 ### Changed
 - Removed unused workflow `rel_build_and_test` in CircleCI config.

--- a/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
+++ b/dashboard/src/components/partials/EntityDetailsContainer/EntityDetailsInformation.js
@@ -17,8 +17,6 @@ import Dictionary, {
 import List from "@material-ui/core/List";
 import ListItem, { ListItemTitle } from "/components/DetailedListItem";
 import Maybe from "/components/Maybe";
-import CodeBlock from "/components/CodeBlock";
-import CodeHighlight from "/components/CodeHighlight/CodeHighlight";
 import { RelativeToCurrentDate } from "/components/RelativeDate";
 import StatusIcon from "/components/CheckStatusIcon";
 import SilencedIcon from "/icons/Silence";
@@ -50,7 +48,6 @@ class EntityDetailsInformation extends React.PureComponent {
         }
         user
         redact
-        extendedAttributes
         deregister
         deregistration {
           handler
@@ -127,12 +124,6 @@ class EntityDetailsInformation extends React.PureComponent {
                   </DictionaryValue>
                 </DictionaryEntry>
                 <DictionaryEntry>
-                  <DictionaryKey>User</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={entity.user} fallback="n/a" />
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
                   <DictionaryKey>Subscriptions</DictionaryKey>
                   <DictionaryValue>
                     {entity.subscriptions.length > 0 ? (
@@ -153,6 +144,51 @@ class EntityDetailsInformation extends React.PureComponent {
             <Grid item xs={12} sm={6}>
               <Dictionary>
                 <DictionaryEntry>
+                  <DictionaryKey>User</DictionaryKey>
+                  <DictionaryValue>
+                    <Maybe value={entity.user} fallback="—" />
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Deregister</DictionaryKey>
+                  <DictionaryValue>
+                    {entity.deregister ? "yes" : "no"}
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Deregistration Handler</DictionaryKey>
+                  <DictionaryValue>
+                    <Maybe value={system.deregistration} fallback="—">
+                      {config => config.handler}
+                    </Maybe>
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Redacted Keys</DictionaryKey>
+                  <DictionaryValue>
+                    {entity.redact.length > 0 ? (
+                      <List disablePadding>
+                        {entity.redact.map(key => (
+                          <ListItem key={key}>
+                            <ListItemTitle>{key}</ListItemTitle>
+                          </ListItem>
+                        ))}
+                      </List>
+                    ) : (
+                      "—"
+                    )}
+                  </DictionaryValue>
+                </DictionaryEntry>
+              </Dictionary>
+            </Grid>
+          </Grid>
+        </CardContent>
+        <Divider />
+        <CardContent>
+          <Grid container spacing={0}>
+            <Grid item xs={12} sm={6}>
+              <Dictionary>
+                <DictionaryEntry>
                   <DictionaryKey>Class</DictionaryKey>
                   <DictionaryValue>{entity.entityClass}</DictionaryValue>
                 </DictionaryEntry>
@@ -162,6 +198,10 @@ class EntityDetailsInformation extends React.PureComponent {
                     <Maybe value={system.hostname} fallback="n/a" />
                   </DictionaryValue>
                 </DictionaryEntry>
+              </Dictionary>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Dictionary>
                 <DictionaryEntry>
                   <DictionaryKey>OS</DictionaryKey>
                   <DictionaryValue>
@@ -209,7 +249,7 @@ class EntityDetailsInformation extends React.PureComponent {
                   <Grid item xs={12} sm={6} key={intr.name}>
                     <Dictionary>
                       <DictionaryEntry>
-                        <DictionaryKey>&nbsp;</DictionaryKey>
+                        <DictionaryKey>Adapter</DictionaryKey>
                         <DictionaryValue>
                           <Strong>{intr.name}</Strong>
                         </DictionaryValue>
@@ -234,20 +274,6 @@ class EntityDetailsInformation extends React.PureComponent {
             )}
           </Grid>
         </CardContent>
-        {Object.keys(entity.extendedAttributes).length > 0 && (
-          <React.Fragment>
-            <Divider />
-            <CodeBlock>
-              <CardContent>
-                <CodeHighlight
-                  language="json"
-                  code={JSON.stringify(entity.extendedAttributes, null, "\t")}
-                  component="code"
-                />
-              </CardContent>
-            </CodeBlock>
-          </React.Fragment>
-        )}
       </Card>
     );
   }


### PR DESCRIPTION
## What is this change?

Reflect deregistration configuration on entity details.

![screen shot 2019-02-05 at 11 27 37 am](https://user-images.githubusercontent.com/194892/52299095-7091f880-2939-11e9-9e0d-ad781e93b5b1.png)

## Why is this change necessary?

Closes #2669 

## Does your change need a Changelog entry?

oui

## Do you need clarification on anything?

non

## Were there any complications while making this change?

non

## Have you reviewed and updated the documentation for this change? Is new documentation required?

non

## Does this change require a new test case?

non