### PR TITLE
Add handlers to v1.CheckResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Check results sent via the agent socket now support handlers.
+
 ## [5.2.0] - 2019-02-06
 
 ### Added

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -1,7 +1,7 @@
 package agent
 
 import (
-	"time"
+	time "github.com/echlebek/timeproxy"
 
 	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"

--- a/agent/entity_test.go
+++ b/agent/entity_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
@@ -38,7 +37,6 @@ func TestGetAgentEntity(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.agent.systemInfo = &types.System{}
-			tc.agent.systemInfoMu = &sync.RWMutex{}
 
 			entity := tc.agent.getAgentEntity()
 			assert.Equal(tc.expectedAgentName, entity.Name)
@@ -83,7 +81,6 @@ func TestGetEntities(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.agent.systemInfo = &types.System{}
-			tc.agent.systemInfoMu = &sync.RWMutex{}
 
 			tc.agent.getEntities(tc.event)
 			assert.Equal(tc.expectedAgentName, tc.event.Entity.Name)

--- a/agent/event.go
+++ b/agent/event.go
@@ -2,7 +2,8 @@ package agent
 
 import (
 	"fmt"
-	"time"
+
+	time "github.com/echlebek/timeproxy"
 
 	"github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types/v1"
@@ -73,6 +74,11 @@ func translateToEvent(a *Agent, result v1.CheckResult, event *v2.Event) error {
 		}
 	}
 
+	handlers := result.Handlers
+	if len(handlers) == 0 && result.Handler != "" {
+		handlers = append(handlers, result.Handler)
+	}
+
 	check := &v2.Check{
 		ObjectMeta:    v2.NewObjectMeta(result.Name, agentEntity.Namespace),
 		Status:        result.Status,
@@ -83,6 +89,7 @@ func translateToEvent(a *Agent, result v1.CheckResult, event *v2.Event) error {
 		Executed:      result.Executed,
 		Duration:      result.Duration,
 		Output:        result.Output,
+		Handlers:      handlers,
 	}
 
 	// add config and check values to the 2.x event

--- a/agent/event_test.go
+++ b/agent/event_test.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	time "github.com/echlebek/timeproxy"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types/v1"
+)
+
+func TestTranslateToEvent(t *testing.T) {
+	agent := &Agent{
+		config: &Config{
+			AgentName:     "test-agent",
+			Namespace:     "test-namespace",
+			Subscriptions: []string{"default"},
+			User:          "test-user",
+		},
+		systemInfo: &corev2.System{},
+	}
+	tests := []struct {
+		Name      string
+		Input     string
+		ExpOutput *corev2.Event
+		ExpError  bool
+	}{
+		{
+			Name:  "check from docs",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handlers": ["slack"]}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "test-agent",
+						Namespace: "test-namespace",
+					},
+					EntityClass:   corev2.EntityAgentClass,
+					Subscriptions: []string{"default"},
+					User:          "test-user",
+					LastSeen:      time.Now().Unix(),
+				},
+			},
+		},
+		{
+			Name:  "check with client",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handlers": ["slack"], "client": "foobar"}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "foobar",
+						Namespace: "test-namespace",
+					},
+					EntityClass: corev2.EntityProxyClass,
+				},
+			},
+		},
+		{
+			Name:  "check with deprecated handler attr",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "slack", "client": "foobar"}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "foobar",
+						Namespace: "test-namespace",
+					},
+					EntityClass: corev2.EntityProxyClass,
+				},
+			},
+		},
+		{
+			Name:  "check with deprecated handler attr and new handlers attr",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "foobar",
+						Namespace: "test-namespace",
+					},
+					EntityClass: corev2.EntityProxyClass,
+				},
+			},
+		},
+		{
+			Name:     "missing name",
+			Input:    `{"output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			ExpError: true,
+		},
+		{
+			Name:     "missing output",
+			Input:    `{"name": "check-mysql-status", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			ExpError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var result v1.CheckResult
+			if err := json.Unmarshal([]byte(test.Input), &result); err != nil {
+				t.Fatal(err)
+			}
+			event := &corev2.Event{}
+			err := translateToEvent(agent, result, event)
+			if got, want := (err != nil), test.ExpError; got != want {
+				if !want {
+					t.Fatal(err)
+				}
+				t.Error("expected non-nil error")
+			}
+
+			if err != nil {
+				return
+			}
+
+			if got, want := fmt.Sprintf("%v", event), fmt.Sprintf("%v", test.ExpOutput); got != want {
+				t.Errorf("bad output: got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/agent/timeproxy_test.go
+++ b/agent/timeproxy_test.go
@@ -5,7 +5,7 @@ import (
 	time "github.com/echlebek/timeproxy"
 )
 
-var mockTime = crock.NewTime(time.Unix(0, 0))
+var mockTime = crock.NewTime(time.Unix(1257894000, 0))
 
 func init() {
 	// Resolution and Multiplier make the mock time advance every `Resolution`

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -3,10 +3,11 @@ package v2
 import (
 	"errors"
 	fmt "fmt"
-	stringsutil "github.com/sensu/sensu-go/util/strings"
 	"net/url"
 	"sort"
 	"time"
+
+	stringsutil "github.com/sensu/sensu-go/util/strings"
 )
 
 // EventFailingState indicates failing check result status

--- a/types/v1/check.go
+++ b/types/v1/check.go
@@ -1,6 +1,8 @@
 package v1
 
 // CheckResult contains the 1.x compatible check result payload
+// This is a subset of 1.x attributes, see:
+// https://docs.sensu.io/sensu-core/1.6/reference/checks/#check-attributes
 type CheckResult struct {
 	Client      string   `json:"client"`
 	Status      uint32   `json:"status"`
@@ -12,4 +14,10 @@ type CheckResult struct {
 	Executed    int64    `json:"executed"`
 	Duration    float64  `json:"duration"`
 	Output      string   `json:"output"`
+
+	// Handler is deprecated but still supported
+	Handler string `json:"handler"`
+
+	// Handlers supercedes Handler
+	Handlers []string `json:"handlers"`
 }


### PR DESCRIPTION
## What is this change?

This commit adds the Handlers field to v1.CheckResult, bringing us
in line with 1.x behaviour for the client socket.

The commit also cleans up a bit of the agent package, by avoiding
the use of pointers for concurrency primitives in the Agent type.
This makes it easier to write tests that rely on the Agent, since
people won't forget to initialize mutexes and waitgroups.

Finally, the use of timeproxy in the tests has been adjusted to
use a non-zero unix time.

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

Closes #2691

## Does your change need a Changelog entry?

Added

## Were there any complications while making this change?

There were no existing unit tests for the function that converts v1.CheckResult to v2.Event.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I've filed an issue for sensu-docs to clarify the intent of the socket feature.

## Does this change require a new test case?

I added several test cases, and I also did QA to make sure that handlers execute when events are sent via the agent socket.