### PR TITLE
Update Go on AppVeyor to 1.11.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ image:
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.10.2
+  GOVERSION: 1.11.5
 
   matrix:
     - GOARCH: amd64


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Updates the Go version on AppVeyor to 1.11.5.

## Why is this change necessary?

We're testing & building on Go 1.11.5 on Circle and this change brings AppVeyor in sync.

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation updates required.

## How did you verify this change?

Using this PR to test.