### PR TITLE
[Api] Return 404 when user is not found for given name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Commands wrap on the event details page and will display "-" if there is no command (keepalives)
+
 ## [5.3.0] - 2019-03-11
 
 ### Added
@@ -23,10 +26,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Asset downloading now uses buffered I/O.
-## Fixed
-- Commands wrap on the event details page and will display "-" if there is no command (keepalives)
-
-## [5.3.0] - 2019-03-11
 
 ### Fixed
 - Check results sent via the agent socket now support handlers.

--- a/CHANGELOGS/unreleased/2829-fixup-find-user.md
+++ b/CHANGELOGS/unreleased/2829-fixup-find-user.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- [Api] Respond with 404 from the users endpoint when user for given name cannot
+  be found.

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -63,7 +63,7 @@ func (r *UsersRouter) find(req *http.Request) (interface{}, error) {
 	}
 	record, err := r.controller.Find(req.Context(), id)
 
-	// Obfustace users password
+	// Obfuscate users password
 	if record != nil {
 		record.Password = ""
 	}

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -1,6 +1,7 @@
 package routers
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
@@ -10,9 +11,22 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+// UsersController represents the controller needs of the UsersRouter.
+type UserController interface {
+	Query(ctx context.Context) ([]*types.User, error)
+	Find(ctx context.Context, name string) (*types.User, error)
+	Create(ctx context.Context, newUser types.User) error
+	CreateOrReplace(ctx context.Context, newOrg types.User) error
+	Disable(ctx context.Context, name string) error
+	Enable(ctx context.Context, name string) error
+	AddGroup(ctx context.Context, name string, group string) error
+	RemoveGroup(ctx context.Context, name string, group string) error
+	RemoveAllGroups(ctx context.Context, name string) error
+}
+
 // UsersRouter handles requests for /users
 type UsersRouter struct {
-	controller actions.UserController
+	controller UserController
 }
 
 // NewUsersRouter instantiates new router for controlling user resources

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -64,7 +64,9 @@ func (r *UsersRouter) find(req *http.Request) (interface{}, error) {
 	record, err := r.controller.Find(req.Context(), id)
 
 	// Obfustace users password
-	record.Password = ""
+	if record != nil {
+		record.Password = ""
+	}
 	return record, err
 }
 

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -60,7 +60,7 @@ func (m *mockUserController) RemoveAllGroups(ctx context.Context, name string) e
 	return m.Called(ctx, name).Error(0)
 }
 
-func newUserTest(t *testing.T) (*mockUserController, *httptest.Server) {
+func newUserTest() (*mockUserController, *httptest.Server) {
 	ctrl := &mockUserController{}
 	routes := &UsersRouter{controller: ctrl}
 	router := mux.NewRouter()
@@ -70,7 +70,7 @@ func newUserTest(t *testing.T) (*mockUserController, *httptest.Server) {
 }
 
 func TestGetUser(t *testing.T) {
-	ctrl, server := newUserTest(t)
+	ctrl, server := newUserTest()
 	defer server.Close()
 
 	endpoint := "/users"

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -1,0 +1,93 @@
+package routers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockUserController struct {
+	mock.Mock
+}
+
+func (m *mockUserController) Create(ctx context.Context, name types.User) error {
+	return m.Called(ctx, name).Error(0)
+}
+
+func (m *mockUserController) CreateOrReplace(ctx context.Context, name types.User) error {
+	return m.Called(ctx, name).Error(0)
+}
+
+func (m *mockUserController) Query(ctx context.Context) ([]*types.User, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*types.User), args.Error(1)
+}
+
+func (m *mockUserController) Find(ctx context.Context, name string) (*types.User, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.User), args.Error(1)
+}
+
+func (m *mockUserController) Disable(ctx context.Context, name string) error {
+	return m.Called(ctx, name).Error(0)
+}
+
+func (m *mockUserController) Enable(ctx context.Context, name string) error {
+	return m.Called(ctx, name).Error(0)
+}
+
+func (m *mockUserController) AddGroup(ctx context.Context, name string, group string) error {
+	return m.Called(ctx, name, group).Error(0)
+}
+
+func (m *mockUserController) RemoveGroup(ctx context.Context, name string, group string) error {
+	return m.Called(ctx, name, group).Error(0)
+}
+
+func (m *mockUserController) RemoveAllGroups(ctx context.Context, name string) error {
+	return m.Called(ctx, name).Error(0)
+}
+
+func newUserTest(t *testing.T) (*mockUserController, *httptest.Server) {
+	ctrl := &mockUserController{}
+	routes := &UsersRouter{controller: ctrl}
+	router := mux.NewRouter()
+	routes.Mount(router)
+
+	return ctrl, httptest.NewServer(router)
+}
+
+func TestGetUser(t *testing.T) {
+	ctrl, server := newUserTest(t)
+	defer server.Close()
+
+	endpoint := "/users"
+	client := &http.Client{}
+
+	// User found
+	user := types.FixtureUser("A")
+	ctrl.On("Find", mock.Anything, "A").Return(user, nil).Once()
+	req := newRequest(t, http.MethodGet, server.URL+path.Join(endpoint, "A"), nil)
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+
+	// Not found
+	ctrl.On("Find", mock.Anything, "B").Return(nil, actions.NewErrorf(actions.NotFound)).Once()
+	req = newRequest(t, http.MethodGet, server.URL+path.Join(endpoint, "B"), nil)
+	res, err = client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, 404, res.StatusCode)
+}


### PR DESCRIPTION
## What is this change?

Checks that the response from the controller was not nil before attempting to obfuscate the user's password. Previously this would lead to a panic, closing the end user's connection without a response.

## Why is this change necessary?

Closes #2828

## Does your change need a Changelog entry?

Yup!

## Do you need clarification on anything?

Nada.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

* unit tests
* manual testing