### PR TITLE
Remove test case for removed method

### DIFF
--- a/backend/apid/graphql/silenced_test.go
+++ b/backend/apid/graphql/silenced_test.go
@@ -26,9 +26,7 @@ func TestSilencedTypeCheckField(t *testing.T) {
 
 func TestSilencedTypeExpiresField(t *testing.T) {
 	silenced := types.FixtureSilenced("unix:http-check")
-
-	_, factory := client.NewClientFactory()
-	impl := &silencedImpl{factory: factory}
+	impl := &silencedImpl{}
 
 	// with expiry unset
 	res, err := impl.Expires(graphql.ResolveParams{Source: silenced})
@@ -40,4 +38,14 @@ func TestSilencedTypeExpiresField(t *testing.T) {
 	res, err = impl.Expires(graphql.ResolveParams{Source: silenced})
 	require.NoError(t, err)
 	assert.NotNil(t, res)
+}
+
+func TestSilencedTypeBeginField(t *testing.T) {
+	silenced := types.FixtureSilenced("unix:http-check")
+	impl := &silencedImpl{}
+
+	// with expiry unset
+	res, err := impl.Begin(graphql.ResolveParams{Source: silenced})
+	require.NoError(t, err)
+	assert.Nil(t, res)
 }

--- a/backend/apid/graphql/silenced_test.go
+++ b/backend/apid/graphql/silenced_test.go
@@ -44,7 +44,6 @@ func TestSilencedTypeBeginField(t *testing.T) {
 	silenced := types.FixtureSilenced("unix:http-check")
 	impl := &silencedImpl{}
 
-	// with expiry unset
 	res, err := impl.Begin(graphql.ResolveParams{Source: silenced})
 	require.NoError(t, err)
 	assert.Nil(t, res)

--- a/backend/apid/graphql/silenced_test.go
+++ b/backend/apid/graphql/silenced_test.go
@@ -10,21 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSilencedTypeCreatorField(t *testing.T) {
-	user := types.FixtureUser("dean learner")
-	silenced := types.FixtureSilenced("unix:*")
-	silenced.Creator = user.Username
-
-	client, factory := client.NewClientFactory()
-	impl := &silencedImpl{factory: factory}
-
-	// Success
-	client.On("FetchUser", user.Username).Return(user, nil).Once()
-	res, err := impl.Creator(graphql.ResolveParams{Source: silenced})
-	require.NoError(t, err)
-	assert.NotEmpty(t, res)
-}
-
 func TestSilencedTypeCheckField(t *testing.T) {
 	check := types.FixtureCheckConfig("http-check")
 	silenced := types.FixtureSilenced("unix:http-check")


### PR DESCRIPTION
## What is this change?

Remove test case that verifies a removed method.

## Why is this change necessary?

I broke `master`. Womp Womp.

```
--- FAIL: TestSilencedTypeCreatorField (0.00s)
    <autogenerated>:1: 
            Error Trace:    silenced_test.go:24
            Error:          Received unexpected error:
                            unable to coerce value for field 'creator'
            Test:           TestSilencedTypeCreatorField
FAIL
```

https://circleci.com/gh/sensu/sensu-go/3392

## Does your change need a Changelog entry?

Largely irrelevant, so probably not.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Not really a "complication" but it is odd that the CI didn't catch this in my [branch](https://github.com/sensu/sensu-go/pull/2843/checks).

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None.