### PR TITLE
Split agent subscriptions properly in CLI flags

### DIFF
--- a/CHANGELOGS/unreleased/2735-entity-subscription-bugfix.md
+++ b/CHANGELOGS/unreleased/2735-entity-subscription-bugfix.md
@@ -1,0 +1,5 @@
+### Fixed
+
+Fixed a bug where agent entity subscriptions would be communicated to the
+backend incorrectly. Due to the scheduler using the subscriptions from the
+HTTP header, this does not have any effect on scheduling.

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -161,21 +161,8 @@ func newStartCommand() *cobra.Command {
 				cfg.BackendURLs = append(cfg.BackendURLs, newURL)
 			}
 
-			// Get a single or a list of redact fields
-			redact := viper.GetString(flagRedact)
-			if redact != "" {
-				cfg.Redact = splitAndTrim(redact)
-			} else {
-				cfg.Redact = viper.GetStringSlice(flagRedact)
-			}
-
-			// Get a single or a list of subscriptions
-			subscriptions := viper.GetString(flagSubscriptions)
-			if subscriptions != "" {
-				cfg.Subscriptions = splitAndTrim(subscriptions)
-			} else {
-				cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
-			}
+			cfg.Redact = viper.GetStringSlice(flagRedact)
+			cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
 
 			sensuAgent := agent.NewAgent(cfg)
 			if err := sensuAgent.Run(); err != nil {
@@ -270,14 +257,14 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "deregistration handler that should process the entity deregistration event.")
 	cmd.Flags().String(flagNamespace, viper.GetString(flagNamespace), "agent namespace")
 	cmd.Flags().String(flagPassword, viper.GetString(flagPassword), "agent password")
-	cmd.Flags().String(flagRedact, viper.GetString(flagRedact), "comma-delimited customized list of fields to redact")
+	cmd.Flags().StringSlice(flagRedact, viper.GetStringSlice(flagRedact), "comma-delimited customized list of fields to redact")
 	cmd.Flags().String(flagSocketHost, viper.GetString(flagSocketHost), "address to bind the Sensu client socket to")
 	cmd.Flags().Bool(flagStatsdDisable, viper.GetBool(flagStatsdDisable), "disables the statsd listener and metrics server")
 	cmd.Flags().StringSlice(flagStatsdEventHandlers, viper.GetStringSlice(flagStatsdEventHandlers), "event handlers for statsd metrics, one per flag")
 	cmd.Flags().Int(flagStatsdFlushInterval, viper.GetInt(flagStatsdFlushInterval), "number of seconds between statsd flush")
 	cmd.Flags().String(flagStatsdMetricsHost, viper.GetString(flagStatsdMetricsHost), "address used for the statsd metrics server")
 	cmd.Flags().Int(flagStatsdMetricsPort, viper.GetInt(flagStatsdMetricsPort), "port used for the statsd metrics server")
-	cmd.Flags().String(flagSubscriptions, viper.GetString(flagSubscriptions), "comma-delimited list of agent subscriptions")
+	cmd.Flags().StringSlice(flagSubscriptions, viper.GetStringSlice(flagSubscriptions), "comma-delimited list of agent subscriptions")
 	cmd.Flags().String(flagUser, viper.GetString(flagUser), "agent user")
 	cmd.Flags().StringSlice(flagBackendURL, viper.GetStringSlice(flagBackendURL), "ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times)")
 	cmd.Flags().Uint32(flagKeepaliveTimeout, uint32(viper.GetInt(flagKeepaliveTimeout)), "number of seconds until agent is considered dead by backend")

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -94,14 +94,6 @@ func newVersionCommand() *cobra.Command {
 	return cmd
 }
 
-func splitAndTrim(s string) []string {
-	r := strings.Split(s, ",")
-	for i := range r {
-		r[i] = strings.TrimSpace(r[i])
-	}
-	return r
-}
-
 func newStartCommand() *cobra.Command {
 	var setupErr error
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -170,8 +170,12 @@ func newStartCommand() *cobra.Command {
 			}
 
 			// Get a single or a list of subscriptions
-			subscriptions := viper.GetStringSlice(flagSubscriptions)
-			cfg.Subscriptions = subscriptions
+			subscriptions := viper.GetString(flagSubscriptions)
+			if subscriptions != "" {
+				cfg.Subscriptions = splitAndTrim(subscriptions)
+			} else {
+				cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
+			}
 
 			sensuAgent := agent.NewAgent(cfg)
 			if err := sensuAgent.Run(); err != nil {
@@ -269,7 +273,7 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagRedact, viper.GetString(flagRedact), "comma-delimited customized list of fields to redact")
 	cmd.Flags().String(flagSocketHost, viper.GetString(flagSocketHost), "address to bind the Sensu client socket to")
 	cmd.Flags().Bool(flagStatsdDisable, viper.GetBool(flagStatsdDisable), "disables the statsd listener and metrics server")
-	cmd.Flags().StringSlice(flagStatsdEventHandlers, viper.GetStringSlice(flagStatsdEventHandlers), "comma-delimited list of event handlers for statsd metrics")
+	cmd.Flags().StringSlice(flagStatsdEventHandlers, viper.GetStringSlice(flagStatsdEventHandlers), "event handlers for statsd metrics, one per flag")
 	cmd.Flags().Int(flagStatsdFlushInterval, viper.GetInt(flagStatsdFlushInterval), "number of seconds between statsd flush")
 	cmd.Flags().String(flagStatsdMetricsHost, viper.GetString(flagStatsdMetricsHost), "address used for the statsd metrics server")
 	cmd.Flags().Int(flagStatsdMetricsPort, viper.GetInt(flagStatsdMetricsPort), "port used for the statsd metrics server")


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where agents were sending the wrong
subscriptions in entities, as they would not be split properly
before being sent to the config.

Due to a quirk in how subscriptions are handled, this doesn't
affect any current scheduling mechanism. Nevertheless,
subscriptions must be properly stored in entities, especially for
future work that depends on entity details being correct.

## Why is this change necessary?

Closes #2753 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No doc changes required.

## How did you verify this change?

Manual verification.