### PR TITLE
Ensure dead entities are buried when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ in the presence cluster member failures and cluster restarts.
 - Pin childprocess to v0.9.0 in CircleCI so fpm can be installed.
 - Substitutions applied to command & hooks are now omitted from events.
 - Fixes a bug where generic store methods assumed a namespace was provided for non-namespaced resources.
+- Keepalive and check TTL database state is now properly garbage-collected on
+entity deletion.
 
 ### Fixed
 - Fixed a bug where `sensuctl version` required configuration files to exist.

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
 	"github.com/sensu/sensu-go/testing/mockring"
+	otherTestutil "github.com/sensu/sensu-go/testing/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,6 +75,12 @@ func TestEventdMonitor(t *testing.T) {
 	event := corev2.FixtureEvent("entity1", "check1")
 	event.Check.Interval = 1
 	event.Check.Ttl = 5
+
+	ctx := otherTestutil.ContextWithNamespace("default")(context.Background())
+
+	if err := store.UpdateEntity(ctx, event.Entity); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := bus.Publish(messaging.TopicEventRaw, event); err != nil {
 		assert.FailNow(t, "failed to publish event to TopicEventRaw")


### PR DESCRIPTION
## What is this change?

This commit fixes bugs in keepalived and eventd, where entities
that have been removed by the user will continue to be partially
registered.

This had the effect of using up extra space in etcd, and writing
out extra logs, but was otherwise inconsequential.

## Why is this change necessary?

Closes #2682 

## Does your change need a Changelog entry?

Added

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required.

## Does this change require a new test case?

Test case added.