### PR TITLE
[Web UI] Actually fix command wrapping on Check Details Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - `sensuctl user list` can now output yaml and wrapped-json
 - Fixed bug with how long commands were displayed on check details page.
 - Web - Fixes issue where timeout value was not displayed.
+- Fixed bug with how long commands were displayed on check details page.
 
 ### Added
 - Additional additional check config and entity information to event details page.

--- a/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
+++ b/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
@@ -161,15 +161,9 @@ class CheckDetailsConfiguration extends React.PureComponent {
                 </DictionaryEntry>
 
                 <DictionaryEntry>
-                  <DictionaryKey>Command</DictionaryKey>
-                  <DictionaryValue explicitRightMargin>
-                    <CodeBlock>
-                      <CodeHighlight
-                        language="bash"
-                        code={check.command}
-                        component="code"
-                      />
-                    </CodeBlock>
+                  <DictionaryKey>Published?</DictionaryKey>
+                  <DictionaryValue>
+                    {check.publish ? "Yes" : "No"}
                   </DictionaryValue>
                 </DictionaryEntry>
 
@@ -195,9 +189,15 @@ class CheckDetailsConfiguration extends React.PureComponent {
             <Grid item xs={12} sm={6}>
               <Dictionary>
                 <DictionaryEntry>
-                  <DictionaryKey>Published?</DictionaryKey>
-                  <DictionaryValue>
-                    {check.publish ? "Yes" : "No"}
+                  <DictionaryKey>Command</DictionaryKey>
+                  <DictionaryValue scrollableContent>
+                    <CodeBlock>
+                      <CodeHighlight
+                        language="bash"
+                        code={check.command}
+                        component="code"
+                      />
+                    </CodeBlock>
                   </DictionaryValue>
                 </DictionaryEntry>
 


### PR DESCRIPTION
## What is this change?
Actually fixes the command values not scrolling when you have a really long string with no spaces.
Actually addresses #2734. My fix earlier this week #2764 did not actually fix the issue.

## Why is this change necessary?
It was broken and my original fix didn't actually fix it.

## Does your change need a Changelog entry?
There's already one in there from my previous attempt at a fix.

## Were there any complications while making this change?
This is sort of a hack. I had to move the command to the right side of the table to make it work. I have talked with another engineer about how we should rework the grid system for better scaling and issues like this. Therefore I couldn't implement a perfect solution today as we would like to do that at a later date.

## How did you verify this change?
Manual testing.