### PR TITLE
Update eslint-config-prettier to v4.1.0

### DIFF
--- a/dashboard/.eslintrc.yml
+++ b/dashboard/.eslintrc.yml
@@ -3,6 +3,7 @@ extends:
   - plugin:jsx-a11y/recommended
   - airbnb
   - prettier
+  - prettier/react
 plugins:
   - import
   - jsx-a11y

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -68,7 +68,7 @@
     "es6-error": "^4.1.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^15.1.0",
-    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-config-react-app": "^2.1.0",
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-loader": "^2.0.0",

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -3071,12 +3071,12 @@ eslint-config-airbnb@^15.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.3.0"
 
-eslint-config-prettier@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
-  integrity sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==
+eslint-config-prettier@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz#181364895899fff9fd3605fecb5c4f20e7d5f395"
+  integrity sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==
   dependencies:
-    get-stdin "^5.0.1"
+    get-stdin "^6.0.0"
 
 eslint-config-react-app@^2.1.0:
   version "2.1.0"
@@ -3806,10 +3806,10 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
-get-stdin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
-  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Update `eslint-config-prettier` to v4.1.0; alleviates linter errors introduces after update `prettier`.

## Why is this change necessary?

The package provides us with,

* verification that prettier was run or code matches prettier's style,
* by virtue of integrated into eslint provides nice error messages and editor support,
* disables any rules that conflict with prettier's style.

## Does your change need a Changelog entry?

Purely related to devtooling, so may not be relevant.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No updates required.

## How did you verify this change?

`yarn lint`