### PR TITLE
closes #2642 separate TLS config for dashboard

### DIFF
--- a/CHANGELOGS/unreleased/2722-seperate_TLS_config_for_dashboard.md
+++ b/CHANGELOGS/unreleased/2722-seperate_TLS_config_for_dashboard.md
@@ -1,0 +1,3 @@
+- adds two new flags for `backend` daemon to optionally allow for seperate TLS cert/key for dashboard.
+  the flags are: `--dashboard-cert-file` and `dashboard-key-file`.
+  The dashboard will use the same TLS config of the API unless these new flags are specified.

--- a/CHANGELOGS/unreleased/2722-seperate_TLS_config_for_dashboard.md
+++ b/CHANGELOGS/unreleased/2722-seperate_TLS_config_for_dashboard.md
@@ -1,3 +1,3 @@
-- adds two new flags for `backend` daemon to optionally allow for seperate TLS cert/key for dashboard.
-  the flags are: `--dashboard-cert-file` and `dashboard-key-file`.
+- adds two new flags for `backend` daemon to optionally allow for separate TLS cert/key for dashboard.
+  the flags are: `--dashboard-cert-file` and `--dashboard-key-file`.
   The dashboard will use the same TLS config of the API unless these new flags are specified.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -250,10 +250,6 @@ func Initialize(config *Config) (*Backend, error) {
 			dashboardTLSConfig.CertFile = config.DashboardTLSCertFile
 			dashboardTLSConfig.KeyFile = config.DashboardTLSKeyFile
 		}
-	} else {
-		// important for this to be nil, since there's
-		// a nil check on dashboardd Start()
-		dashboardTLSConfig = nil
 	}
 	dashboard, err := dashboardd.New(dashboardd.Config{
 		APIURL: config.APIURL,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -234,21 +234,20 @@ func Initialize(config *Config) (*Backend, error) {
 	}
 	b.Daemons = append(b.Daemons, api)
 
-	// Initialize dashboardd
+	// Initialize dashboardd TLS config
 	var dashboardTLSConfig *types.TLSOptions
-	if config.TLS != nil {
-		// dashboardd TLS config defaults to the same as the apid
-		dashboardTLSConfig = &types.TLSOptions{
-			CertFile:           config.TLS.GetCertFile(),
-			KeyFile:            config.TLS.GetKeyFile(),
-			TrustedCAFile:      config.TLS.GetTrustedCAFile(),
-			InsecureSkipVerify: config.TLS.GetInsecureSkipVerify(),
-		}
 
-		// override the TLS cert/key if user specified them
-		if config.DashboardTLSCertFile != "" && config.DashboardTLSKeyFile != "" {
-			dashboardTLSConfig.CertFile = config.DashboardTLSCertFile
-			dashboardTLSConfig.KeyFile = config.DashboardTLSKeyFile
+	// Always use dashboard tls options when they are specified
+	if config.DashboardTLSCertFile != "" && config.DashboardTLSKeyFile != "" {
+		dashboardTLSConfig = &types.TLSOptions{
+			CertFile: config.DashboardTLSCertFile,
+			KeyFile:  config.DashboardTLSKeyFile,
+		}
+	} else if config.TLS != nil {
+		// use apid tls config if no dashboard tls options are specified
+		dashboardTLSConfig = &types.TLSOptions{
+			CertFile: config.TLS.GetCertFile(),
+			KeyFile:  config.TLS.GetKeyFile(),
 		}
 	}
 	dashboard, err := dashboardd.New(dashboardd.Config{

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -32,6 +32,8 @@ const (
 	flagAPIURL                = "api-url"
 	flagDashboardHost         = "dashboard-host"
 	flagDashboardPort         = "dashboard-port"
+	flagDashboardCertFile     = "dashboard-cert-file"
+	flagDashboardKeyFile      = "dashboard-key-file"
 	flagDeregistrationHandler = "deregistration-handler"
 	flagCacheDir              = "cache-dir"
 	flagStateDir              = "state-dir"
@@ -154,6 +156,8 @@ func newStartCommand() *cobra.Command {
 				APIURL:                viper.GetString(flagAPIURL),
 				DashboardHost:         viper.GetString(flagDashboardHost),
 				DashboardPort:         viper.GetInt(flagDashboardPort),
+				DashboardTLSCertFile:  viper.GetString(flagDashboardCertFile),
+				DashboardTLSKeyFile:   viper.GetString(flagDashboardKeyFile),
 				DeregistrationHandler: viper.GetString(flagDeregistrationHandler),
 				CacheDir:              viper.GetString(flagCacheDir),
 				StateDir:              viper.GetString(flagStateDir),
@@ -256,6 +260,8 @@ func newStartCommand() *cobra.Command {
 	viper.SetDefault(flagAPIURL, "http://localhost:8080")
 	viper.SetDefault(flagDashboardHost, "[::]")
 	viper.SetDefault(flagDashboardPort, 3000)
+	viper.SetDefault(flagDashboardCertFile, "")
+	viper.SetDefault(flagDashboardKeyFile, "")
 	viper.SetDefault(flagDeregistrationHandler, "")
 	viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-backend"))
 	viper.SetDefault(flagStateDir, path.SystemDataDir("sensu-backend"))
@@ -287,6 +293,8 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
 	cmd.Flags().String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")
 	cmd.Flags().Int(flagDashboardPort, viper.GetInt(flagDashboardPort), "dashboard listener port")
+	cmd.Flags().String(flagDashboardCertFile, viper.GetString(flagDashboardCertFile), "dashboard TLS certificate in PEM format")
+	cmd.Flags().String(flagDashboardKeyFile, viper.GetString(flagDashboardKeyFile), "dashboard TLS certificate key in PEM format")
 	cmd.Flags().String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "default deregistration handler")
 	cmd.Flags().String(flagCacheDir, viper.GetString(flagCacheDir), "path to store cached data")
 	cmd.Flags().StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")

--- a/backend/config.go
+++ b/backend/config.go
@@ -31,8 +31,10 @@ type Config struct {
 	APIURL           string
 
 	// Dashboardd Configuration
-	DashboardHost string
-	DashboardPort int
+	DashboardHost        string
+	DashboardPort        int
+	DashboardTLSCertFile string
+	DashboardTLSKeyFile  string
 
 	// Pipelined Configuration
 	DeregistrationHandler string


### PR DESCRIPTION
Signed-off-by: gbolo <george.bolo@gmail.com>

## What is this change?

See #2642


## Why is this change necessary?

In the chance that someone would like to present a different certificate on the dashboard port

## Does your change need a Changelog entry?

yes

## Do you need clarification on anything?

there are two new flags. The behaviour of omitting the flags is the same as the previous release (backwards compatible). Is this desired?


## Were there any complications while making this change?

no

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I have not updated the docs yet, this change will require that.

## Does this change require a new test case?

would be nice, I did not include one yet.
