### PR TITLE
Use codeblock to prevent breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Check results sent via the agent socket now support handlers.
+- Fixed bug with how long commands were displayed on check details page.
 
 ### Added
 - Additional additional check config and entity information to event details page.

--- a/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
+++ b/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
@@ -159,11 +159,13 @@ class CheckDetailsConfiguration extends React.PureComponent {
                 <DictionaryEntry>
                   <DictionaryKey>Command</DictionaryKey>
                   <DictionaryValue explicitRightMargin>
-                    <CodeHighlight
-                      language="bash"
-                      code={check.command}
-                      component={Code}
-                    />
+                    <CodeBlock>
+                      <CodeHighlight
+                        language="bash"
+                        code={check.command}
+                        component="code"
+                      />
+                    </CodeBlock>
                   </DictionaryValue>
                 </DictionaryEntry>
 

--- a/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
+++ b/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
@@ -4,7 +4,6 @@ import gql from "graphql-tag";
 
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
-import Code from "/components/Code";
 import CronDescriptor from "/components/partials/CronDescriptor";
 import Dictionary, {
   DictionaryKey,


### PR DESCRIPTION
## What is this change?
Closes #2734 
Uses a code block to prevent breakage when the command gets too long.
<img width="978" alt="screen shot 2019-03-04 at 10 27 20 am" src="https://user-images.githubusercontent.com/1707663/53754219-246aa300-3e68-11e9-92fa-655f66c4973e.png">

## Why is this change necessary?
It broke before 

## Does your change need a Changelog entry?
Yes

## How did you verify this change?
Manually tested. There is a still a test case for this in TestRail.