### PR TITLE
Refactoring of the list handlers

### DIFF
--- a/CHANGELOGS/unreleased/list-handlers.md
+++ b/CHANGELOGS/unreleased/list-handlers.md
@@ -1,0 +1,6 @@
+### Changed
+- apid uses a new generic router for listing resources.
+- The store uses the generic List function for listing resources.
+
+### Fixed
+- Fixed the `/events/:entity` route in the REST API.

--- a/backend/apid/actions/cluster.go
+++ b/backend/apid/actions/cluster.go
@@ -12,24 +12,29 @@ type ClusterController struct {
 	cluster clientv3.Cluster
 }
 
+// NewClusterController provides a new controller for the etcd cluster
 func NewClusterController(cluster clientv3.Cluster) ClusterController {
 	return ClusterController{
 		cluster: cluster,
 	}
 }
 
+// MemberList returns the list of members in the cluster
 func (c ClusterController) MemberList(ctx context.Context) (*clientv3.MemberListResponse, error) {
 	return c.cluster.MemberList(ctx)
 }
 
+// MemberAdd adds a member to the cluster
 func (c ClusterController) MemberAdd(ctx context.Context, addrs []string) (*clientv3.MemberAddResponse, error) {
 	return c.cluster.MemberAdd(ctx, addrs)
 }
 
+// MemberRemove removes a member from the cluster
 func (c ClusterController) MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
 	return c.cluster.MemberRemove(ctx, id)
 }
 
+// MemberUpdate updates the specified member addresses
 func (c ClusterController) MemberUpdate(ctx context.Context, id uint64, addrs []string) (*clientv3.MemberUpdateResponse, error) {
 	return c.cluster.MemberUpdate(ctx, id, addrs)
 }

--- a/backend/apid/actions/clusterroles_test.go
+++ b/backend/apid/actions/clusterroles_test.go
@@ -20,7 +20,7 @@ func TestNewClusterRoleController(t *testing.T) {
 	actions := NewClusterRoleController(store)
 
 	assert.NotNil(actions)
-	assert.Equal(store, actions.Store)
+	assert.Equal(store, actions.store)
 }
 
 func TestClusterRoleCreate(t *testing.T) {
@@ -276,86 +276,52 @@ func TestClusterRoleGet(t *testing.T) {
 
 func TestClusterRoleList(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		storeErr              error
-		continueToken         string
-		expectedResult        []*types.ClusterRole
-		expectedContinueToken string
-		expectedErr           bool
-		expectedErrCode       ErrCode
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.ClusterRole
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",
 			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
+			records: []*types.ClusterRole{
 				types.FixtureClusterRole("read-write"),
 				types.FixtureClusterRole("read-only"),
 				types.FixtureClusterRole("sysadmin"),
 			},
+			expectedLen: 3,
 		},
 		{
-			name:            "Not found",
-			ctx:             context.Background(),
-			storeErr:        &store.ErrNotFound{},
-			expectedErr:     true,
-			expectedErrCode: NotFound,
-		},
-		{
-			name:            "Store error",
-			ctx:             context.Background(),
-			storeErr:        errors.New("some error"),
-			expectedErr:     true,
-			expectedErrCode: InternalErr,
-		},
-		{
-			name: "no continue token",
+			name: "Not found",
 			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
-				types.FixtureClusterRole("clusterRole1"),
-				types.FixtureClusterRole("clusterRole2"),
-			},
-			continueToken:         "",
-			expectedContinueToken: "",
 		},
 		{
-			name: "base64url encode continue token",
-			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
-				types.FixtureClusterRole("clusterRole1"),
-				types.FixtureClusterRole("clusterRole2"),
-			},
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
+			name:        "Store error",
+			ctx:         context.Background(),
+			storeErr:    errors.New("some error"),
+			expectedErr: NewError(InternalErr, errors.New("some error")),
 		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
-		actions := NewClusterRoleController(store)
+		s := &mockstore.MockStore{}
+		actions := NewClusterRoleController(s)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			store.
-				On("ListClusterRoles", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.expectedResult, tc.continueToken, tc.storeErr)
+			// Mock store methods
+			pred := &store.SelectionPredicate{}
+			s.On("ListClusterRoles", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			result, continueToken, err := actions.List(tc.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			if tc.expectedErr {
-				inferErr, ok := err.(Error)
-				if ok {
-					assert.Equal(tc.expectedErrCode, inferErr.Code)
-				} else {
-					assert.Error(err)
-					assert.FailNow("Return value was not of type 'Error'")
-				}
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.expectedResult, result)
-				assert.Equal(tc.expectedContinueToken, continueToken)
-			}
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -47,37 +47,6 @@ func (a EventController) List(ctx context.Context, pred *store.SelectionPredicat
 	return resources, nil
 }
 
-// func (a EventController) Query(ctx context.Context, entityName, checkName string) ([]*corev2.Event, string, error) {
-// 	var results []*corev2.Event
-// 	var nextContinueToken string
-
-// 	pageSize := corev2.PageSizeFromContext(ctx)
-// 	continueToken := corev2.PageContinueFromContext(ctx)
-
-// 	// Fetch from store
-// 	var serr error
-// 	if entityName != "" && checkName != "" {
-// 		var result *corev2.Event
-// 		result, serr = a.store.GetEventByEntityCheck(ctx, entityName, checkName)
-// 		if result != nil {
-// 			results = append(results, result)
-// 		}
-// 	} else if entityName != "" {
-// 		results, nextContinueToken, serr = a.store.GetEventsByEntity(ctx, entityName, int64(pageSize), continueToken)
-// 	} else {
-// 		results, nextContinueToken, serr = a.store.GetEvents(ctx, int64(pageSize), continueToken)
-// 	}
-
-// 	if serr != nil {
-// 		return nil, "", NewError(InternalErr, serr)
-// 	}
-
-// 	// Encode the continue token with base64url (RFC 4648), without padding
-// 	encodedNextContinueToken := base64.RawURLEncoding.EncodeToString([]byte(nextContinueToken))
-
-// 	return results, encodedNextContinueToken, nil
-// }
-
 // Find returns resource associated with given parameters if available to the
 // viewer.
 func (a EventController) Find(ctx context.Context, entity, check string) (*corev2.Event, error) {

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -29,8 +29,8 @@ func (a EventController) List(ctx context.Context, pred *store.SelectionPredicat
 	var err error
 
 	// Fetch from store
-	if pred.Suffix != "" {
-		results, err = a.store.GetEventsByEntity(ctx, pred.Suffix, pred)
+	if pred.Subcollection != "" {
+		results, err = a.store.GetEventsByEntity(ctx, pred.Subcollection, pred)
 	} else {
 		results, err = a.store.GetEvents(ctx, pred)
 	}

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -23,7 +23,7 @@ func NewEventController(store store.EventStore, bus messaging.MessageBus) EventC
 	}
 }
 
-// Query returns resources available to the viewer filter by given params.
+// List returns resources available to the viewer filter by given params.
 func (a EventController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
 	var results []*corev2.Event
 	var err error

--- a/backend/apid/actions/events_test.go
+++ b/backend/apid/actions/events_test.go
@@ -33,7 +33,6 @@ func TestEventList(t *testing.T) {
 		ctx         context.Context
 		events      []*types.Event
 		entity      string
-		check       string
 		storeErr    error
 		expectedLen int
 		expectedErr error

--- a/backend/apid/actions/mutators_test.go
+++ b/backend/apid/actions/mutators_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
@@ -18,7 +19,7 @@ func TestNewMutatorController(t *testing.T) {
 	store := &mockstore.MockStore{}
 	ctl := NewMutatorController(store)
 	assert.NotNil(ctl)
-	assert.Equal(store, ctl.Store)
+	assert.Equal(store, ctl.store)
 }
 
 func TestMutatorCreateOrReplace(t *testing.T) {
@@ -121,7 +122,7 @@ func TestMutatorCreate(t *testing.T) {
 			expectedErrCode: AlreadyExistsErr,
 		},
 		{
-			name:            "Store Err on Fetch",
+			name:            "store Err on Fetch",
 			ctx:             defaultCtx,
 			argument:        types.FixtureMutator("grumpy"),
 			fetchErr:        errors.New("nein"),
@@ -196,7 +197,7 @@ func TestMutatorDestroy(t *testing.T) {
 			expectedErrCode: NotFound,
 		},
 		{
-			name:            "Store Err on Delete",
+			name:            "store Err on Delete",
 			ctx:             defaultCtx,
 			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
@@ -205,7 +206,7 @@ func TestMutatorDestroy(t *testing.T) {
 			expectedErrCode: InternalErr,
 		},
 		{
-			name:            "Store Err on Fetch",
+			name:            "store Err on Fetch",
 			ctx:             defaultCtx,
 			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
@@ -248,23 +249,21 @@ func TestMutatorDestroy(t *testing.T) {
 	}
 }
 
-func TestMutatorQuery(t *testing.T) {
+func TestMutatorList(t *testing.T) {
 	readCtx := context.Background()
 
-	tests := []struct {
-		name                  string
-		ctx                   context.Context
-		mutators              []*types.Mutator
-		storeErr              error
-		continueToken         string
-		expectedLen           int
-		expectedContinueToken string
-		expectedErr           error
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		records     []*types.Mutator
+		storeErr    error
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name:        "No Params, No Mutators",
 			ctx:         readCtx,
-			mutators:    nil,
+			records:     nil,
 			expectedLen: 0,
 			storeErr:    nil,
 			expectedErr: nil,
@@ -272,7 +271,7 @@ func TestMutatorQuery(t *testing.T) {
 		{
 			name: "No Params With Mutators",
 			ctx:  readCtx,
-			mutators: []*types.Mutator{
+			records: []*types.Mutator{
 				types.FixtureMutator("homer"),
 				types.FixtureMutator("bart"),
 			},
@@ -283,7 +282,7 @@ func TestMutatorQuery(t *testing.T) {
 		{
 			name: "Mutator Param",
 			ctx:  readCtx,
-			mutators: []*types.Mutator{
+			records: []*types.Mutator{
 				types.FixtureMutator("mr. burns"),
 			},
 			expectedLen: 1,
@@ -291,53 +290,32 @@ func TestMutatorQuery(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name:        "Store Failure",
+			name:        "store Failure",
 			ctx:         readCtx,
-			mutators:    nil,
+			records:     nil,
 			expectedLen: 0,
 			storeErr:    errors.New(""),
 			expectedErr: NewError(InternalErr, errors.New("")),
 		},
-		{
-			name: "no continue token",
-			ctx:  readCtx,
-			mutators: []*types.Mutator{
-				types.FixtureMutator("mutator1"),
-				types.FixtureMutator("mutator2"),
-			},
-			continueToken:         "",
-			expectedLen:           2,
-			expectedContinueToken: "",
-		},
-		{
-			name: "base64url encode continue token",
-			ctx:  readCtx,
-			mutators: []*types.Mutator{
-				types.FixtureMutator("mutator1"),
-				types.FixtureMutator("mutator2"),
-			},
-			continueToken:         "Albert Camus",
-			expectedLen:           2,
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
-		},
 	}
 
-	for _, test := range tests {
-		store := &mockstore.MockStore{}
-		ctl := NewMutatorController(store)
+	for _, tc := range testCases {
+		s := &mockstore.MockStore{}
+		actions := NewMutatorController(s)
 
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
 			// Mock store methods
-			store.On("GetMutators", test.ctx, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(test.mutators, test.continueToken, test.storeErr)
+			pred := &store.SelectionPredicate{}
+			s.On("GetMutators", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			results, continueToken, err := ctl.Query(test.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			assert.EqualValues(test.expectedErr, err)
-			assert.EqualValues(test.expectedContinueToken, continueToken)
-			assert.Len(results, test.expectedLen)
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/rolebindings_test.go
+++ b/backend/apid/actions/rolebindings_test.go
@@ -20,7 +20,7 @@ func TestNewRoleBindingController(t *testing.T) {
 	actions := NewRoleBindingController(store)
 
 	assert.NotNil(actions)
-	assert.Equal(store, actions.Store)
+	assert.Equal(store, actions.store)
 }
 
 func TestRoleBindingCreate(t *testing.T) {
@@ -276,84 +276,52 @@ func TestRoleBindingGet(t *testing.T) {
 
 func TestRoleBindingList(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		storeErr              error
-		continueToken         string
-		expectedResult        []*types.RoleBinding
-		expectedContinueToken string
-		expectedErr           bool
-		expectedErrCode       ErrCode
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.RoleBinding
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",
 			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
+			records: []*types.RoleBinding{
 				types.FixtureRoleBinding("read-write", "default"),
 				types.FixtureRoleBinding("read-only", "default"),
 				types.FixtureRoleBinding("sysadmin", "IT"),
 			},
+			expectedLen: 3,
 		},
 		{
-			name:            "Not found",
-			ctx:             context.Background(),
-			storeErr:        &store.ErrNotFound{},
-			expectedErr:     true,
-			expectedErrCode: NotFound,
-		},
-		{
-			name:            "Store error",
-			ctx:             context.Background(),
-			storeErr:        errors.New("some error"),
-			expectedErr:     true,
-			expectedErrCode: InternalErr,
-		},
-		{
-			name: "no continue token",
+			name: "Not found",
 			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
-				types.FixtureRoleBinding("roleBinding1", "default"),
-			},
-			continueToken:         "",
-			expectedContinueToken: "",
 		},
 		{
-			name: "base64url encode continue token",
-			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
-				types.FixtureRoleBinding("roleBinding1", "default"),
-			},
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
+			name:        "Store error",
+			ctx:         context.Background(),
+			storeErr:    errors.New("some error"),
+			expectedErr: NewError(InternalErr, errors.New("some error")),
 		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
-		actions := NewRoleBindingController(store)
+		s := &mockstore.MockStore{}
+		actions := NewRoleBindingController(s)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			store.
-				On("ListRoleBindings", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.expectedResult, tc.continueToken, tc.storeErr)
+			// Mock store methods
+			pred := &store.SelectionPredicate{}
+			s.On("ListRoleBindings", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			result, continueToken, err := actions.List(tc.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			if tc.expectedErr {
-				inferErr, ok := err.(Error)
-				if ok {
-					assert.Equal(tc.expectedErrCode, inferErr.Code)
-				} else {
-					assert.Error(err)
-					assert.FailNow("Return value was not of type 'Error'")
-				}
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.expectedResult, result)
-				assert.Equal(tc.expectedContinueToken, continueToken)
-			}
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/roles_test.go
+++ b/backend/apid/actions/roles_test.go
@@ -276,13 +276,12 @@ func TestRoleGet(t *testing.T) {
 
 func TestRoleList(t *testing.T) {
 	testCases := []struct {
-		name          string
-		ctx           context.Context
-		storeErr      error
-		continueToken string
-		records       []*types.Role
-		expectedLen   int
-		expectedErr   error
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.Role
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",

--- a/backend/apid/actions/silenced_test.go
+++ b/backend/apid/actions/silenced_test.go
@@ -289,14 +289,14 @@ func TestSilencedCreate(t *testing.T) {
 		expectedErr     bool
 		expectedErrCode ErrCode
 		expectedCreator string
-		expectedId      string
+		expectedID      string
 	}{
 		{
 			name:        "Created",
 			ctx:         defaultCtx,
 			argument:    types.FixtureSilenced("*:silence1"),
 			expectedErr: false,
-			expectedId:  "*:silence1",
+			expectedID:  "*:silence1",
 		},
 		{
 			name:            "Already Exists",
@@ -305,7 +305,7 @@ func TestSilencedCreate(t *testing.T) {
 			fetchResult:     types.FixtureSilenced("*:silence1"),
 			expectedErr:     true,
 			expectedErrCode: AlreadyExistsErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Store Err on Create",
@@ -314,7 +314,7 @@ func TestSilencedCreate(t *testing.T) {
 			createErr:       errors.New("dunno"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Store Err on Fetch",
@@ -323,7 +323,7 @@ func TestSilencedCreate(t *testing.T) {
 			fetchErr:        errors.New("dunno"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Validation Error",
@@ -331,7 +331,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        badSilence,
 			expectedErr:     true,
 			expectedErrCode: InvalidArgument,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Creator",
@@ -339,7 +339,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        types.FixtureSilenced("*:silence1"),
 			expectedErr:     false,
 			expectedCreator: "foo",
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Other Id",
@@ -347,7 +347,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        types.FixtureSilenced("unix:*"),
 			expectedErr:     false,
 			expectedCreator: "foo",
-			expectedId:      "unix:*",
+			expectedID:      "unix:*",
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestSilencedCreate(t *testing.T) {
 						_ = json.Unmarshal(bytes, &entry)
 
 						assert.Equal(tc.expectedCreator, entry.Creator)
-						assert.Equal(tc.expectedId, entry.Name)
+						assert.Equal(tc.expectedID, entry.Name)
 					}
 				})
 

--- a/backend/apid/actions/users.go
+++ b/backend/apid/actions/users.go
@@ -21,12 +21,16 @@ func NewUserController(store store.Store) UserController {
 	}
 }
 
-// Query returns resources available to the viewer filter by given params.
+// List returns resources available to the viewer filter by given params.
 func (a UserController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
 	// Fetch from store
 	results, err := a.store.GetAllUsers(pred)
 	if err != nil {
 		return nil, NewError(InternalErr, err)
+	}
+
+	for i := range results {
+		results[i].Password = ""
 	}
 
 	resources := make([]corev2.Resource, len(results))

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,20 +30,10 @@ func (r *AssetsRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:assets}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:assets}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *AssetsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *AssetsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -17,7 +18,7 @@ import (
 type CheckController interface {
 	Create(context.Context, types.CheckConfig) error
 	CreateOrReplace(context.Context, types.CheckConfig) error
-	Query(context.Context) ([]*types.CheckConfig, string, error)
+	List(context.Context, *store.SelectionPredicate) ([]corev2.Resource, error)
 	Find(context.Context, string) (*types.CheckConfig, error)
 	Destroy(context.Context, string) error
 	AddCheckHook(context.Context, string, types.HookList) error
@@ -46,8 +47,10 @@ func (r *ChecksRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:checks}")
+	routes.List(r.controller.List)
+	// routes.Router.HandleFunc(routes.PathPrefix, listerHandler(r.controller.List)).Methods(http.MethodGet)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:checks}")
+	// routes.Router.HandleFunc("/{resource:checks}", listerHandler(r.controller.List)).Methods(http.MethodGet)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 
@@ -57,16 +60,6 @@ func (r *ChecksRouter) Mount(parent *mux.Router) {
 
 	// handlefunc returns a custom status and response
 	parent.HandleFunc(path.Join(routes.PathPrefix, "{id}/execute"), r.adhocRequest).Methods(http.MethodPost)
-}
-
-func (r *ChecksRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *ChecksRouter) find(req *http.Request) (interface{}, error) {
@@ -146,17 +139,17 @@ func (r *ChecksRouter) removeCheckHook(req *http.Request) (interface{}, error) {
 func (r *ChecksRouter) adhocRequest(w http.ResponseWriter, req *http.Request) {
 	adhocReq := types.AdhocRequest{}
 	if err := UnmarshalBody(req, &adhocReq); err != nil {
-		writeError(w, err)
+		WriteError(w, err)
 		return
 	}
 	params := mux.Vars(req)
 	id, err := url.PathUnescape(params["id"])
 	if err != nil {
-		writeError(w, err)
+		WriteError(w, err)
 		return
 	}
 	if err := r.controller.QueueAdhocRequest(req.Context(), id, &adhocReq); err != nil {
-		writeError(w, err)
+		WriteError(w, err)
 		return
 	}
 
@@ -164,12 +157,12 @@ func (r *ChecksRouter) adhocRequest(w http.ResponseWriter, req *http.Request) {
 	response["issued"] = time.Now().Unix()
 	jsonResponse, err := json.Marshal(response)
 	if err != nil {
-		writeError(w, err)
+		WriteError(w, err)
 		return
 	}
 
 	w.WriteHeader(http.StatusAccepted)
 	if _, err := w.Write(jsonResponse); err != nil {
-		writeError(w, err)
+		WriteError(w, err)
 	}
 }

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -48,9 +48,7 @@ func (r *ChecksRouter) Mount(parent *mux.Router) {
 	routes.Del(r.destroy)
 	routes.Get(r.find)
 	routes.List(r.controller.List)
-	// routes.Router.HandleFunc(routes.PathPrefix, listerHandler(r.controller.List)).Methods(http.MethodGet)
 	routes.ListAllNamespaces(r.controller.List, "/{resource:checks}")
-	// routes.Router.HandleFunc("/{resource:checks}", listerHandler(r.controller.List)).Methods(http.MethodGet)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 

--- a/backend/apid/routers/clusterrolebindings.go
+++ b/backend/apid/routers/clusterrolebindings.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -29,7 +28,7 @@ func (r *ClusterRoleBindingsRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterrolebindings}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
@@ -80,14 +79,4 @@ func (r *ClusterRoleBindingsRouter) find(req *http.Request) (interface{}, error)
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *ClusterRoleBindingsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/clusterroles.go
+++ b/backend/apid/routers/clusterroles.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -29,7 +28,7 @@ func (r *ClusterRolesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterroles}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
@@ -80,14 +79,4 @@ func (r *ClusterRolesRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *ClusterRolesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:entities}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:entities}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -56,16 +55,6 @@ func (r *EntitiesRouter) find(req *http.Request) (interface{}, error) {
 	}
 	record, err := r.controller.Find(req.Context(), id)
 	return record, err
-}
-
-func (r *EntitiesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *EntitiesRouter) create(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -38,9 +38,9 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 	routes.Path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
 	routes.Path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
 
-	// Additionaly allow a suffix to be specified when listing events, which
-	// correspond to the entity name here
-	parent.HandleFunc(path.Join(routes.PathPrefix, "{suffix}"), listerHandler(r.controller.List)).Methods(http.MethodGet)
+	// Additionaly allow a subcollection to be specified when listing events,
+	// which correspond to the entity name here
+	parent.HandleFunc(path.Join(routes.PathPrefix, "{subcollection}"), listerHandler(r.controller.List)).Methods(http.MethodGet)
 }
 
 func (r *EventsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -3,6 +3,7 @@ package routers
 import (
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -39,7 +40,7 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 
 	// Additionaly allow a suffix to be specified when listing events, which
 	// correspond to the entity name here
-	parent.HandleFunc("{suffix}", listerHandler(r.controller.List)).Methods(http.MethodGet)
+	parent.HandleFunc(path.Join(routes.PathPrefix, "{suffix}"), listerHandler(r.controller.List)).Methods(http.MethodGet)
 }
 
 func (r *EventsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/extensions.go
+++ b/backend/apid/routers/extensions.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,19 +31,9 @@ func (r *ExtensionsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.deregister)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:extensions}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:extensions}")
 	routes.Put(r.register)
-}
-
-func (r *ExtensionsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *ExtensionsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *EventFiltersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:filters}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:filters}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *EventFiltersRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *EventFiltersRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *HandlersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:handlers}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:handlers}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -72,14 +71,4 @@ func (r *HandlersRouter) find(req *http.Request) (interface{}, error) {
 		return nil, err
 	}
 	return r.controller.Find(req.Context(), id)
-}
-
-func (r *HandlersRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *HooksRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:hooks}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:hooks}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *HooksRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *HooksRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/lister.go
+++ b/backend/apid/routers/lister.go
@@ -1,0 +1,64 @@
+package routers
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+// ListControllerFunc represents a generic controller for listing resources
+type ListControllerFunc func(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error)
+
+// listerFunc represents the function signature of a Lister
+type listerFunc func(ListControllerFunc) http.HandlerFunc
+
+// Lister represents the active Lister function
+var Lister listerFunc
+
+func init() {
+	// Assign the core lister
+	Lister = lister
+}
+
+// lister handles resources listing with pagination support
+func lister(list ListControllerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pred := &store.SelectionPredicate{
+			Continue: corev2.PageContinueFromContext(r.Context()),
+			Limit:    int64(corev2.PageSizeFromContext(r.Context())),
+		}
+
+		params := actions.QueryParams(mux.Vars(r))
+		if suffix := url.PathEscape(params["suffix"]); suffix != "" {
+			pred.Suffix = suffix
+		}
+
+		results, err := list(r.Context(), pred)
+		if err != nil {
+			WriteError(w, err)
+			return
+		}
+
+		if pred.Continue != "" {
+			encodedContinue := base64.RawURLEncoding.EncodeToString([]byte(pred.Continue))
+			w.Header().Set(corev2.PaginationContinueHeader, encodedContinue)
+		}
+
+		RespondWith(w, results)
+	}
+}
+
+// We can't directly use a Lister in the mux.Router because it cannot be
+// modified at runtime, which is required for sensu-enterprise-go, therefore we
+// need this little wrapper
+func listerHandler(list ListControllerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		Lister(list).ServeHTTP(w, r)
+	}
+}

--- a/backend/apid/routers/lister.go
+++ b/backend/apid/routers/lister.go
@@ -35,8 +35,8 @@ func List(list ListControllerFunc) http.HandlerFunc {
 		}
 
 		params := actions.QueryParams(mux.Vars(r))
-		if suffix := url.PathEscape(params["suffix"]); suffix != "" {
-			pred.Suffix = suffix
+		if subcollection := url.PathEscape(params["subcollection"]); subcollection != "" {
+			pred.Subcollection = subcollection
 		}
 
 		results, err := list(r.Context(), pred)

--- a/backend/apid/routers/lister.go
+++ b/backend/apid/routers/lister.go
@@ -23,11 +23,11 @@ var Lister listerFunc
 
 func init() {
 	// Assign the core lister
-	Lister = lister
+	Lister = List
 }
 
-// lister handles resources listing with pagination support
-func lister(list ListControllerFunc) http.HandlerFunc {
+// List handles resources listing with pagination support
+func List(list ListControllerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		pred := &store.SelectionPredicate{
 			Continue: corev2.PageContinueFromContext(r.Context()),

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -1,0 +1,131 @@
+package routers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/middlewares"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockGenericController struct {
+	mock.Mock
+}
+
+func (m *mockGenericController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
+}
+
+// func TestList(t *testing.T) {
+// controller := &mockGenericController{}
+
+// r, err := http.NewRequest("GET", "/foo", nil)
+// if err != nil {
+// 	t.Fatal(err)
+// }
+// w := httptest.NewRecorder()
+
+// router := mux.NewRouter()
+// router.PathPrefix("/foo/{suffix}").HandlerFunc(List(controller.List))
+// router.PathPrefix("/foo").HandlerFunc(List(controller.List))
+
+// fixtures := []corev2.Resource{types.FixtureCheckConfig("check1")}
+// controller.On("List", mock.Anything, mock.AnythingOfType("*store.SelectionPredicate")).Return(fixtures, nil)
+
+// router.ServeHTTP(w, r)
+// }
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name                   string
+		path                   string
+		results                []corev2.Resource
+		controllerErr          error
+		continueToken          string
+		expectedContinueHeader string
+		expectedLen            int
+		expectedPred           *store.SelectionPredicate
+		expectedStatus         int
+	}{
+		{
+			name:           "list without pagination",
+			path:           "/foo",
+			results:        []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			expectedLen:    1,
+			expectedPred:   &store.SelectionPredicate{},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "list with suffix but without pagination",
+			path:           "/foo/bar",
+			results:        []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			expectedLen:    1,
+			expectedPred:   &store.SelectionPredicate{Suffix: "bar"},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "controller error",
+			path:           "/foo",
+			controllerErr:  errors.New("error"),
+			expectedPred:   &store.SelectionPredicate{},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:                   "continue token",
+			path:                   "/foo",
+			results:                []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			continueToken:          "bar",
+			expectedLen:            1,
+			expectedPred:           &store.SelectionPredicate{},
+			expectedStatus:         http.StatusOK,
+			expectedContinueHeader: "YmFy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &mockGenericController{}
+			controller.On("List", mock.Anything, mock.AnythingOfType("*store.SelectionPredicate")).
+				Return(tt.results, tt.controllerErr).
+				Run(func(args mock.Arguments) {
+					pred := args[1].(*store.SelectionPredicate)
+					assert.Equal(t, tt.expectedPred, pred)
+
+					if tt.continueToken != "" {
+						pred.Continue = tt.continueToken
+					}
+				})
+
+			r, err := http.NewRequest("GET", tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.PathPrefix("/foo/{suffix}").HandlerFunc(List(controller.List))
+			router.PathPrefix("/foo").HandlerFunc(List(controller.List))
+			middleware := middlewares.Pagination{}
+			router.Use(middleware.Then)
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if w.Code < 400 {
+				payload := []interface{}{}
+				if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+					t.Fatal(err)
+				}
+				assert.Len(t, payload, tt.expectedLen)
+			}
+			assert.Equal(t, tt.expectedContinueHeader, w.Header().Get(corev2.PaginationContinueHeader))
+		})
+	}
+}

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -25,25 +25,6 @@ func (m *mockGenericController) List(ctx context.Context, pred *store.SelectionP
 	return args.Get(0).([]corev2.Resource), args.Error(1)
 }
 
-// func TestList(t *testing.T) {
-// controller := &mockGenericController{}
-
-// r, err := http.NewRequest("GET", "/foo", nil)
-// if err != nil {
-// 	t.Fatal(err)
-// }
-// w := httptest.NewRecorder()
-
-// router := mux.NewRouter()
-// router.PathPrefix("/foo/{suffix}").HandlerFunc(List(controller.List))
-// router.PathPrefix("/foo").HandlerFunc(List(controller.List))
-
-// fixtures := []corev2.Resource{types.FixtureCheckConfig("check1")}
-// controller.On("List", mock.Anything, mock.AnythingOfType("*store.SelectionPredicate")).Return(fixtures, nil)
-
-// router.ServeHTTP(w, r)
-// }
-
 func TestList(t *testing.T) {
 	tests := []struct {
 		name                   string

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -46,11 +46,11 @@ func TestList(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
-			name:           "list with suffix but without pagination",
+			name:           "list with subcollection but without pagination",
 			path:           "/foo/bar",
 			results:        []corev2.Resource{corev2.FixtureCheck("check-cpu")},
 			expectedLen:    1,
-			expectedPred:   &store.SelectionPredicate{Suffix: "bar"},
+			expectedPred:   &store.SelectionPredicate{Subcollection: "bar"},
 			expectedStatus: http.StatusOK,
 		},
 		{
@@ -92,7 +92,7 @@ func TestList(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			router.PathPrefix("/foo/{suffix}").HandlerFunc(List(controller.List))
+			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List))
 			router.PathPrefix("/foo").HandlerFunc(List(controller.List))
 			middleware := middlewares.Pagination{}
 			router.Use(middleware.Then)

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *MutatorsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:mutators}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:mutators}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *MutatorsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *MutatorsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
 // NamespacesController represents the controller needs of the NamespacesRouter.
 type NamespacesController interface {
-	Query(ctx context.Context) ([]*types.Namespace, string, error)
+	List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error)
 	Find(ctx context.Context, name string) (*types.Namespace, error)
 	Create(ctx context.Context, newOrg types.Namespace) error
 	CreateOrReplace(ctx context.Context, newOrg types.Namespace) error
@@ -37,21 +38,11 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:namespaces}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *NamespacesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *NamespacesRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -9,6 +9,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
+
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/mock"
@@ -26,9 +29,9 @@ func (m *mockOrgController) CreateOrReplace(ctx context.Context, org types.Names
 	return m.Called(ctx, org).Error(0)
 }
 
-func (m *mockOrgController) Query(ctx context.Context) ([]*types.Namespace, string, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]*types.Namespace), args.String(1), args.Error(2)
+func (m *mockOrgController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
 }
 
 func (m *mockOrgController) Find(ctx context.Context, org string) (*types.Namespace, error) {
@@ -152,8 +155,8 @@ func TestListNamespaces(t *testing.T) {
 
 	client := new(http.Client)
 
-	fixtures := []*types.Namespace{types.FixtureNamespace("default")}
-	controller.On("Query", mock.Anything).Return(fixtures, "", nil)
+	fixtures := []corev2.Resource{types.FixtureNamespace("default")}
+	controller.On("List", mock.Anything, &store.SelectionPredicate{}).Return(fixtures, nil)
 	endpoint := "/namespaces"
 	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
 

--- a/backend/apid/routers/rolebindings.go
+++ b/backend/apid/routers/rolebindings.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *RoleBindingsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:rolebindings}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:rolebindings}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -82,14 +81,4 @@ func (r *RoleBindingsRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *RoleBindingsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *RolesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:roles}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:roles}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -82,14 +81,4 @@ func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *RolesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -31,8 +31,8 @@ func (r *SilencedRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:silenced}")
+	routes.Router.HandleFunc(routes.PathPrefix, listHandler(r.list)).Methods(http.MethodGet)
+	routes.Router.HandleFunc("/{resource:silenced}", listHandler(r.list)).Methods(http.MethodGet)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,9 +29,9 @@ func (m *mockUserController) CreateOrReplace(ctx context.Context, name types.Use
 	return m.Called(ctx, name).Error(0)
 }
 
-func (m *mockUserController) Query(ctx context.Context) ([]*types.User, string, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]*types.User), args.String(1), args.Error(2)
+func (m *mockUserController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
 }
 
 func (m *mockUserController) Find(ctx context.Context, name string) (*types.User, error) {

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -33,7 +33,7 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	}
 
 	// Get cluster roles binding
-	clusterRoleBindings, _, err := a.Store.ListClusterRoleBindings(ctx, 0, "")
+	clusterRoleBindings, err := a.Store.ListClusterRoleBindings(ctx, &store.SelectionPredicate{})
 	if err != nil {
 		switch err := err.(type) {
 		case *store.ErrNotFound:
@@ -81,7 +81,7 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	// First, make sure we have a namespace
 	if len(attrs.Namespace) > 0 {
 		// Get roles binding
-		roleBindings, _, err := a.Store.ListRoleBindings(ctx, 0, "")
+		roleBindings, err := a.Store.ListRoleBindings(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			switch err := err.(type) {
 			case *store.ErrNotFound:

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -33,7 +33,7 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 		return fmt.Errorf("error deleting entity in store: %s", err)
 	}
 
-	events, _, err := adapterPtr.Store.GetEventsByEntity(ctx, entity.Name, 0, "")
+	events, err := adapterPtr.Store.GetEventsByEntity(ctx, entity.Name, &store.SelectionPredicate{})
 	if err != nil {
 		return fmt.Errorf("error fetching events for entity: %s", err)
 	}

--- a/backend/keepalived/deregisterer_test.go
+++ b/backend/keepalived/deregisterer_test.go
@@ -3,6 +3,8 @@ package keepalived
 import (
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/store"
+
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/testing/mockbus"
 	"github.com/sensu/sensu-go/testing/mockstore"
@@ -27,7 +29,7 @@ func TestDeregister(t *testing.T) {
 	check := types.FixtureCheck("check")
 	event := types.FixtureEvent(entity.Name, check.Name)
 
-	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, int64(0), "").Return([]*types.Event{event}, "", nil)
+	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, &store.SelectionPredicate{}).Return([]*types.Event{event}, nil)
 	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.Name, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 
@@ -54,7 +56,7 @@ func TestDeregistrationHandler(t *testing.T) {
 	}
 	check := types.FixtureCheck("check")
 
-	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, int64(0), "").Return([]*types.Event{}, "", nil)
+	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, &store.SelectionPredicate{}).Return([]*types.Event{}, nil)
 	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.Name, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -84,7 +84,7 @@ func (c *CheckWatcher) startScheduler(check *types.CheckConfig) error {
 // Start starts the CheckWatcher.
 func (c *CheckWatcher) Start() error {
 	// for each check
-	checkConfigs, _, err := c.store.GetCheckConfigs(c.ctx, 0, "")
+	checkConfigs, err := c.store.GetCheckConfigs(c.ctx, &store.SelectionPredicate{})
 	if err != nil {
 		return err
 	}

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -27,11 +27,11 @@ func TestCheckWatcherSmoke(t *testing.T) {
 
 	checkA := types.FixtureCheckConfig("a")
 	checkB := types.FixtureCheckConfig("b")
-	st.On("GetCheckConfigs", mock.Anything, int64(0), "").Return([]*types.CheckConfig{checkA, checkB}, "", nil)
+	st.On("GetCheckConfigs", mock.Anything, &store.SelectionPredicate{}).Return([]*types.CheckConfig{checkA, checkB}, nil)
 	st.On("GetCheckConfigByName", mock.Anything, "a").Return(checkA, nil)
 	st.On("GetCheckConfigByName", mock.Anything, "b").Return(checkB, nil)
-	st.On("GetAssets", mock.Anything, int64(0), "").Return([]*types.Asset{}, "", nil)
-	st.On("GetHookConfigs", mock.Anything, int64(0), "").Return([]*types.HookConfig{}, "", nil)
+	st.On("GetAssets", mock.Anything, &store.SelectionPredicate{}).Return([]*types.Asset{}, nil)
+	st.On("GetHookConfigs", mock.Anything, &store.SelectionPredicate{}).Return([]*types.HookConfig{}, nil)
 
 	watcherChan := make(chan store.WatchEventCheckConfig)
 	st.On("GetCheckConfigWatcher", mock.Anything).Return((<-chan store.WatchEventCheckConfig)(watcherChan), nil)

--- a/backend/schedulerd/entity_cache.go
+++ b/backend/schedulerd/entity_cache.go
@@ -70,8 +70,8 @@ type EntityCache struct {
 
 // NewEntityCache creates a new EntityCache. It retrieves all entities from the
 // store on creation.
-func NewEntityCache(ctx context.Context, store store.EntityStore) (*EntityCache, error) {
-	entities, _, err := store.GetEntities(ctx, 0, "")
+func NewEntityCache(ctx context.Context, s store.EntityStore) (*EntityCache, error) {
+	entities, err := s.GetEntities(ctx, &store.SelectionPredicate{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating EntityCache: %s", err)
 	}
@@ -82,7 +82,7 @@ func NewEntityCache(ctx context.Context, store store.EntityStore) (*EntityCache,
 	cache := &EntityCache{
 		sliceCache: entities,
 		mapCache:   mapCache,
-		watcher:    store.GetEntityWatcher(ctx),
+		watcher:    s.GetEntityWatcher(ctx),
 	}
 	go cache.start(ctx)
 	return cache, nil

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -320,7 +320,7 @@ func publishRoundRobinProxyCheckRequests(executor *CheckExecutor, check *corev2.
 	return nil
 }
 
-func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequest, error) {
+func buildRequest(check *types.CheckConfig, s store.Store) (*types.CheckRequest, error) {
 	request := &types.CheckRequest{}
 	request.Config = check
 
@@ -330,7 +330,7 @@ func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequ
 	// the check in the first place.
 	if len(check.RuntimeAssets) != 0 {
 		// Explode assets; get assets & filter out those that are irrelevant
-		assets, _, err := store.GetAssets(ctx, 0, "")
+		assets, err := s.GetAssets(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequ
 	// the check in the first place.
 	if len(check.CheckHooks) != 0 {
 		// Explode hooks; get hooks & filter out those that are irrelevant
-		hooks, _, err := store.GetHookConfigs(ctx, 0, "")
+		hooks, err := s.GetHookConfigs(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/store/etcd/asset_store_test.go
+++ b/backend/store/etcd/asset_store_test.go
@@ -4,25 +4,22 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestAssetStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		asset := types.FixtureAsset("ruby")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, asset.Namespace)
 
-		err := store.UpdateAsset(ctx, asset)
+		err := s.UpdateAsset(ctx, asset)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetAssetByName(ctx, "ruby")
+		retrieved, err := s.GetAssetByName(ctx, "ruby")
 		assert.NoError(t, err)
 		assert.NotNil(t, retrieved)
 
@@ -30,121 +27,16 @@ func TestAssetStorage(t *testing.T) {
 		assert.Equal(t, asset.URL, retrieved.URL)
 		assert.Equal(t, asset.Sha512, retrieved.Sha512)
 
-		assets, continueToken, err := store.GetAssets(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		assets, err := s.GetAssets(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, assets)
 		assert.Equal(t, 1, len(assets))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating an asset in a nonexistent org should not work
 		asset.Namespace = "missing"
-		err = store.UpdateAsset(ctx, asset)
+		err = s.UpdateAsset(ctx, asset)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetAssetsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureAsset(objectName)
-
-			if err := store.UpdateAsset(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateAsset(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetAssetsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetAssets(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetAssets(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -11,25 +11,25 @@ import (
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestCheckConfigStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		check := types.FixtureCheckConfig("check1")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, check.Namespace)
 
+		pred := &store.SelectionPredicate{}
+
 		// We should receive an empty slice if no results were found
-		checks, continueToken, err := store.GetCheckConfigs(ctx, 0, "")
+		checks, err := s.GetCheckConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, checks)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateCheckConfig(ctx, check)
+		err = s.UpdateCheckConfig(ctx, check)
 		require.NoError(t, err)
 
-		retrieved, err := store.GetCheckConfigByName(ctx, "check1")
+		retrieved, err := s.GetCheckConfigByName(ctx, "check1")
 		assert.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -39,121 +39,18 @@ func TestCheckConfigStorage(t *testing.T) {
 		assert.Equal(t, check.Command, retrieved.Command)
 		assert.Equal(t, check.Stdin, retrieved.Stdin)
 
-		checks, continueToken, err = store.GetCheckConfigs(ctx, 0, "")
+		checks, err = s.GetCheckConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, checks)
 		assert.Equal(t, 1, len(checks))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
+		for _, check := range checks {
+			fmt.Printf("TestCheckConfigStorage: %#v\n", check)
+		}
 
 		// Updating a check in a nonexistent org and env should not work
 		check.Namespace = "missing"
-		err = store.UpdateCheckConfig(ctx, check)
+		err = s.UpdateCheckConfig(ctx, check)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetCheckConfigsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureCheckConfig(objectName)
-
-			if err := store.UpdateCheckConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateCheckConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetCheckConfigsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetCheckConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetCheckConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -44,9 +43,6 @@ func TestCheckConfigStorage(t *testing.T) {
 		assert.NotEmpty(t, checks)
 		assert.Equal(t, 1, len(checks))
 		assert.Empty(t, pred.Continue)
-		for _, check := range checks {
-			fmt.Printf("TestCheckConfigStorage: %#v\n", check)
-		}
 
 		// Updating a check in a nonexistent org and env should not work
 		check.Namespace = "missing"

--- a/backend/store/etcd/clusterrole_store.go
+++ b/backend/store/etcd/clusterrole_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetClusterRole(ctx context.Context, name string) (*types.Cluster
 }
 
 // ListClusterRoles ...
-func (s *Store) ListClusterRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRole, string, error) {
+func (s *Store) ListClusterRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRole, error) {
 	clusterRoles := []*types.ClusterRole{}
-	nextContinueToken, err := List(ctx, s.client, getClusterRolesPath, &clusterRoles, pageSize, continueToken)
-	return clusterRoles, nextContinueToken, err
+	err := List(ctx, s.client, getClusterRolesPath, &clusterRoles, pred)
+	return clusterRoles, err
 }
 
 // UpdateClusterRole ...

--- a/backend/store/etcd/clusterrolebinding_store.go
+++ b/backend/store/etcd/clusterrolebinding_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetClusterRoleBinding(ctx context.Context, name string) (*types.
 }
 
 // ListClusterRoleBindings ...
-func (s *Store) ListClusterRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRoleBinding, string, error) {
+func (s *Store) ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRoleBinding, error) {
 	roles := []*types.ClusterRoleBinding{}
-	nextContinueToken, err := List(ctx, s.client, getClusterRoleBindingsPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getClusterRoleBindingsPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateClusterRoleBinding ...

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
 const (
@@ -76,8 +74,8 @@ func (s *Store) GetEntityByName(ctx context.Context, name string) (*corev2.Entit
 }
 
 // GetEntities returns the entities for the namespace in the supplied context.
-func (s *Store) GetEntities(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Entity, error) {
-	entities := []*types.Entity{}
+func (s *Store) GetEntities(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Entity, error) {
+	entities := []*corev2.Entity{}
 	err := List(ctx, s.client, getEntitiesPath, &entities, pred)
 	return entities, err
 }

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
@@ -76,45 +76,10 @@ func (s *Store) GetEntityByName(ctx context.Context, name string) (*corev2.Entit
 }
 
 // GetEntities returns the entities for the namespace in the supplied context.
-func (s *Store) GetEntities(ctx context.Context, pageSize int64, continueToken string) (entities []*corev2.Entity, nextContinueToken string, err error) {
-	opts := []clientv3.OpOption{
-		clientv3.WithLimit(pageSize),
-	}
-
-	keyPrefix := getEntitiesPath(ctx, "")
-	rangeEnd := clientv3.GetPrefixRangeEnd(keyPrefix)
-	opts = append(opts, clientv3.WithRange(rangeEnd))
-
-	resp, err := s.client.Get(ctx, path.Join(keyPrefix, continueToken), opts...)
-	if err != nil {
-		return nil, "", err
-	}
-	if len(resp.Kvs) == 0 {
-		return []*corev2.Entity{}, "", nil
-	}
-
-	for _, kv := range resp.Kvs {
-		entity := &corev2.Entity{}
-		err = json.Unmarshal(kv.Value, entity)
-		if err != nil {
-			return nil, "", err
-		}
-		if entity.Labels == nil {
-			entity.Labels = make(map[string]string)
-		}
-		if entity.Annotations == nil {
-			entity.Annotations = make(map[string]string)
-		}
-
-		entities = append(entities, entity)
-	}
-
-	if pageSize != 0 && resp.Count > pageSize {
-		lastEntity := entities[len(entities)-1]
-		nextContinueToken = computeContinueToken(ctx, lastEntity)
-	}
-
-	return entities, nextContinueToken, nil
+func (s *Store) GetEntities(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Entity, error) {
+	entities := []*types.Entity{}
+	err := List(ctx, s.client, getEntitiesPath, &entities, pred)
+	return entities, err
 }
 
 // UpdateEntity updates an Entity.

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -4,162 +4,54 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestEntityStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		entity := types.FixtureEntity("entity")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, entity.Namespace)
+		pred := &store.SelectionPredicate{}
 
 		// We should receive an empty slice if no results were found
-		entities, continueToken, err := store.GetEntities(ctx, 0, "")
+		entities, err := s.GetEntities(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, entities)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateEntity(ctx, entity)
+		err = s.UpdateEntity(ctx, entity)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetEntityByName(ctx, entity.Name)
+		retrieved, err := s.GetEntityByName(ctx, entity.Name)
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 		assert.Equal(t, entity.Name, retrieved.Name)
 
-		entities, continueToken, err = store.GetEntities(ctx, 0, "")
+		entities, err = s.GetEntities(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(entities))
 		assert.Equal(t, entity.Name, entities[0].Name)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.DeleteEntity(ctx, entity)
+		err = s.DeleteEntity(ctx, entity)
 		assert.NoError(t, err)
 
-		retrieved, err = store.GetEntityByName(ctx, entity.Name)
+		retrieved, err = s.GetEntityByName(ctx, entity.Name)
 		assert.Nil(t, retrieved)
 		assert.NoError(t, err)
 
 		// Nonexistent entity deletion should return no error.
-		err = store.DeleteEntity(ctx, entity)
+		err = s.DeleteEntity(ctx, entity)
 		assert.NoError(t, err)
 
 		// Updating an enity in a nonexistent org and env should not work
 		entity.Namespace = "missing"
-		err = store.UpdateEntity(ctx, entity)
+		err = s.UpdateEntity(ctx, entity)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetEntitiesPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureEntity(objectName)
-
-			if err := store.UpdateEntity(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateEntity(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetEntitiesPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetEntities(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetEntities(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/extension_registry_test.go
+++ b/backend/store/etcd/extension_registry_test.go
@@ -4,149 +4,39 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestExtensionStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		ext := types.FixtureExtension("frobber")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, ext.Namespace)
 
-		err := store.RegisterExtension(ctx, ext)
+		err := s.RegisterExtension(ctx, ext)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetExtension(ctx, "frobber")
+		retrieved, err := s.GetExtension(ctx, "frobber")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
 		assert.Equal(t, ext.Name, retrieved.Name)
 		assert.Equal(t, ext.URL, retrieved.URL)
 
-		extensions, continueToken, err := store.GetExtensions(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		extensions, err := s.GetExtensions(ctx, pred)
 		require.NoError(t, err)
 		assert.NotEmpty(t, extensions)
 		assert.Equal(t, 1, len(extensions))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating an ext in a nonexistent org should not work
 		ext.Namespace = "missing"
-		err = store.RegisterExtension(ctx, ext)
+		err = s.RegisterExtension(ctx, ext)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetExtensionsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureExtension(objectName)
-
-			ctx := context.WithValue(context.Background(), types.NamespaceKey, object.Namespace)
-			if err := store.RegisterExtension(ctx, object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			ctx = context.WithValue(context.Background(), types.NamespaceKey, object.Namespace)
-			if err := store.RegisterExtension(ctx, object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetExtensionsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetExtensions(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetExtensions(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/filter_store_test.go
+++ b/backend/store/etcd/filter_store_test.go
@@ -4,32 +4,30 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestEventFilterStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		filter := types.FixtureEventFilter("filter1")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, filter.Namespace)
 
 		// We should receive an empty slice if no results were found
-		filters, continueToken, err := store.GetEventFilters(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		filters, err := s.GetEventFilters(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, filters)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateEventFilter(ctx, filter)
+		err = s.UpdateEventFilter(ctx, filter)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetEventFilterByName(ctx, "filter1")
+		retrieved, err := s.GetEventFilterByName(ctx, "filter1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +35,15 @@ func TestEventFilterStorage(t *testing.T) {
 		assert.Equal(t, filter.Action, retrieved.Action)
 		assert.Equal(t, filter.Expressions, retrieved.Expressions)
 
-		filters, continueToken, err = store.GetEventFilters(ctx, 0, "")
+		filters, err = s.GetEventFilters(ctx, pred)
 		require.NoError(t, err)
 		require.NotEmpty(t, filters)
 		assert.Equal(t, 1, len(filters))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a filter in a nonexistent namespace
 		filter.Namespace = "missing"
-		err = store.UpdateEventFilter(ctx, filter)
+		err = s.UpdateEventFilter(ctx, filter)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetEventFiltersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureEventFilter(objectName)
-
-			if err := store.UpdateEventFilter(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateEventFilter(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetEventFiltersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetEventFilters(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetEventFilters(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/handler_store_test.go
+++ b/backend/store/etcd/handler_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestHandlerStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		handler := corev2.FixtureHandler("handler1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, handler.Namespace)
 
 		// We should receive an empty slice if no results were found
-		handlers, continueToken, err := store.GetHandlers(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		handlers, err := s.GetHandlers(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, handlers)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateHandler(ctx, handler)
+		err = s.UpdateHandler(ctx, handler)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetHandlerByName(ctx, "handler1")
+		retrieved, err := s.GetHandlerByName(ctx, "handler1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +37,15 @@ func TestHandlerStorage(t *testing.T) {
 		assert.Equal(t, handler.Command, retrieved.Command)
 		assert.Equal(t, handler.Timeout, retrieved.Timeout)
 
-		handlers, continueToken, err = store.GetHandlers(ctx, 0, "")
+		handlers, err = s.GetHandlers(ctx, pred)
 		require.NoError(t, err)
 		require.NotEmpty(t, handlers)
 		assert.Equal(t, 1, len(handlers))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a handler in a nonexistent org and env should not work
 		handler.Namespace = "missing"
-		err = store.UpdateHandler(ctx, handler)
+		err = s.UpdateHandler(ctx, handler)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetHandlersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureHandler(objectName)
-
-			if err := store.UpdateHandler(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateHandler(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetHandlersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetHandlers(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetHandlers(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/hook_store_test.go
+++ b/backend/store/etcd/hook_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestHookConfigStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		hook := corev2.FixtureHookConfig("hook1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, hook.Namespace)
 
 		// We should receive an empty slice if no results were found
-		hooks, continueToken, err := store.GetHookConfigs(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		hooks, err := s.GetHookConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, hooks)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateHookConfig(ctx, hook)
+		err = s.UpdateHookConfig(ctx, hook)
 		require.NoError(t, err)
 
-		retrieved, err := store.GetHookConfigByName(ctx, "hook1")
+		retrieved, err := s.GetHookConfigByName(ctx, "hook1")
 		assert.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +37,15 @@ func TestHookConfigStorage(t *testing.T) {
 		assert.Equal(t, hook.Timeout, retrieved.Timeout)
 		assert.Equal(t, hook.Stdin, retrieved.Stdin)
 
-		hooks, continueToken, err = store.GetHookConfigs(ctx, 0, "")
+		hooks, err = s.GetHookConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, hooks)
 		assert.Equal(t, 1, len(hooks))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a hook in a nonexistent org and env should not work
 		hook.Namespace = "missing"
-		err = store.UpdateHookConfig(ctx, hook)
+		err = s.UpdateHookConfig(ctx, hook)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetHookConfigsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureHookConfig(objectName)
-
-			if err := store.UpdateHookConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateHookConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetHookConfigsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetHookConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetHookConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/mutator_store_test.go
+++ b/backend/store/etcd/mutator_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestMutatorStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		mutator := corev2.FixtureMutator("mutator1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, mutator.Namespace)
 
 		// We should receive an empty slice if no results were found
-		mutators, continueToken, err := store.GetMutators(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		mutators, err := s.GetMutators(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, mutators)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateMutator(ctx, mutator)
+		err = s.UpdateMutator(ctx, mutator)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetMutatorByName(ctx, "mutator1")
+		retrieved, err := s.GetMutatorByName(ctx, "mutator1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -36,121 +36,15 @@ func TestMutatorStorage(t *testing.T) {
 		assert.Equal(t, mutator.Command, retrieved.Command)
 		assert.Equal(t, mutator.Timeout, retrieved.Timeout)
 
-		mutators, continueToken, err = store.GetMutators(ctx, 0, "")
+		mutators, err = s.GetMutators(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, mutators)
 		assert.Equal(t, 1, len(mutators))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a mutator in a nonexistent org and env should not work
 		mutator.Namespace = "missing"
-		err = store.UpdateMutator(ctx, mutator)
+		err = s.UpdateMutator(ctx, mutator)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetMutatorsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureMutator(objectName)
-
-			if err := store.UpdateMutator(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateMutator(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetMutatorsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetMutators(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetMutators(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/namespace_store_test.go
+++ b/backend/store/etcd/namespace_store_test.go
@@ -4,158 +4,66 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestnamespaceStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		ctx := context.Background()
 
 		// We should receive the default namespace (set in store_test.go)
-		namespaces, _, err := store.ListNamespaces(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		namespaces, err := s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(namespaces))
 
 		// We should be able to create a new namespace
 		namespace := types.FixtureNamespace("acme")
-		err = store.CreateNamespace(ctx, namespace)
+		err = s.CreateNamespace(ctx, namespace)
 		assert.NoError(t, err)
 
-		result, err := store.GetNamespace(ctx, namespace.Name)
+		result, err := s.GetNamespace(ctx, namespace.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, namespace.Name, result.Name)
 
 		// Missing namespace
-		result, err = store.GetNamespace(ctx, "missing")
+		result, err = s.GetNamespace(ctx, "missing")
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 
 		// Get all namespaces
-		namespaces, _, err = store.ListNamespaces(ctx, 0, "")
+		namespaces, err = s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, namespaces)
 		assert.Equal(t, 2, len(namespaces))
 
 		// Delete a non-empty namespace
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.Error(t, err)
 
 		// Delete a non-empty namespace w/ roles
-		require.NoError(t, store.UpdateRole(ctx, types.FixtureRole("1", namespace.Name)))
-		require.NoError(t, store.UpdateRole(ctx, types.FixtureRole("2", "asdf")))
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		require.NoError(t, s.UpdateRole(ctx, types.FixtureRole("1", namespace.Name)))
+		require.NoError(t, s.UpdateRole(ctx, types.FixtureRole("2", "asdf")))
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.Error(t, err)
 
 		// Delete an empty namespace
-		require.NoError(t, store.DeleteRole(ctx, "1"))
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		require.NoError(t, s.DeleteRole(ctx, "1"))
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.NoError(t, err)
 
 		// Delete a missing namespace
-		err = store.DeleteNamespace(ctx, "missing")
+		err = s.DeleteNamespace(ctx, "missing")
 		assert.Error(t, err)
 
 		// Get again all namespaces
-		namespaces, _, err = store.ListNamespaces(ctx, 0, "")
+		namespaces, err = s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(namespaces))
 	})
-}
-
-func TestListNamespacesPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureNamespace(objectName)
-
-			if err := store.CreateNamespace(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		// We get rid of the default namespace so that it doesn't
-		// interfere with our tests below.
-		if err := store.DeleteNamespace(context.Background(), "default"); err != nil {
-			t.Fatal(err)
-		}
-
-		ctx := context.Background()
-		t.Run("paginate through namespaces", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 10, 21)
-		})
-
-		t.Run("page size equals one", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 1, 21)
-		})
-
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testListNamespacesPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.ListNamespaces(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.ListNamespaces(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/role_store.go
+++ b/backend/store/etcd/role_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetRole(ctx context.Context, name string) (*types.Role, error) {
 }
 
 // ListRoles ...
-func (s *Store) ListRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.Role, string, error) {
+func (s *Store) ListRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Role, error) {
 	roles := []*types.Role{}
-	nextContinueToken, err := List(ctx, s.client, getRolesPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getRolesPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateRole ...

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBin
 }
 
 // ListRoleBindings ...
-func (s *Store) ListRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.RoleBinding, string, error) {
+func (s *Store) ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.RoleBinding, error) {
 	roles := []*types.RoleBinding{}
-	nextContinueToken, err := List(ctx, s.client, getRoleBindingsPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getRoleBindingsPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateRoleBinding ...

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -187,13 +187,15 @@ func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn,
 
 		// Initialize the annotations and labels if they are nil
 		objValue := reflect.ValueOf(obj).Elem()
-		meta := objValue.Elem().FieldByName("ObjectMeta")
-		if meta.CanSet() {
-			if meta.FieldByName("Labels").Len() == 0 && meta.FieldByName("Labels").CanSet() {
-				meta.FieldByName("Labels").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
-			}
-			if meta.FieldByName("Annotations").Len() == 0 && meta.FieldByName("Annotations").CanSet() {
-				meta.FieldByName("Annotations").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
+		if objValue.Kind() == reflect.Ptr {
+			meta := objValue.Elem().FieldByName("ObjectMeta")
+			if meta.CanSet() {
+				if meta.FieldByName("Labels").Len() == 0 && meta.FieldByName("Labels").CanSet() {
+					meta.FieldByName("Labels").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
+				}
+				if meta.FieldByName("Annotations").Len() == 0 && meta.FieldByName("Annotations").CanSet() {
+					meta.FieldByName("Annotations").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
+				}
 			}
 		}
 

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -153,48 +153,61 @@ type KeyBuilderFn func(context.Context, string) string
 
 // List retrieves all keys from storage under the provided prefix key, while
 // supporting all namespaces, and deserialize it into objsPtr.
-func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn, objsPtr interface{}, pageSize int64, continueToken string) (string, error) {
+func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn, objsPtr interface{}, pred *store.SelectionPredicate) error {
 	// Make sure the interface is a pointer, and that the element at this address
 	// is a slice.
 	v := reflect.ValueOf(objsPtr)
 	if v.Kind() != reflect.Ptr {
-		return "", fmt.Errorf("expected pointer, but got %v type", v.Type())
+		return fmt.Errorf("expected pointer, but got %v type", v.Type())
 	}
 	if v.Elem().Kind() != reflect.Slice {
-		return "", fmt.Errorf("expected slice, but got %s", v.Elem().Kind())
+		return fmt.Errorf("expected slice, but got %s", v.Elem().Kind())
 	}
 	v = v.Elem()
 
 	opts := []clientv3.OpOption{
-		clientv3.WithLimit(pageSize),
+		clientv3.WithLimit(pred.Limit),
 	}
 
 	key := keyBuilder(ctx, "")
 	rangeEnd := clientv3.GetPrefixRangeEnd(key)
 	opts = append(opts, clientv3.WithRange(rangeEnd))
 
-	resp, err := client.Get(ctx, path.Join(key, continueToken), opts...)
+	resp, err := client.Get(ctx, path.Join(key, pred.Continue), opts...)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	for _, kv := range resp.Kvs {
 		// Decode and append the value to v, which must be a slice.
 		obj := reflect.New(v.Type().Elem()).Interface()
 		if err := json.Unmarshal(kv.Value, obj); err != nil {
-			return "", &store.ErrDecode{Key: key, Err: err}
+			return &store.ErrDecode{Key: key, Err: err}
+		}
+
+		// Initialize the annotations and labels if they are nil
+		objValue := reflect.ValueOf(obj).Elem()
+		meta := objValue.Elem().FieldByName("ObjectMeta")
+		if meta.CanSet() {
+			if meta.FieldByName("Labels").Len() == 0 && meta.FieldByName("Labels").CanSet() {
+				meta.FieldByName("Labels").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
+			}
+			if meta.FieldByName("Annotations").Len() == 0 && meta.FieldByName("Annotations").CanSet() {
+				meta.FieldByName("Annotations").Set(reflect.MakeMap(reflect.TypeOf(make(map[string]string))))
+			}
 		}
 
 		v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 	}
 
-	nextContinueToken := ""
-	if pageSize != 0 && resp.Count > pageSize {
+	if pred.Limit != 0 && resp.Count > pred.Limit {
 		lastObject := v.Index(v.Len() - 1).Interface().(corev2.Resource)
-		nextContinueToken = computeContinueToken(ctx, lastObject)
+		pred.Continue = computeContinueToken(ctx, lastObject)
+	} else {
+		pred.Continue = ""
 	}
 
-	return nextContinueToken, nil
+	return nil
 }
 
 // Update a key given with the serialized object.

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 )
 
 func TestUserStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		password := "P@ssw0rd!"
 		passwordDigest, err := bcrypt.HashPassword(password)
 		require.NoError(t, err)
@@ -32,48 +31,48 @@ func TestUserStorage(t *testing.T) {
 		defer cancel()
 
 		// We should receive an empty array if no users exist
-		users, err := store.GetUsers()
+		users, err := s.GetUsers()
 		assert.NoError(t, err)
 		assert.Empty(t, users)
 
 		user := types.FixtureUser("foo")
 		user.Password = passwordDigest
-		err = store.CreateUser(user)
+		err = s.CreateUser(user)
 		assert.NoError(t, err)
 
 		// The user should be fetchable
-		result, err := store.GetUser(ctx, "foo")
+		result, err := s.GetUser(ctx, "foo")
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 
 		// Successful authentication
-		_, err = store.AuthenticateUser(ctx, "foo", password)
+		_, err = s.AuthenticateUser(ctx, "foo", password)
 		assert.NoError(t, err)
 
 		// Unsuccessful authentication with wrong password
-		_, err = store.AuthenticateUser(ctx, "foo", "foo")
+		_, err = s.AuthenticateUser(ctx, "foo", "foo")
 		assert.Error(t, err)
 
 		// User already exist
-		err = store.CreateUser(user)
+		err = s.CreateUser(user)
 		assert.Error(t, err)
 
 		mockedUser := types.FixtureUser("bar")
 		mockedUser.Password = passwordDigest
-		err = store.UpdateUser(mockedUser)
+		err = s.UpdateUser(mockedUser)
 		assert.NoError(t, err)
 
-		result, err = store.GetUser(ctx, mockedUser.Username)
+		result, err = s.GetUser(ctx, mockedUser.Username)
 		assert.NoError(t, err)
 		assert.Equal(t, mockedUser.Username, result.Username)
 
 		// Missing user
-		missingUser, err := store.GetUser(ctx, "missingUser")
+		missingUser, err := s.GetUser(ctx, "missingUser")
 		assert.NoError(t, err)
 		assert.Nil(t, missingUser)
 
 		// Get all users
-		users, err = store.GetUsers()
+		users, err = s.GetUsers()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, users)
 		assert.Equal(t, 2, len(users))
@@ -81,127 +80,44 @@ func TestUserStorage(t *testing.T) {
 		// Generate a token for the bar user
 		claims := corev2.FixtureClaims("bar", nil)
 		token, _, _ := jwt.AccessToken(claims)
-		err = store.AllowTokens(token)
+		err = s.AllowTokens(token)
 		assert.NoError(t, err)
 
 		// Disable a user that does not exist
-		err = store.DeleteUser(ctx, &types.User{Username: "Frankieie"})
+		err = s.DeleteUser(ctx, &types.User{Username: "Frankieie"})
 		assert.NoError(t, err)
 
 		// Ensure that a user with that name wasn't created
-		baduser, err := store.GetUser(ctx, "Frankieie")
+		baduser, err := s.GetUser(ctx, "Frankieie")
 		assert.NoError(t, err)
 		assert.Nil(t, baduser)
 
 		// Disable a user, which also removes all issued tokens
-		err = store.DeleteUser(ctx, mockedUser)
+		err = s.DeleteUser(ctx, mockedUser)
 		assert.NoError(t, err)
 
 		// Make sure the user is now disabled
-		disabledUser, _ := store.GetUser(ctx, mockedUser.Username)
+		disabledUser, _ := s.GetUser(ctx, mockedUser.Username)
 		assert.True(t, disabledUser.Disabled)
 
 		// Make sure the token was revoked
-		_, err = store.GetToken(claims.Subject, claims.Id)
+		_, err = s.GetToken(claims.Subject, claims.Id)
 		assert.Error(t, err)
 
 		// Authentication should be unsuccessful with a disabled user
-		_, err = store.AuthenticateUser(ctx, mockedUser.Username, password)
+		_, err = s.AuthenticateUser(ctx, mockedUser.Username, password)
 		assert.Error(t, err)
 
 		// The deleted (disabled) user should not be returned
 		// Get all users
-		users, err = store.GetUsers()
+		users, err = s.GetUsers()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(users))
 
 		// Disabled user should appear when fetching all users
-		users, _, err = store.GetAllUsers(0, "")
+		pred := &store.SelectionPredicate{}
+		users, err = s.GetAllUsers(pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(users))
 	})
-}
-
-func TestGetAllUsersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureUser(objectName)
-
-			if err := store.CreateUser(object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		t.Run("paginate through users", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 10, 21)
-		})
-
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 1, 21)
-		})
-
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetAllUsersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetAllUsers(int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Username != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Username)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetAllUsers(int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Username != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Username)
-			}
-		}
-	}
 }

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -80,6 +80,18 @@ func (e *ErrInternal) Error() string {
 	return fmt.Sprintf("internal error: %s", e.Message)
 }
 
+// SelectionPredicate represents the way to select resources from storage
+type SelectionPredicate struct {
+	// Continue provides the key from which the selection should start. If
+	// returned empty from the store, it indicates that there's no additional
+	// resources available
+	Continue string
+	// Limit indicates the number of resources to retrieve
+	Limit int64
+	// Suffix provides an additional value to append to the key path
+	Suffix string
+}
+
 // A WatchEventCheckConfig contains the modified store object and the action that occured
 // during the modification.
 type WatchEventCheckConfig struct {
@@ -187,7 +199,7 @@ type AssetStore interface {
 
 	// GetAssets returns all assets in the given ctx's namespace. A nil
 	// slice with no error is returned if none were found.
-	GetAssets(ctx context.Context, pageSize int64, continueToken string) (assets []*types.Asset, nextContinueToken string, err error)
+	GetAssets(ctx context.Context, pred *SelectionPredicate) ([]*types.Asset, error)
 
 	// GetAssetByName returns an asset using the given name and the namespace
 	// stored in ctx. The resulting asset is nil if none was found.
@@ -219,7 +231,7 @@ type CheckConfigStore interface {
 	// GetCheckConfigs returns all checks configurations in the given ctx's
 	// namespace. A nil slice with no error is returned if none
 	// were found.
-	GetCheckConfigs(ctx context.Context, pageSize int64, continueToken string) (checks []*types.CheckConfig, nextContinueToken string, err error)
+	GetCheckConfigs(ctx context.Context, pred *SelectionPredicate) ([]*types.CheckConfig, error)
 
 	// GetCheckConfigByName returns a check's configuration using the given name
 	// and the namespace stored in ctx. The resulting check is
@@ -254,7 +266,7 @@ type ClusterRoleBindingStore interface {
 
 	// ListRoles returns all cluster role binding. An error is returned if no
 	// binding were found
-	ListClusterRoleBindings(ctx context.Context, pageSize int64, continueToken string) (clusterRoleBindings []*types.ClusterRoleBinding, nextContinueToken string, err error)
+	ListClusterRoleBindings(ctx context.Context, pred *SelectionPredicate) (clusterRoleBindings []*types.ClusterRoleBinding, err error)
 
 	// UpdateRole creates or updates a given cluster role binding.
 	UpdateClusterRoleBinding(ctx context.Context, clusterRoleBinding *types.ClusterRoleBinding) error
@@ -277,7 +289,7 @@ type ClusterRoleStore interface {
 
 	// ListClusterRoles returns all cluster roles. An error is returned if no
 	// roles were found
-	ListClusterRoles(ctx context.Context, pageSize int64, continueToken string) (clusterRoles []*types.ClusterRole, nextContinueToken string, err error)
+	ListClusterRoles(ctx context.Context, pred *SelectionPredicate) (clusterRoles []*types.ClusterRole, err error)
 
 	// UpdateClusterRole creates or updates a given cluster role.
 	UpdateClusterRole(ctx context.Context, clusterRole *types.ClusterRole) error
@@ -292,7 +304,7 @@ type HookConfigStore interface {
 	// GetHookConfigs returns all hooks configurations in the given ctx's
 	// namespace. A nil slice with no error is returned if none
 	// were found.
-	GetHookConfigs(ctx context.Context, pageSize int64, continueToken string) (hooks []*types.HookConfig, newContinueToken string, err error)
+	GetHookConfigs(ctx context.Context, pred *SelectionPredicate) ([]*types.HookConfig, error)
 
 	// GetHookConfigByName returns a hook's configuration using the given name and
 	// the namespace stored in ctx. The resulting hook is nil if none was found.
@@ -313,7 +325,7 @@ type EntityStore interface {
 
 	// GetEntities returns all entities in the given ctx's namespace. A nil slice
 	// with no error is returned if none were found.
-	GetEntities(ctx context.Context, pageSize int64, continueToken string) (entities []*types.Entity, nextContinueToken string, err error)
+	GetEntities(ctx context.Context, pred *SelectionPredicate) ([]*types.Entity, error)
 
 	// GetEntityByName returns an entity using the given name and the namespace stored
 	// in ctx. The resulting entity is nil if none was found.
@@ -333,17 +345,11 @@ type EventStore interface {
 
 	// GetEvents returns all events in the given ctx's namespace. A nil slice with
 	// no error is returned if none were found.
-	//
-	// To get paginated results, the pageSize argument should be strictly positive.
-	// continueToken lets one continue paginating from the given token. The second
-	// value returned by GetEvents, nextContinueToken, is a potential "continue
-	// token" that lets the caller continue paginating in subsequent calls. If that
-	// new token is "", the last page is already being returned.
-	GetEvents(ctx context.Context, pageSize int64, continueToken string) (events []*corev2.Event, nextContinueToken string, err error)
+	GetEvents(ctx context.Context, pred *SelectionPredicate) ([]*corev2.Event, error)
 
 	// GetEventsByEntity returns all events for the given entity within the ctx's
 	// namespace. A nil slice with no error is returned if none were found.
-	GetEventsByEntity(ctx context.Context, entity string, pageSize int64, continueToken string) (events []*corev2.Event, nextContinueToken string, err error)
+	GetEventsByEntity(ctx context.Context, entity string, pred *SelectionPredicate) ([]*corev2.Event, error)
 
 	// GetEventByEntityCheck returns an event using the given entity and check,
 	// within the namespace stored in ctx. The resulting event
@@ -362,7 +368,7 @@ type EventFilterStore interface {
 
 	// GetEventFilters returns all filters in the given ctx's namespace. A nil
 	// slice with no error is returned if none were found.
-	GetEventFilters(ctx context.Context, pageSize int64, continueToken string) (filters []*types.EventFilter, newContinueToken string, err error)
+	GetEventFilters(ctx context.Context, pred *SelectionPredicate) ([]*types.EventFilter, error)
 
 	// GetEventFilterByName returns a filter using the given name and the
 	// namespace stored in ctx. The resulting filter is nil if none was found.
@@ -380,7 +386,7 @@ type HandlerStore interface {
 
 	// GetHandlers returns all handlers in the given ctx's namespace. A nil slice
 	// with no error is returned if none were found.
-	GetHandlers(ctx context.Context, pageSize int64, continueToken string) (handlers []*types.Handler, newContinueToken string, err error)
+	GetHandlers(ctx context.Context, pred *SelectionPredicate) ([]*types.Handler, error)
 
 	// GetHandlerByName returns a handler using the given name and the namespace
 	// stored in ctx. The resulting handler is nil if none was found.
@@ -416,7 +422,7 @@ type MutatorStore interface {
 
 	// GetMutators returns all mutators in the given ctx's namespace. A nil slice
 	// with no error is returned if none were found.
-	GetMutators(ctx context.Context, pageSize int64, continueToken string) (mutators []*types.Mutator, newContinueToken string, err error)
+	GetMutators(ctx context.Context, pred *SelectionPredicate) ([]*types.Mutator, error)
 
 	// GetMutatorByName returns a mutator using the given name and the
 	// namespace stored in ctx. The resulting mutator is nil if
@@ -437,7 +443,7 @@ type NamespaceStore interface {
 
 	// ListNamespaces returns all namespaces. A nil slice with no error is
 	// returned if none were found.
-	ListNamespaces(ctx context.Context, pageSize int64, continueToken string) (namespaces []*types.Namespace, newContinueToken string, err error)
+	ListNamespaces(ctx context.Context, pred *SelectionPredicate) ([]*types.Namespace, error)
 
 	// GetNamespace returns a namespace using the given name. The
 	// result is nil if none was found.
@@ -464,7 +470,7 @@ type RoleBindingStore interface {
 
 	// ListRoles returns all role binding. An error is returned if no binding were
 	// found
-	ListRoleBindings(ctx context.Context, pageSize int64, continueToke string) (roleBindings []*types.RoleBinding, nextContinueToken string, err error)
+	ListRoleBindings(ctx context.Context, pred *SelectionPredicate) (roleBindings []*types.RoleBinding, err error)
 
 	// UpdateRole creates or updates a given role binding.
 	UpdateRoleBinding(ctx context.Context, roleBinding *types.RoleBinding) error
@@ -486,7 +492,7 @@ type RoleStore interface {
 	GetRole(ctx context.Context, name string) (*types.Role, error)
 
 	// ListRoles returns all roles. An error is returned if no roles were found
-	ListRoles(ctx context.Context, pageSize int64, continueToken string) (roles []*types.Role, nextContinueToken string, err error)
+	ListRoles(ctx context.Context, pred *SelectionPredicate) (roles []*types.Role, err error)
 
 	// UpdateRole creates or updates a given role.
 	UpdateRole(ctx context.Context, role *types.Role) error
@@ -569,7 +575,7 @@ type UserStore interface {
 
 	// GetUsers returns all users, including the disabled ones. A nil slice with
 	// no error is  returned if none were found.
-	GetAllUsers(pageSize int64, continueToken string) (users []*types.User, newContinueToken string, err error)
+	GetAllUsers(pred *SelectionPredicate) ([]*types.User, error)
 
 	// UpdateHandler updates a given user.
 	UpdateUser(user *types.User) error
@@ -610,5 +616,5 @@ type ExtensionRegistry interface {
 	GetExtension(ctx context.Context, name string) (*types.Extension, error)
 
 	// GetExtensions gets all the extensions for the namespace in ctx.
-	GetExtensions(ctx context.Context, pageSize int64, continueToken string) (extensions []*types.Extension, newContinueToken string, err error)
+	GetExtensions(ctx context.Context, pred *SelectionPredicate) ([]*types.Extension, error)
 }

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -88,8 +88,8 @@ type SelectionPredicate struct {
 	Continue string
 	// Limit indicates the number of resources to retrieve
 	Limit int64
-	// Suffix provides an additional value to append to the key path
-	Suffix string
+	// Subcollection represents a sub-collection of the primary collection
+	Subcollection string
 }
 
 // A WatchEventCheckConfig contains the modified store object and the action that occured

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -243,7 +243,7 @@ func (t *Tessend) collect(now int64) *Data {
 	var clientCount, serverCount float64
 
 	// collect client count
-	entities, _, err := t.store.GetEntities(t.ctx, 0, "")
+	entities, err := t.store.GetEntities(t.ctx, &store.SelectionPredicate{})
 	if err != nil {
 		logger.WithError(err).Error("unable to retrieve client count")
 	}

--- a/testing/mockstore/assets.go
+++ b/testing/mockstore/assets.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteAssetByName(ctx context.Context, name string) error {
 }
 
 // GetAssets ...
-func (s *MockStore) GetAssets(ctx context.Context, pageSize int64, continueToken string) ([]*types.Asset, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Asset), args.String(1), args.Error(2)
+func (s *MockStore) GetAssets(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Asset, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Asset), args.Error(1)
 }
 
 // GetAssetByName ...

--- a/testing/mockstore/check_config.go
+++ b/testing/mockstore/check_config.go
@@ -14,9 +14,9 @@ func (s *MockStore) DeleteCheckConfigByName(ctx context.Context, name string) er
 }
 
 // GetCheckConfigs ...
-func (s *MockStore) GetCheckConfigs(ctx context.Context, pageSize int64, continueToken string) ([]*types.CheckConfig, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.CheckConfig), args.String(1), args.Error(2)
+func (s *MockStore) GetCheckConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*types.CheckConfig, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.CheckConfig), args.Error(1)
 }
 
 // GetCheckConfigByName ...

--- a/testing/mockstore/clusterrole.go
+++ b/testing/mockstore/clusterrole.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetClusterRole(ctx context.Context, name string) (*types.Clu
 }
 
 // ListClusterRoles ...
-func (s *MockStore) ListClusterRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRole, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.ClusterRole), args.String(1), args.Error(2)
+func (s *MockStore) ListClusterRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRole, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.ClusterRole), args.Error(1)
 }
 
 // UpdateClusterRole ...

--- a/testing/mockstore/clusterrolebinding.go
+++ b/testing/mockstore/clusterrolebinding.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetClusterRoleBinding(ctx context.Context, name string) (*ty
 }
 
 // ListClusterRoleBindings ...
-func (s *MockStore) ListClusterRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRoleBinding, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.ClusterRoleBinding), args.String(1), args.Error(2)
+func (s *MockStore) ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRoleBinding, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.ClusterRoleBinding), args.Error(1)
 }
 
 // UpdateClusterRoleBinding ...

--- a/testing/mockstore/entities.go
+++ b/testing/mockstore/entities.go
@@ -20,9 +20,9 @@ func (s *MockStore) DeleteEntityByName(ctx context.Context, id string) error {
 }
 
 // GetEntities ...
-func (s *MockStore) GetEntities(ctx context.Context, pageSize int64, continueToken string) ([]*types.Entity, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Entity), args.String(1), args.Error(2)
+func (s *MockStore) GetEntities(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Entity, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Entity), args.Error(1)
 }
 
 // GetEntityByName ...

--- a/testing/mockstore/events.go
+++ b/testing/mockstore/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
 // DeleteEventByEntityCheck ...
@@ -13,15 +14,15 @@ func (s *MockStore) DeleteEventByEntityCheck(ctx context.Context, entityName, ch
 }
 
 // GetEvents ...
-func (s *MockStore) GetEvents(ctx context.Context, pageSize int64, continueToken string) ([]*corev2.Event, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*corev2.Event), args.String(1), args.Error(2)
+func (s *MockStore) GetEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
 // GetEventsByEntity ...
-func (s *MockStore) GetEventsByEntity(ctx context.Context, entityName string, pageSize int64, continueToken string) ([]*corev2.Event, string, error) {
-	args := s.Called(ctx, entityName, pageSize, continueToken)
-	return args.Get(0).([]*corev2.Event), args.String(1), args.Error(2)
+func (s *MockStore) GetEventsByEntity(ctx context.Context, entityName string, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	args := s.Called(ctx, entityName, pred)
+	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
 // GetEventByEntityCheck ...

--- a/testing/mockstore/extension.go
+++ b/testing/mockstore/extension.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -21,7 +22,7 @@ func (s *MockStore) GetExtension(ctx context.Context, name string) (*types.Exten
 	return args.Get(0).(*types.Extension), args.Error(1)
 }
 
-func (s *MockStore) GetExtensions(ctx context.Context, pageSize int64, continueToken string) ([]*types.Extension, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Extension), args.String(1), args.Error(2)
+func (s *MockStore) GetExtensions(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Extension, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Extension), args.Error(1)
 }

--- a/testing/mockstore/filters.go
+++ b/testing/mockstore/filters.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteEventFilterByName(ctx context.Context, name string) er
 }
 
 // GetEventFilters ...
-func (s *MockStore) GetEventFilters(ctx context.Context, pageSize int64, continueToken string) ([]*types.EventFilter, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.EventFilter), args.String(1), args.Error(2)
+func (s *MockStore) GetEventFilters(ctx context.Context, pred *store.SelectionPredicate) ([]*types.EventFilter, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.EventFilter), args.Error(1)
 }
 
 // GetEventFilterByName ...

--- a/testing/mockstore/handlers.go
+++ b/testing/mockstore/handlers.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteHandlerByName(ctx context.Context, name string) error 
 }
 
 // GetHandlers ...
-func (s *MockStore) GetHandlers(ctx context.Context, pageSize int64, continueToken string) ([]*types.Handler, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Handler), args.String(1), args.Error(2)
+func (s *MockStore) GetHandlers(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Handler, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Handler), args.Error(1)
 }
 
 // GetHandlerByName ...

--- a/testing/mockstore/hook_config.go
+++ b/testing/mockstore/hook_config.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteHookConfigByName(ctx context.Context, name string) err
 }
 
 // GetHookConfigs ...
-func (s *MockStore) GetHookConfigs(ctx context.Context, pageSize int64, continueToken string) ([]*types.HookConfig, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.HookConfig), args.String(1), args.Error(2)
+func (s *MockStore) GetHookConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*types.HookConfig, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.HookConfig), args.Error(1)
 }
 
 // GetHookConfigByName ...

--- a/testing/mockstore/mutators.go
+++ b/testing/mockstore/mutators.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteMutatorByName(ctx context.Context, name string) error 
 }
 
 // GetMutators ...
-func (s *MockStore) GetMutators(ctx context.Context, pageSize int64, continueToken string) ([]*types.Mutator, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Mutator), args.String(1), args.Error(2)
+func (s *MockStore) GetMutators(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Mutator, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Mutator), args.Error(1)
 }
 
 // GetMutatorByName ...

--- a/testing/mockstore/namespaces.go
+++ b/testing/mockstore/namespaces.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -19,9 +20,9 @@ func (s *MockStore) DeleteNamespace(ctx context.Context, name string) error {
 }
 
 // ListNamespaces ...
-func (s *MockStore) ListNamespaces(ctx context.Context, pageSize int64, continueToken string) ([]*types.Namespace, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Namespace), args.String(1), args.Error(2)
+func (s *MockStore) ListNamespaces(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Namespace, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Namespace), args.Error(1)
 }
 
 // GetNamespace ...

--- a/testing/mockstore/role.go
+++ b/testing/mockstore/role.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetRole(ctx context.Context, name string) (*types.Role, erro
 }
 
 // ListRoles ...
-func (s *MockStore) ListRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.Role, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Role), args.String(1), args.Error(2)
+func (s *MockStore) ListRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Role, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Role), args.Error(1)
 }
 
 // UpdateRole ...

--- a/testing/mockstore/rolebinding.go
+++ b/testing/mockstore/rolebinding.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetRoleBinding(ctx context.Context, name string) (*types.Rol
 }
 
 // ListRoleBindings ...
-func (s *MockStore) ListRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.RoleBinding, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.RoleBinding), args.String(1), args.Error(2)
+func (s *MockStore) ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.RoleBinding, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.RoleBinding), args.Error(1)
 }
 
 // UpdateRoleBinding ...

--- a/testing/mockstore/users.go
+++ b/testing/mockstore/users.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -40,9 +41,9 @@ func (s *MockStore) GetUsers() ([]*types.User, error) {
 }
 
 // GetAllUsers ...
-func (s *MockStore) GetAllUsers(pageSize int64, continueToken string) ([]*types.User, string, error) {
-	args := s.Called(pageSize, continueToken)
-	return args.Get(0).([]*types.User), args.String(1), args.Error(2)
+func (s *MockStore) GetAllUsers(pred *store.SelectionPredicate) ([]*types.User, error) {
+	args := s.Called(pred)
+	return args.Get(0).([]*types.User), args.Error(1)
 }
 
 // UpdateUser ...


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This is a required refactoring to support enterprise API filtering.

I apologize in advance for the size of this PR. Most changes simply consist of renaming/removing/moving stuff around. It can be summarized as follow:

- All _controllers_ were renamed from `query` to `list` for consistency
- These controllers now only deal with fetching and returning results from the store as `[]corev2.Resource`; we now deal with pagination in the generic lister _router_ (more about that below)
	- Therefore I removed all unit tests focusing on pagination for these controllers
- We now use a `*store.SelectionPredicate{}` to pass information about the request (pagination etc.) from apid to the store, which reduces the number of arguments and parameters required.
- The `store` are no longer exported in controllers (no idea why they were in the first place)
- `listerHandler` and `List` functions were introduced (see `backend/apid/routers/lister.go`)
	- `listerHandler()` is a workaround for mux.Router; the original idea was to override it from sensu-enterprise-go but turns out it isn't possible. Once the router is started, the actual handlers are immutable, so what I did is have it call the function stored in the `Lister` variable instead, which refers to the `List()` function in core. Then, from sensu-enterprise-go, we can assign a new function to this variable during runtime.
- The `Lister` function is responsible for handling pagination and fetching results from the store (via the controller function passed as a parameter). It also deals with a `suffix` route variable, in case we want to list a subresource (e.g. `/events/:entity`).
- All specific routers for listing were removed since they are no longer required
- All listing methods in the store are now using the generic `List` function, so  the pagination logic for etcd is now located in a single place.
	- Therefore all unit tests specific to pagination were removed except for the generic function

N.B. It seems like silenced entries do not support pagination at this time so I had to figure out a workaround for now

## Why is this change necessary?

Required for https://github.com/sensu/sensu-enterprise-go/issues/282.

## Does your change need a Changelog entry?

Yep.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

It would have been faster to do if we had generic handlers and stores for our core resources!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This is only a refactoring, no changes in functionality are expected at this point.

## How did you verify this change?

I manually verified every route.
