### PR TITLE
Implement tessend and etcd watcher

### DIFF
--- a/CHANGELOGS/unreleased/2791-tessen-daemon.md
+++ b/CHANGELOGS/unreleased/2791-tessen-daemon.md
@@ -1,0 +1,2 @@
+### Added
+- Added the TessenD daemon.

--- a/CHANGELOGS/unreleased/2792-tessen-etcd-watcher.md
+++ b/CHANGELOGS/unreleased/2792-tessen-etcd-watcher.md
@@ -1,0 +1,5 @@
+### Added
+- Added an etcd watcher for tessen configuration.
+
+### Removed
+- Removed the unused etcd watcher for hook configurations.

--- a/api/core/v2/tessen.go
+++ b/api/core/v2/tessen.go
@@ -5,14 +5,14 @@ import (
 )
 
 const (
-	// LowerBound is the minimum frequency that tessen will phone home
-	LowerBound = 1
+	// LowerBound is the minimum frequency that tessen will phone home, in seconds
+	LowerBound = 60
 
-	// UpperBound is the maximum frequency that tessen will phone home
-	UpperBound = 360
+	// UpperBound is the maximum frequency that tessen will phone home, in seconds
+	UpperBound = 21600
 
-	// DefaultTessenFrequency is the default frequency at which tessen will phone home
-	DefaultTessenFrequency = 1
+	// DefaultTessenFrequency is the default frequency at which tessen will phone home, in seconds
+	DefaultTessenFrequency = 60
 
 	// TessenPath is the store and api path for tessen
 	TessenPath = "/tessen"

--- a/api/core/v2/tessen.go
+++ b/api/core/v2/tessen.go
@@ -5,23 +5,23 @@ import (
 )
 
 const (
-	// LowerBound is the minimum frequency that tessen will phone home, in seconds
+	// LowerBound is the minimum interval that tessen will phone home, in seconds
 	LowerBound = 60
 
-	// UpperBound is the maximum frequency that tessen will phone home, in seconds
+	// UpperBound is the maximum interval that tessen will phone home, in seconds
 	UpperBound = 21600
 
-	// DefaultTessenFrequency is the default frequency at which tessen will phone home, in seconds
-	DefaultTessenFrequency = 60
+	// DefaultTessenInterval is the default interval at which tessen will phone home, in seconds
+	DefaultTessenInterval = 60
 
 	// TessenPath is the store and api path for tessen
 	TessenPath = "/tessen"
 )
 
-// ValidateFrequency returns an error if the tessen frequency is not within the upper and lower bound limits
-func ValidateFrequency(freq uint32) error {
+// ValidateInterval returns an error if the tessen interval is not within the upper and lower bound limits
+func ValidateInterval(freq uint32) error {
 	if !(freq >= LowerBound && freq <= UpperBound) {
-		return fmt.Errorf("tessen frequency must be in between the lower and upper bound limits (%d-%d)", LowerBound, UpperBound)
+		return fmt.Errorf("tessen interval must be in between the lower and upper bound limits (%d-%d)", LowerBound, UpperBound)
 	}
 	return nil
 }

--- a/api/core/v2/tessen_test.go
+++ b/api/core/v2/tessen_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateFrequency(t *testing.T) {
-	assert.Error(t, ValidateFrequency(UpperBound+1))
-	assert.Error(t, ValidateFrequency(LowerBound-1))
-	assert.NoError(t, ValidateFrequency(UpperBound-1))
-	assert.NoError(t, ValidateFrequency(LowerBound+1))
+func TestValidateInterval(t *testing.T) {
+	assert.Error(t, ValidateInterval(UpperBound+1))
+	assert.Error(t, ValidateInterval(LowerBound-1))
+	assert.NoError(t, ValidateInterval(UpperBound-1))
+	assert.NoError(t, ValidateInterval(LowerBound+1))
 }

--- a/backend/apid/actions/tessen.go
+++ b/backend/apid/actions/tessen.go
@@ -1,7 +1,7 @@
 package actions
 
 import (
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"golang.org/x/net/context"
 )
@@ -19,7 +19,7 @@ func NewTessenController(store store.TessenConfigStore) TessenController {
 }
 
 // CreateOrUpdate creates or updates the tessen configuration
-func (c TessenController) CreateOrUpdate(ctx context.Context, config *v2.TessenConfig) error {
+func (c TessenController) CreateOrUpdate(ctx context.Context, config *corev2.TessenConfig) error {
 	if err := c.store.CreateOrUpdateTessenConfig(ctx, config); err != nil {
 		switch err := err.(type) {
 		case *store.ErrNotValid:
@@ -33,7 +33,7 @@ func (c TessenController) CreateOrUpdate(ctx context.Context, config *v2.TessenC
 }
 
 // Get gets the tessen configuration
-func (c TessenController) Get(ctx context.Context) (*v2.TessenConfig, error) {
+func (c TessenController) Get(ctx context.Context) (*corev2.TessenConfig, error) {
 	config, err := c.store.GetTessenConfig(ctx)
 	if err != nil {
 		switch err := err.(type) {

--- a/backend/apid/actions/tessen_test.go
+++ b/backend/apid/actions/tessen_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +26,7 @@ func TestCreateOrUpdateTessenConfig(t *testing.T) {
 	testCases := []struct {
 		name            string
 		ctx             context.Context
-		argument        *v2.TessenConfig
+		argument        *corev2.TessenConfig
 		storeErr        error
 		expectedErr     bool
 		expectedErrCode ErrCode
@@ -34,12 +34,12 @@ func TestCreateOrUpdateTessenConfig(t *testing.T) {
 		{
 			name:     "Create or update",
 			ctx:      context.Background(),
-			argument: v2.DefaultTessenConfig(),
+			argument: corev2.DefaultTessenConfig(),
 		},
 		{
 			name:            "Invalid input",
 			ctx:             context.Background(),
-			argument:        v2.DefaultTessenConfig(),
+			argument:        corev2.DefaultTessenConfig(),
 			storeErr:        &store.ErrNotValid{},
 			expectedErr:     true,
 			expectedErrCode: InvalidArgument,
@@ -47,7 +47,7 @@ func TestCreateOrUpdateTessenConfig(t *testing.T) {
 		{
 			name:            "Store error",
 			ctx:             context.Background(),
-			argument:        v2.DefaultTessenConfig(),
+			argument:        corev2.DefaultTessenConfig(),
 			storeErr:        errors.New("some error"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
@@ -87,14 +87,14 @@ func TestGetTessenConfig(t *testing.T) {
 		name            string
 		ctx             context.Context
 		storeErr        error
-		expectedResult  *v2.TessenConfig
+		expectedResult  *corev2.TessenConfig
 		expectedErr     bool
 		expectedErrCode ErrCode
 	}{
 		{
 			name:           "Get",
 			ctx:            context.Background(),
-			expectedResult: v2.DefaultTessenConfig(),
+			expectedResult: corev2.DefaultTessenConfig(),
 		},
 		{
 			name:            "Not found",

--- a/backend/apid/routers/tessen.go
+++ b/backend/apid/routers/tessen.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // TessenController represents the controller needs of the TessenRouter.
 type TessenController interface {
-	CreateOrUpdate(context.Context, *v2.TessenConfig) error
-	Get(context.Context) (*v2.TessenConfig, error)
+	CreateOrUpdate(context.Context, *corev2.TessenConfig) error
+	Get(context.Context) (*corev2.TessenConfig, error)
 }
 
 // TessenRouter handles requests for /tessen.
@@ -30,7 +30,7 @@ func NewTessenRouter(ctrl TessenController) *TessenRouter {
 func (r *TessenRouter) Mount(parent *mux.Router) {
 	routes := ResourceRoute{
 		Router:     parent,
-		PathPrefix: v2.TessenPath,
+		PathPrefix: corev2.TessenPath,
 	}
 
 	routes.Path("", r.get).Methods(http.MethodGet)
@@ -38,7 +38,7 @@ func (r *TessenRouter) Mount(parent *mux.Router) {
 }
 
 func (r *TessenRouter) createOrUpdate(req *http.Request) (interface{}, error) {
-	obj := &v2.TessenConfig{}
+	obj := &corev2.TessenConfig{}
 	if err := UnmarshalBody(req, &obj); err != nil {
 		return nil, err
 	}

--- a/backend/apid/routers/tessen_test.go
+++ b/backend/apid/routers/tessen_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -18,13 +18,13 @@ type mockTessenController struct {
 	mock.Mock
 }
 
-func (m *mockTessenController) CreateOrUpdate(ctx context.Context, config *v2.TessenConfig) error {
+func (m *mockTessenController) CreateOrUpdate(ctx context.Context, config *corev2.TessenConfig) error {
 	return m.Called(ctx, config).Error(0)
 }
 
-func (m *mockTessenController) Get(ctx context.Context) (*v2.TessenConfig, error) {
+func (m *mockTessenController) Get(ctx context.Context) (*corev2.TessenConfig, error) {
 	args := m.Called(ctx)
-	return args.Get(0).(*v2.TessenConfig), args.Error(1)
+	return args.Get(0).(*corev2.TessenConfig), args.Error(1)
 }
 
 func newTessenTest(t *testing.T) (*mockTessenController, *httptest.Server) {
@@ -43,9 +43,9 @@ func TestPutTessen(t *testing.T) {
 	client := new(http.Client)
 
 	controller.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil)
-	b, _ := json.Marshal(v2.DefaultTessenConfig())
+	b, _ := json.Marshal(corev2.DefaultTessenConfig())
 	body := bytes.NewReader(b)
-	endpoint := v2.TessenPath
+	endpoint := corev2.TessenPath
 	req := newRequest(t, http.MethodPut, server.URL+endpoint, body)
 
 	resp, err := client.Do(req)
@@ -67,9 +67,9 @@ func TestGetTessen(t *testing.T) {
 
 	client := new(http.Client)
 
-	fixture := v2.DefaultTessenConfig()
+	fixture := corev2.DefaultTessenConfig()
 	controller.On("Get", mock.Anything).Return(fixture, nil)
-	endpoint := v2.TessenPath
+	endpoint := corev2.TessenPath
 	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
 
 	resp, err := client.Do(req)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/backend/agentd"
 	"github.com/sensu/sensu-go/backend/apid"
@@ -216,7 +216,7 @@ func Initialize(config *Config) (*Backend, error) {
 	// Prepare the authentication providers
 	authenticator := &authentication.Authenticator{}
 	basic := &basic.Provider{
-		ObjectMeta: v2.ObjectMeta{Name: basic.Type},
+		ObjectMeta: corev2.ObjectMeta{Name: basic.Type},
 		Store:      store,
 	}
 	authenticator.AddProvider(basic)
@@ -408,15 +408,15 @@ func (b *Backend) Stop() {
 	<-b.done
 }
 
-func (b *Backend) getBackendEntity(config *Config) *v2.Entity {
-	entity := &v2.Entity{
-		EntityClass: v2.EntityBackendClass,
+func (b *Backend) getBackendEntity(config *Config) *corev2.Entity {
+	entity := &corev2.Entity{
+		EntityClass: corev2.EntityBackendClass,
 		System:      getSystemInfo(),
-		ObjectMeta:  v2.NewObjectMeta(getDefaultBackendID(), ""),
+		ObjectMeta:  corev2.NewObjectMeta(getDefaultBackendID(), ""),
 	}
 
 	if config.DeregistrationHandler != "" {
-		entity.Deregistration = v2.Deregistration{
+		entity.Deregistration = corev2.Deregistration{
 			Handler: config.DeregistrationHandler,
 		}
 	}
@@ -435,7 +435,7 @@ func getDefaultBackendID() string {
 }
 
 // getSystemInfo returns the system info of the backend
-func getSystemInfo() v2.System {
+func getSystemInfo() corev2.System {
 	info, err := system.Info()
 	if err != nil {
 		logger.WithError(err).Error("error getting system info")

--- a/backend/store/etcd/tessen_store.go
+++ b/backend/store/etcd/tessen_store.go
@@ -2,23 +2,27 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 
 	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
-func getTessenPath() string {
-	return fmt.Sprintf("%s%s", EtcdRoot, v2.TessenPath)
-}
+const (
+	tessenPathPrefix = "tessen"
+)
+
+var (
+	tessenKeyBuilder = store.NewKeyBuilder(tessenPathPrefix)
+)
 
 // CreateOrUpdateTessenConfig creates or updates the tessen configuration
 func (s *Store) CreateOrUpdateTessenConfig(ctx context.Context, config *v2.TessenConfig) error {
-	return CreateOrUpdate(ctx, s.client, getTessenPath(), "", config)
+	return CreateOrUpdate(ctx, s.client, tessenKeyBuilder.Build(""), "", config)
 }
 
 // GetTessenConfig gets the tessen configuration
 func (s *Store) GetTessenConfig(ctx context.Context) (*v2.TessenConfig, error) {
 	config := &v2.TessenConfig{}
-	err := Get(ctx, s.client, getTessenPath(), config)
+	err := Get(ctx, s.client, tessenKeyBuilder.Build(""), config)
 	return config, err
 }

--- a/backend/store/etcd/tessen_store_test.go
+++ b/backend/store/etcd/tessen_store_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,7 +21,7 @@ func TestTessenStorage(t *testing.T) {
 		assert.Empty(t, config)
 
 		// We should not receive an error if the tessen config is valid
-		config = &v2.TessenConfig{
+		config = &corev2.TessenConfig{
 			OptOut: true,
 		}
 		err = store.CreateOrUpdateTessenConfig(ctx, config)
@@ -34,7 +34,7 @@ func TestTessenStorage(t *testing.T) {
 		assert.True(t, config.OptOut)
 
 		// We should not receive an error if the tessen config is valid
-		config = &v2.TessenConfig{}
+		config = &corev2.TessenConfig{}
 		err = store.CreateOrUpdateTessenConfig(ctx, config)
 		assert.NoError(t, err)
 

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
@@ -79,48 +80,10 @@ func (s *Store) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEve
 	return ch
 }
 
-// GetHookConfigWatcher returns a channel that emits WatchEventHookConfig structs notifying
-// the caller that a HookConfig was updated. If the watcher runs into a terminal error
+// GetEntityWatcher returns a channel that emits WatchEventEntity structs notifying
+// the caller that an Entity was updated. If the watcher runs into a terminal error
 // or the context passed is cancelled, then the channel will be closed. The caller must
 // restart the watcher, if needed.
-func (s *Store) GetHookConfigWatcher(ctx context.Context) <-chan store.WatchEventHookConfig {
-	ch := make(chan store.WatchEventHookConfig)
-	watcherChan := s.client.Watch(ctx, hookKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
-
-	go func() {
-		defer close(ch)
-
-		var (
-			watchEvent store.WatchEventHookConfig
-			action     store.WatchActionType
-			hookCfg    *corev2.HookConfig
-		)
-
-		for watchResponse := range watcherChan {
-			for _, event := range watchResponse.Events {
-				action = GetWatcherAction(event)
-				if action == store.WatchUnknown {
-					logger.Error("unknown etcd watch action: ", event.Type.String())
-				}
-
-				hookCfg = &corev2.HookConfig{}
-				if err := json.Unmarshal(event.Kv.Value, hookCfg); err != nil {
-					logger.WithField("key", event.Kv.Key).WithError(err).Error("unable to unmarshal hook config from key")
-				}
-
-				watchEvent = store.WatchEventHookConfig{
-					Action:     action,
-					HookConfig: hookCfg,
-				}
-
-				ch <- watchEvent
-			}
-		}
-	}()
-
-	return ch
-}
-
 func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEntity {
 	ch := make(chan store.WatchEventEntity, 1)
 	wc := s.client.Watch(ctx, entityKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
@@ -153,6 +116,47 @@ func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEnt
 				watchEvent := store.WatchEventEntity{
 					Action: action,
 					Entity: &entity,
+				}
+
+				ch <- watchEvent
+			}
+		}
+	}()
+	return ch
+}
+
+// GetTessenConfigWatcher returns a channel that emits WatchEventTessenConfig structs notifying
+// the caller that a TessenConfig was updated. If the watcher runs into a terminal error
+// or the context passed is cancelled, then the channel will be closed. The caller must
+// restart the watcher, if needed.
+func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEventTessenConfig {
+	ch := make(chan store.WatchEventTessenConfig, 1)
+	wc := s.client.Watch(ctx, tessenKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
+	go func() {
+		defer close(ch)
+
+		for resp := range wc {
+			for _, event := range resp.Events {
+				action := GetWatcherAction(event)
+				if action == store.WatchUnknown {
+					logger.Errorf("unknown etcd watch action: %s", event.Type.String())
+					continue
+				}
+
+				var tessen *v2.TessenConfig
+				if action != store.WatchDelete {
+					if err := json.Unmarshal(event.Kv.Value, &tessen); err != nil {
+						logger.WithError(err).Error("error unmarshaling watch event")
+						continue
+					}
+				} else {
+					// use default tessen config if it's deleted
+					tessen = v2.DefaultTessenConfig()
+				}
+
+				watchEvent := store.WatchEventTessenConfig{
+					Action:       action,
+					TessenConfig: tessen,
 				}
 
 				ch <- watchEvent

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
@@ -143,7 +142,7 @@ func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEv
 					continue
 				}
 
-				var tessen *v2.TessenConfig
+				var tessen *corev2.TessenConfig
 				if action != store.WatchDelete {
 					if err := json.Unmarshal(event.Kv.Value, &tessen); err != nil {
 						logger.WithError(err).Error("error unmarshaling watch event")
@@ -151,7 +150,7 @@ func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEv
 					}
 				} else {
 					// use default tessen config if it's deleted
-					tessen = v2.DefaultTessenConfig()
+					tessen = corev2.DefaultTessenConfig()
 				}
 
 				watchEvent := store.WatchEventTessenConfig{

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // ErrAlreadyExists is returned when an object already exists
@@ -99,6 +98,12 @@ type WatchEventHookConfig struct {
 type WatchEventEntity struct {
 	Entity *corev2.Entity
 	Action WatchActionType
+}
+
+// WatchEventTessenConfig is a notification that the tessen config store has been updated.
+type WatchEventTessenConfig struct {
+	TessenConfig *corev2.TessenConfig
+	Action       WatchActionType
 }
 
 // Store is used to abstract the durable storage used by the Sensu backend
@@ -295,12 +300,6 @@ type HookConfigStore interface {
 
 	// UpdateHookConfig creates or updates a given hook's configuration.
 	UpdateHookConfig(ctx context.Context, check *types.HookConfig) error
-
-	// GetHookConfigWatcher returns a channel that emits WatchEventHookConfig structs notifying
-	// the caller that a HookConfig was updated. If the watcher runs into a terminal error
-	// or the context passed is cancelled, then the channel will be closed. The caller must
-	// restart the watcher, if needed.
-	GetHookConfigWatcher(ctx context.Context) <-chan WatchEventHookConfig
 }
 
 // EntityStore provides methods for managing entities
@@ -529,6 +528,9 @@ type TessenConfigStore interface {
 
 	// GetTessenConfig gets the tessen configuration
 	GetTessenConfig(context.Context) (*corev2.TessenConfig, error)
+
+	// GetTessenConfigWatcher returns a tessen config watcher
+	GetTessenConfigWatcher(context.Context) <-chan WatchEventTessenConfig
 }
 
 // TokenStore provides methods for managing the JWT access list

--- a/backend/tessend/LICENSE
+++ b/backend/tessend/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -1,0 +1,100 @@
+package tessend
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	v2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+const (
+	// TimestampFormat is the string representation for the license timestamps e.g.
+	// "2018-07-26T12:12:06-04:00"
+	TimestampFormat = time.RFC3339
+)
+
+// Data is the payload sent to tessen
+type Data struct {
+	// General information about the Sensu installation.
+	Cluster Cluster `json:"cluster"`
+
+	// Metric data.
+	Metrics v2.Metrics `json:"metrics"`
+}
+
+// Cluster is the cluster information sent to tessen
+type Cluster struct {
+	// ID is the ID of the sensu-enterprise-go cluster.
+	ID string `json:"id"`
+
+	// Version is the Sensu release version (e.g. "1.4.1").
+	Version string `json:"sensu_version"`
+
+	// License is the Cluster's license.
+	License License
+}
+
+// Timestamp is an alias to time.Time with json Marshaling/Unmarshaling support
+type Timestamp time.Time
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	stamp := fmt.Sprintf("%q", time.Time(t).Format(TimestampFormat))
+	return []byte(stamp), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return fmt.Errorf("Cannot unmarshal the license timestamp")
+	}
+
+	value, err := time.Parse(TimestampFormat, str)
+	if err != nil {
+		return err
+	}
+
+	*t = Timestamp(value)
+	return nil
+}
+
+// License holds information about a user's enterprise software license,
+// including duration of validity and enabled features.
+type License struct {
+	// Version is the license format version.
+	Version int `json:"version"`
+
+	// Issuer is the name of the account that issued the license.
+	Issuer string `json:"issuer"`
+
+	// AccountName is the name of the customer account.
+	AccountName string `json:"accountName"`
+
+	// AccountID is the ID of the customer account.
+	AccountID uint64 `json:"accountID"`
+
+	// Issued is the time at which the license was issued.
+	Issued Timestamp `json:"issued"`
+
+	// ValidUntil is the time at which the license will expire.
+	ValidUntil Timestamp `json:"validUntil"`
+
+	// Plan is the subscription plan the license is associated with.
+	Plan string `json:"plan"`
+
+	// Features are a list of features enabled by this license.
+	Features []string `json:"features"`
+}
+
+// LicenseFile represents the content of a license file
+type LicenseFile struct {
+	// License contains the actual license
+	License License `json:"license"`
+}
+
+// Wrapper wraps the LicenseFile for unmarshalling
+type Wrapper struct {
+	Value LicenseFile `json:"spec"`
+}

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -1,18 +1,10 @@
 package tessend
 
 import (
-	"encoding/json"
-	"fmt"
-	"time"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 const (
-	// TimestampFormat is the string representation for the license timestamps e.g.
-	// "2018-07-26T12:12:06-04:00"
-	TimestampFormat = time.RFC3339
-
 	licenseStorePath = "/sensu.io/api/enterprise/licensing/v2/license"
 )
 
@@ -31,69 +23,16 @@ type Cluster struct {
 	ID string `json:"id"`
 
 	// Version is the Sensu release version (e.g. "1.4.1").
-	Version string `json:"sensu_version"`
+	Version string `json:"version"`
 
 	// License is the Cluster's license.
-	License License `json:"license"`
-}
-
-// Timestamp is an alias to time.Time with json Marshaling/Unmarshaling support
-type Timestamp time.Time
-
-// MarshalJSON implements the json.Marshaler interface.
-func (t Timestamp) MarshalJSON() ([]byte, error) {
-	stamp := fmt.Sprintf("%q", time.Time(t).Format(TimestampFormat))
-	return []byte(stamp), nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface.
-func (t *Timestamp) UnmarshalJSON(b []byte) error {
-	var str string
-	if err := json.Unmarshal(b, &str); err != nil {
-		return fmt.Errorf("Cannot unmarshal the license timestamp")
-	}
-
-	value, err := time.Parse(TimestampFormat, str)
-	if err != nil {
-		return err
-	}
-
-	*t = Timestamp(value)
-	return nil
-}
-
-// License holds information about a user's enterprise software license,
-// including duration of validity and enabled features.
-type License struct {
-	// Version is the license format version.
-	Version int `json:"version"`
-
-	// Issuer is the name of the account that issued the license.
-	Issuer string `json:"issuer"`
-
-	// AccountName is the name of the customer account.
-	AccountName string `json:"accountName"`
-
-	// AccountID is the ID of the customer account.
-	AccountID uint64 `json:"accountID"`
-
-	// Issued is the time at which the license was issued.
-	Issued Timestamp `json:"issued"`
-
-	// ValidUntil is the time at which the license will expire.
-	ValidUntil Timestamp `json:"validUntil"`
-
-	// Plan is the subscription plan the license is associated with.
-	Plan string `json:"plan"`
-
-	// Features are a list of features enabled by this license.
-	Features []string `json:"features"`
+	License interface{} `json:"license"`
 }
 
 // LicenseFile represents the content of a license file
 type LicenseFile struct {
 	// License contains the actual license
-	License License `json:"license"`
+	License interface{} `json:"license"`
 }
 
 // Wrapper wraps the LicenseFile for unmarshalling

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 const (
 	// TimestampFormat is the string representation for the license timestamps e.g.
 	// "2018-07-26T12:12:06-04:00"
 	TimestampFormat = time.RFC3339
+
+	licenseStorePath = "/sensu.io/api/enterprise/licensing/v2/license"
 )
 
 // Data is the payload sent to tessen
@@ -20,7 +22,7 @@ type Data struct {
 	Cluster Cluster `json:"cluster"`
 
 	// Metric data.
-	Metrics v2.Metrics `json:"metrics"`
+	Metrics corev2.Metrics `json:"metrics"`
 }
 
 // Cluster is the cluster information sent to tessen

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -34,7 +34,7 @@ type Cluster struct {
 	Version string `json:"sensu_version"`
 
 	// License is the Cluster's license.
-	License License
+	License License `json:"license"`
 }
 
 // Timestamp is an alias to time.Time with json Marshaling/Unmarshaling support

--- a/backend/tessend/logger.go
+++ b/backend/tessend/logger.go
@@ -1,0 +1,7 @@
+package tessend
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "tessend",
+})

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -1,0 +1,305 @@
+package tessend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/ringv2"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/etcd"
+	"github.com/sensu/sensu-go/version"
+	"github.com/sirupsen/logrus"
+)
+
+const tessenURL = "https://tessen.sensu.io/v2/data"
+
+// Tessend is the tessen daemon
+type Tessend struct {
+	interval  uint32
+	store     store.Store
+	ctx       context.Context
+	cancel    context.CancelFunc
+	errChan   chan error
+	ringPool  *ringv2.Pool
+	interrupt chan *v2.TessenConfig
+	cluster   clientv3.Cluster
+	client    *clientv3.Client
+	url       string
+}
+
+// Option is a functional option.
+type Option func(*Tessend) error
+
+// Config configures Tessend.
+type Config struct {
+	Store    store.Store
+	RingPool *ringv2.Pool
+	Cluster  clientv3.Cluster
+	Client   *clientv3.Client
+}
+
+// New creates a new APId.
+func New(c Config, opts ...Option) (*Tessend, error) {
+	t := &Tessend{
+		interval: v2.DefaultTessenFrequency,
+		store:    c.Store,
+		ringPool: c.RingPool,
+		cluster:  c.Cluster,
+		client:   c.Client,
+		errChan:  make(chan error, 1),
+		url:      tessenURL,
+	}
+	t.ctx, t.cancel = context.WithCancel(context.Background())
+	t.interrupt = make(chan *v2.TessenConfig)
+
+	return t, nil
+}
+
+// Start the Scheduler daemon.
+func (t *Tessend) Start() error {
+	tessenConfig, err := t.store.GetTessenConfig(t.ctx)
+	// create the default tessen config if one does not already exist
+	if err != nil || tessenConfig == nil {
+		tessenConfig = v2.DefaultTessenConfig()
+		err = t.store.CreateOrUpdateTessenConfig(t.ctx, tessenConfig)
+		if err != nil {
+			// log the error and continue with the default config
+			logger.WithError(err).Error("unable to update tessen store")
+		}
+	}
+
+	if err := t.start(tessenConfig); err != nil {
+		return err
+	}
+
+	go t.startWatcher()
+
+	return nil
+}
+
+// Stop the scheduler daemon.
+func (t *Tessend) Stop() error {
+	t.cancel()
+	close(t.errChan)
+	return nil
+}
+
+// Err returns a channel on which to listen for terminal errors.
+func (t *Tessend) Err() <-chan error {
+	return t.errChan
+}
+
+// Name returns the daemon name
+func (t *Tessend) Name() string {
+	return "tessend"
+}
+
+func (t *Tessend) startWatcher() {
+	watchChan := t.store.GetTessenConfigWatcher(t.ctx)
+	for {
+		select {
+		case watchEvent, ok := <-watchChan:
+			if !ok {
+				// The watchChan has closed. Restart the watcher.
+				watchChan = t.store.GetTessenConfigWatcher(t.ctx)
+				continue
+			}
+			t.handleWatchEvent(watchEvent)
+		case <-t.ctx.Done():
+			return
+		}
+	}
+}
+
+func (t *Tessend) handleWatchEvent(watchEvent store.WatchEventTessenConfig) {
+	tessen := watchEvent.TessenConfig
+
+	switch watchEvent.Action {
+	case store.WatchCreate:
+		logger.WithField("opt-out", tessen.OptOut).Debug("tessen configuration created")
+	case store.WatchUpdate:
+		logger.WithField("opt-out", tessen.OptOut).Debug("tessen configuration updated")
+	case store.WatchDelete:
+		logger.WithField("opt-out", tessen.OptOut).Debug("tessen configuration deleted")
+	}
+
+	t.interrupt <- tessen
+}
+
+// start starts a new scheduler for tessen
+func (t *Tessend) start(tessen *v2.TessenConfig) error {
+	// Guard against updates while the daemon is shutting down
+	if err := t.ctx.Err(); err != nil {
+		return err
+	}
+
+	go t.schedule(tessen)
+
+	return nil
+}
+
+func (t *Tessend) schedule(tessen *v2.TessenConfig) {
+	timer := time.NewTimer(time.Duration(time.Second * time.Duration(t.interval)))
+	// Attempt to send data immediately if tessen is enabled
+	if t.enabled(tessen) {
+		t.collectAndSend()
+	}
+
+	for {
+		select {
+		case <-t.ctx.Done():
+			timer.Stop()
+			return
+		case config := <-t.interrupt:
+			timer.Stop()
+			defer func() {
+				go t.schedule(config)
+			}()
+			return
+		case <-timer.C:
+		}
+		// Attempt to send data if tessen is enabled
+		if t.enabled(tessen) {
+			t.collectAndSend()
+		}
+		timer.Reset(time.Duration(time.Second * time.Duration(t.interval)))
+	}
+}
+
+// enabled checks the tessen config for opt-out status, and verifies the existence of an enterprise license.
+// It returns a boolean value indicating if tessen should be enabled or not.
+func (t *Tessend) enabled(tessen *v2.TessenConfig) bool {
+	if !tessen.OptOut {
+		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted in, enabling tessen.. thank you so much for your support 💚")
+		return true
+	}
+
+	wrapper := &Wrapper{}
+	err := etcd.Get(t.ctx, t.client, "/sensu.io/api/enterprise/licensing/v2/license", wrapper)
+	if err != nil {
+		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out, patiently waiting for you to opt back in")
+	} else {
+		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out but a enterprise license is detected, enabling tessen.. thank you so much for your support 💚")
+	}
+
+	return err == nil
+}
+
+// collectAndSend is a durable function to collect and send data to tessen.
+// Errors are logged and tessen continues to the best of its ability.
+func (t *Tessend) collectAndSend() {
+	// collect data
+	data := t.collect(time.Now().UTC().Unix())
+
+	logger.WithFields(logrus.Fields{
+		"url":                       t.url,
+		"id":                        data.Cluster.ID,
+		data.Metrics.Points[0].Name: data.Metrics.Points[0].Value,
+		data.Metrics.Points[1].Name: data.Metrics.Points[1].Value,
+	}).Info("sending data to tessen")
+
+	// send data
+	resp, err := t.send(data)
+	if err != nil {
+		logger.WithError(err).Error("tessen phone-home service failed")
+		return
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		logger.Errorf("bad status: %d (%q)", resp.StatusCode, string(body))
+		return
+	}
+
+	// parse the response header for an integer value
+	interval, err := strconv.ParseUint(resp.Header.Get("tessen-reporting-interval"), 10, 32)
+	if err != nil {
+		logger.Debugf("invalid tessen response header: %v", err)
+		return
+	}
+
+	// validate the returned interval is within the upper/lower bound limits
+	err = v2.ValidateFrequency(uint32(interval))
+	if err != nil {
+		logger.Debugf("invalid tessen response header: %v", err)
+		return
+	}
+
+	// update the tessen interval if the response header returns a new value
+	if t.interval != uint32(interval) {
+		t.interval = uint32(interval)
+		logger.WithField("interval", t.interval).Debug("tessen interval updated")
+	}
+}
+
+// collect data and populate the data payload
+func (t *Tessend) collect(now int64) *Data {
+	var clusterID string
+	var clientCount, serverCount float64
+
+	// collect client count
+	entities, _, err := t.store.GetEntities(t.ctx, 0, "")
+	if err != nil {
+		logger.WithError(err).Error("unable to retrieve client count")
+	}
+	if entities != nil {
+		clientCount = float64(len(entities))
+	}
+
+	// collect server count and cluster id
+	servers, err := t.cluster.MemberList(t.ctx)
+	if err != nil {
+		logger.WithError(err).Error("unable to retrieve cluster information")
+	}
+	if servers != nil {
+		clusterID = strconv.FormatUint(servers.Header.ClusterId, 10)
+		serverCount = float64(len(servers.Members))
+	}
+
+	// collect license information
+	license := License{}
+	wrapper := &Wrapper{}
+	err = etcd.Get(t.ctx, t.client, "/sensu.io/api/enterprise/licensing/v2/license", wrapper)
+	if err != nil {
+		logger.Debugf("cannot retrieve license: %v", err)
+	} else {
+		license = wrapper.Value.License
+	}
+
+	// populate data payload
+	data := &Data{
+		Cluster: Cluster{
+			ID:      clusterID,
+			Version: version.Version,
+			License: license,
+		},
+		Metrics: v2.Metrics{
+			Points: []*v2.MetricPoint{
+				&v2.MetricPoint{
+					Name:      "client_count",
+					Value:     clientCount,
+					Timestamp: now,
+				},
+				&v2.MetricPoint{
+					Name:      "server_count",
+					Value:     serverCount,
+					Timestamp: now,
+				},
+			},
+		},
+	}
+
+	return data
+}
+
+// send the data payload to the tessen url
+func (t *Tessend) send(data *Data) (*http.Response, error) {
+	b, _ := json.Marshal(data)
+	return http.Post(t.url, "application/json", bytes.NewBuffer(b))
+}

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -261,11 +261,19 @@ func (t *Tessend) collect(now int64) *Data {
 		serverCount = float64(len(servers.Members))
 	}
 
+	// collect license information
+	wrapper := &Wrapper{}
+	err = etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
+	if err != nil {
+		logger.Debugf("cannot retrieve license: %v", err)
+	}
+
 	// populate data payload
 	data := &Data{
 		Cluster: Cluster{
 			ID:      clusterID,
-			Version: version.Version,
+			Version: version.Semver(),
+			License: wrapper.Value.License,
 		},
 		Metrics: corev2.Metrics{
 			Points: []*corev2.MetricPoint{
@@ -281,15 +289,6 @@ func (t *Tessend) collect(now int64) *Data {
 				},
 			},
 		},
-	}
-
-	// collect license information
-	wrapper := &Wrapper{}
-	err = etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
-	if err != nil {
-		logger.Debugf("cannot retrieve license: %v", err)
-	} else {
-		data.Cluster.License = wrapper.Value.License
 	}
 
 	return data

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -147,6 +147,7 @@ func (t *Tessend) start(tessen *corev2.TessenConfig) error {
 
 func (t *Tessend) schedule(tessen *corev2.TessenConfig) {
 	timer := time.NewTimer(time.Duration(time.Second * time.Duration(t.interval)))
+	defer timer.Stop()
 	// Attempt to send data immediately if tessen is enabled
 	if t.enabled(tessen) {
 		t.collectAndSend()
@@ -155,10 +156,8 @@ func (t *Tessend) schedule(tessen *corev2.TessenConfig) {
 	for {
 		select {
 		case <-t.ctx.Done():
-			timer.Stop()
 			return
 		case config := <-t.interrupt:
-			timer.Stop()
 			defer func() {
 				go t.schedule(config)
 			}()

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/etcd"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/stretchr/testify/assert"
@@ -68,7 +68,7 @@ func TestTessend200InvalidHeaderKey(t *testing.T) {
 	require.NoError(t, tessend.Start())
 	time.Sleep(3 * time.Second)
 	assert.NoError(t, tessend.Stop())
-	require.Equal(t, uint32(v2.DefaultTessenInterval), tessend.interval)
+	require.Equal(t, uint32(corev2.DefaultTessenInterval), tessend.interval)
 	assert.Equal(t, tessend.Name(), "tessend")
 }
 
@@ -85,7 +85,7 @@ func TestTessend200InvalidHeaderValue(t *testing.T) {
 	require.NoError(t, tessend.Start())
 	time.Sleep(3 * time.Second)
 	assert.NoError(t, tessend.Stop())
-	require.Equal(t, uint32(v2.DefaultTessenInterval), tessend.interval)
+	require.Equal(t, uint32(corev2.DefaultTessenInterval), tessend.interval)
 	assert.Equal(t, tessend.Name(), "tessend")
 }
 
@@ -105,7 +105,7 @@ func TestTessend500(t *testing.T) {
 }
 
 func TestTessendEnabled(t *testing.T) {
-	tessen := v2.DefaultTessenConfig()
+	tessen := corev2.DefaultTessenConfig()
 	tessend := newTessendTest(t)
 	require.True(t, tessend.enabled(tessen))
 	tessen.OptOut = true

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -68,7 +68,7 @@ func TestTessend200InvalidHeaderKey(t *testing.T) {
 	require.NoError(t, tessend.Start())
 	time.Sleep(3 * time.Second)
 	assert.NoError(t, tessend.Stop())
-	require.Equal(t, uint32(v2.DefaultTessenFrequency), tessend.interval)
+	require.Equal(t, uint32(v2.DefaultTessenInterval), tessend.interval)
 	assert.Equal(t, tessend.Name(), "tessend")
 }
 
@@ -85,7 +85,7 @@ func TestTessend200InvalidHeaderValue(t *testing.T) {
 	require.NoError(t, tessend.Start())
 	time.Sleep(3 * time.Second)
 	assert.NoError(t, tessend.Stop())
-	require.Equal(t, uint32(v2.DefaultTessenFrequency), tessend.interval)
+	require.Equal(t, uint32(v2.DefaultTessenInterval), tessend.interval)
 	assert.Equal(t, tessend.Name(), "tessend")
 }
 

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -1,0 +1,113 @@
+// +build integration,!race
+
+package tessend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/etcd"
+	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTessendTest(t *testing.T) *Tessend {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	cluster := clientv3.NewCluster(client)
+
+	store := etcdstore.NewStore(client, e.Name())
+
+	tessend, err := New(Config{
+		Store:   store,
+		Cluster: cluster,
+		Client:  client,
+	})
+	require.NoError(t, err)
+	return tessend
+}
+
+func TestTessend200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("tessen-reporting-interval", "1800")
+		assert.NotEmpty(t, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tessend := newTessendTest(t)
+	tessend.url = ts.URL
+	require.NoError(t, tessend.Start())
+	time.Sleep(3 * time.Second)
+	assert.NoError(t, tessend.Stop())
+	require.Equal(t, uint32(1800), tessend.interval)
+	assert.Equal(t, tessend.Name(), "tessend")
+}
+
+func TestTessend200InvalidHeaderKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("foo", "1800")
+		assert.NotEmpty(t, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tessend := newTessendTest(t)
+	tessend.url = ts.URL
+	require.NoError(t, tessend.Start())
+	time.Sleep(3 * time.Second)
+	assert.NoError(t, tessend.Stop())
+	require.Equal(t, uint32(v2.DefaultTessenFrequency), tessend.interval)
+	assert.Equal(t, tessend.Name(), "tessend")
+}
+
+func TestTessend200InvalidHeaderValue(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("tessen-reporting-interval", "216000")
+		assert.NotEmpty(t, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tessend := newTessendTest(t)
+	tessend.url = ts.URL
+	require.NoError(t, tessend.Start())
+	time.Sleep(3 * time.Second)
+	assert.NoError(t, tessend.Stop())
+	require.Equal(t, uint32(v2.DefaultTessenFrequency), tessend.interval)
+	assert.Equal(t, tessend.Name(), "tessend")
+}
+
+func TestTessend500(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotEmpty(t, r.Body)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	tessend := newTessendTest(t)
+	tessend.url = ts.URL
+	require.NoError(t, tessend.Start())
+	time.Sleep(3 * time.Second)
+	assert.NoError(t, tessend.Stop())
+	assert.Equal(t, tessend.Name(), "tessend")
+}
+
+func TestTessendEnabled(t *testing.T) {
+	tessen := v2.DefaultTessenConfig()
+	tessend := newTessendTest(t)
+	require.True(t, tessend.enabled(tessen))
+	tessen.OptOut = true
+	require.False(t, tessend.enabled(tessen))
+}

--- a/testing/mockstore/hook_config.go
+++ b/testing/mockstore/hook_config.go
@@ -3,7 +3,6 @@ package mockstore
 import (
 	"context"
 
-	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -29,10 +28,4 @@ func (s *MockStore) GetHookConfigByName(ctx context.Context, name string) (*type
 func (s *MockStore) UpdateHookConfig(ctx context.Context, hook *types.HookConfig) error {
 	args := s.Called(ctx, hook)
 	return args.Error(0)
-}
-
-// GetHookConfigWatcher ...
-func (s *MockStore) GetHookConfigWatcher(ctx context.Context) <-chan store.WatchEventHookConfig {
-	args := s.Called(ctx)
-	return args.Get(0).(<-chan store.WatchEventHookConfig)
 }

--- a/testing/mockstore/tessen.go
+++ b/testing/mockstore/tessen.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
 // CreateOrUpdateTessenConfig ...
@@ -16,4 +17,10 @@ func (s *MockStore) CreateOrUpdateTessenConfig(ctx context.Context, config *v2.T
 func (s *MockStore) GetTessenConfig(ctx context.Context) (*v2.TessenConfig, error) {
 	args := s.Called(ctx)
 	return args.Get(0).(*v2.TessenConfig), args.Error(1)
+}
+
+// GetTessenConfigWatcher ...
+func (s *MockStore) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEventTessenConfig {
+	args := s.Called(ctx)
+	return args.Get(0).(<-chan store.WatchEventTessenConfig)
 }

--- a/testing/mockstore/tessen.go
+++ b/testing/mockstore/tessen.go
@@ -3,20 +3,20 @@ package mockstore
 import (
 	"context"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
 // CreateOrUpdateTessenConfig ...
-func (s *MockStore) CreateOrUpdateTessenConfig(ctx context.Context, config *v2.TessenConfig) error {
+func (s *MockStore) CreateOrUpdateTessenConfig(ctx context.Context, config *corev2.TessenConfig) error {
 	args := s.Called(ctx, config)
 	return args.Error(0)
 }
 
 // GetTessenConfig ...
-func (s *MockStore) GetTessenConfig(ctx context.Context) (*v2.TessenConfig, error) {
+func (s *MockStore) GetTessenConfig(ctx context.Context) (*corev2.TessenConfig, error) {
 	args := s.Called(ctx)
-	return args.Get(0).(*v2.TessenConfig), args.Error(1)
+	return args.Get(0).(*corev2.TessenConfig), args.Error(1)
 }
 
 // GetTessenConfigWatcher ...


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Implements TessenD and TessenConfig watcher 🎉 Does not yet implement the ring, so right now every backend in the cluster will send data. Removes the unused hook config watcher.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2792
Closes https://github.com/sensu/sensu-go/issues/2791

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

See the [Tessen Chronograf](https://calvinklein-c257063e.influxcloud.net/sources/0/dashboards/3?lower=now%28%29%20-%2015m). TestRail tests will be added at the completion of the feature.