### PR TITLE
[Web UI] Format command on event details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Fixed
 - Commands wrap on the event details page and will display "-" if there is no command (keepalives)
 
-## [5.2.2] - 2019-03-11
+## [5.3.0] - 2019-03-11
 
 ### Fixed
 - Check results sent via the agent socket now support handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Asset downloading now uses buffered I/O.
+## Fixed
+- Commands wrap on the event details page and will display "-" if there is no command (keepalives)
+
+## [5.2.2] - 2019-03-11
 
 ### Fixed
 - Check results sent via the agent socket now support handlers.

--- a/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
+++ b/dashboard/src/components/partials/CheckDetailsContainer/CheckDetailsConfiguration.js
@@ -191,13 +191,17 @@ class CheckDetailsConfiguration extends React.PureComponent {
                 <DictionaryEntry>
                   <DictionaryKey>Command</DictionaryKey>
                   <DictionaryValue scrollableContent>
-                    <CodeBlock>
-                      <CodeHighlight
-                        language="bash"
-                        code={check.command}
-                        component="code"
-                      />
-                    </CodeBlock>
+                    {check.command ? (
+                      <CodeBlock>
+                        <CodeHighlight
+                          language="bash"
+                          code={check.command}
+                          component="code"
+                        />
+                      </CodeBlock>
+                    ) : (
+                      "—"
+                    )}
                   </DictionaryValue>
                 </DictionaryEntry>
 

--- a/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/dashboard/src/components/partials/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -307,12 +307,12 @@ class EventDetailsCheckSummary extends React.PureComponent {
                       </DictionaryValue>
                     </DictionaryEntry>
                     <DictionaryEntry>
-                      <DictionaryKey>Command</DictionaryKey>
-                      <DictionaryValue explicitRightMargin>
+                      <DictionaryKey>STDIN</DictionaryKey>
+                      <DictionaryValue>
                         <CodeHighlight
                           language="bash"
-                          code={check.command}
                           component={Code}
+                          code={check.stdin || "false"}
                         />
                       </DictionaryValue>
                     </DictionaryEntry>
@@ -377,13 +377,19 @@ class EventDetailsCheckSummary extends React.PureComponent {
                 <Grid item xs={12} sm={6}>
                   <Dictionary>
                     <DictionaryEntry>
-                      <DictionaryKey>STDIN</DictionaryKey>
-                      <DictionaryValue>
-                        <CodeHighlight
-                          language="bash"
-                          component={Code}
-                          code={check.stdin || "false"}
-                        />
+                      <DictionaryKey>Command</DictionaryKey>
+                      <DictionaryValue scrollableContent>
+                        {check.command ? (
+                          <CodeBlock>
+                            <CodeHighlight
+                              language="bash"
+                              code={check.command}
+                              component="code"
+                            />
+                          </CodeBlock>
+                        ) : (
+                          "—"
+                        )}
                       </DictionaryValue>
                     </DictionaryEntry>
                     <DictionaryEntry>


### PR DESCRIPTION
## What is this change?
Closes #2781 
Adds some scrolling for commands on the events page. Also formats the value in the case of null commands (keepalives)

<img width="1086" alt="screen shot 2019-03-07 at 2 22 54 pm" src="https://user-images.githubusercontent.com/1707663/53993549-93ecc680-40e4-11e9-95d5-3d03598e2943.png">
<img width="827" alt="screen shot 2019-03-07 at 2 23 07 pm" src="https://user-images.githubusercontent.com/1707663/53993550-93ecc680-40e4-11e9-8d93-26a59bda3a3a.png">

## Why is this change necessary?
Displays nicer, matches the scrolling we have on the checks page

## Does your change need a Changelog entry?
Added one