### PR TITLE
Don't allow metrics to be stored in any case

### DIFF
--- a/CHANGELOGS/unreleased/2743-dinnae-store-metrics.md
+++ b/CHANGELOGS/unreleased/2743-dinnae-store-metrics.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug where metrics could be persisted to etcd in some cases.

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -160,7 +160,7 @@ func (s *Store) GetEventByEntityCheck(ctx context.Context, entityName, checkName
 
 // UpdateEvent updates an event.
 func (s *Store) UpdateEvent(ctx context.Context, event *types.Event) error {
-	if event.Check == nil {
+	if event == nil || event.Check == nil {
 		return errors.New("event has no check")
 	}
 
@@ -172,9 +172,21 @@ func (s *Store) UpdateEvent(ctx context.Context, event *types.Event) error {
 		return err
 	}
 
+	if event.HasMetrics() {
+		// Taking pains to not modify our input, set metrics to nil so they are
+		// not persisted.
+		newEvent := *event
+		event = &newEvent
+		event.Metrics = nil
+	}
+
 	// Truncate check output if the output is larger than MaxOutputSize
 	if size := event.Check.MaxOutputSize; size > 0 && int64(len(event.Check.Output)) > size {
-		event.Check.Output = event.Check.Output[:size]
+		// Taking pains to not modify our input, set a bound on the check
+		// output size.
+		check := *event.Check
+		check.Output = check.Output[:size]
+		event.Check = &check
 	}
 
 	// update the history

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -7,18 +7,18 @@ import (
 	"reflect"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEventStorageMaxOutputSize(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
-		event := types.FixtureEvent("entity1", "check1")
+		event := corev2.FixtureEvent("entity1", "check1")
 		event.Check.Output = "VERY LONG"
 		event.Check.MaxOutputSize = 4
-		ctx := context.WithValue(context.Background(), types.NamespaceKey, event.Entity.Namespace)
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, event.Entity.Namespace)
 		if err := store.UpdateEvent(ctx, event); err != nil {
 			t.Fatal(err)
 		}
@@ -34,8 +34,8 @@ func TestEventStorageMaxOutputSize(t *testing.T) {
 
 func TestEventStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
-		event := types.FixtureEvent("entity1", "check1")
-		ctx := context.WithValue(context.Background(), types.NamespaceKey, event.Entity.Namespace)
+		event := corev2.FixtureEvent("entity1", "check1")
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, event.Entity.Namespace)
 
 		// Set these to nil in order to avoid comparison issues between {} and nil
 		event.Check.Labels = nil
@@ -64,19 +64,19 @@ func TestEventStorage(t *testing.T) {
 		}
 
 		// Get all events with wildcards
-		ctx = context.WithValue(ctx, types.NamespaceKey, types.NamespaceTypeAll)
+		ctx = context.WithValue(ctx, corev2.NamespaceKey, corev2.NamespaceTypeAll)
 		events, err = store.GetEvents(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(events))
 
 		// Get all events from a missing namespace
-		ctx = context.WithValue(ctx, types.NamespaceKey, "acme")
+		ctx = context.WithValue(ctx, corev2.NamespaceKey, "acme")
 		events, err = store.GetEvents(ctx)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(events))
 
 		// Set back the context
-		ctx = context.WithValue(ctx, types.NamespaceKey, event.Entity.Namespace)
+		ctx = context.WithValue(ctx, corev2.NamespaceKey, event.Entity.Namespace)
 
 		newEv, err = store.GetEventByEntityCheck(ctx, "", "foo")
 		assert.Nil(t, newEv)
@@ -111,4 +111,25 @@ func TestEventStorage(t *testing.T) {
 		err = store.UpdateEvent(ctx, event)
 		assert.Error(t, err)
 	})
+}
+
+func TestDinnaeStoreMetrics(t *testing.T) {
+	testWithEtcd(t, func(store store.Store) {
+		event := corev2.FixtureEvent("entity1", "check1")
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, event.Entity.Namespace)
+		event.Metrics = &corev2.Metrics{
+			Handlers: []string{"metrix"},
+		}
+
+		if err := store.UpdateEvent(ctx, event); err != nil {
+			t.Fatal(err)
+		}
+
+		if event, err := store.GetEventByEntityCheck(ctx, event.Entity.Name, event.Check.Name); err != nil {
+			t.Fatal(err)
+		} else if event.Metrics != nil {
+			t.Fatal("expected nil metrics")
+		}
+	})
+
 }

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -114,7 +114,7 @@ func TestEventStorage(t *testing.T) {
 	})
 }
 
-func TestDinnaeStoreMetrics(t *testing.T) {
+func TestDoNotStoreMetrics(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
 		event := corev2.FixtureEvent("entity1", "check1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, event.Entity.Namespace)


### PR DESCRIPTION
## What is this change?

This commit explicitly nils out metrics when events arrive at the
store, in order to ensure that metrics are never stored in etcd.

Care is taken to not write to the pointer that is given to the
store. To this end, some unrelated existing code in the same
UpdateEvent method has also been modified to be safer.

## Why is this change necessary?

Closes #2743 

## Does your change need a Changelog entry?

Included

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This change brings us in line with the documentation.

## How did you verify this change?

A new integration test.