### PR TITLE
Don't store events with a zero timestamp

### DIFF
--- a/CHANGELOGS/unreleased/2636-event-timestamp.md
+++ b/CHANGELOGS/unreleased/2636-event-timestamp.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug where events could be stored without a timestamp.

--- a/api/core/v2/event_test.go
+++ b/api/core/v2/event_test.go
@@ -31,6 +31,15 @@ func TestEventValidate(t *testing.T) {
 	assert.NoError(t, event.Validate())
 }
 
+func TestEventValidateNoTimestamp(t *testing.T) {
+	// Events without a timestamp are valid
+	event := FixtureEvent("entity", "check")
+	event.Timestamp = 0
+	if err := event.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMarshalJSON(t *testing.T) {
 	event := FixtureEvent("entity", "check")
 	_, err := json.Marshal(event)

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/store"
@@ -175,6 +176,12 @@ func (s *Store) UpdateEvent(ctx context.Context, event *types.Event) error {
 	// Truncate check output if the output is larger than MaxOutputSize
 	if size := event.Check.MaxOutputSize; size > 0 && int64(len(event.Check.Output)) > size {
 		event.Check.Output = event.Check.Output[:size]
+	}
+
+	if event.Timestamp == 0 {
+		// If the event is being created for the first time, it may not include
+		// a timestamp. Use the current time.
+		event.Timestamp = time.Now().Unix()
 	}
 
 	// update the history

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -112,3 +112,24 @@ func TestEventStorage(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestUpdateEventWithZeroTimestamp_GH2636(t *testing.T) {
+	testWithEtcd(t, func(store store.Store) {
+		event := types.FixtureEvent("entity1", "check1")
+		ctx := context.WithValue(context.Background(), types.NamespaceKey, event.Entity.Namespace)
+		event.Timestamp = 0
+
+		if err := store.UpdateEvent(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+
+		storedEvent, err := store.GetEventByEntityCheck(ctx, event.Entity.Name, event.Check.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if storedEvent.Timestamp == 0 {
+			t.Fatal("expected non-zero timestamp")
+		}
+	})
+}


### PR DESCRIPTION
## What is this change?

Events that are sent to the store with a zero value as a timestamp
will now be given the current time instead.

## Why is this change necessary?

Closes #2636 

## How did you verify this change?

Integration test