### PR TITLE
[WIP] Rough POC of handler annotations -> handler env vars

### DIFF
--- a/api/core/v2/util.go
+++ b/api/core/v2/util.go
@@ -16,6 +16,12 @@ func FakeHandlerCommand(command string, args ...string) *Handler {
 	env := []string{"GO_WANT_HELPER_HANDLER_PROCESS=1"}
 
 	handler := &Handler{
+		ObjectMeta: ObjectMeta{
+			Namespace:   "default",
+			Name:        "fake",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
 		Command: trimmedCmd,
 		EnvVars: env,
 	}

--- a/backend/pipelined/handle_test.go
+++ b/backend/pipelined/handle_test.go
@@ -160,6 +160,7 @@ func TestPipelinedPipeHandler(t *testing.T) {
 
 	handler := types.FakeHandlerCommand("cat")
 	handler.Type = "pipe"
+	handler.Annotations["sensu.io/plugins/foo"] = "bar"
 
 	event := &types.Event{}
 	eventData, _ := json.Marshal(event)


### PR DESCRIPTION
This pull-request is intended to kick off a discussion about Handler configuration through annotations and Check/Entity configuration overrides. These changes translate Handler annotations to valid environment variables for the Handler to optionally read while executing for an Event. I will add to the pro/con list as we discuss/comment.

Pros:
- Consistent way of setting configuration values across object types

Cons:
- Already a way to set ENV variables for handlers (this adds a second way)