### PR TITLE
[Web UI] Add additional info to event details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Check results sent via the agent socket now support handlers.
 
+### Added
+- Additional additional check config and entity information to event details page.
+
 ## [5.2.1] - 2019-02-11
 
 ### Fixed

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -83,6 +83,8 @@ class EventDetailsCheckResult extends React.PureComponent {
         cron
         timeout
         ttl
+        state
+        totalStateChange
         roundRobin
         handlers {
           name
@@ -170,6 +172,14 @@ class EventDetailsCheckResult extends React.PureComponent {
                     ({statusCode})
                   </DictionaryValue>
                 </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Total State Change</DictionaryKey>
+                  <DictionaryValue>
+                    {entity.totalStateChange || 0}
+                    {"%"}
+                  </DictionaryValue>
+                </DictionaryEntry>
+
                 {check.silenced.length > 0 && (
                   <DictionaryEntry>
                     <DictionaryKey>Silenced By</DictionaryKey>
@@ -367,6 +377,16 @@ class EventDetailsCheckResult extends React.PureComponent {
                 </Grid>
                 <Grid item xs={12} sm={6}>
                   <Dictionary>
+                    <DictionaryEntry>
+                      <DictionaryKey>STDIN</DictionaryKey>
+                      <DictionaryValue>
+                        <CodeHighlight
+                          language="bash"
+                          component={Code}
+                          code={check.stdin || false}
+                        />
+                      </DictionaryValue>
+                    </DictionaryEntry>
                     <DictionaryEntry>
                       <DictionaryKey>Schedule</DictionaryKey>
                       <DictionaryValue>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -38,13 +38,14 @@ import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 
-const styles = () => ({
+const styles = theme => ({
   alignmentFix: {
     boxSizing: "border-box",
   },
   fullWidth: {
     width: "100%",
   },
+  expand: { color: theme.palette.text.secondary },
 });
 
 class EventDetailsCheckResult extends React.PureComponent {
@@ -269,12 +270,11 @@ class EventDetailsCheckResult extends React.PureComponent {
                 Check did not write to STDOUT.
               </Typography>
             </CardContent>
-            <Divider />
           </React.Fragment>
         )}
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography variant="button">
+            <Typography variant="button" className={classes.expand}>
               Check Configuration Summary
             </Typography>
           </ExpansionPanelSummary>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -284,6 +284,20 @@ class EventDetailsCheckResult extends React.PureComponent {
                 <Grid item xs={12} sm={6}>
                   <Dictionary>
                     <DictionaryEntry>
+                      <DictionaryKey>Check</DictionaryKey>
+                      <DictionaryValue>
+                        {check.name !== "keepalive" ? (
+                          <InlineLink
+                            to={`/${entity.namespace}/checks/${check.name}`}
+                          >
+                            {check.name}
+                          </InlineLink>
+                        ) : (
+                          check.name
+                        )}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
                       <DictionaryKey>Command</DictionaryKey>
                       <DictionaryValue explicitRightMargin>
                         <CodeHighlight

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckResult.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import gql from "graphql-tag";
+import { withStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Divider from "@material-ui/core/Divider";
@@ -32,12 +33,26 @@ import CodeBlock from "/components/CodeBlock";
 import Code from "/components/Code";
 import CodeHighlight from "/components/CodeHighlight/CodeHighlight";
 import ListItem, { ListItemTitle } from "/components/DetailedListItem";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+
+const styles = () => ({
+  alignmentFix: {
+    boxSizing: "border-box",
+  },
+  fullWidth: {
+    width: "100%",
+  },
+});
 
 class EventDetailsCheckResult extends React.PureComponent {
   static propTypes = {
     check: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
     event: PropTypes.object.isRequired,
+    classes: PropTypes.object.isRequired,
   };
 
   static fragments = {
@@ -126,7 +141,7 @@ class EventDetailsCheckResult extends React.PureComponent {
   };
 
   render() {
-    const { event, check, entity } = this.props;
+    const { event, check, entity, classes } = this.props;
     const statusCode = check.status;
     const status = statusCodeToId(check.status);
     const formatter = new Intl.NumberFormat("en-US");
@@ -192,7 +207,9 @@ class EventDetailsCheckResult extends React.PureComponent {
                   <DictionaryKey>Check</DictionaryKey>
                   <DictionaryValue>
                     {check.name !== "keepalive" ? (
-                      <InlineLink to={`/checks/${check.name}`}>
+                      <InlineLink
+                        to={`/${entity.namespace}/checks/${check.name}`}
+                      >
                         {check.name}
                       </InlineLink>
                     ) : (
@@ -237,7 +254,6 @@ class EventDetailsCheckResult extends React.PureComponent {
             </Grid>
           </Grid>
         </CardContent>
-
         {check.output ? (
           <React.Fragment>
             <Divider />
@@ -256,169 +272,153 @@ class EventDetailsCheckResult extends React.PureComponent {
             <Divider />
           </React.Fragment>
         )}
-        <CardContent>
-          <Typography variant="headline" paragraph>
-            Check Configuration Summary
-          </Typography>
-          <Grid container spacing={0}>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Check</DictionaryKey>
-                  <DictionaryValue>{check.name}</DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Command</DictionaryKey>
-                  <DictionaryValue explicitRightMargin>
-                    <CodeHighlight
-                      language="bash"
-                      code={check.command}
-                      component={Code}
-                    />
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Subscriptions</DictionaryKey>
-                  <DictionaryValue>
-                    {check.subscriptions.length > 0 ? (
-                      <List disablePadding>
-                        {check.subscriptions.map(subscription => (
-                          <ListItem key={subscription}>
-                            <ListItemTitle>{subscription}</ListItemTitle>
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      "—"
-                    )}
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Schedule</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={check.cron} fallback={`${check.interval}s`}>
-                      {cron => <CronDescriptor capitalize expression={cron} />}
-                    </Maybe>
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Round Robin</DictionaryKey>
-                  <DictionaryValue>
-                    {check.roundRobin ? "Yes" : "No"}
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-          </Grid>
-        </CardContent>
-        <Divider />
-        <CardContent>
-          <Grid container spacing={0}>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Timeout</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={check.timeout} fallback="Never">
-                      {timeout => `${timeout}s`}
-                    </Maybe>
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>TTL</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={check.ttl} fallback="Forever">
-                      {ttl => `${ttl}s`}
-                    </Maybe>
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Flap Threshold</DictionaryKey>
-                  <DictionaryValue>
-                    High: {check.highFlapThreshold} Low:{" "}
-                    {check.lowFlapThreshold}
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Accepts STDIN?</DictionaryKey>
-                  <DictionaryValue>
-                    {check.stdin ? "Yes" : "No"}
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-          </Grid>
-        </CardContent>
-        <Divider />
-        <CardContent>
-          <Grid container spacing={0}>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Handlers</DictionaryKey>
-                  <DictionaryValue>
-                    {check.handlers.length > 0 ? (
-                      <List disablePadding>
-                        {check.handlers.map(handler => (
-                          <ListItem key={handler.name}>
-                            <ListItemTitle>{handler.name}</ListItemTitle>
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      "—"
-                    )}
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Hooks</DictionaryKey>
-                  <DictionaryValue>{this.renderHooks()}</DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Assets</DictionaryKey>
-                  <DictionaryValue>{this.renderAssets()}</DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>Metric Format</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={check.outputMetricFormat} fallback="None" />
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Metric Handlers</DictionaryKey>
-                  <DictionaryValue>
-                    {check.outputMetricHandlers.length > 0 ? (
-                      <List disablePadding>
-                        {check.outputMetricHandlers.map(handler => (
-                          <ListItem key={handler.name}>
-                            <ListItemTitle>{handler.name}</ListItemTitle>
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      "—"
-                    )}
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-          </Grid>
-        </CardContent>
+        <ExpansionPanel>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="button">
+              Check Configuration Summary
+            </Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <CardContent className={classes.fullWidth}>
+              <Grid container spacing={0}>
+                <Grid item xs={12} sm={6}>
+                  <Dictionary>
+                    <DictionaryEntry>
+                      <DictionaryKey>Command</DictionaryKey>
+                      <DictionaryValue explicitRightMargin>
+                        <CodeHighlight
+                          language="bash"
+                          code={check.command}
+                          component={Code}
+                        />
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Subscriptions</DictionaryKey>
+                      <DictionaryValue>
+                        {check.subscriptions.length > 0 ? (
+                          <List disablePadding>
+                            {check.subscriptions.map(subscription => (
+                              <ListItem key={subscription}>
+                                <ListItemTitle>{subscription}</ListItemTitle>
+                              </ListItem>
+                            ))}
+                          </List>
+                        ) : (
+                          "—"
+                        )}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Timeout</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={check.timeout} fallback="Never">
+                          {timeout => `${timeout}s`}
+                        </Maybe>
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>TTL</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={check.ttl} fallback="Forever">
+                          {ttl => `${ttl}s`}
+                        </Maybe>
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Handlers</DictionaryKey>
+                      <DictionaryValue>
+                        {check.handlers.length > 0 ? (
+                          <List disablePadding>
+                            {check.handlers.map(handler => (
+                              <ListItem key={handler.name}>
+                                <ListItemTitle>{handler.name}</ListItemTitle>
+                              </ListItem>
+                            ))}
+                          </List>
+                        ) : (
+                          "—"
+                        )}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Hooks</DictionaryKey>
+                      <DictionaryValue>{this.renderHooks()}</DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Assets</DictionaryKey>
+                      <DictionaryValue>{this.renderAssets()}</DictionaryValue>
+                    </DictionaryEntry>
+                  </Dictionary>
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <Dictionary>
+                    <DictionaryEntry>
+                      <DictionaryKey>Schedule</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe
+                          value={check.cron}
+                          fallback={`${check.interval}s`}
+                        >
+                          {cron => (
+                            <CronDescriptor capitalize expression={cron} />
+                          )}
+                        </Maybe>
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Round Robin</DictionaryKey>
+                      <DictionaryValue>
+                        {check.roundRobin ? "Yes" : "No"}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Flap Threshold</DictionaryKey>
+                      <DictionaryValue>
+                        High: {check.highFlapThreshold} Low:{" "}
+                        {check.lowFlapThreshold}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Accepts STDIN?</DictionaryKey>
+                      <DictionaryValue>
+                        {check.stdin ? "Yes" : "No"}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Metric Format</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe
+                          value={check.outputMetricFormat}
+                          fallback="None"
+                        />
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Metric Handlers</DictionaryKey>
+                      <DictionaryValue>
+                        {check.outputMetricHandlers.length > 0 ? (
+                          <List disablePadding>
+                            {check.outputMetricHandlers.map(handler => (
+                              <ListItem key={handler.name}>
+                                <ListItemTitle>{handler.name}</ListItemTitle>
+                              </ListItem>
+                            ))}
+                          </List>
+                        ) : (
+                          "—"
+                        )}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                  </Dictionary>
+                </Grid>
+              </Grid>
+            </CardContent>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </Card>
     );
   }
 }
 
-export default EventDetailsCheckResult;
+export default withStyles(styles)(EventDetailsCheckResult);

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -48,7 +48,7 @@ const styles = theme => ({
   expand: { color: theme.palette.text.secondary },
 });
 
-class EventDetailsCheckResult extends React.PureComponent {
+class EventDetailsCheckSummary extends React.PureComponent {
   static propTypes = {
     check: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -58,12 +58,12 @@ class EventDetailsCheckResult extends React.PureComponent {
 
   static fragments = {
     event: gql`
-      fragment EventDetailsCheckResult_event on Event {
+      fragment EventDetailsCheckSummary_event on Event {
         isSilenced
       }
     `,
     check: gql`
-      fragment EventDetailsCheckResult_check on Check {
+      fragment EventDetailsCheckSummary_check on Check {
         status
         lastOK
         occurrences
@@ -83,7 +83,6 @@ class EventDetailsCheckResult extends React.PureComponent {
         cron
         timeout
         ttl
-        state
         totalStateChange
         roundRobin
         handlers {
@@ -103,7 +102,7 @@ class EventDetailsCheckResult extends React.PureComponent {
       }
     `,
     entity: gql`
-      fragment EventDetailsCheckResult_entity on Entity {
+      fragment EventDetailsCheckSummary_entity on Entity {
         name
         namespace
       }
@@ -455,4 +454,4 @@ class EventDetailsCheckResult extends React.PureComponent {
   }
 }
 
-export default withStyles(styles)(EventDetailsCheckResult);
+export default withStyles(styles)(EventDetailsCheckSummary);

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -382,7 +382,7 @@ class EventDetailsCheckSummary extends React.PureComponent {
                         <CodeHighlight
                           language="bash"
                           component={Code}
-                          code={check.stdin || false}
+                          code={check.stdin || "false"}
                         />
                       </DictionaryValue>
                     </DictionaryEntry>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -6,11 +6,10 @@ import Content from "/components/Content";
 import Grid from "@material-ui/core/Grid";
 import Loader from "/components/util/Loader";
 import RelatedEntitiesCard from "/components/partials/RelatedEntitiesCard";
-import EntityDetailsInformation from "/components/partials/EntityDetailsContainer/EntityDetailsInformation";
 
-import CheckResult from "./EventDetailsCheckResult";
+import CheckResult from "./EventDetailsCheckSummary";
 import Toolbar from "./EventDetailsToolbar";
-import Summary from "./EventDetailsSummary";
+import EntitySummary from "./EventDetailsEntitySummary";
 
 class EventDetailsContainer extends React.Component {
   static propTypes = {
@@ -31,16 +30,15 @@ class EventDetailsContainer extends React.Component {
         timestamp
         deleted @client
         ...EventDetailsToolbar_event
-        ...EventDetailsCheckResult_event
+        ...EventDetailsCheckSummary_event
 
         check {
-          ...EventDetailsCheckResult_check
+          ...EventDetailsCheckSummary_check
         }
         entity {
-          ...EventDetailsCheckResult_entity
+          ...EventDetailsCheckSummary_entity
           ...RelatedEntitiesCard_entity
-          ...EventDetailsSummary_entity
-          ...EntityDetailsInformation_entity
+          ...EventDetailsEntitySummary_entity
         }
       }
 
@@ -48,8 +46,7 @@ class EventDetailsContainer extends React.Component {
       ${CheckResult.fragments.check}
       ${CheckResult.fragments.entity}
       ${RelatedEntitiesCard.fragments.entity}
-      ${EntityDetailsInformation.fragments.entity}
-      ${Summary.fragments.entity}
+      ${EntitySummary.fragments.entity}
       ${Toolbar.fragments.event}
     `,
   };
@@ -76,7 +73,7 @@ class EventDetailsContainer extends React.Component {
                 <RelatedEntitiesCard entity={event.entity} />
               </Grid>
               <Grid item xs={12} md={7}>
-                <Summary entity={event.entity} />
+                <EntitySummary entity={event.entity} />
               </Grid>
             </Grid>
           </React.Fragment>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -78,10 +78,10 @@ class EventDetailsContainer extends React.Component {
                   entity={event.entity}
                 />
               </Grid>
-              <Grid item xs={12} md={6}>
+              <Grid item xs={12} md={5}>
                 <RelatedEntitiesCard entity={event.entity} />
               </Grid>
-              <Grid item xs={12} md={6}>
+              <Grid item xs={12} md={7}>
                 <Summary entity={event.entity} />
               </Grid>
             </Grid>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -7,12 +7,6 @@ import Grid from "@material-ui/core/Grid";
 import Loader from "/components/util/Loader";
 import RelatedEntitiesCard from "/components/partials/RelatedEntitiesCard";
 import EntityDetailsInformation from "/components/partials/EntityDetailsContainer/EntityDetailsInformation";
-import ExpansionPanel from "@material-ui/core/ExpansionPanel";
-import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
-import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import Typography from "@material-ui/core/Typography";
-import Card from "@material-ui/core/Card";
 
 import CheckResult from "./EventDetailsCheckResult";
 import Toolbar from "./EventDetailsToolbar";

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsContent.js
@@ -6,6 +6,13 @@ import Content from "/components/Content";
 import Grid from "@material-ui/core/Grid";
 import Loader from "/components/util/Loader";
 import RelatedEntitiesCard from "/components/partials/RelatedEntitiesCard";
+import EntityDetailsInformation from "/components/partials/EntityDetailsContainer/EntityDetailsInformation";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
 
 import CheckResult from "./EventDetailsCheckResult";
 import Toolbar from "./EventDetailsToolbar";
@@ -34,12 +41,12 @@ class EventDetailsContainer extends React.Component {
 
         check {
           ...EventDetailsCheckResult_check
-          ...EventDetailsSummary_check
         }
         entity {
           ...EventDetailsCheckResult_entity
           ...RelatedEntitiesCard_entity
           ...EventDetailsSummary_entity
+          ...EntityDetailsInformation_entity
         }
       }
 
@@ -47,7 +54,7 @@ class EventDetailsContainer extends React.Component {
       ${CheckResult.fragments.check}
       ${CheckResult.fragments.entity}
       ${RelatedEntitiesCard.fragments.entity}
-      ${Summary.fragments.check}
+      ${EntityDetailsInformation.fragments.entity}
       ${Summary.fragments.entity}
       ${Toolbar.fragments.event}
     `,
@@ -75,7 +82,7 @@ class EventDetailsContainer extends React.Component {
                 <RelatedEntitiesCard entity={event.entity} />
               </Grid>
               <Grid item xs={12} md={6}>
-                <Summary check={event.check} entity={event.entity} />
+                <Summary entity={event.entity} />
               </Grid>
             </Grid>
           </React.Fragment>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsEntitySummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsEntitySummary.js
@@ -40,7 +40,7 @@ const styles = theme => ({
   expand: { color: theme.palette.text.secondary },
 });
 
-class EventDetailsSummary extends React.Component {
+class EventDetailsEntitySummary extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
@@ -48,7 +48,7 @@ class EventDetailsSummary extends React.Component {
 
   static fragments = {
     entity: gql`
-      fragment EventDetailsSummary_entity on Entity {
+      fragment EventDetailsEntitySummary_entity on Entity {
         name
         entityClass
         subscriptions
@@ -301,4 +301,4 @@ class EventDetailsSummary extends React.Component {
   }
 }
 
-export default withStyles(styles)(EventDetailsSummary);
+export default withStyles(styles)(EventDetailsEntitySummary);

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsEntitySummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsEntitySummary.js
@@ -246,7 +246,7 @@ class EventDetailsEntitySummary extends React.Component {
               // interfaces.
               intr.mac &&
               intr.addresses.length > 0 && (
-                <ExpansionPanelDetails>
+                <ExpansionPanelDetails key={intr.name}>
                   <Grid item xs={12} sm={6}>
                     <Dictionary>
                       <DictionaryEntry>

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -37,9 +37,17 @@ const Strong = withStyles(() => ({
   },
 }))(Typography);
 
+const styles = () => ({
+  smaller: { width: "20%" },
+  fullWidth: {
+    width: "100%",
+  },
+});
+
 class EventDetailsSummary extends React.Component {
   static propTypes = {
     check: PropTypes.object.isRequired,
+    classes: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
   };
 
@@ -83,6 +91,7 @@ class EventDetailsSummary extends React.Component {
     const {
       entity: entityProp,
       entity: { system },
+      classes,
     } = this.props;
     const { namespace, ...entity } = entityProp;
     const statusCode = entity.status;
@@ -100,15 +109,23 @@ class EventDetailsSummary extends React.Component {
             )}
           </Typography>
           <Grid container spacing={0}>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} sm={12}>
               <Dictionary>
                 <DictionaryEntry>
-                  <DictionaryKey>Entity</DictionaryKey>
-                  <DictionaryValue>{entity.name}</DictionaryValue>
+                  <DictionaryKey className={classes.smaller}>
+                    Entity
+                  </DictionaryKey>
+                  <DictionaryValue className={classes.fullWidth}>
+                    <InlineLink to={`/${namespace}/entities/${entity.name}`}>
+                      {entity.name}
+                    </InlineLink>
+                  </DictionaryValue>
                 </DictionaryEntry>
                 <DictionaryEntry>
-                  <DictionaryKey>Status</DictionaryKey>
-                  <DictionaryValue>
+                  <DictionaryKey className={classes.smaller}>
+                    Status
+                  </DictionaryKey>
+                  <DictionaryValue className={classes.fullWidth}>
                     <StatusIcon inline small statusCode={statusCode} />{" "}
                     {`${status} `}
                     ({statusCode})
@@ -116,58 +133,32 @@ class EventDetailsSummary extends React.Component {
                 </DictionaryEntry>
                 {entity.silences.length > 0 && (
                   <DictionaryEntry>
-                    <DictionaryKey>Silenced By</DictionaryKey>
-                    <DictionaryValue>
+                    <DictionaryKey className={classes.smaller}>
+                      Silenced By
+                    </DictionaryKey>
+                    <DictionaryValue className={classes.fullWidth}>
                       {entity.silences.map(s => s.name).join(", ")}
                     </DictionaryValue>
                   </DictionaryEntry>
                 )}
                 <DictionaryEntry>
-                  <DictionaryKey>Last Seen</DictionaryKey>
-                  <DictionaryValue>
+                  <DictionaryKey className={classes.smaller}>
+                    Last Seen
+                  </DictionaryKey>
+                  <DictionaryValue className={classes.fullWidth}>
                     <Maybe value={entity.lastSeen} fallback="n/a">
                       {val => <RelativeToCurrentDate dateTime={val} />}
                     </Maybe>
                   </DictionaryValue>
                 </DictionaryEntry>
                 <DictionaryEntry>
-                  <DictionaryKey>Subscriptions</DictionaryKey>
-                  <DictionaryValue>
-                    {entity.subscriptions.length > 0 ? (
-                      <List disablePadding>
-                        {entity.subscriptions.map(subscription => (
-                          <ListItem key={subscription}>
-                            <ListItemTitle>{subscription}</ListItemTitle>
-                          </ListItem>
-                        ))}
-                      </List>
-                    ) : (
-                      "—"
-                    )}
-                  </DictionaryValue>
-                </DictionaryEntry>
-              </Dictionary>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Dictionary>
-                <DictionaryEntry>
-                  <DictionaryKey>User</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={entity.user} fallback="—" />
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Deregister</DictionaryKey>
-                  <DictionaryValue>
-                    {entity.deregister ? "yes" : "no"}
-                  </DictionaryValue>
-                </DictionaryEntry>
-                <DictionaryEntry>
-                  <DictionaryKey>Deregistration Handler</DictionaryKey>
-                  <DictionaryValue>
-                    <Maybe value={system.deregistration} fallback="—">
-                      {config => config.handler}
-                    </Maybe>
+                  <DictionaryKey className={classes.smaller}>
+                    Subscriptions
+                  </DictionaryKey>
+                  <DictionaryValue className={classes.fullWidth}>
+                    {entity.subscriptions.length > 0
+                      ? entity.subscriptions.join(", ")
+                      : "—"}
                   </DictionaryValue>
                 </DictionaryEntry>
               </Dictionary>
@@ -179,113 +170,133 @@ class EventDetailsSummary extends React.Component {
             <Typography variant="button">More</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <CardContent>
-              <Grid container spacing={0}>
-                <Grid item xs={12} sm={6}>
-                  <Dictionary>
-                    <DictionaryEntry>
-                      <DictionaryKey>Class</DictionaryKey>
-                      <DictionaryValue>{entity.entityClass}</DictionaryValue>
-                    </DictionaryEntry>
-                    <DictionaryEntry>
-                      <DictionaryKey>Hostname</DictionaryKey>
-                      <DictionaryValue>
-                        <Maybe value={system.hostname} fallback="n/a" />
-                      </DictionaryValue>
-                    </DictionaryEntry>
-                  </Dictionary>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                  <Dictionary>
-                    <DictionaryEntry>
-                      <DictionaryKey>Redacted Keys</DictionaryKey>
-                      <DictionaryValue>
-                        {entity.redact.length > 0 ? (
-                          <List disablePadding>
-                            {entity.redact.map(key => (
-                              <ListItem key={key}>
-                                <ListItemTitle>{key}</ListItemTitle>
-                              </ListItem>
-                            ))}
-                          </List>
-                        ) : (
-                          "—"
-                        )}
-                      </DictionaryValue>
-                    </DictionaryEntry>
+            <Grid container spacing={0}>
+              <Grid item xs={12} sm={6}>
+                <Dictionary>
+                  <DictionaryEntry>
+                    <DictionaryKey>Class</DictionaryKey>
+                    <DictionaryValue>{entity.entityClass}</DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>Hostname</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={system.hostname} fallback="n/a" />
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>User</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={entity.user} fallback="—" />
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>Deregister</DictionaryKey>
+                    <DictionaryValue>
+                      {entity.deregister ? "yes" : "no"}
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>Deregistration Handler</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={system.deregistration} fallback="—">
+                        {config => config.handler}
+                      </Maybe>
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                </Dictionary>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <Dictionary>
+                  <DictionaryEntry>
+                    <DictionaryKey>OS</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={system.os} fallback="n/a" />
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>Platform</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={system.platform} fallback="n/a">
+                        {() =>
+                          [
+                            `${system.platform} ${system.platformVersion}`,
+                            system.platformFamily,
+                          ]
+                            .reduce(
+                              (memo, val) => (val ? [...memo, val] : memo),
+                              [],
+                            )
+                            .join(" / ")
+                        }
+                      </Maybe>
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                  <DictionaryEntry>
+                    <DictionaryKey>Architecture</DictionaryKey>
+                    <DictionaryValue>
+                      <Maybe value={system.arch} fallback="n/a" />
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                </Dictionary>
+              </Grid>
+            </Grid>
+          </ExpansionPanelDetails>
+          <Divider />
+          {system.network.interfaces.map(
+            intr =>
+              // Only display network interfaces that have a MAC address at
+              // this time. This avoids displaying the loopback and tunnel
+              // interfaces.
+              intr.mac &&
+              intr.addresses.length > 0 && (
+                <ExpansionPanelDetails>
+                  <Grid item xs={12} sm={6}>
+                    <Dictionary>
+                      <DictionaryEntry>
+                        <DictionaryKey>Adapter</DictionaryKey>
+                        <DictionaryValue>
+                          <Strong>{intr.name}</Strong>
+                        </DictionaryValue>
+                      </DictionaryEntry>
+                      <DictionaryEntry>
+                        <DictionaryKey>MAC</DictionaryKey>
+                        <DictionaryValue>
+                          <Maybe value={intr.mac} fallback={"n/a"} />
+                        </DictionaryValue>
+                      </DictionaryEntry>
+                      {intr.addresses.map((address, i) => (
+                        <DictionaryEntry key={address}>
+                          <DictionaryKey>
+                            {i === 0 ? "IP Address" : <span>&nbsp;</span>}
+                          </DictionaryKey>
+                          <DictionaryValue>{address}</DictionaryValue>
+                        </DictionaryEntry>
+                      ))}
+                    </Dictionary>
+                  </Grid>
+                </ExpansionPanelDetails>
+              ),
+          )}
 
-                    <DictionaryEntry>
-                      <DictionaryKey>OS</DictionaryKey>
-                      <DictionaryValue>
-                        <Maybe value={system.os} fallback="n/a" />
-                      </DictionaryValue>
-                    </DictionaryEntry>
-                    <DictionaryEntry>
-                      <DictionaryKey>Platform</DictionaryKey>
-                      <DictionaryValue>
-                        <Maybe value={system.platform} fallback="n/a">
-                          {() =>
-                            [
-                              `${system.platform} ${system.platformVersion}`,
-                              system.platformFamily,
-                            ]
-                              .reduce(
-                                (memo, val) => (val ? [...memo, val] : memo),
-                                [],
-                              )
-                              .join(" / ")
-                          }
-                        </Maybe>
-                      </DictionaryValue>
-                    </DictionaryEntry>
-                    <DictionaryEntry>
-                      <DictionaryKey>Architecture</DictionaryKey>
-                      <DictionaryValue>
-                        <Maybe value={system.arch} fallback="n/a" />
-                      </DictionaryValue>
-                    </DictionaryEntry>
-                  </Dictionary>
-                </Grid>
+          <Divider />
+          <ExpansionPanelDetails>
+            <Grid container spacing={0}>
+              <Grid item xs={12} sm={12}>
+                <Dictionary>
+                  <DictionaryEntry>
+                    <DictionaryKey className={classes.smaller}>
+                      Redacted Keys
+                    </DictionaryKey>
+                    <DictionaryValue className={classes.fullWidth}>
+                      {entity.redact.length > 0
+                        ? entity.redact.join(", ")
+                        : "—"}
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                </Dictionary>
               </Grid>
-            </CardContent>
+            </Grid>
             <Divider />
-            <CardContent>
-              <Grid container spacing={0}>
-                {system.network.interfaces.map(
-                  intr =>
-                    // Only display network interfaces that have a MAC address at
-                    // this time. This avoids displaying the loopback and tunnel
-                    // interfaces.
-                    intr.mac &&
-                    intr.addresses.length > 0 && (
-                      <Grid item xs={12} sm={6} key={intr.name}>
-                        <Dictionary>
-                          <DictionaryEntry>
-                            <DictionaryKey>Adapter</DictionaryKey>
-                            <DictionaryValue>
-                              <Strong>{intr.name}</Strong>
-                            </DictionaryValue>
-                          </DictionaryEntry>
-                          <DictionaryEntry>
-                            <DictionaryKey>MAC</DictionaryKey>
-                            <DictionaryValue>
-                              <Maybe value={intr.mac} fallback={"n/a"} />
-                            </DictionaryValue>
-                          </DictionaryEntry>
-                          {intr.addresses.map((address, i) => (
-                            <DictionaryEntry key={address}>
-                              <DictionaryKey>
-                                {i === 0 ? "IP Address" : <span>&nbsp;</span>}
-                              </DictionaryKey>
-                              <DictionaryValue>{address}</DictionaryValue>
-                            </DictionaryEntry>
-                          ))}
-                        </Dictionary>
-                      </Grid>
-                    ),
-                )}
-              </Grid>
-            </CardContent>
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </Card>
@@ -293,4 +304,4 @@ class EventDetailsSummary extends React.Component {
   }
 }
 
-export default EventDetailsSummary;
+export default withStyles(styles)(EventDetailsSummary);

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -56,49 +56,8 @@ class EventDetailsSummary extends React.Component {
       <Card>
         <CardContent>
           <Typography variant="headline" paragraph>
-            Config Summary
+            Entity Summary
           </Typography>
-          <Dictionary>
-            <DictionaryEntry>
-              <DictionaryKey>Check</DictionaryKey>
-              <DictionaryValue>
-                {check.name !== "keepalive" ? (
-                  <InlineLink to={`/${namespace}/checks/${check.name}`}>
-                    {check.name}
-                  </InlineLink>
-                ) : (
-                  check.name
-                )}
-              </DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Schedule</DictionaryKey>
-              <DictionaryValue>
-                <Maybe value={check.cron} fallback={`${check.interval}s`}>
-                  {cron => <CronDescriptor capitalize expression={cron} />}
-                </Maybe>
-              </DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Timeout</DictionaryKey>
-              <DictionaryValue>{check.timeout}s</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>TTL</DictionaryKey>
-              <DictionaryValue>{check.ttl}s</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Subscriptions</DictionaryKey>
-              <DictionaryValue>
-                {check.subscriptions.length > 0
-                  ? check.subscriptions.join(", ")
-                  : "none"}
-              </DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
-        </CardContent>
-        <Divider />
-        <CardContent>
           <Dictionary>
             <DictionaryEntry>
               <DictionaryKey>Entity</DictionaryKey>
@@ -124,20 +83,6 @@ class EventDetailsSummary extends React.Component {
             </DictionaryEntry>
           </Dictionary>
         </CardContent>
-        {check.command && (
-          <React.Fragment>
-            <Divider />
-            <CodeBlock>
-              <CardContent>
-                <CodeHighlight
-                  language="bash"
-                  code={`# Executed command\n$ ${check.command}`}
-                  component="code"
-                />
-              </CardContent>
-            </CodeBlock>
-          </React.Fragment>
-        )}
       </Card>
     );
   }

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -15,6 +15,27 @@ import CodeHighlight from "/components/CodeHighlight/CodeHighlight";
 import Maybe from "/components/Maybe";
 import InlineLink from "/components/InlineLink";
 import Typography from "@material-ui/core/Typography";
+import Tooltip from "@material-ui/core/Tooltip";
+import SilencedIcon from "/icons/Silence";
+import Grid from "@material-ui/core/Grid";
+import StatusIcon from "/components/CheckStatusIcon";
+import List from "@material-ui/core/List";
+import ListItem, { ListItemTitle } from "/components/DetailedListItem";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import ExpansionPanel from "@material-ui/core/ExpansionPanel";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
+import { statusCodeToId } from "/utils/checkStatus";
+import { withStyles } from "@material-ui/core/styles";
+import { RelativeToCurrentDate } from "/components/RelativeDate";
+
+const Strong = withStyles(() => ({
+  root: {
+    color: "inherit",
+    fontSize: "inherit",
+    fontWeight: 500,
+  },
+}))(Typography);
 
 class EventDetailsSummary extends React.Component {
   static propTypes = {
@@ -25,64 +46,248 @@ class EventDetailsSummary extends React.Component {
   static fragments = {
     entity: gql`
       fragment EventDetailsSummary_entity on Entity {
-        namespace
-        system {
-          platform
-        }
-
         name
         entityClass
         subscriptions
-      }
-    `,
-    check: gql`
-      fragment EventDetailsSummary_check on Check {
-        name
-        command
-        interval
-        cron
-        subscriptions
-        timeout
-        ttl
+        lastSeen
+        status
+        silences {
+          name
+        }
+        user
+        redact
+        deregister
+        deregistration {
+          handler
+        }
+        system {
+          arch
+          os
+          hostname
+          platform
+          platformFamily
+          platformVersion
+          network {
+            interfaces {
+              name
+              addresses
+              mac
+            }
+          }
+        }
       }
     `,
   };
 
   render() {
-    const { entity: entityProp, check } = this.props;
+    const {
+      entity: entityProp,
+      entity: { system },
+    } = this.props;
     const { namespace, ...entity } = entityProp;
+    const statusCode = entity.status;
+    const status = statusCodeToId(statusCode);
 
     return (
       <Card>
         <CardContent>
           <Typography variant="headline" paragraph>
             Entity Summary
+            {entity.silences.length > 0 && (
+              <Tooltip title="Silenced">
+                <SilencedIcon style={{ float: "right" }} />
+              </Tooltip>
+            )}
           </Typography>
-          <Dictionary>
-            <DictionaryEntry>
-              <DictionaryKey>Entity</DictionaryKey>
-              <DictionaryValue>
-                <InlineLink to={`/${namespace}/entities/${entity.name}`}>
-                  {entity.name}
-                </InlineLink>
-              </DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Class</DictionaryKey>
-              <DictionaryValue>{entity.entityClass}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Platform</DictionaryKey>
-              <DictionaryValue>{entity.system.platform}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Subscriptions</DictionaryKey>
-              <DictionaryValue>
-                {entity.subscriptions.join(", ")}
-              </DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
+          <Grid container spacing={0}>
+            <Grid item xs={12} sm={6}>
+              <Dictionary>
+                <DictionaryEntry>
+                  <DictionaryKey>Entity</DictionaryKey>
+                  <DictionaryValue>{entity.name}</DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Status</DictionaryKey>
+                  <DictionaryValue>
+                    <StatusIcon inline small statusCode={statusCode} />{" "}
+                    {`${status} `}
+                    ({statusCode})
+                  </DictionaryValue>
+                </DictionaryEntry>
+                {entity.silences.length > 0 && (
+                  <DictionaryEntry>
+                    <DictionaryKey>Silenced By</DictionaryKey>
+                    <DictionaryValue>
+                      {entity.silences.map(s => s.name).join(", ")}
+                    </DictionaryValue>
+                  </DictionaryEntry>
+                )}
+                <DictionaryEntry>
+                  <DictionaryKey>Last Seen</DictionaryKey>
+                  <DictionaryValue>
+                    <Maybe value={entity.lastSeen} fallback="n/a">
+                      {val => <RelativeToCurrentDate dateTime={val} />}
+                    </Maybe>
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Subscriptions</DictionaryKey>
+                  <DictionaryValue>
+                    {entity.subscriptions.length > 0 ? (
+                      <List disablePadding>
+                        {entity.subscriptions.map(subscription => (
+                          <ListItem key={subscription}>
+                            <ListItemTitle>{subscription}</ListItemTitle>
+                          </ListItem>
+                        ))}
+                      </List>
+                    ) : (
+                      "—"
+                    )}
+                  </DictionaryValue>
+                </DictionaryEntry>
+              </Dictionary>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Dictionary>
+                <DictionaryEntry>
+                  <DictionaryKey>User</DictionaryKey>
+                  <DictionaryValue>
+                    <Maybe value={entity.user} fallback="—" />
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Deregister</DictionaryKey>
+                  <DictionaryValue>
+                    {entity.deregister ? "yes" : "no"}
+                  </DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
+                  <DictionaryKey>Deregistration Handler</DictionaryKey>
+                  <DictionaryValue>
+                    <Maybe value={system.deregistration} fallback="—">
+                      {config => config.handler}
+                    </Maybe>
+                  </DictionaryValue>
+                </DictionaryEntry>
+              </Dictionary>
+            </Grid>
+          </Grid>
         </CardContent>
+        <ExpansionPanel>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="button">More</Typography>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <CardContent>
+              <Grid container spacing={0}>
+                <Grid item xs={12} sm={6}>
+                  <Dictionary>
+                    <DictionaryEntry>
+                      <DictionaryKey>Class</DictionaryKey>
+                      <DictionaryValue>{entity.entityClass}</DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Hostname</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={system.hostname} fallback="n/a" />
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                  </Dictionary>
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <Dictionary>
+                    <DictionaryEntry>
+                      <DictionaryKey>Redacted Keys</DictionaryKey>
+                      <DictionaryValue>
+                        {entity.redact.length > 0 ? (
+                          <List disablePadding>
+                            {entity.redact.map(key => (
+                              <ListItem key={key}>
+                                <ListItemTitle>{key}</ListItemTitle>
+                              </ListItem>
+                            ))}
+                          </List>
+                        ) : (
+                          "—"
+                        )}
+                      </DictionaryValue>
+                    </DictionaryEntry>
+
+                    <DictionaryEntry>
+                      <DictionaryKey>OS</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={system.os} fallback="n/a" />
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Platform</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={system.platform} fallback="n/a">
+                          {() =>
+                            [
+                              `${system.platform} ${system.platformVersion}`,
+                              system.platformFamily,
+                            ]
+                              .reduce(
+                                (memo, val) => (val ? [...memo, val] : memo),
+                                [],
+                              )
+                              .join(" / ")
+                          }
+                        </Maybe>
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                    <DictionaryEntry>
+                      <DictionaryKey>Architecture</DictionaryKey>
+                      <DictionaryValue>
+                        <Maybe value={system.arch} fallback="n/a" />
+                      </DictionaryValue>
+                    </DictionaryEntry>
+                  </Dictionary>
+                </Grid>
+              </Grid>
+            </CardContent>
+            <Divider />
+            <CardContent>
+              <Grid container spacing={0}>
+                {system.network.interfaces.map(
+                  intr =>
+                    // Only display network interfaces that have a MAC address at
+                    // this time. This avoids displaying the loopback and tunnel
+                    // interfaces.
+                    intr.mac &&
+                    intr.addresses.length > 0 && (
+                      <Grid item xs={12} sm={6} key={intr.name}>
+                        <Dictionary>
+                          <DictionaryEntry>
+                            <DictionaryKey>Adapter</DictionaryKey>
+                            <DictionaryValue>
+                              <Strong>{intr.name}</Strong>
+                            </DictionaryValue>
+                          </DictionaryEntry>
+                          <DictionaryEntry>
+                            <DictionaryKey>MAC</DictionaryKey>
+                            <DictionaryValue>
+                              <Maybe value={intr.mac} fallback={"n/a"} />
+                            </DictionaryValue>
+                          </DictionaryEntry>
+                          {intr.addresses.map((address, i) => (
+                            <DictionaryEntry key={address}>
+                              <DictionaryKey>
+                                {i === 0 ? "IP Address" : <span>&nbsp;</span>}
+                              </DictionaryKey>
+                              <DictionaryValue>{address}</DictionaryValue>
+                            </DictionaryEntry>
+                          ))}
+                        </Dictionary>
+                      </Grid>
+                    ),
+                )}
+              </Grid>
+            </CardContent>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </Card>
     );
   }

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsSummary.js
@@ -3,15 +3,12 @@ import PropTypes from "prop-types";
 import gql from "graphql-tag";
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
-import CronDescriptor from "/components/partials/CronDescriptor";
 import Divider from "@material-ui/core/Divider";
 import Dictionary, {
   DictionaryKey,
   DictionaryValue,
   DictionaryEntry,
 } from "/components/Dictionary";
-import CodeBlock from "/components/CodeBlock";
-import CodeHighlight from "/components/CodeHighlight/CodeHighlight";
 import Maybe from "/components/Maybe";
 import InlineLink from "/components/InlineLink";
 import Typography from "@material-ui/core/Typography";
@@ -19,8 +16,6 @@ import Tooltip from "@material-ui/core/Tooltip";
 import SilencedIcon from "/icons/Silence";
 import Grid from "@material-ui/core/Grid";
 import StatusIcon from "/components/CheckStatusIcon";
-import List from "@material-ui/core/List";
-import ListItem, { ListItemTitle } from "/components/DetailedListItem";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
@@ -37,16 +32,16 @@ const Strong = withStyles(() => ({
   },
 }))(Typography);
 
-const styles = () => ({
+const styles = theme => ({
   smaller: { width: "20%" },
   fullWidth: {
     width: "100%",
   },
+  expand: { color: theme.palette.text.secondary },
 });
 
 class EventDetailsSummary extends React.Component {
   static propTypes = {
-    check: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
     entity: PropTypes.object.isRequired,
   };
@@ -167,7 +162,9 @@ class EventDetailsSummary extends React.Component {
         </CardContent>
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography variant="button">More</Typography>
+            <Typography variant="button" className={classes.expand}>
+              More
+            </Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <Grid container spacing={0}>


### PR DESCRIPTION
## What is this change?
Closes #2666 
Adds several missing fields to the event details page. Fields for both the check config and the entity.

<img width="1088" alt="screen shot 2019-02-21 at 4 18 08 pm" src="https://user-images.githubusercontent.com/1707663/53211191-3ab96900-35f5-11e9-912c-a5567dba5772.png">

<img width="1087" alt="screen shot 2019-02-21 at 4 18 15 pm" src="https://user-images.githubusercontent.com/1707663/53211192-3ab96900-35f5-11e9-9253-e000b22f32f7.png">

<img width="1086" alt="screen shot 2019-02-21 at 4 18 25 pm" src="https://user-images.githubusercontent.com/1707663/53211193-3b51ff80-35f5-11e9-8182-782481542307.png">

## Why is this change necessary?
We wanted to show more information on the details page.

## Does your change need a Changelog entry?
Yes.

## Do you need clarification on anything?
We will likely need to discuss if anything can be removed or if we need to rearrange the way the data is displayed. What items should be initially hidden, etc.

Additionally, some information isn't displayed at all yet in the web ui but was requested in the ticket - `state`, `total_state_change`, etc. I did not add them yet, as it might make more sense for them to be displayed in the respective details pages first.

## Were there any complications while making this change?
Trying to decide what information to display and what to hide was challenging for me. I'd like to discuss this further as mentioned above.

## How did you verify this change?
Manual testing. Our test cases should cover these changes.
