### PR TITLE
closes #2657 - strengthen our TLS security posture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ gcs-service-account.json
 *.wixpdb
 *.msi
 version-bin
+
+# editors
+.idea

--- a/CHANGELOGS/unreleased/2700-strengthen_TLS_security_posture.md
+++ b/CHANGELOGS/unreleased/2700-strengthen_TLS_security_posture.md
@@ -1,0 +1,6 @@
+- fixed all known TLS vulnerabilities affecting the backend server:
+    - TLS min version increased to 1.2
+    - Removed ALL but perfect-forward-secrecy ciphers
+- removed requirement of specifying `--trusted-ca-file` when using TLS on backend
+- prevented backend from loading server TLS configuration for http client
+- enforced uniform TLS configuration for all three backend components (apid, agentd, dashboardd)

--- a/api/core/v2/tls.go
+++ b/api/core/v2/tls.go
@@ -37,9 +37,8 @@ var (
 // ToServerTLSConfig should only be used for server TLS configuration. outputs a tls.Config from TLSOptions
 func (t *TLSOptions) ToServerTLSConfig() (*tls.Config, error) {
 	cfg := tls.Config{}
-
-	if t.CertFile != "" || t.KeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+	if t.GetCertFile() != "" && t.GetKeyFile() != "" {
+		cert, err := tls.LoadX509KeyPair(t.GetCertFile(), t.GetKeyFile())
 		if err != nil {
 			return nil, fmt.Errorf("Error loading tls server certificate: %s", err)
 		}
@@ -70,15 +69,12 @@ func (t *TLSOptions) ToClientTLSConfig() (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		// TODO(gbolo): we need an option to first load the system root CAs, then append the user specified CA(s).
-		// In this current form, our client will ONLY trust the specified CA(s).
-		// This may be desired by the user, but if this client config is used for a variety of endpoints,
-		// then perhaps the user should decide if they want system roots enabled or not.
+		// client trust store should ONLY consist of specified CAs
 		cfg.RootCAs = caCertPool
 	}
 
-	if t.CertFile != "" || t.KeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+	if t.GetCertFile() != "" && t.GetKeyFile() != "" {
+		cert, err := tls.LoadX509KeyPair(t.GetCertFile(), t.GetKeyFile())
 		if err != nil {
 			return nil, fmt.Errorf("Error loading tls client certificate: %s", err)
 		}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -81,9 +81,15 @@ func New(c Config, opts ...Option) (*APId, error) {
 			return nil, err
 		}
 
-		// TODO(palourde): We should avoid using the loopback interface
-		c.TLS.InsecureSkipVerify = true
-		tlsClientConfig, err = c.TLS.ToClientTLSConfig()
+		// TODO(gbolo): since the backend does not yet support mutual TLS
+		// this client does not need a cert and key. Once we do support
+		// mutual TLS we need new options for client cert and key
+		cTLSOptions := types.TLSOptions{
+			TrustedCAFile: c.TLS.TrustedCAFile,
+			// TODO(palourde): We should avoid using the loopback interface
+			InsecureSkipVerify: true,
+		}
+		tlsClientConfig, err = cTLSOptions.ToClientTLSConfig()
 		if err != nil {
 			return nil, err
 		}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -73,6 +73,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		Authenticator:       c.Authenticator,
 	}
 
+	// prepare TLS configs (both server and client)
 	var tlsServerConfig, tlsClientConfig *tls.Config
 	var err error
 	if c.TLS != nil {

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -96,6 +96,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		Handler:      router,
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
+		TLSConfig:    tlsConfig,
 	}
 
 	for _, o := range opts {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -172,8 +172,11 @@ func newStartCommand() *cobra.Command {
 			// Sensu APIs TLS config
 			certFile := viper.GetString(flagCertFile)
 			keyFile := viper.GetString(flagKeyFile)
-			trustedCAFile := viper.GetString(flagTrustedCAFile)
 			insecureSkipTLSVerify := viper.GetBool(flagInsecureSkipTLSVerify)
+			// TODO(gbolo): trustedCAFile will be useful in the future when TLS mutual auth is supported.
+			// Not used for backend right now, but leaving it here for now since it appears
+			// that it is being used for etcd client config
+			trustedCAFile := viper.GetString(flagTrustedCAFile)
 
 			if certFile != "" && keyFile != "" {
 				cfg.TLS = &types.TLSOptions{
@@ -181,18 +184,6 @@ func newStartCommand() *cobra.Command {
 					KeyFile:            keyFile,
 					TrustedCAFile:      trustedCAFile,
 					InsecureSkipVerify: insecureSkipTLSVerify,
-				}
-			} else if certFile != "" || keyFile != "" || trustedCAFile != "" {
-				emptyFlags := []string{}
-				if certFile == "" {
-					emptyFlags = append(emptyFlags, flagCertFile)
-				}
-				if keyFile == "" {
-					emptyFlags = append(emptyFlags, flagKeyFile)
-				}
-
-				if len(emptyFlags) > 0 {
-					return fmt.Errorf("missing the following cert flags: %s", emptyFlags)
 				}
 			}
 
@@ -298,7 +289,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")
 	cmd.Flags().String(flagCertFile, viper.GetString(flagCertFile), "TLS certificate in PEM format")
 	cmd.Flags().String(flagKeyFile, viper.GetString(flagKeyFile), "TLS certificate key in PEM format")
-	cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format")
+	cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format used for etcd client (mutual TLS)")
 	cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
 	cmd.Flags().Bool(flagDebug, false, "enable debugging and profiling features")
 	cmd.Flags().String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug]")

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -173,9 +173,8 @@ func newStartCommand() *cobra.Command {
 			certFile := viper.GetString(flagCertFile)
 			keyFile := viper.GetString(flagKeyFile)
 			insecureSkipTLSVerify := viper.GetBool(flagInsecureSkipTLSVerify)
-			// TODO(gbolo): trustedCAFile will be useful in the future when TLS mutual auth is supported.
-			// Not used for backend right now, but leaving it here for now since it appears
-			// that it is being used for etcd client config
+			// TODO(ccressent gbolo): issue #2548
+			// Eventually this should be changed: --insecure-skip-tls-verify --etcd-insecure-skip-tls-verify
 			trustedCAFile := viper.GetString(flagTrustedCAFile)
 
 			if certFile != "" && keyFile != "" {
@@ -185,6 +184,10 @@ func newStartCommand() *cobra.Command {
 					TrustedCAFile:      trustedCAFile,
 					InsecureSkipVerify: insecureSkipTLSVerify,
 				}
+			} else if certFile == "" && keyFile != "" {
+				return fmt.Errorf("tls configuration error, missing flag: --%s", flagCertFile)
+			} else if certFile != "" && keyFile == "" {
+				return fmt.Errorf("tls configuration error, missing flag: --%s", flagKeyFile)
 			}
 
 			// Etcd TLS config

--- a/backend/dashboardd/dashboardd.go
+++ b/backend/dashboardd/dashboardd.go
@@ -218,7 +218,7 @@ func newBackendProxy(APIURL string, TLS *types.TLSOptions) (*httputil.ReversePro
 
 	// Configure TLS
 	if TLS != nil {
-		cfg, err := TLS.ToTLSConfig()
+		cfg, err := TLS.ToServerTLSConfig()
 		if err != nil {
 			return nil, err
 		}

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -207,7 +207,7 @@ func (e *Etcd) NewClient() (*clientv3.Client, error) {
 	}
 
 	// Translate our TLS options to a *tls.Config
-	tlsConfig, err := tlsOptions.ToTLSClientConfig()
+	tlsConfig, err := tlsOptions.ToClientTLSConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/transport/client.go
+++ b/transport/client.go
@@ -21,7 +21,7 @@ func connect(wsServerURL string, tlsOpts *types.TLSOptions, requestHeader http.H
 	dialer := websocket.DefaultDialer
 
 	if tlsOpts != nil {
-		dialer.TLSClientConfig, err = tlsOpts.ToTLSClientConfig()
+		dialer.TLSClientConfig, err = tlsOpts.ToClientTLSConfig()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What is this change?

Enforces stronger TLS settings

## Why is this change necessary?

To mitigate known TLS vulnerabilities. The existing TLS settings were affected by:
```
LUCKY13 (CVE-2013-0169)  - uses cipher block chaining (CBC) ciphers with TLS.
SWEET32 (CVE-2016-2183, CVE-2016-6329)  - VULNERABLE, uses 64 bit block ciphers
BEAST (CVE-2011-3389) - TLS1: ECDHE-RSA-AES128-SHA
                          ECDHE-RSA-AES256-SHA
                          AES128-SHA AES256-SHA
                          ECDHE-RSA-DES-CBC3-SHA
                          DES-CBC3-SHA 
```

## Does your change need a Changelog entry?

it's transparent (app functionality is no changed), but perhaps it should be mentioned?

## Do you need clarification on anything?

no, but if a reviewer is not super familiar with TLS, I offer the explanation(s) below:
- min version of TLS 1.2 is being offered in order to ONLY support the best possible ciphers
- `DefaultCipherSuites` was modified to remove CBC ciphers and non-TLS_1.2 ciphers. This list now ONLY includes *(perfect) forward secrecy* ciphers
- `tlsCurvePreferences` was added to prefer EC curve X25519. this is an opensource curve with no NSA involvement.
- `+build go1.8` was added to prevent older go versions from attempting to compile this package (since some curves and ciphers are not available in previous versions)

## Were there any complications while making this change?

no

## Have you reviewed and updated the documentation for this change? Is new documentation required?

no changes to doc required

## Does this change require a new test case?

probably not
