### PR TITLE
Use contexts for cancellation

### DIFF
--- a/CHANGELOGS/unreleased/2756-agent-cancellation.md
+++ b/CHANGELOGS/unreleased/2756-agent-cancellation.md
@@ -1,3 +1,6 @@
 ### Fixed
 - Fixed a bug where agents would sometimes refuse to terminate on SIGTERM and
 SIGINT.
+- Fixed a bug where agents would always try to reconnect to the same backend,
+even when multiple backends were specified. Agents will now try to connect to
+other backends, in pseudorandom fashion.

--- a/CHANGELOGS/unreleased/2756-agent-cancellation.md
+++ b/CHANGELOGS/unreleased/2756-agent-cancellation.md
@@ -1,0 +1,3 @@
+### Fixed
+- Fixed a bug where agents would sometimes refuse to terminate on SIGTERM and
+SIGINT.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -48,7 +49,6 @@ type Agent struct {
 	config          *Config
 	connected       bool
 	connectedMu     sync.RWMutex
-	context         context.Context
 	entity          *v2.Entity
 	executor        command.Executor
 	handler         *handler.MessageHandler
@@ -57,7 +57,6 @@ type Agent struct {
 	inProgressMu    *sync.Mutex
 	statsdServer    *statsd.Server
 	sendq           chan *transport.Message
-	stopping        chan struct{}
 	systemInfo      *v2.System
 	systemInfoMu    sync.RWMutex
 	wg              sync.WaitGroup
@@ -67,19 +66,14 @@ type Agent struct {
 // NewAgent creates a new Agent. It returns non-nil error if there is any error
 // when creating the config.CacheDir.
 func NewAgent(config *Config) (*Agent, error) {
-	ctx := context.TODO()
-	ctx, cancel := context.WithCancel(ctx)
 	agent := &Agent{
 		backendSelector: &RandomBackendSelector{Backends: config.BackendURLs},
-		cancel:          cancel,
-		context:         ctx,
 		connected:       false,
 		config:          config,
 		executor:        command.NewExecutor(),
 		handler:         handler.NewMessageHandler(),
 		inProgress:      make(map[string]*v2.CheckConfig),
 		inProgressMu:    &sync.Mutex{},
-		stopping:        make(chan struct{}),
 		sendq:           make(chan *transport.Message, 10),
 		systemInfo:      &v2.System{},
 	}
@@ -119,7 +113,7 @@ func (a *Agent) refreshSystemInfo() error {
 	return nil
 }
 
-func (a *Agent) refreshSystemInfoPeriodically() {
+func (a *Agent) refreshSystemInfoPeriodically(ctx context.Context) {
 	defer logger.Debug("shutting down system info collector")
 	ticker := time.NewTicker(time.Duration(DefaultSystemInfoRefreshInterval) * time.Second)
 	defer ticker.Stop()
@@ -130,7 +124,7 @@ func (a *Agent) refreshSystemInfoPeriodically() {
 			if err := a.refreshSystemInfo(); err != nil {
 				logger.WithError(err).Error("failed to refresh system info")
 			}
-		case <-a.stopping:
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -157,7 +151,12 @@ func (a *Agent) buildTransportHeaderMap() http.Header {
 // 7. Start refreshing system info periodically.
 // 8. Start sending periodic keepalives.
 // 9. Start the API server, shutdown the agent if doing so fails.
-func (a *Agent) Run() error {
+func (a *Agent) Run(ctx context.Context) error {
+	defer func() {
+		if err := a.apiQueue.Close(); err != nil {
+			logger.WithError(err).Error("error closing API queue")
+		}
+	}()
 	userCredentials := fmt.Sprintf("%s:%s", a.config.User, a.config.Password)
 	userCredentials = base64.StdEncoding.EncodeToString([]byte(userCredentials))
 	a.header = a.buildTransportHeaderMap()
@@ -171,54 +170,55 @@ func (a *Agent) Run() error {
 		return fmt.Errorf("bad keepalive timeout: %d (minimum value is 5 seconds)", timeout)
 	}
 
-	assetManager := asset.NewManager(a.config.CacheDir, a.getAgentEntity(), a.stopping, &a.wg)
+	assetManager := asset.NewManager(a.config.CacheDir, a.getAgentEntity(), &a.wg)
 	var err error
-	a.assetGetter, err = assetManager.StartAssetManager()
+	a.assetGetter, err = assetManager.StartAssetManager(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Start the statsd listener only if the agent configuration has it enabled
 	if !a.config.StatsdServer.Disable {
-		a.StartStatsd()
+		a.StartStatsd(ctx)
 	}
 
-	go a.connectionManager()
-	go a.refreshSystemInfoPeriodically()
-	go a.handleAPIQueue(a.context)
+	go a.connectionManager(ctx)
+	go a.refreshSystemInfoPeriodically(ctx)
+	go a.handleAPIQueue(ctx)
 
+	a.wg.Wait()
 	return nil
 }
 
-func (a *Agent) connectionManager() {
+func (a *Agent) connectionManager(ctx context.Context) {
 	defer logger.Debug("shutting down connection manager")
 	for {
-		select {
-		case <-a.stopping:
-			return
-		default:
-		}
-
 		a.connectedMu.Lock()
 		a.connected = false
 		a.connectedMu.Unlock()
 
-		conn := connectWithBackoff(a.backendSelector.Select(), a.config.TLS, a.header)
+		conn, err := connectWithBackoff(ctx, a.backendSelector.Select(), a.config.TLS, a.header)
+		if err != nil {
+			if err == ctx.Err() {
+				return
+			}
+			log.Fatal(err)
+		}
 
 		a.connectedMu.Lock()
 		a.connected = true
 		a.connectedMu.Unlock()
 
-		done := make(chan struct{})
-
-		go a.receiveLoop(conn, done)
-		a.sendLoop(conn, done)
+		ctx, cancel := context.WithCancel(ctx)
+		go a.receiveLoop(ctx, cancel, conn)
+		if err := a.sendLoop(ctx, cancel, conn); err != nil && err != ctx.Err() {
+			logger.WithError(err).Error("error sending messages")
+		}
 	}
 }
 
-func (a *Agent) receiveLoop(conn transport.Transport, done chan struct{}) {
-	defer close(done)
-
+func (a *Agent) receiveLoop(ctx context.Context, cancel context.CancelFunc, conn transport.Transport) {
+	defer cancel()
 	for {
 		m, err := conn.Receive()
 		if err != nil {
@@ -231,7 +231,7 @@ func (a *Agent) receiveLoop(conn transport.Transport, done chan struct{}) {
 				"type":    msg.Type,
 				"payload": string(msg.Payload),
 			}).Info("message received")
-			err := a.handler.Handle(msg.Type, msg.Payload)
+			err := a.handler.Handle(ctx, msg.Type, msg.Payload)
 			if err != nil {
 				logger.WithError(err).Error("error handling message")
 			}
@@ -239,7 +239,8 @@ func (a *Agent) receiveLoop(conn transport.Transport, done chan struct{}) {
 	}
 }
 
-func (a *Agent) sendLoop(conn transport.Transport, done chan struct{}) error {
+func (a *Agent) sendLoop(ctx context.Context, cancel context.CancelFunc, conn transport.Transport) error {
+	defer cancel()
 	keepalive := time.NewTicker(time.Duration(a.config.KeepaliveInterval) * time.Second)
 	defer keepalive.Stop()
 	logger.Info("sending keepalive")
@@ -249,9 +250,7 @@ func (a *Agent) sendLoop(conn transport.Transport, done chan struct{}) error {
 	}
 	for {
 		select {
-		case <-done:
-			return nil
-		case <-a.stopping:
+		case <-ctx.Done():
 			if err := conn.Close(); err != nil {
 				logger.WithError(err).Error("error closing websocket connection")
 				return err
@@ -310,7 +309,7 @@ func (a *Agent) Connected() bool {
 
 // StartAPI starts the Agent HTTP API. After attempting to start the API, if the
 // HTTP server encounters a fatal error, it will shutdown the rest of the agent.
-func (a *Agent) StartAPI() {
+func (a *Agent) StartAPI(ctx context.Context) {
 	// Prepare the HTTP API server
 	a.api = newServer(a)
 
@@ -331,7 +330,8 @@ func (a *Agent) StartAPI() {
 		// This is _only_ for the purpose of making Stop() a blocking call.
 		// The goroutine running the HTTP Server has to return before Stop()
 		// can return, so we use this to signal that goroutine to shutdown.
-		<-a.stopping
+		defer a.wg.Done()
+		<-ctx.Done()
 		logger.Info("API shutting down")
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -340,51 +340,39 @@ func (a *Agent) StartAPI() {
 		if err := a.api.Shutdown(ctx); err != nil {
 			logger.WithError(err).Error("error shutting down the API server")
 		}
-
-		a.wg.Done()
 	}()
 }
 
 // StartSocketListeners starts the agent's TCP and UDP socket listeners.
-func (a *Agent) StartSocketListeners() {
-	if _, _, err := a.createListenSockets(); err != nil {
+func (a *Agent) StartSocketListeners(ctx context.Context) {
+	if _, _, err := a.createListenSockets(ctx); err != nil {
 		logger.WithError(err).Error("unable to start socket listeners")
 	}
 }
 
-// Stop shuts down the agent. It will block until all listening goroutines
-// have returned.
-func (a *Agent) Stop() {
-	a.cancel()
-	close(a.stopping)
-	if err := a.apiQueue.Close(); err != nil {
-		logger.WithError(err).Error("error closing API queue")
-	}
-	a.wg.Wait()
-}
-
 // StartStatsd starts up a StatsD listener on the agent, logs an error for any
 // failures.
-func (a *Agent) StartStatsd() {
+func (a *Agent) StartStatsd(ctx context.Context) {
 	logger.Info("starting statsd server on address: ", a.statsdServer.MetricsAddr)
 
 	go func() {
-		if err := a.statsdServer.Run(a.context); err != nil {
+		if err := a.statsdServer.Run(ctx); err != nil && err != ctx.Err() {
 			logger.WithError(err).Errorf("error with statsd server on address: %s, statsd listener will not run", a.statsdServer.MetricsAddr)
 		}
 	}()
 }
 
-func connectWithBackoff(url string, tlsOpts *v2.TLSOptions, header http.Header) transport.Transport {
+func connectWithBackoff(ctx context.Context, url string, tlsOpts *v2.TLSOptions, header http.Header) (transport.Transport, error) {
 	var conn transport.Transport
 
 	backoff := retry.ExponentialBackoff{
 		InitialDelayInterval: 10 * time.Millisecond,
 		MaxDelayInterval:     10 * time.Second,
 		Multiplier:           10,
+		Ctx:                  ctx,
 	}
 
-	if err := backoff.Retry(func(retry int) (bool, error) {
+	err := backoff.Retry(func(retry int) (bool, error) {
 		c, err := transport.Connect(url, tlsOpts, header)
 		if err != nil {
 			logger.WithError(err).Error("reconnection attempt failed")
@@ -396,9 +384,7 @@ func connectWithBackoff(url string, tlsOpts *v2.TLSOptions, header http.Header) 
 		conn = c
 
 		return true, nil
-	}); err != nil {
-		logger.WithError(err).Fatal("could not connect to transport")
-	}
+	})
 
-	return conn
+	return conn, err
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -45,7 +45,6 @@ type Agent struct {
 	api             *http.Server
 	assetGetter     asset.Getter
 	backendSelector BackendSelector
-	cancel          context.CancelFunc
 	config          *Config
 	connected       bool
 	connectedMu     sync.RWMutex

--- a/agent/check_handler_env_test_unix.go
+++ b/agent/check_handler_env_test_unix.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func TestEnvVars(t *testing.T) {
 	agent.sendq = ch
 
 	entity := agent.getAgentEntity()
-	agent.executeCheck(request, entity)
+	agent.executeCheck(context.Background(), request, entity)
 	msg := <-ch
 	event := &types.Event{}
 	assert.NoError(t, json.Unmarshal(msg.Payload, event))

--- a/agent/check_handler_env_test_windows.go
+++ b/agent/check_handler_env_test_windows.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -29,7 +30,7 @@ func TestEnvVars(t *testing.T) {
 	agent.sendq = ch
 
 	entity := agent.getAgentEntity()
-	agent.executeCheck(request, entity)
+	agent.executeCheck(context.TODO(), request, entity)
 	msg := <-ch
 	event := &types.Event{}
 	assert.NoError(t, json.Unmarshal(msg.Payload, event))

--- a/agent/config.go
+++ b/agent/config.go
@@ -92,6 +92,12 @@ type Config struct {
 	// DeregistrationHandler specifies a single deregistration handler
 	DeregistrationHandler string
 
+	// DisableAPI disables the events API
+	DisableAPI bool
+
+	// DisableSockets disables the event sockets
+	DisableSockets bool
+
 	// EventsAPIRateLimit is the maximum number of events per second that will
 	// be transmitted to the backend from the events API
 	EventsAPIRateLimit rate.Limit

--- a/agent/sockets_test.go
+++ b/agent/sockets_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"net"
 	"testing"
@@ -24,7 +25,9 @@ func TestHandleTCPMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	addr, _, err := ta.createListenSockets()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _, err := ta.createListenSockets(ctx)
 	assert.NoError(err)
 	if err != nil {
 		assert.FailNow("createListenSockets() failed to run")
@@ -59,7 +62,6 @@ func TestHandleTCPMessages(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
-	ta.Stop()
 }
 
 func TestHandleUDPMessages(t *testing.T) {
@@ -74,7 +76,10 @@ func TestHandleUDPMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, addr, err := ta.createListenSockets()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, addr, err := ta.createListenSockets(ctx)
 	assert.NoError(err)
 	if err != nil {
 		assert.FailNow("createListenSockets() failed to run")
@@ -109,7 +114,6 @@ func TestHandleUDPMessages(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
-	ta.Stop()
 }
 
 func TestMultiWriteTimeoutTCP(t *testing.T) {
@@ -124,7 +128,10 @@ func TestMultiWriteTimeoutTCP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	addr, _, err := ta.createListenSockets()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr, _, err := ta.createListenSockets(ctx)
 	assert.NoError(err)
 	if err != nil {
 		assert.FailNow("createListenSockets() failed to run")
@@ -153,7 +160,6 @@ func TestMultiWriteTimeoutTCP(t *testing.T) {
 	}
 	assert.Equal("invalid", string(readData[:numBytes]))
 	require.NoError(t, tcpClient.Close())
-	ta.Stop()
 }
 
 func TestReceiveMultiWriteTCP(t *testing.T) {
@@ -167,8 +173,9 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	addr, _, err := ta.createListenSockets()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _, err := ta.createListenSockets(ctx)
 	assert.NoError(err)
 	if err != nil {
 		assert.FailNow("createListenSockets() failed to run")
@@ -200,8 +207,6 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
-
-	ta.Stop()
 }
 
 func TestReceivePingTCP(t *testing.T) {
@@ -215,8 +220,9 @@ func TestReceivePingTCP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	addr, _, err := ta.createListenSockets()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _, err := ta.createListenSockets(ctx)
 	assert.NoError(err)
 	if err != nil {
 		assert.FailNow("createListenSockets() failed to run")
@@ -240,5 +246,4 @@ func TestReceivePingTCP(t *testing.T) {
 	numBytes, err := tcpClient.Read(readData)
 	require.NoError(t, err)
 	assert.Equal("pong", string(readData[:numBytes]))
-	ta.Stop()
 }

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"testing"
@@ -159,7 +160,7 @@ func TestReceiveMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go ta.StartStatsd()
+	go ta.StartStatsd(context.TODO())
 	// Give the server a second to start up
 	time.Sleep(time.Second * 1)
 

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -13,6 +13,7 @@
 package asset
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/sensu/sensu-go/types"
@@ -28,8 +29,11 @@ const (
 // and expanding an asset. Calls to the Get method block until the Asset has
 // fetched, verified, and expanded or it returns an error indicating why getting
 // the asset failed.
+//
+// If the context is canceled while Get is in progress, then the operation will
+// be canceled and the error from the context will be returned.
 type Getter interface {
-	Get(*types.Asset) (*RuntimeAsset, error)
+	Get(context.Context, *types.Asset) (*RuntimeAsset, error)
 }
 
 // A RuntimeAsset is a locally expanded Asset.

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -66,7 +67,7 @@ type boltDBAssetManager struct {
 //
 // If a value is not returned, the asset is not installed or not installed
 // correctly. We then proceed to attempt asset installation.
-func (b *boltDBAssetManager) Get(asset *types.Asset) (*RuntimeAsset, error) {
+func (b *boltDBAssetManager) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
 	key := []byte(asset.Sha512)
 	var localAsset *RuntimeAsset
 
@@ -117,7 +118,7 @@ func (b *boltDBAssetManager) Get(asset *types.Asset) (*RuntimeAsset, error) {
 		}
 
 		// install the asset
-		tmpFile, err := b.fetcher.Fetch(asset.URL)
+		tmpFile, err := b.fetcher.Fetch(ctx, asset.URL)
 		if err != nil {
 			return err
 		}

--- a/asset/boltdb_manager_test.go
+++ b/asset/boltdb_manager_test.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -17,7 +18,7 @@ type mockFetcher struct {
 	pass bool
 }
 
-func (m *mockFetcher) Fetch(string) (*os.File, error) {
+func (m *mockFetcher) Fetch(context.Context, string) (*os.File, error) {
 	if m.pass {
 		return ioutil.TempFile(os.TempDir(), "boltdb_manager_test_fetcher")
 	}
@@ -93,7 +94,7 @@ func TestGetExistingAsset(t *testing.T) {
 		db: db,
 	}
 
-	fetchedAsset, err := manager.Get(a)
+	fetchedAsset, err := manager.Get(context.TODO(), a)
 	if err != nil {
 		t.Logf("expected no error getting asset, got: %v", err)
 		t.Failed()
@@ -130,7 +131,7 @@ func TestGetNonexistentAsset(t *testing.T) {
 		URL: "nonexistent.tar",
 	}
 
-	runtimeAsset, err := manager.Get(a)
+	runtimeAsset, err := manager.Get(context.TODO(), a)
 	if runtimeAsset != nil {
 		t.Logf("expected nil runtime asset, got %v", runtimeAsset)
 		t.Failed()
@@ -168,7 +169,7 @@ func TestGetInvalidAsset(t *testing.T) {
 		URL: "",
 	}
 
-	runtimeAsset, err := manager.Get(a)
+	runtimeAsset, err := manager.Get(context.TODO(), a)
 	if runtimeAsset != nil {
 		t.Logf("expected nil runtime asset, got %v", runtimeAsset)
 		t.Failed()
@@ -207,7 +208,7 @@ func TestFailedExpand(t *testing.T) {
 		URL: "",
 	}
 
-	runtimeAsset, err := manager.Get(a)
+	runtimeAsset, err := manager.Get(context.TODO(), a)
 	if runtimeAsset != nil {
 		t.Logf("expected nil runtime asset, got %v", runtimeAsset)
 		t.Fail()
@@ -251,7 +252,7 @@ func TestSuccessfulGetAsset(t *testing.T) {
 		URL:    "path",
 	}
 
-	runtimeAsset, err := manager.Get(a)
+	runtimeAsset, err := manager.Get(context.TODO(), a)
 	if err != nil {
 		t.Logf("expected no error, got: %v", err)
 		t.Fail()
@@ -270,7 +271,7 @@ func TestSuccessfulGetAsset(t *testing.T) {
 		t.Fail()
 	}
 
-	runtimeAsset, err = manager.Get(a)
+	runtimeAsset, err = manager.Get(context.TODO(), a)
 	if err != nil {
 		t.Logf("expected not to receive error, got: %v", err)
 		t.Fail()

--- a/asset/fetcher_test.go
+++ b/asset/fetcher_test.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,11 +33,11 @@ func TestFetchExistingAsset(t *testing.T) {
 	localAssetPath := getFixturePath(assetName)
 
 	fetcher := &httpFetcher{
-		URLGetter: func(path string) (io.ReadCloser, error) {
+		URLGetter: func(ctx context.Context, path string) (io.ReadCloser, error) {
 			return os.Open(path)
 		},
 	}
-	f, err := fetcher.Fetch(localAssetPath)
+	f, err := fetcher.Fetch(context.TODO(), localAssetPath)
 	if err != nil {
 		t.Logf("expected no error, got: %v", err)
 		t.FailNow()

--- a/asset/filtered_manager.go
+++ b/asset/filtered_manager.go
@@ -1,6 +1,8 @@
 package asset
 
 import (
+	"context"
+
 	"github.com/sensu/sensu-go/js"
 	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"
@@ -25,7 +27,7 @@ type filteredManager struct {
 }
 
 // Get fetches, verifies, and expands an asset, but only if it is filtered.
-func (f *filteredManager) Get(asset *types.Asset) (*RuntimeAsset, error) {
+func (f *filteredManager) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
 	fields := logrus.Fields{
 		"entity":  f.entity.Name,
 		"asset":   asset.Name,
@@ -43,7 +45,7 @@ func (f *filteredManager) Get(asset *types.Asset) (*RuntimeAsset, error) {
 	}
 
 	logger.WithFields(fields).Debug("entity filtered, installing asset")
-	return f.getter.Get(asset)
+	return f.getter.Get(ctx, asset)
 }
 
 // isFiltered evaluates the given asset's filters and returns true if all of

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -16,7 +17,7 @@ type MockGetter struct {
 }
 
 // Get satisfies the asset.Getter interface
-func (m *MockGetter) Get(*types.Asset) (*RuntimeAsset, error) {
+func (m *MockGetter) Get(context.Context, *types.Asset) (*RuntimeAsset, error) {
 	m.getCalled = true
 	return m.asset, m.err
 }
@@ -33,7 +34,7 @@ func NewTestFilteredManager() (*MockGetter, *types.Entity, *filteredManager) {
 func TestFilteredManagerCallsGetter(t *testing.T) {
 	mockGetter, _, filteredManager := NewTestFilteredManager()
 
-	actualAsset, err := filteredManager.Get(types.FixtureAsset("test-asset"))
+	actualAsset, err := filteredManager.Get(context.TODO(), types.FixtureAsset("test-asset"))
 	assert.NoError(t, err)
 	assert.Equal(t, mockGetter.asset, actualAsset)
 	assert.True(t, mockGetter.getCalled)
@@ -45,7 +46,7 @@ func TestFilteredManagerFilteredAsset(t *testing.T) {
 
 	fixtureAsset := types.FixtureAsset("test-asset")
 	fixtureAsset.Filters = []string{fmt.Sprintf("entity.name == '%s'", entity.Name)}
-	actualAsset, err := filteredManager.Get(fixtureAsset)
+	actualAsset, err := filteredManager.Get(context.TODO(), fixtureAsset)
 	assert.NoError(t, err)
 	assert.Equal(t, mockGetter.asset, actualAsset)
 	assert.True(t, mockGetter.getCalled)
@@ -57,7 +58,7 @@ func TestFilteredManagerUnfilteredAsset(t *testing.T) {
 
 	fixtureAsset := types.FixtureAsset("test-asset")
 	fixtureAsset.Filters = []string{"entity.name == 'foo'"}
-	actualAsset, err := filteredManager.Get(fixtureAsset)
+	actualAsset, err := filteredManager.Get(context.TODO(), fixtureAsset)
 	assert.NoError(t, err)
 	assert.Nil(t, actualAsset)
 	assert.False(t, mockGetter.getCalled)
@@ -68,7 +69,7 @@ func TestFilteredManagerError(t *testing.T) {
 	mockGetter, _, filteredManager := NewTestFilteredManager()
 	mockGetter.err = errors.New("TestFilteredManagerError")
 
-	_, err := filteredManager.Get(types.FixtureAsset("test-asset"))
+	_, err := filteredManager.Get(context.TODO(), types.FixtureAsset("test-asset"))
 	assert.Error(t, err)
 	assert.True(t, mockGetter.getCalled)
 }

--- a/asset/integration_test.go
+++ b/asset/integration_test.go
@@ -1,6 +1,7 @@
 package asset_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,7 +16,7 @@ import (
 
 type localFetcher struct{}
 
-func (f *localFetcher) Fetch(path string) (*os.File, error) {
+func (f *localFetcher) Fetch(ctx context.Context, path string) (*os.File, error) {
 	return os.Open(path)
 }
 
@@ -88,7 +89,7 @@ func TestBoltDBManager(t *testing.T) {
 		t.Fail()
 	}
 
-	runtimeAsset, err := getter.Get(fixtureAsset)
+	runtimeAsset, err := getter.Get(context.TODO(), fixtureAsset)
 	if err != nil {
 		t.Logf("error getting runtime asset, expected nil: %v", err)
 		t.Fail()

--- a/asset/set.go
+++ b/asset/set.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -46,10 +47,10 @@ func (r RuntimeAssetSet) Scripts() (map[string]io.ReadCloser, error) {
 }
 
 // GetAll gets a list of assets with the provided getter.
-func GetAll(getter Getter, assets []types.Asset) (RuntimeAssetSet, error) {
+func GetAll(ctx context.Context, getter Getter, assets []types.Asset) (RuntimeAssetSet, error) {
 	runtimeAssets := make([]*RuntimeAsset, 0, len(assets))
 	for _, asset := range assets {
-		runtimeAsset, err := getter.Get(&asset)
+		runtimeAsset, err := getter.Get(ctx, &asset)
 		if err != nil {
 			return nil, err
 		}

--- a/asset/set_test.go
+++ b/asset/set_test.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -32,7 +33,7 @@ type mockGetter struct {
 	err error
 }
 
-func (m *mockGetter) Get(asset *types.Asset) (*RuntimeAsset, error) {
+func (m *mockGetter) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -51,11 +52,11 @@ func TestGetAll(t *testing.T) {
 	mockGetter := mockGetter{}
 	expectedRuntimeAssets := RuntimeAssetSet{}
 	for _, asset := range assets {
-		runtimeAsset, _ := mockGetter.Get(&asset)
+		runtimeAsset, _ := mockGetter.Get(context.TODO(), &asset)
 		expectedRuntimeAssets = append(expectedRuntimeAssets, runtimeAsset)
 	}
 
-	actualRuntimeAssets, err := GetAll(&mockGetter, assets)
+	actualRuntimeAssets, err := GetAll(context.TODO(), &mockGetter, assets)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRuntimeAssets, actualRuntimeAssets)
 }
@@ -66,7 +67,7 @@ func TestGetAllError(t *testing.T) {
 	mockGetter := mockGetter{err: errors.New("test error")}
 	expectedRuntimeAssets := (RuntimeAssetSet)(nil)
 
-	actualRuntimeAssets, err := GetAll(&mockGetter, assets)
+	actualRuntimeAssets, err := GetAll(context.TODO(), &mockGetter, assets)
 	assert.Error(t, err)
 	assert.Equal(t, expectedRuntimeAssets, actualRuntimeAssets)
 }
@@ -77,7 +78,7 @@ func TestGetAllFilterNil(t *testing.T) {
 	assets[1].Name = "nil"
 	mockGetter := mockGetter{}
 
-	actualRuntimeAssets, err := GetAll(&mockGetter, assets)
+	actualRuntimeAssets, err := GetAll(context.TODO(), &mockGetter, assets)
 	assert.NoError(t, err)
 	assert.NotContains(t, actualRuntimeAssets, nil)
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -134,8 +134,8 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize asset manager
 	backendEntity := b.getBackendEntity(config)
 	logger.WithField("entity", backendEntity).Info("backend entity information")
-	assetManager := asset.NewManager(config.CacheDir, backendEntity, make(chan struct{}), &sync.WaitGroup{})
-	assetGetter, err := assetManager.StartAssetManager()
+	assetManager := asset.NewManager(config.CacheDir, backendEntity, &sync.WaitGroup{})
+	assetGetter, err := assetManager.StartAssetManager(b.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing asset manager: %s", err)
 	}

--- a/backend/pipelined/filter.go
+++ b/backend/pipelined/filter.go
@@ -133,7 +133,7 @@ func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool
 				// if the product of all expressions is true.
 				ctx := types.SetContextFromResource(context.Background(), filter)
 				matchedAssets := asset.GetAssets(ctx, p.store, filter.RuntimeAssets)
-				assets, err := asset.GetAll(p.assetGetter, matchedAssets)
+				assets, err := asset.GetAll(context.TODO(), p.assetGetter, matchedAssets)
 				if err != nil {
 					logger.WithFields(fields).WithError(err).Error("failed to retrieve assets for filter")
 				}

--- a/backend/pipelined/handle.go
+++ b/backend/pipelined/handle.go
@@ -203,7 +203,7 @@ func (p *Pipelined) pipeHandler(handler *types.Handler, eventData []byte) (*comm
 		ctx := types.SetContextFromResource(context.Background(), handler)
 		matchedAssets := asset.GetAssets(ctx, p.store, handler.RuntimeAssets)
 
-		assets, err := asset.GetAll(p.assetGetter, matchedAssets)
+		assets, err := asset.GetAll(context.TODO(), p.assetGetter, matchedAssets)
 		if err != nil {
 			logger.WithFields(fields).WithError(err).Error("failed to retrieve assets for handler")
 		} else {

--- a/backend/pipelined/mutate.go
+++ b/backend/pipelined/mutate.go
@@ -143,7 +143,7 @@ func (p *Pipelined) pipeMutator(mutator *types.Mutator, event *types.Event) ([]b
 		ctx := types.SetContextFromResource(context.Background(), mutator)
 		matchedAssets := asset.GetAssets(ctx, p.store, mutator.RuntimeAssets)
 
-		assets, err := asset.GetAll(p.assetGetter, matchedAssets)
+		assets, err := asset.GetAll(context.TODO(), p.assetGetter, matchedAssets)
 		if err != nil {
 			logger.WithFields(fields).WithError(err).Error("failed to retrieve assets for mutator")
 		} else {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,13 +1,14 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
 
 // MessageHandlerFunc is a function accepting a byte array message payload
 // that returns an optional error.
-type MessageHandlerFunc func(payload []byte) error
+type MessageHandlerFunc func(ctx context.Context, payload []byte) error
 
 // A MessageHandler is responsible for routing messages of a set of types to
 // their associated handler functions.
@@ -49,11 +50,11 @@ func (h *MessageHandler) AddHandler(msgType string, handlerFunc MessageHandlerFu
 // Handle is used to dispatch a message of msgType type with a byte-array
 // payload. This will return an error if the handler function returns an error
 // or if there is no handler for a given message type.
-func (h *MessageHandler) Handle(msgType string, payload []byte) error {
+func (h *MessageHandler) Handle(ctx context.Context, msgType string, payload []byte) error {
 	handleFunc, err := h.getHandlerFor(msgType)
 	if err != nil {
 		return err
 	}
 
-	return handleFunc(payload)
+	return handleFunc(ctx, payload)
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,21 +9,21 @@ import (
 
 func TestFuncAddHandler(t *testing.T) {
 	handler := NewMessageHandler()
-	handler.AddHandler("MessageType", func(payload []byte) error {
+	handler.AddHandler("MessageType", func(ctx context.Context, payload []byte) error {
 		assert.EqualValues(t, []byte{0}, payload)
 		return nil
 	})
 
-	assert.NoError(t, handler.Handle("MessageType", []byte{0}))
+	assert.NoError(t, handler.Handle(context.TODO(), "MessageType", []byte{0}))
 }
 
 func BenchmarkHandleMessage(b *testing.B) {
 	handler := NewMessageHandler()
-	handler.AddHandler("MessageType", func(payload []byte) error {
+	handler.AddHandler("MessageType", func(ctx context.Context, payload []byte) error {
 		return nil
 	})
 
 	for n := 0; n < b.N; n++ {
-		_ = handler.Handle("MessageType", []byte{0})
+		_ = handler.Handle(context.TODO(), "MessageType", []byte{0})
 	}
 }


### PR DESCRIPTION
## What is this change?

Use contexts for cancellation through the agent application. This
means threading a context through components that are also used in
the backend, so the backend has been nominally modified as well.

Note that cancellation problems still exist in the backend and will
require a larger, focused effort to resolve.

The Agent Stop() method has been removed, and Agent Run() now
blocks until the agent context is cancelled.

The asset manager now accepts a context, and will stop trying to
retrieve assets when the context is cancelled. This prevents
problems with asset managers never stopping, when assets cannot be
retrieved.

The agent's connection manager now stops trying to reconnect when
a context cancellation is observed.

Agents now shut down cleanly when SIGTERM and SIGINT are received.
All in-progress HTTP connections are given 1s to shut down and are
then terminated forcibly.

Agents still block on SIGTERM and SIGINT, but the longer waits for
shutdown should now be resolved.

## Why is this change necessary?

Closes #2756 
Closes #2533 

## Does your change need a Changelog entry?

Yes, added.

## Were there any complications while making this change?

Several components required refactoring to accomplish this.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes are required.

## How did you verify this change?

Automated testing covers running the agent quite well. I also did manual testing to ensure that agents terminate properly when asset download is in-flight.