### PR TITLE
Don't set a timeout for asset downloads

### DIFF
--- a/CHANGELOGS/unreleased/2745-bugfix_asset_fetcher.md
+++ b/CHANGELOGS/unreleased/2745-bugfix_asset_fetcher.md
@@ -1,0 +1,5 @@
+### Fixed
+- Assets downloads no longer specify a client timeout.
+
+### Changed
+- Asset downloading now uses buffered I/O.


### PR DESCRIPTION
## What is this change?

This commit instructs the asset fetcher to not apply any HTTP
client timeout when fetching assets. Previously, assets that took
longer than 30s to download would retry until they took less than
30s to download.

Buffering has also been added, which should improve the performance
of asset downloads.

## Why is this change necessary?

Closes #2745 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required.

## How did you verify this change?

Verified manually by Jef.