### PR TITLE
[GraphQL] Add generic put mutation

### DIFF
--- a/CHANGELOGS/unreleased/2847-add-put-mutation.md
+++ b/CHANGELOGS/unreleased/2847-add-put-mutation.md
@@ -1,0 +1,2 @@
+### Added
+- [GraphQL] Added mutation to create / update using wrapped resources.

--- a/backend/apid/graphql/error.go
+++ b/backend/apid/graphql/error.go
@@ -8,6 +8,7 @@ import (
 )
 
 var _ schema.StandardErrorFieldResolvers = (*stdErrImpl)(nil)
+var _ graphql.InterfaceTypeResolver = (*errImpl)(nil)
 
 type stdErr struct {
 	code    schema.ErrCode
@@ -75,4 +76,18 @@ func (stdErrImpl) Message(p graphql.ResolveParams) (string, error) {
 func (stdErrImpl) IsTypeOf(record interface{}, _ graphql.IsTypeOfParams) bool {
 	_, ok := record.(stdErr)
 	return ok
+}
+
+//
+// Implement Error
+//
+
+type errImpl struct{}
+
+func (errImpl) ResolveType(obj interface{}, _ graphql.ResolveTypeParams) *graphql.Type {
+	switch obj.(type) {
+	case stdErr:
+		return &schema.StandardErrorType
+	}
+	return nil
 }

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -1,9 +1,9 @@
 package graphql
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -36,7 +36,7 @@ func (r *mutationsImpl) PutWrapped(p schema.MutationPutWrappedFieldResolverParam
 	raw := p.Args.Raw
 
 	// decode given
-	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec := json.NewDecoder(strings.NewReader(raw))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&ret); err != nil {
 		return map[string]interface{}{

--- a/backend/apid/graphql/schema/errors.graphql
+++ b/backend/apid/graphql/schema/errors.graphql
@@ -10,6 +10,10 @@ interface Error {
   code: ErrCode!
 }
 
+"""
+StandardError is the standard implementation of an error that includes a
+message.
+"""
 type StandardError implements Error {
   "The field associated with the error."
   input: String

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -10,6 +10,23 @@ import (
 	time "time"
 )
 
+// MutationPutWrappedFieldResolverArgs contains arguments provided to putWrapped when selected
+type MutationPutWrappedFieldResolverArgs struct {
+	Raw string // Raw - self descriptive
+}
+
+// MutationPutWrappedFieldResolverParams contains contextual info to resolve putWrapped field
+type MutationPutWrappedFieldResolverParams struct {
+	graphql.ResolveParams
+	Args MutationPutWrappedFieldResolverArgs
+}
+
+// MutationPutWrappedFieldResolver implement to resolve requests for the Mutation's putWrapped field.
+type MutationPutWrappedFieldResolver interface {
+	// PutWrapped implements response to request for putWrapped field.
+	PutWrapped(p MutationPutWrappedFieldResolverParams) (interface{}, error)
+}
+
 // MutationCreateCheckFieldResolverArgs contains arguments provided to createCheck when selected
 type MutationCreateCheckFieldResolverArgs struct {
 	Input *CreateCheckInput // Input - self descriptive
@@ -225,6 +242,7 @@ type MutationDeleteSilenceFieldResolver interface {
 //   }
 //
 type MutationFieldResolvers interface {
+	MutationPutWrappedFieldResolver
 	MutationCreateCheckFieldResolver
 	MutationUpdateCheckFieldResolver
 	MutationExecuteCheckFieldResolver
@@ -282,6 +300,12 @@ type MutationFieldResolvers interface {
 //   }
 //
 type MutationAliases struct{}
+
+// PutWrapped implements response to request for 'putWrapped' field.
+func (_ MutationAliases) PutWrapped(p MutationPutWrappedFieldResolverParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
 
 // CreateCheck implements response to request for 'createCheck' field.
 func (_ MutationAliases) CreateCheck(p MutationCreateCheckFieldResolverParams) (interface{}, error) {
@@ -344,6 +368,19 @@ var MutationType = graphql.NewType("Mutation", graphql.ObjectKind)
 func RegisterMutation(svc *graphql.Service, impl MutationFieldResolvers) {
 	svc.RegisterObject(_ObjectTypeMutationDesc, impl)
 }
+func _ObjTypeMutationPutWrappedHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(MutationPutWrappedFieldResolver)
+	return func(p graphql1.ResolveParams) (interface{}, error) {
+		frp := MutationPutWrappedFieldResolverParams{ResolveParams: p}
+		err := mapstructure.Decode(p.Args, &frp.Args)
+		if err != nil {
+			return nil, err
+		}
+
+		return resolver.PutWrapped(frp)
+	}
+}
+
 func _ObjTypeMutationCreateCheckHandler(impl interface{}) graphql1.FieldResolveFn {
 	resolver := impl.(MutationCreateCheckFieldResolver)
 	return func(p graphql1.ResolveParams) (interface{}, error) {
@@ -535,6 +572,16 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 				Name:              "executeCheck",
 				Type:              graphql.OutputType("ExecuteCheckPayload"),
 			},
+			"putWrapped": &graphql1.Field{
+				Args: graphql1.FieldConfigArgument{"raw": &graphql1.ArgumentConfig{
+					Description: "self descriptive",
+					Type:        graphql1.NewNonNull(graphql1.String),
+				}},
+				DeprecationReason: "",
+				Description:       "Create or overrwrite resource from given wrapped resource.",
+				Name:              "putWrapped",
+				Type:              graphql1.NewNonNull(graphql.OutputType("PutWrappedPayload")),
+			},
 			"resolveEvent": &graphql1.Field{
 				Args: graphql1.FieldConfigArgument{"input": &graphql1.ArgumentConfig{
 					Description: "self descriptive",
@@ -580,8 +627,208 @@ var _ObjectTypeMutationDesc = graphql.ObjectDesc{
 		"deleteEvent":   _ObjTypeMutationDeleteEventHandler,
 		"deleteSilence": _ObjTypeMutationDeleteSilenceHandler,
 		"executeCheck":  _ObjTypeMutationExecuteCheckHandler,
+		"putWrapped":    _ObjTypeMutationPutWrappedHandler,
 		"resolveEvent":  _ObjTypeMutationResolveEventHandler,
 		"updateCheck":   _ObjTypeMutationUpdateCheckHandler,
+	},
+}
+
+// PutWrappedPayloadNodeFieldResolver implement to resolve requests for the PutWrappedPayload's node field.
+type PutWrappedPayloadNodeFieldResolver interface {
+	// Node implements response to request for node field.
+	Node(p graphql.ResolveParams) (interface{}, error)
+}
+
+// PutWrappedPayloadErrorsFieldResolver implement to resolve requests for the PutWrappedPayload's errors field.
+type PutWrappedPayloadErrorsFieldResolver interface {
+	// Errors implements response to request for errors field.
+	Errors(p graphql.ResolveParams) (interface{}, error)
+}
+
+//
+// PutWrappedPayloadFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'PutWrappedPayload' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type PutWrappedPayloadFieldResolvers interface {
+	PutWrappedPayloadNodeFieldResolver
+	PutWrappedPayloadErrorsFieldResolver
+}
+
+// PutWrappedPayloadAliases implements all methods on PutWrappedPayloadFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type PutWrappedPayloadAliases struct{}
+
+// Node implements response to request for 'node' field.
+func (_ PutWrappedPayloadAliases) Node(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Errors implements response to request for 'errors' field.
+func (_ PutWrappedPayloadAliases) Errors(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// PutWrappedPayloadType self descriptive
+var PutWrappedPayloadType = graphql.NewType("PutWrappedPayload", graphql.ObjectKind)
+
+// RegisterPutWrappedPayload registers PutWrappedPayload object type with given service.
+func RegisterPutWrappedPayload(svc *graphql.Service, impl PutWrappedPayloadFieldResolvers) {
+	svc.RegisterObject(_ObjectTypePutWrappedPayloadDesc, impl)
+}
+func _ObjTypePutWrappedPayloadNodeHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(PutWrappedPayloadNodeFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Node(frp)
+	}
+}
+
+func _ObjTypePutWrappedPayloadErrorsHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(PutWrappedPayloadErrorsFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Errors(frp)
+	}
+}
+
+func _ObjectTypePutWrappedPayloadConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "self descriptive",
+		Fields: graphql1.Fields{
+			"errors": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "Includes any failed preconditions or unrecoverable errors that occurred while\nexecuting the mutation.",
+				Name:              "errors",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Error")))),
+			},
+			"node": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "The newly created / updated resource",
+				Name:              "node",
+				Type:              graphql.OutputType("Node"),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see PutWrappedPayloadFieldResolvers.")
+		},
+		Name: "PutWrappedPayload",
+	}
+}
+
+// describe PutWrappedPayload's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypePutWrappedPayloadDesc = graphql.ObjectDesc{
+	Config: _ObjectTypePutWrappedPayloadConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"errors": _ObjTypePutWrappedPayloadErrorsHandler,
+		"node":   _ObjTypePutWrappedPayloadNodeHandler,
 	},
 }
 

--- a/backend/apid/graphql/schema/mutations.graphql
+++ b/backend/apid/graphql/schema/mutations.graphql
@@ -4,6 +4,13 @@ The root query for implementing GraphQL mutations.
 type Mutation {
 
   #
+  # Generic
+  #
+
+  "Create or overrwrite resource from given wrapped resource."
+  putWrapped(raw: String!): PutWrappedPayload!
+
+  #
   # Checks
   #
 
@@ -45,6 +52,21 @@ type Mutation {
 
   "Removes given silence."
   deleteSilence(input: DeleteRecordInput!): DeleteRecordPayload
+}
+
+#
+# Generic
+#
+
+type PutWrappedPayload {
+  "The newly created / updated resource"
+  node: Node
+
+  """
+  Includes any failed preconditions or unrecoverable errors that occurred while
+  executing the mutation.
+  """
+  errors: [Error!]!
 }
 
 """

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -36,7 +36,6 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterAsset(svc, &assetImpl{})
 	schema.RegisterNamespace(svc, &namespaceImpl{factory: clientFactory})
 	schema.RegisterErrCode(svc)
-	schema.RegisterError(svc, nil)
 	schema.RegisterEvent(svc, &eventImpl{})
 	schema.RegisterEventsListOrder(svc)
 	schema.RegisterHandler(svc, &handlerImpl{factory: clientFactory})
@@ -57,7 +56,6 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterSchema(svc)
 	schema.RegisterSilenced(svc, &silencedImpl{factory: clientFactory})
 	schema.RegisterSilencedConnection(svc, &schema.SilencedConnectionAliases{})
-	schema.RegisterStandardError(svc, stdErrImpl{})
 	schema.RegisterSubscriptionSet(svc, subscriptionSetImpl{})
 	schema.RegisterSubscriptionSetOrder(svc)
 	schema.RegisterSubscriptionOccurences(svc, &schema.SubscriptionOccurencesAliases{})
@@ -123,6 +121,11 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterSilenceInputs(svc)
 	schema.RegisterUpdateCheckInput(svc)
 	schema.RegisterUpdateCheckPayload(svc, &checkMutationPayload{})
+	schema.RegisterPutWrappedPayload(svc, &schema.PutWrappedPayloadAliases{})
+
+	// Errors
+	schema.RegisterStandardError(svc, stdErrImpl{})
+	schema.RegisterError(svc, &errImpl{})
 
 	err := svc.Regenerate()
 	return &wrapper, err

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -194,7 +194,18 @@ func newSchema(reg *typeRegister) (graphql.Schema, error) {
 		schemaCfg.Subscription = subscriptionType.(*graphql.Object)
 	}
 
-	return graphql.NewSchema(schemaCfg)
+	schema, err := graphql.NewSchema(schemaCfg)
+	if err != nil {
+		return schema, err
+	}
+
+	for _, ttype := range typeMap {
+		if err = schema.AppendType(ttype); err != nil {
+			return schema, err
+		}
+	}
+
+	return schema, err
 }
 
 func registerTypes(m graphql.TypeMap, col ...map[string]registerTypeFn) {

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/graphql-go/graphql"
+	"github.com/sensu/sensu-go/util/strings"
 )
 
 // Service ...TODO...
@@ -159,6 +160,16 @@ func (r *typeRegister) addType(name string, kind Kind, fn registerTypeFn) {
 	r.types[kind][name] = fn
 }
 
+func (r *typeRegister) typeNames() []string {
+	out := []string{}
+	for _, ltypes := range r.types {
+		for name := range ltypes {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
 func (r *typeRegister) setSchema(desc SchemaDesc) {
 	r.schema = desc
 }
@@ -199,7 +210,11 @@ func newSchema(reg *typeRegister) (graphql.Schema, error) {
 		return schema, err
 	}
 
-	for _, ttype := range typeMap {
+	ltypes := reg.typeNames()
+	for _, ttype := range schema.TypeMap() {
+		if registered := strings.InArray(ttype.Name(), ltypes); registered {
+			continue
+		}
 		if err = schema.AppendType(ttype); err != nil {
 			return schema, err
 		}


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Adds a generic mutation that takes a wrapped resource, stores it and returns the new resource.

schema changes in brief,

```graphql
type PutWrappedPayload {
  resource: Node
  errors: [Error!]!
}

type Mutation {
  putWrapped(raw: string!): PutWrappedResourcePayload!
}
```

example usage

```graphql
mutation AddCheck {
  putWrapped(raw: ```
    {
      "metadata": {
        "type": "CheckConfig",
        "name": "test"
      },
      "spec": {
        // ...
      },
      // ...
    }
  ```) {
    resource {
      __typename
      ... on CheckConfig {
        id
        command
        # whatever other fields the UI might rely on at given time
      }
    }
    errors {
      code
    }
  }
}
```

## Why is this change necessary?

Closes sensu/sensu-enterprise-go#315.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

The `StandardError` type was not working properly, which led to a painful amount of debugging.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Unit tests & manual testing.