### PR TITLE
[GraphQL] Query for wrapped resource

### DIFF
--- a/CHANGELOGS/unreleased/2849-add-wrapped-field.md
+++ b/CHANGELOGS/unreleased/2849-add-wrapped-field.md
@@ -1,0 +1,2 @@
+### Added
+- [GraphQL] Added field returning wrapped resource given ID.

--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/graphql"
+	"github.com/sensu/sensu-go/types"
 )
 
 var _ schema.QueryFieldResolvers = (*queryImpl)(nil)
@@ -56,6 +57,16 @@ func (r *queryImpl) Check(p schema.QueryCheckFieldResolverParams) (interface{}, 
 func (r *queryImpl) Node(p schema.QueryNodeFieldResolverParams) (interface{}, error) {
 	resolver := r.nodeResolver
 	return resolver.Find(p.Context, p.Args.ID, p.Info)
+}
+
+// WrappedNode implements response to request for 'wrappedNode' field.
+func (r *queryImpl) WrappedNode(p schema.QueryWrappedNodeFieldResolverParams) (interface{}, error) {
+	resolver := r.nodeResolver
+	res, err := resolver.Find(p.Context, p.Args.ID, p.Info)
+	if rres, ok := res.(types.Resource); ok {
+		return types.WrapResource(rres), err
+	}
+	return nil, err
 }
 
 //

--- a/backend/apid/graphql/schema/schema.graphql
+++ b/backend/apid/graphql/schema/schema.graphql
@@ -37,4 +37,12 @@ type Query {
     "The ID of an object."
     id: ID!
   ): Node
+
+  """
+  Node fetches an object given its ID and returns it as wrapped resource.
+  """
+  wrappedNode(
+    "The ID of an object."
+    id: ID!
+  ): JSON
 }


### PR DESCRIPTION
## What is this change?

Add field to Query type to retrieve the wrapped representation of any type.

Usage

```graphql
query FetchWrapped($id1: ID!, $id2: ID!, $id3: ID!) {
  fetchForEditing:  wrappedNode(id: $id1)
  toSensuctlCreate: wrappedNode(id: $id2)
  anotherAlias:     wrappedNode(id:$id3)
}
```

Example response

```json5
{
  "data": {
    "fetchForEditing": {
      "type": "CheckConfig",
      "api_version": "core/v2",
      "metadata": {
        "name": "my-ttl-check",
        "namespace": "sensu-devel"
      },
      "spec": {
        // ...
      },
    "toSensuctlCreate": {
      "type": "Asset",
      // ...
    },
    "anotherAlias": {
      "type": "WhateverYouDream",
      // ...
    },
  },
}
```

## Why is this change necessary?

Closes sensu/sensu-enterprise-go#316

## Does your change need a Changelog entry?

Yup

## Do you need clarification on anything?

No

## Were there any complications while making this change?

Nada

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No

## How did you verify this change?

Manual testing.