### PR TITLE
fixes #2659 - persist Trusted-CA-File to config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- `sensuctl configure` now persists the value of the flag `--trusted-ca-file` to configuration on disk.
+
 ## [5.2.0] - 2019-02-06
 
 ### Added

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -10,6 +10,11 @@ func (c *Config) APIUrl() string {
 	return c.Cluster.APIUrl
 }
 
+// CAFile returns the trusted CA File
+func (c *Config) CAFile() string {
+	return c.Cluster.TrustedCAFile
+}
+
 // Edition returns the active cluster edition. Defaults to core
 func (c *Config) Edition() string {
 	if c.Cluster.Edition == "" {

--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -16,6 +16,13 @@ func (c *Config) SaveAPIUrl(url string) error {
 	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }
 
+// SaveCAFile saves the Trusted CA File into a configuration file
+func (c *Config) SaveCAFile(CAFile string) error {
+	c.Cluster.TrustedCAFile = CAFile
+
+	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
+}
+
 // SaveEdition saves the Sensu edition to a configuration file
 func (c *Config) SaveEdition(edition string) error {
 	c.Cluster.Edition = edition

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -37,6 +37,7 @@ type Config interface {
 // Read contains all methods related to reading configuration
 type Read interface {
 	APIUrl() string
+	CAFile() string
 	Edition() string
 	Format() string
 	Namespace() string
@@ -46,6 +47,7 @@ type Read interface {
 // Write contains all methods related to setting and writting configuration
 type Write interface {
 	SaveAPIUrl(string) error
+	SaveCAFile(string) error
 	SaveEdition(string) error
 	SaveFormat(string) error
 	SaveNamespace(string) error

--- a/cli/client/config/inmemory/inmemory.go
+++ b/cli/client/config/inmemory/inmemory.go
@@ -8,6 +8,7 @@ import (
 // Config describes details associated with making requests
 type Config struct {
 	url       string
+	cafile    string
 	edition   string
 	format    string
 	namespace string
@@ -18,6 +19,7 @@ type Config struct {
 func New(url string) *Config {
 	config := Config{
 		url:       url,
+		cafile:    "",
 		edition:   config.DefaultEdition,
 		format:    config.FormatJSON,
 		namespace: config.DefaultNamespace,
@@ -29,6 +31,11 @@ func New(url string) *Config {
 // APIUrl describes the URL where the API can be found
 func (c *Config) APIUrl() string {
 	return c.url
+}
+
+// CAFile describes the location of Trusted CA File
+func (c *Config) CAFile() string {
+	return c.cafile
 }
 
 // Edition describes the edition of the Sensu product
@@ -54,6 +61,12 @@ func (c *Config) Tokens() *types.Tokens {
 // SaveAPIUrl updates the current value
 func (c *Config) SaveAPIUrl(val string) error {
 	c.url = val
+	return nil
+}
+
+// SaveCAFile updates the current value
+func (c *Config) SaveCAFile(val string) error {
+	c.cafile = val
 	return nil
 }
 

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -19,6 +19,12 @@ func (m *MockConfig) APIUrl() string {
 	return args.String(0)
 }
 
+// CAFile mocks the Trusted-CA-File config
+func (m *MockConfig) CAFile() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // Edition mocks the cluster edition
 func (m *MockConfig) Edition() string {
 	args := m.Called()
@@ -40,6 +46,12 @@ func (m *MockConfig) Namespace() string {
 // SaveAPIUrl mocks saving the API URL
 func (m *MockConfig) SaveAPIUrl(url string) error {
 	args := m.Called(url)
+	return args.Error(0)
+}
+
+// SaveCAFile mocks saving the Trusted-CA-File
+func (m *MockConfig) SaveCAFile(CAFile string) error {
+	args := m.Called(CAFile)
 	return args.Error(0)
 }
 

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/AlecAivazis/survey"
 	"github.com/sensu/sensu-go/cli"
-	config "github.com/sensu/sensu-go/cli/client/config"
-	hooks "github.com/sensu/sensu-go/cli/commands/hooks"
+	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/cli/commands/hooks"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -60,6 +60,15 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 
 			// Write new API URL to disk
 			if err = cli.Config.SaveAPIUrl(answers.URL); err != nil {
+				fmt.Fprintln(cmd.OutOrStderr())
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
+			// Write Trusted CA File to disk
+			if err = cli.Config.SaveCAFile(cli.Config.CAFile()); err != nil {
 				fmt.Fprintln(cmd.OutOrStderr())
 				return fmt.Errorf(
 					"unable to write new configuration file with error: %s",

--- a/cli/commands/configure/configure_test.go
+++ b/cli/commands/configure/configure_test.go
@@ -21,6 +21,7 @@ func TestCommand(t *testing.T) {
 	mockConfig := cli.Config.(*client.MockConfig)
 	mockConfig.On("Format").Return(config.DefaultFormat)
 	mockConfig.On("APIUrl").Return("http://127.0.0.1:8080")
+	mockConfig.On("CAFile").Return("")
 
 	cmd := Command(cli)
 
@@ -37,8 +38,10 @@ func TestCommandRunEClosureWithFlags(t *testing.T) {
 	mockClient := cli.Client.(*client.MockClient)
 	mockConfig := cli.Config.(*client.MockConfig)
 	mockConfig.On("APIUrl").Return("http://127.0.0.1:8080")
+	mockConfig.On("CAFile").Return("")
 	mockConfig.On("Format").Return(config.DefaultFormat)
 	mockConfig.On("SaveAPIUrl", mock.Anything).Return(nil)
+	mockConfig.On("SaveCAFile", mock.Anything).Return(nil)
 	mockClient.On("CreateAccessToken", mock.Anything, mock.Anything, mock.Anything).Return(&types.Tokens{}, nil)
 	mockConfig.On("SaveTokens", mock.Anything).Return(nil)
 	mockConfig.On("SaveFormat", mock.Anything).Return(nil)


### PR DESCRIPTION
sensuctl configure now persists the value of the flag
--trusted-ca-file to configuration on disk.

Signed-off-by: gbolo <george.bolo@gmail.com>

## What is this change? Why is this change necessary?

see #2659 

## Does your change need a Changelog entry?

yes, already included in PR

## Do you need clarification on anything?

do we want to ask for this during interactive configuration? I assumed no.


## Were there any complications while making this change?

not really

## Have you reviewed and updated the documentation for this change? Is new documentation required?

not yet

## Does this change require a new test case?

test case was updated with new methods
