### PR TITLE
Audit and fix all etcd watchers

### DIFF
--- a/CHANGELOGS/unreleased/2635-bugfix-watchers.md
+++ b/CHANGELOGS/unreleased/2635-bugfix-watchers.md
@@ -1,0 +1,6 @@
+### Fixed
+* Fixed an issue where etcd watchers were used incorrectly. This was causing
+100% CPU usage in some components, as they would loop endlessly trying to get
+results from watchers that broke, due to their stream terminating. Other
+components would simply stop updating. Watchers now get reinstated when the
+client regains connectivity.

--- a/CHANGELOGS/unreleased/list-handlers.md
+++ b/CHANGELOGS/unreleased/list-handlers.md
@@ -1,0 +1,6 @@
+### Changed
+- apid uses a new generic router for listing resources.
+- The store uses the generic List function for listing resources.
+
+### Fixed
+- Fixed the `/events/:entity` route in the REST API.

--- a/backend/apid/actions/cluster.go
+++ b/backend/apid/actions/cluster.go
@@ -12,24 +12,29 @@ type ClusterController struct {
 	cluster clientv3.Cluster
 }
 
+// NewClusterController provides a new controller for the etcd cluster
 func NewClusterController(cluster clientv3.Cluster) ClusterController {
 	return ClusterController{
 		cluster: cluster,
 	}
 }
 
+// MemberList returns the list of members in the cluster
 func (c ClusterController) MemberList(ctx context.Context) (*clientv3.MemberListResponse, error) {
 	return c.cluster.MemberList(ctx)
 }
 
+// MemberAdd adds a member to the cluster
 func (c ClusterController) MemberAdd(ctx context.Context, addrs []string) (*clientv3.MemberAddResponse, error) {
 	return c.cluster.MemberAdd(ctx, addrs)
 }
 
+// MemberRemove removes a member from the cluster
 func (c ClusterController) MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error) {
 	return c.cluster.MemberRemove(ctx, id)
 }
 
+// MemberUpdate updates the specified member addresses
 func (c ClusterController) MemberUpdate(ctx context.Context, id uint64, addrs []string) (*clientv3.MemberUpdateResponse, error) {
 	return c.cluster.MemberUpdate(ctx, id, addrs)
 }

--- a/backend/apid/actions/clusterroles_test.go
+++ b/backend/apid/actions/clusterroles_test.go
@@ -20,7 +20,7 @@ func TestNewClusterRoleController(t *testing.T) {
 	actions := NewClusterRoleController(store)
 
 	assert.NotNil(actions)
-	assert.Equal(store, actions.Store)
+	assert.Equal(store, actions.store)
 }
 
 func TestClusterRoleCreate(t *testing.T) {
@@ -276,86 +276,52 @@ func TestClusterRoleGet(t *testing.T) {
 
 func TestClusterRoleList(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		storeErr              error
-		continueToken         string
-		expectedResult        []*types.ClusterRole
-		expectedContinueToken string
-		expectedErr           bool
-		expectedErrCode       ErrCode
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.ClusterRole
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",
 			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
+			records: []*types.ClusterRole{
 				types.FixtureClusterRole("read-write"),
 				types.FixtureClusterRole("read-only"),
 				types.FixtureClusterRole("sysadmin"),
 			},
+			expectedLen: 3,
 		},
 		{
-			name:            "Not found",
-			ctx:             context.Background(),
-			storeErr:        &store.ErrNotFound{},
-			expectedErr:     true,
-			expectedErrCode: NotFound,
-		},
-		{
-			name:            "Store error",
-			ctx:             context.Background(),
-			storeErr:        errors.New("some error"),
-			expectedErr:     true,
-			expectedErrCode: InternalErr,
-		},
-		{
-			name: "no continue token",
+			name: "Not found",
 			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
-				types.FixtureClusterRole("clusterRole1"),
-				types.FixtureClusterRole("clusterRole2"),
-			},
-			continueToken:         "",
-			expectedContinueToken: "",
 		},
 		{
-			name: "base64url encode continue token",
-			ctx:  context.Background(),
-			expectedResult: []*types.ClusterRole{
-				types.FixtureClusterRole("clusterRole1"),
-				types.FixtureClusterRole("clusterRole2"),
-			},
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
+			name:        "Store error",
+			ctx:         context.Background(),
+			storeErr:    errors.New("some error"),
+			expectedErr: NewError(InternalErr, errors.New("some error")),
 		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
-		actions := NewClusterRoleController(store)
+		s := &mockstore.MockStore{}
+		actions := NewClusterRoleController(s)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			store.
-				On("ListClusterRoles", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.expectedResult, tc.continueToken, tc.storeErr)
+			// Mock store methods
+			pred := &store.SelectionPredicate{}
+			s.On("ListClusterRoles", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			result, continueToken, err := actions.List(tc.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			if tc.expectedErr {
-				inferErr, ok := err.(Error)
-				if ok {
-					assert.Equal(tc.expectedErrCode, inferErr.Code)
-				} else {
-					assert.Error(err)
-					assert.FailNow("Return value was not of type 'Error'")
-				}
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.expectedResult, result)
-				assert.Equal(tc.expectedContinueToken, continueToken)
-			}
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
@@ -12,48 +11,40 @@ import (
 
 // EventController expose actions in which a viewer can perform.
 type EventController struct {
-	Store store.EventStore
-	Bus   messaging.MessageBus
+	store store.EventStore
+	bus   messaging.MessageBus
 }
 
 // NewEventController returns new EventController
 func NewEventController(store store.EventStore, bus messaging.MessageBus) EventController {
 	return EventController{
-		Store: store,
-		Bus:   bus,
+		store: store,
+		bus:   bus,
 	}
 }
 
-// Query returns resources available to the viewer filter by given params.
-func (a EventController) Query(ctx context.Context, entityName, checkName string) ([]*corev2.Event, string, error) {
+// List returns resources available to the viewer filter by given params.
+func (a EventController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
 	var results []*corev2.Event
-	var nextContinueToken string
-
-	pageSize := corev2.PageSizeFromContext(ctx)
-	continueToken := corev2.PageContinueFromContext(ctx)
+	var err error
 
 	// Fetch from store
-	var serr error
-	if entityName != "" && checkName != "" {
-		var result *corev2.Event
-		result, serr = a.Store.GetEventByEntityCheck(ctx, entityName, checkName)
-		if result != nil {
-			results = append(results, result)
-		}
-	} else if entityName != "" {
-		results, nextContinueToken, serr = a.Store.GetEventsByEntity(ctx, entityName, int64(pageSize), continueToken)
+	if pred.Subcollection != "" {
+		results, err = a.store.GetEventsByEntity(ctx, pred.Subcollection, pred)
 	} else {
-		results, nextContinueToken, serr = a.Store.GetEvents(ctx, int64(pageSize), continueToken)
+		results, err = a.store.GetEvents(ctx, pred)
 	}
 
-	if serr != nil {
-		return nil, "", NewError(InternalErr, serr)
+	if err != nil {
+		return nil, NewError(InternalErr, err)
 	}
 
-	// Encode the continue token with base64url (RFC 4648), without padding
-	encodedNextContinueToken := base64.RawURLEncoding.EncodeToString([]byte(nextContinueToken))
+	resources := make([]corev2.Resource, len(results))
+	for i, v := range results {
+		resources[i] = corev2.Resource(v)
+	}
 
-	return results, encodedNextContinueToken, nil
+	return resources, nil
 }
 
 // Find returns resource associated with given parameters if available to the
@@ -64,7 +55,7 @@ func (a EventController) Find(ctx context.Context, entity, check string) (*corev
 		return nil, NewErrorf(InvalidArgument, "Find() requires both an entity and a check")
 	}
 
-	result, err := a.Store.GetEventByEntityCheck(ctx, entity, check)
+	result, err := a.store.GetEventByEntityCheck(ctx, entity, check)
 	if err != nil {
 		return nil, NewError(InternalErr, err)
 	}
@@ -82,13 +73,13 @@ func (a EventController) Destroy(ctx context.Context, entity, check string) erro
 		return NewErrorf(InvalidArgument, "Destroy() requires both an entity and a check")
 	}
 
-	result, err := a.Store.GetEventByEntityCheck(ctx, entity, check)
+	result, err := a.store.GetEventByEntityCheck(ctx, entity, check)
 	if err != nil {
 		return NewError(InternalErr, err)
 	}
 
 	if result != nil {
-		err := a.Store.DeleteEventByEntityCheck(ctx, entity, check)
+		err := a.store.DeleteEventByEntityCheck(ctx, entity, check)
 		if err != nil {
 			return NewError(InternalErr, err)
 		}
@@ -110,7 +101,7 @@ func (a EventController) Create(ctx context.Context, event corev2.Event) error {
 		check := event.Check
 		entity := event.Entity
 
-		e, err := a.Store.GetEventByEntityCheck(ctx, entity.Name, check.Name)
+		e, err := a.store.GetEventByEntityCheck(ctx, entity.Name, check.Name)
 		if err != nil {
 			return NewError(InternalErr, err)
 		} else if e != nil {
@@ -119,7 +110,7 @@ func (a EventController) Create(ctx context.Context, event corev2.Event) error {
 	}
 
 	// Publish to event pipeline
-	if err := a.Bus.Publish(messaging.TopicEventRaw, &event); err != nil {
+	if err := a.bus.Publish(messaging.TopicEventRaw, &event); err != nil {
 		return NewError(InternalErr, err)
 	}
 
@@ -134,7 +125,7 @@ func (a EventController) CreateOrReplace(ctx context.Context, event corev2.Event
 	}
 
 	// Publish to event pipeline
-	if err := a.Bus.Publish(messaging.TopicEventRaw, &event); err != nil {
+	if err := a.bus.Publish(messaging.TopicEventRaw, &event); err != nil {
 		return NewError(InternalErr, err)
 	}
 

--- a/backend/apid/actions/events_test.go
+++ b/backend/apid/actions/events_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockbus"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
@@ -20,24 +21,21 @@ func TestNewEventController(t *testing.T) {
 	eventController := NewEventController(store, bus)
 
 	assert.NotNil(eventController)
-	assert.Equal(store, eventController.Store)
-	assert.Equal(bus, eventController.Bus)
+	assert.Equal(store, eventController.store)
+	assert.Equal(bus, eventController.bus)
 }
 
-func TestEventQuery(t *testing.T) {
+func TestEventList(t *testing.T) {
 	defaultCtx := context.Background()
 
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		events                []*types.Event
-		entity                string
-		check                 string
-		continueToken         string
-		storeErr              error
-		expectedLen           int
-		expectedContinueToken string
-		expectedErr           error
+		name        string
+		ctx         context.Context
+		events      []*types.Event
+		entity      string
+		storeErr    error
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name:        "No Params No Events",
@@ -70,7 +68,7 @@ func TestEventQuery(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name:        "Store Failure",
+			name:        "store Failure",
 			ctx:         defaultCtx,
 			events:      nil,
 			entity:      "entity1",
@@ -78,51 +76,28 @@ func TestEventQuery(t *testing.T) {
 			storeErr:    errors.New(""),
 			expectedErr: NewError(InternalErr, errors.New("")),
 		},
-		{
-			name: "no continue token",
-			ctx:  defaultCtx,
-			events: []*types.Event{
-				types.FixtureEvent("entity1", "check1"),
-				types.FixtureEvent("entity2", "check2"),
-			},
-			expectedLen:           2,
-			continueToken:         "",
-			expectedContinueToken: "",
-		},
-		{
-			name: "base64url encode continue token",
-			ctx:  defaultCtx,
-			events: []*types.Event{
-				types.FixtureEvent("entity1", "check1"),
-				types.FixtureEvent("entity2", "check2"),
-			},
-			expectedLen:           2,
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
-		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
+		s := &mockstore.MockStore{}
 		bus := &mockbus.MockBus{}
-		eventController := NewEventController(store, bus)
+		eventController := NewEventController(s, bus)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
 			// Mock store methods
-			store.On("GetEvents", tc.ctx, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.events, tc.continueToken, tc.storeErr)
+			pred := &store.SelectionPredicate{}
+			s.On("GetEvents", tc.ctx, pred).Return(tc.events, tc.storeErr)
 
-			store.On("GetEventsByEntity", tc.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.events, tc.continueToken, tc.storeErr)
+			s.On("GetEventsByEntity", tc.ctx, mock.AnythingOfType("string"), pred).
+				Return(tc.events, tc.storeErr)
 
 			// Exec Query
-			results, continueToken, err := eventController.Query(tc.ctx, tc.entity, tc.check)
+			results, err := eventController.List(tc.ctx, pred)
 
 			// Assert
 			assert.EqualValues(tc.expectedErr, err)
-			assert.EqualValues(tc.expectedContinueToken, continueToken)
 			assert.Len(results, tc.expectedLen)
 		})
 	}
@@ -321,7 +296,7 @@ func TestEventCreate(t *testing.T) {
 			expectedErrCode: AlreadyExistsErr,
 		},
 		{
-			name:            "Store Err on Fetch",
+			name:            "store Err on Fetch",
 			ctx:             defaultCtx,
 			argument:        types.FixtureEvent("entity1", "check1"),
 			fetchErr:        errors.New("dunno"),

--- a/backend/apid/actions/mutators_test.go
+++ b/backend/apid/actions/mutators_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
@@ -18,7 +19,7 @@ func TestNewMutatorController(t *testing.T) {
 	store := &mockstore.MockStore{}
 	ctl := NewMutatorController(store)
 	assert.NotNil(ctl)
-	assert.Equal(store, ctl.Store)
+	assert.Equal(store, ctl.store)
 }
 
 func TestMutatorCreateOrReplace(t *testing.T) {
@@ -121,7 +122,7 @@ func TestMutatorCreate(t *testing.T) {
 			expectedErrCode: AlreadyExistsErr,
 		},
 		{
-			name:            "Store Err on Fetch",
+			name:            "store Err on Fetch",
 			ctx:             defaultCtx,
 			argument:        types.FixtureMutator("grumpy"),
 			fetchErr:        errors.New("nein"),
@@ -196,7 +197,7 @@ func TestMutatorDestroy(t *testing.T) {
 			expectedErrCode: NotFound,
 		},
 		{
-			name:            "Store Err on Delete",
+			name:            "store Err on Delete",
 			ctx:             defaultCtx,
 			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
@@ -205,7 +206,7 @@ func TestMutatorDestroy(t *testing.T) {
 			expectedErrCode: InternalErr,
 		},
 		{
-			name:            "Store Err on Fetch",
+			name:            "store Err on Fetch",
 			ctx:             defaultCtx,
 			mutator:         "mutator1",
 			fetchResult:     types.FixtureMutator("mutator1"),
@@ -248,23 +249,21 @@ func TestMutatorDestroy(t *testing.T) {
 	}
 }
 
-func TestMutatorQuery(t *testing.T) {
+func TestMutatorList(t *testing.T) {
 	readCtx := context.Background()
 
-	tests := []struct {
-		name                  string
-		ctx                   context.Context
-		mutators              []*types.Mutator
-		storeErr              error
-		continueToken         string
-		expectedLen           int
-		expectedContinueToken string
-		expectedErr           error
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		records     []*types.Mutator
+		storeErr    error
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name:        "No Params, No Mutators",
 			ctx:         readCtx,
-			mutators:    nil,
+			records:     nil,
 			expectedLen: 0,
 			storeErr:    nil,
 			expectedErr: nil,
@@ -272,7 +271,7 @@ func TestMutatorQuery(t *testing.T) {
 		{
 			name: "No Params With Mutators",
 			ctx:  readCtx,
-			mutators: []*types.Mutator{
+			records: []*types.Mutator{
 				types.FixtureMutator("homer"),
 				types.FixtureMutator("bart"),
 			},
@@ -283,7 +282,7 @@ func TestMutatorQuery(t *testing.T) {
 		{
 			name: "Mutator Param",
 			ctx:  readCtx,
-			mutators: []*types.Mutator{
+			records: []*types.Mutator{
 				types.FixtureMutator("mr. burns"),
 			},
 			expectedLen: 1,
@@ -291,53 +290,32 @@ func TestMutatorQuery(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name:        "Store Failure",
+			name:        "store Failure",
 			ctx:         readCtx,
-			mutators:    nil,
+			records:     nil,
 			expectedLen: 0,
 			storeErr:    errors.New(""),
 			expectedErr: NewError(InternalErr, errors.New("")),
 		},
-		{
-			name: "no continue token",
-			ctx:  readCtx,
-			mutators: []*types.Mutator{
-				types.FixtureMutator("mutator1"),
-				types.FixtureMutator("mutator2"),
-			},
-			continueToken:         "",
-			expectedLen:           2,
-			expectedContinueToken: "",
-		},
-		{
-			name: "base64url encode continue token",
-			ctx:  readCtx,
-			mutators: []*types.Mutator{
-				types.FixtureMutator("mutator1"),
-				types.FixtureMutator("mutator2"),
-			},
-			continueToken:         "Albert Camus",
-			expectedLen:           2,
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
-		},
 	}
 
-	for _, test := range tests {
-		store := &mockstore.MockStore{}
-		ctl := NewMutatorController(store)
+	for _, tc := range testCases {
+		s := &mockstore.MockStore{}
+		actions := NewMutatorController(s)
 
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
 			// Mock store methods
-			store.On("GetMutators", test.ctx, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(test.mutators, test.continueToken, test.storeErr)
+			pred := &store.SelectionPredicate{}
+			s.On("GetMutators", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			results, continueToken, err := ctl.Query(test.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			assert.EqualValues(test.expectedErr, err)
-			assert.EqualValues(test.expectedContinueToken, continueToken)
-			assert.Len(results, test.expectedLen)
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/rolebindings_test.go
+++ b/backend/apid/actions/rolebindings_test.go
@@ -20,7 +20,7 @@ func TestNewRoleBindingController(t *testing.T) {
 	actions := NewRoleBindingController(store)
 
 	assert.NotNil(actions)
-	assert.Equal(store, actions.Store)
+	assert.Equal(store, actions.store)
 }
 
 func TestRoleBindingCreate(t *testing.T) {
@@ -276,84 +276,52 @@ func TestRoleBindingGet(t *testing.T) {
 
 func TestRoleBindingList(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		storeErr              error
-		continueToken         string
-		expectedResult        []*types.RoleBinding
-		expectedContinueToken string
-		expectedErr           bool
-		expectedErrCode       ErrCode
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.RoleBinding
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",
 			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
+			records: []*types.RoleBinding{
 				types.FixtureRoleBinding("read-write", "default"),
 				types.FixtureRoleBinding("read-only", "default"),
 				types.FixtureRoleBinding("sysadmin", "IT"),
 			},
+			expectedLen: 3,
 		},
 		{
-			name:            "Not found",
-			ctx:             context.Background(),
-			storeErr:        &store.ErrNotFound{},
-			expectedErr:     true,
-			expectedErrCode: NotFound,
-		},
-		{
-			name:            "Store error",
-			ctx:             context.Background(),
-			storeErr:        errors.New("some error"),
-			expectedErr:     true,
-			expectedErrCode: InternalErr,
-		},
-		{
-			name: "no continue token",
+			name: "Not found",
 			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
-				types.FixtureRoleBinding("roleBinding1", "default"),
-			},
-			continueToken:         "",
-			expectedContinueToken: "",
 		},
 		{
-			name: "base64url encode continue token",
-			ctx:  context.Background(),
-			expectedResult: []*types.RoleBinding{
-				types.FixtureRoleBinding("roleBinding1", "default"),
-			},
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
+			name:        "Store error",
+			ctx:         context.Background(),
+			storeErr:    errors.New("some error"),
+			expectedErr: NewError(InternalErr, errors.New("some error")),
 		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
-		actions := NewRoleBindingController(store)
+		s := &mockstore.MockStore{}
+		actions := NewRoleBindingController(s)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			store.
-				On("ListRoleBindings", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.expectedResult, tc.continueToken, tc.storeErr)
+			// Mock store methods
+			pred := &store.SelectionPredicate{}
+			s.On("ListRoleBindings", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			result, continueToken, err := actions.List(tc.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			if tc.expectedErr {
-				inferErr, ok := err.(Error)
-				if ok {
-					assert.Equal(tc.expectedErrCode, inferErr.Code)
-				} else {
-					assert.Error(err)
-					assert.FailNow("Return value was not of type 'Error'")
-				}
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.expectedResult, result)
-				assert.Equal(tc.expectedContinueToken, continueToken)
-			}
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/roles_test.go
+++ b/backend/apid/actions/roles_test.go
@@ -20,7 +20,7 @@ func TestNewRoleController(t *testing.T) {
 	actions := NewRoleController(store)
 
 	assert.NotNil(actions)
-	assert.Equal(store, actions.Store)
+	assert.Equal(store, actions.store)
 }
 
 func TestRoleCreate(t *testing.T) {
@@ -276,84 +276,52 @@ func TestRoleGet(t *testing.T) {
 
 func TestRoleList(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		ctx                   context.Context
-		storeErr              error
-		continueToken         string
-		expectedResult        []*types.Role
-		expectedContinueToken string
-		expectedErr           bool
-		expectedErrCode       ErrCode
+		name        string
+		ctx         context.Context
+		storeErr    error
+		records     []*types.Role
+		expectedLen int
+		expectedErr error
 	}{
 		{
 			name: "List",
 			ctx:  context.Background(),
-			expectedResult: []*types.Role{
+			records: []*types.Role{
 				types.FixtureRole("read-write", "default"),
 				types.FixtureRole("read-only", "default"),
 				types.FixtureRole("sysadmin", "IT"),
 			},
+			expectedLen: 3,
 		},
 		{
-			name:            "Not found",
-			ctx:             context.Background(),
-			storeErr:        &store.ErrNotFound{},
-			expectedErr:     true,
-			expectedErrCode: NotFound,
-		},
-		{
-			name:            "Store error",
-			ctx:             context.Background(),
-			storeErr:        errors.New("some error"),
-			expectedErr:     true,
-			expectedErrCode: InternalErr,
-		},
-		{
-			name: "no continue token",
+			name: "Not found",
 			ctx:  context.Background(),
-			expectedResult: []*types.Role{
-				types.FixtureRole("role1", "default"),
-			},
-			continueToken:         "",
-			expectedContinueToken: "",
 		},
 		{
-			name: "base64url encode continue token",
-			ctx:  context.Background(),
-			expectedResult: []*types.Role{
-				types.FixtureRole("role1", "default"),
-			},
-			continueToken:         "Albert Camus",
-			expectedContinueToken: "QWxiZXJ0IENhbXVz",
+			name:        "Store error",
+			ctx:         context.Background(),
+			storeErr:    errors.New("some error"),
+			expectedErr: NewError(InternalErr, errors.New("some error")),
 		},
 	}
 
 	for _, tc := range testCases {
-		store := &mockstore.MockStore{}
-		actions := NewRoleController(store)
+		s := &mockstore.MockStore{}
+		actions := NewRoleController(s)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			store.
-				On("ListRoles", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
-				Return(tc.expectedResult, tc.continueToken, tc.storeErr)
+			// Mock store methods
+			pred := &store.SelectionPredicate{}
+			s.On("ListRoles", tc.ctx, pred).Return(tc.records, tc.storeErr)
 
-			result, continueToken, err := actions.List(tc.ctx)
+			// Exec Query
+			results, err := actions.List(tc.ctx, pred)
 
-			if tc.expectedErr {
-				inferErr, ok := err.(Error)
-				if ok {
-					assert.Equal(tc.expectedErrCode, inferErr.Code)
-				} else {
-					assert.Error(err)
-					assert.FailNow("Return value was not of type 'Error'")
-				}
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.expectedResult, result)
-				assert.Equal(tc.expectedContinueToken, continueToken)
-			}
+			// Assert
+			assert.EqualValues(tc.expectedErr, err)
+			assert.Len(results, tc.expectedLen)
 		})
 	}
 }

--- a/backend/apid/actions/silenced_test.go
+++ b/backend/apid/actions/silenced_test.go
@@ -289,14 +289,14 @@ func TestSilencedCreate(t *testing.T) {
 		expectedErr     bool
 		expectedErrCode ErrCode
 		expectedCreator string
-		expectedId      string
+		expectedID      string
 	}{
 		{
 			name:        "Created",
 			ctx:         defaultCtx,
 			argument:    types.FixtureSilenced("*:silence1"),
 			expectedErr: false,
-			expectedId:  "*:silence1",
+			expectedID:  "*:silence1",
 		},
 		{
 			name:            "Already Exists",
@@ -305,7 +305,7 @@ func TestSilencedCreate(t *testing.T) {
 			fetchResult:     types.FixtureSilenced("*:silence1"),
 			expectedErr:     true,
 			expectedErrCode: AlreadyExistsErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Store Err on Create",
@@ -314,7 +314,7 @@ func TestSilencedCreate(t *testing.T) {
 			createErr:       errors.New("dunno"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Store Err on Fetch",
@@ -323,7 +323,7 @@ func TestSilencedCreate(t *testing.T) {
 			fetchErr:        errors.New("dunno"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Validation Error",
@@ -331,7 +331,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        badSilence,
 			expectedErr:     true,
 			expectedErrCode: InvalidArgument,
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Creator",
@@ -339,7 +339,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        types.FixtureSilenced("*:silence1"),
 			expectedErr:     false,
 			expectedCreator: "foo",
-			expectedId:      "*:silence1",
+			expectedID:      "*:silence1",
 		},
 		{
 			name:            "Other Id",
@@ -347,7 +347,7 @@ func TestSilencedCreate(t *testing.T) {
 			argument:        types.FixtureSilenced("unix:*"),
 			expectedErr:     false,
 			expectedCreator: "foo",
-			expectedId:      "unix:*",
+			expectedID:      "unix:*",
 		},
 	}
 
@@ -372,7 +372,7 @@ func TestSilencedCreate(t *testing.T) {
 						_ = json.Unmarshal(bytes, &entry)
 
 						assert.Equal(tc.expectedCreator, entry.Creator)
-						assert.Equal(tc.expectedId, entry.Name)
+						assert.Equal(tc.expectedID, entry.Name)
 					}
 				})
 

--- a/backend/apid/actions/users.go
+++ b/backend/apid/actions/users.go
@@ -2,7 +2,6 @@ package actions
 
 import (
 	"context"
-	"encoding/base64"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
@@ -12,33 +11,34 @@ import (
 
 // UserController exposes actions in which a viewer can perform.
 type UserController struct {
-	Store interface {
-		store.UserStore
-	}
+	store store.UserStore
 }
 
 // NewUserController returns new UserController
 func NewUserController(store store.Store) UserController {
 	return UserController{
-		Store: store,
+		store: store,
 	}
 }
 
-// Query returns resources available to the viewer filter by given params.
-func (a UserController) Query(ctx context.Context) ([]*types.User, string, error) {
-	pageSize := corev2.PageSizeFromContext(ctx)
-	continueToken := corev2.PageContinueFromContext(ctx)
-
+// List returns resources available to the viewer filter by given params.
+func (a UserController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
 	// Fetch from store
-	results, newContinueToken, serr := a.Store.GetAllUsers(int64(pageSize), continueToken)
-	if serr != nil {
-		return nil, "", NewError(InternalErr, serr)
+	results, err := a.store.GetAllUsers(pred)
+	if err != nil {
+		return nil, NewError(InternalErr, err)
 	}
 
-	// Encode the continue token with base64url (RFC 4648), without padding
-	encodedNewContinueToken := base64.RawURLEncoding.EncodeToString([]byte(newContinueToken))
+	for i := range results {
+		results[i].Password = ""
+	}
 
-	return results, encodedNewContinueToken, nil
+	resources := make([]corev2.Resource, len(results))
+	for i, v := range results {
+		resources[i] = corev2.Resource(v)
+	}
+
+	return resources, nil
 }
 
 // Find returns resource associated with given parameters if available to the
@@ -59,7 +59,7 @@ func (a UserController) Find(ctx context.Context, name string) (*types.User, err
 // Create creates a new user. It returns an error if the user already exists.
 func (a UserController) Create(ctx context.Context, newUser types.User) error {
 	// Check for existing
-	if e, err := a.Store.GetUser(ctx, newUser.Username); err != nil {
+	if e, err := a.store.GetUser(ctx, newUser.Username); err != nil {
 		return NewError(InternalErr, err)
 	} else if e != nil {
 		return NewErrorf(AlreadyExistsErr)
@@ -88,7 +88,7 @@ func (a UserController) CreateOrReplace(ctx context.Context, newUser types.User)
 	newUser.Password = hash
 
 	// Persist
-	if err := a.Store.UpdateUser(&newUser); err != nil {
+	if err := a.store.UpdateUser(&newUser); err != nil {
 		return NewError(InternalErr, err)
 	}
 
@@ -105,7 +105,7 @@ func (a UserController) Disable(ctx context.Context, name string) error {
 
 	// Disable
 	if !result.Disabled {
-		if serr := a.Store.DeleteUser(ctx, result); serr != nil {
+		if serr := a.store.DeleteUser(ctx, result); serr != nil {
 			return NewError(InternalErr, serr)
 		}
 	}
@@ -174,7 +174,7 @@ func (a UserController) RemoveAllGroups(ctx context.Context, username string) er
 }
 
 func (a UserController) findUser(ctx context.Context, name string) (*types.User, error) {
-	result, serr := a.Store.GetUser(ctx, name)
+	result, serr := a.store.GetUser(ctx, name)
 	if serr != nil {
 		return nil, NewError(InternalErr, serr)
 	} else if result == nil {
@@ -185,7 +185,7 @@ func (a UserController) findUser(ctx context.Context, name string) (*types.User,
 }
 
 func (a UserController) updateUser(ctx context.Context, user *types.User) error {
-	if err := a.Store.UpdateUser(user); err != nil {
+	if err := a.store.UpdateUser(user); err != nil {
 		return NewError(InternalErr, err)
 	}
 

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,20 +30,10 @@ func (r *AssetsRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:assets}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:assets}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *AssetsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *AssetsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/clusterrolebindings.go
+++ b/backend/apid/routers/clusterrolebindings.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -29,7 +28,7 @@ func (r *ClusterRoleBindingsRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterrolebindings}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
@@ -80,14 +79,4 @@ func (r *ClusterRoleBindingsRouter) find(req *http.Request) (interface{}, error)
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *ClusterRoleBindingsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/clusterroles.go
+++ b/backend/apid/routers/clusterroles.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -29,7 +28,7 @@ func (r *ClusterRolesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterroles}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
@@ -80,14 +79,4 @@ func (r *ClusterRolesRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *ClusterRolesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:entities}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:entities}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -56,16 +55,6 @@ func (r *EntitiesRouter) find(req *http.Request) (interface{}, error) {
 	}
 	record, err := r.controller.Find(req.Context(), id)
 	return record, err
-}
-
-func (r *EntitiesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *EntitiesRouter) create(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -3,14 +3,13 @@ package routers
 import (
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // EventsRouter handles requests for /events
@@ -33,35 +32,15 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Post(r.create)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:events}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:events}")
 	routes.Path("{entity}/{check}", r.find).Methods(http.MethodGet)
 	routes.Path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
 	routes.Path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
 
-	parent.HandleFunc("{entity}", listHandler(r.listByEntity)).Methods(http.MethodGet)
-}
-
-func (r *EventsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context(), "", "")
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
-}
-
-func (r *EventsRouter) listByEntity(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	params := actions.QueryParams(mux.Vars(req))
-	entity := url.PathEscape(params["entity"])
-	records, continueToken, err := r.controller.Query(req.Context(), entity, "")
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
+	// Additionaly allow a subcollection to be specified when listing events,
+	// which correspond to the entity name here
+	parent.HandleFunc(path.Join(routes.PathPrefix, "{subcollection}"), listerHandler(r.controller.List)).Methods(http.MethodGet)
 }
 
 func (r *EventsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/extensions.go
+++ b/backend/apid/routers/extensions.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,19 +31,9 @@ func (r *ExtensionsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.deregister)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:extensions}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:extensions}")
 	routes.Put(r.register)
-}
-
-func (r *ExtensionsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *ExtensionsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *EventFiltersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:filters}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:filters}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *EventFiltersRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *EventFiltersRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *HandlersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:handlers}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:handlers}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -72,14 +71,4 @@ func (r *HandlersRouter) find(req *http.Request) (interface{}, error) {
 		return nil, err
 	}
 	return r.controller.Find(req.Context(), id)
-}
-
-func (r *HandlersRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *HooksRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:hooks}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:hooks}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *HooksRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *HooksRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/lister.go
+++ b/backend/apid/routers/lister.go
@@ -1,0 +1,64 @@
+package routers
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+// ListControllerFunc represents a generic controller for listing resources
+type ListControllerFunc func(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error)
+
+// listerFunc represents the function signature of a Lister
+type listerFunc func(ListControllerFunc) http.HandlerFunc
+
+// Lister represents the active Lister function
+var Lister listerFunc
+
+func init() {
+	// Assign the core lister
+	Lister = List
+}
+
+// List handles resources listing with pagination support
+func List(list ListControllerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		pred := &store.SelectionPredicate{
+			Continue: corev2.PageContinueFromContext(r.Context()),
+			Limit:    int64(corev2.PageSizeFromContext(r.Context())),
+		}
+
+		params := actions.QueryParams(mux.Vars(r))
+		if subcollection := url.PathEscape(params["subcollection"]); subcollection != "" {
+			pred.Subcollection = subcollection
+		}
+
+		results, err := list(r.Context(), pred)
+		if err != nil {
+			WriteError(w, err)
+			return
+		}
+
+		if pred.Continue != "" {
+			encodedContinue := base64.RawURLEncoding.EncodeToString([]byte(pred.Continue))
+			w.Header().Set(corev2.PaginationContinueHeader, encodedContinue)
+		}
+
+		RespondWith(w, results)
+	}
+}
+
+// We can't directly use a Lister in the mux.Router because it cannot be
+// modified at runtime, which is required for sensu-enterprise-go, therefore we
+// need this little wrapper
+func listerHandler(list ListControllerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		Lister(list).ServeHTTP(w, r)
+	}
+}

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -1,0 +1,112 @@
+package routers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/middlewares"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockGenericController struct {
+	mock.Mock
+}
+
+func (m *mockGenericController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
+}
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name                   string
+		path                   string
+		results                []corev2.Resource
+		controllerErr          error
+		continueToken          string
+		expectedContinueHeader string
+		expectedLen            int
+		expectedPred           *store.SelectionPredicate
+		expectedStatus         int
+	}{
+		{
+			name:           "list without pagination",
+			path:           "/foo",
+			results:        []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			expectedLen:    1,
+			expectedPred:   &store.SelectionPredicate{},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "list with subcollection but without pagination",
+			path:           "/foo/bar",
+			results:        []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			expectedLen:    1,
+			expectedPred:   &store.SelectionPredicate{Subcollection: "bar"},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "controller error",
+			path:           "/foo",
+			controllerErr:  errors.New("error"),
+			expectedPred:   &store.SelectionPredicate{},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:                   "continue token",
+			path:                   "/foo",
+			results:                []corev2.Resource{corev2.FixtureCheck("check-cpu")},
+			continueToken:          "bar",
+			expectedLen:            1,
+			expectedPred:           &store.SelectionPredicate{},
+			expectedStatus:         http.StatusOK,
+			expectedContinueHeader: "YmFy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &mockGenericController{}
+			controller.On("List", mock.Anything, mock.AnythingOfType("*store.SelectionPredicate")).
+				Return(tt.results, tt.controllerErr).
+				Run(func(args mock.Arguments) {
+					pred := args[1].(*store.SelectionPredicate)
+					assert.Equal(t, tt.expectedPred, pred)
+
+					if tt.continueToken != "" {
+						pred.Continue = tt.continueToken
+					}
+				})
+
+			r, err := http.NewRequest("GET", tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List))
+			router.PathPrefix("/foo").HandlerFunc(List(controller.List))
+			middleware := middlewares.Pagination{}
+			router.Use(middleware.Then)
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if w.Code < 400 {
+				payload := []interface{}{}
+				if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+					t.Fatal(err)
+				}
+				assert.Len(t, payload, tt.expectedLen)
+			}
+			assert.Equal(t, tt.expectedContinueHeader, w.Header().Get(corev2.PaginationContinueHeader))
+		})
+	}
+}

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,20 +31,10 @@ func (r *MutatorsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:mutators}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:mutators}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *MutatorsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *MutatorsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
 // NamespacesController represents the controller needs of the NamespacesRouter.
 type NamespacesController interface {
-	Query(ctx context.Context) ([]*types.Namespace, string, error)
+	List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error)
 	Find(ctx context.Context, name string) (*types.Namespace, error)
 	Create(ctx context.Context, newOrg types.Namespace) error
 	CreateOrReplace(ctx context.Context, newOrg types.Namespace) error
@@ -37,21 +38,11 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:namespaces}",
 	}
-	routes.List(r.list)
+	routes.List(r.controller.List)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)
 	routes.Put(r.createOrReplace)
-}
-
-func (r *NamespacesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	records, continueToken, err := r.controller.Query(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return records, err
 }
 
 func (r *NamespacesRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -9,6 +9,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
+
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/mock"
@@ -26,9 +29,9 @@ func (m *mockOrgController) CreateOrReplace(ctx context.Context, org types.Names
 	return m.Called(ctx, org).Error(0)
 }
 
-func (m *mockOrgController) Query(ctx context.Context) ([]*types.Namespace, string, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]*types.Namespace), args.String(1), args.Error(2)
+func (m *mockOrgController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
 }
 
 func (m *mockOrgController) Find(ctx context.Context, org string) (*types.Namespace, error) {
@@ -152,8 +155,8 @@ func TestListNamespaces(t *testing.T) {
 
 	client := new(http.Client)
 
-	fixtures := []*types.Namespace{types.FixtureNamespace("default")}
-	controller.On("Query", mock.Anything).Return(fixtures, "", nil)
+	fixtures := []corev2.Resource{types.FixtureNamespace("default")}
+	controller.On("List", mock.Anything, &store.SelectionPredicate{}).Return(fixtures, nil)
 	endpoint := "/namespaces"
 	req := newRequest(t, http.MethodGet, server.URL+endpoint, nil)
 

--- a/backend/apid/routers/rolebindings.go
+++ b/backend/apid/routers/rolebindings.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *RoleBindingsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:rolebindings}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:rolebindings}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -82,14 +81,4 @@ func (r *RoleBindingsRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *RoleBindingsRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -32,8 +31,8 @@ func (r *RolesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:roles}")
+	routes.List(r.controller.List)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:roles}")
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }
@@ -82,14 +81,4 @@ func (r *RolesRouter) find(req *http.Request) (interface{}, error) {
 
 	obj, err := r.controller.Get(req.Context(), id)
 	return obj, err
-}
-
-func (r *RolesRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {
-	objs, continueToken, err := r.controller.List(req.Context())
-
-	if continueToken != "" {
-		w.Header().Set(corev2.PaginationContinueHeader, continueToken)
-	}
-
-	return objs, err
 }

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -31,8 +31,8 @@ func (r *SilencedRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.list)
-	routes.ListAllNamespaces(r.list, "/{resource:silenced}")
+	routes.Router.HandleFunc(routes.PathPrefix, listHandler(r.list)).Methods(http.MethodGet)
+	routes.Router.HandleFunc("/{resource:silenced}", listHandler(r.list)).Methods(http.MethodGet)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,9 +29,9 @@ func (m *mockUserController) CreateOrReplace(ctx context.Context, name types.Use
 	return m.Called(ctx, name).Error(0)
 }
 
-func (m *mockUserController) Query(ctx context.Context) ([]*types.User, string, error) {
-	args := m.Called(ctx)
-	return args.Get(0).([]*types.User), args.String(1), args.Error(2)
+func (m *mockUserController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]corev2.Resource), args.Error(1)
 }
 
 func (m *mockUserController) Find(ctx context.Context, name string) (*types.User, error) {

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -33,7 +33,7 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	}
 
 	// Get cluster roles binding
-	clusterRoleBindings, _, err := a.Store.ListClusterRoleBindings(ctx, 0, "")
+	clusterRoleBindings, err := a.Store.ListClusterRoleBindings(ctx, &store.SelectionPredicate{})
 	if err != nil {
 		switch err := err.(type) {
 		case *store.ErrNotFound:
@@ -81,7 +81,7 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	// First, make sure we have a namespace
 	if len(attrs.Namespace) > 0 {
 		// Get roles binding
-		roleBindings, _, err := a.Store.ListRoleBindings(ctx, 0, "")
+		roleBindings, err := a.Store.ListRoleBindings(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			switch err := err.(type) {
 			case *store.ErrNotFound:

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -33,7 +33,7 @@ func (adapterPtr *Deregistration) Deregister(entity *types.Entity) error {
 		return fmt.Errorf("error deleting entity in store: %s", err)
 	}
 
-	events, _, err := adapterPtr.Store.GetEventsByEntity(ctx, entity.Name, 0, "")
+	events, err := adapterPtr.Store.GetEventsByEntity(ctx, entity.Name, &store.SelectionPredicate{})
 	if err != nil {
 		return fmt.Errorf("error fetching events for entity: %s", err)
 	}

--- a/backend/keepalived/deregisterer_test.go
+++ b/backend/keepalived/deregisterer_test.go
@@ -3,6 +3,8 @@ package keepalived
 import (
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/store"
+
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/testing/mockbus"
 	"github.com/sensu/sensu-go/testing/mockstore"
@@ -27,7 +29,7 @@ func TestDeregister(t *testing.T) {
 	check := types.FixtureCheck("check")
 	event := types.FixtureEvent(entity.Name, check.Name)
 
-	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, int64(0), "").Return([]*types.Event{event}, "", nil)
+	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, &store.SelectionPredicate{}).Return([]*types.Event{event}, nil)
 	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.Name, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 
@@ -54,7 +56,7 @@ func TestDeregistrationHandler(t *testing.T) {
 	}
 	check := types.FixtureCheck("check")
 
-	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, int64(0), "").Return([]*types.Event{}, "", nil)
+	mockStore.On("GetEventsByEntity", mock.Anything, entity.Name, &store.SelectionPredicate{}).Return([]*types.Event{}, nil)
 	mockStore.On("DeleteEventByEntityCheck", mock.Anything, entity.Name, check.Name).Return(nil)
 	mockStore.On("DeleteEntity", mock.Anything, entity).Return(nil)
 

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -84,7 +84,7 @@ func (c *CheckWatcher) startScheduler(check *types.CheckConfig) error {
 // Start starts the CheckWatcher.
 func (c *CheckWatcher) Start() error {
 	// for each check
-	checkConfigs, _, err := c.store.GetCheckConfigs(c.ctx, 0, "")
+	checkConfigs, err := c.store.GetCheckConfigs(c.ctx, &store.SelectionPredicate{})
 	if err != nil {
 		return err
 	}

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -27,11 +27,11 @@ func TestCheckWatcherSmoke(t *testing.T) {
 
 	checkA := types.FixtureCheckConfig("a")
 	checkB := types.FixtureCheckConfig("b")
-	st.On("GetCheckConfigs", mock.Anything, int64(0), "").Return([]*types.CheckConfig{checkA, checkB}, "", nil)
+	st.On("GetCheckConfigs", mock.Anything, &store.SelectionPredicate{}).Return([]*types.CheckConfig{checkA, checkB}, nil)
 	st.On("GetCheckConfigByName", mock.Anything, "a").Return(checkA, nil)
 	st.On("GetCheckConfigByName", mock.Anything, "b").Return(checkB, nil)
-	st.On("GetAssets", mock.Anything, int64(0), "").Return([]*types.Asset{}, "", nil)
-	st.On("GetHookConfigs", mock.Anything, int64(0), "").Return([]*types.HookConfig{}, "", nil)
+	st.On("GetAssets", mock.Anything, &store.SelectionPredicate{}).Return([]*types.Asset{}, nil)
+	st.On("GetHookConfigs", mock.Anything, &store.SelectionPredicate{}).Return([]*types.HookConfig{}, nil)
 
 	watcherChan := make(chan store.WatchEventCheckConfig)
 	st.On("GetCheckConfigWatcher", mock.Anything).Return((<-chan store.WatchEventCheckConfig)(watcherChan), nil)

--- a/backend/schedulerd/entity_cache.go
+++ b/backend/schedulerd/entity_cache.go
@@ -70,8 +70,8 @@ type EntityCache struct {
 
 // NewEntityCache creates a new EntityCache. It retrieves all entities from the
 // store on creation.
-func NewEntityCache(ctx context.Context, store store.EntityStore) (*EntityCache, error) {
-	entities, _, err := store.GetEntities(ctx, 0, "")
+func NewEntityCache(ctx context.Context, s store.EntityStore) (*EntityCache, error) {
+	entities, err := s.GetEntities(ctx, &store.SelectionPredicate{})
 	if err != nil {
 		return nil, fmt.Errorf("error creating EntityCache: %s", err)
 	}
@@ -82,7 +82,7 @@ func NewEntityCache(ctx context.Context, store store.EntityStore) (*EntityCache,
 	cache := &EntityCache{
 		sliceCache: entities,
 		mapCache:   mapCache,
-		watcher:    store.GetEntityWatcher(ctx),
+		watcher:    s.GetEntityWatcher(ctx),
 	}
 	go cache.start(ctx)
 	return cache, nil

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -320,7 +320,7 @@ func publishRoundRobinProxyCheckRequests(executor *CheckExecutor, check *corev2.
 	return nil
 }
 
-func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequest, error) {
+func buildRequest(check *types.CheckConfig, s store.Store) (*types.CheckRequest, error) {
 	request := &types.CheckRequest{}
 	request.Config = check
 
@@ -330,7 +330,7 @@ func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequ
 	// the check in the first place.
 	if len(check.RuntimeAssets) != 0 {
 		// Explode assets; get assets & filter out those that are irrelevant
-		assets, _, err := store.GetAssets(ctx, 0, "")
+		assets, err := s.GetAssets(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			return nil, err
 		}
@@ -346,7 +346,7 @@ func buildRequest(check *types.CheckConfig, store store.Store) (*types.CheckRequ
 	// the check in the first place.
 	if len(check.CheckHooks) != 0 {
 		// Explode hooks; get hooks & filter out those that are irrelevant
-		hooks, _, err := store.GetHookConfigs(ctx, 0, "")
+		hooks, err := s.GetHookConfigs(ctx, &store.SelectionPredicate{})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/schedulerd/roundrobin_cron.go
+++ b/backend/schedulerd/roundrobin_cron.go
@@ -126,31 +126,19 @@ func (s *RoundRobinCronScheduler) updateRings() {
 			return
 		}
 	}
+	// Cancel any ring watchers that should no longer exist
+	for _, watcher := range s.cancels {
+		watcher.Cancel()
+	}
 	for _, sub := range s.check.Subscriptions {
 		key := ringv2.Path(s.check.Namespace, sub)
-		if val, ok := s.cancels[key]; ok {
-			// The watcher already exists
-			if len(proxyEntities) > 0 && val.AgentEntitiesRequest != agentEntitiesRequest {
-				// The number of proxy entities has changed, we need a new
-				// watcher.
-				val.Cancel()
-			} else {
-				newCancels[key] = val
-				continue
-			}
-		}
+
 		// Create a new watcher
 		ctx, cancel := context.WithCancel(s.ctx)
 		wc := s.ringPool.Get(key).Watch(ctx, s.check.Name, agentEntitiesRequest, int(s.check.Interval), s.check.Cron)
 		val := ringCancel{Cancel: cancel, AgentEntitiesRequest: agentEntitiesRequest}
 		go s.handleEvents(s.executor, wc, proxyEntities)
 		newCancels[key] = val
-	}
-	// Cancel any cancels that should no longer exist
-	for key, watcher := range s.cancels {
-		if _, ok := newCancels[key]; !ok {
-			watcher.Cancel()
-		}
 	}
 	s.cancels = newCancels
 }

--- a/backend/store/etcd/asset_store_test.go
+++ b/backend/store/etcd/asset_store_test.go
@@ -4,25 +4,22 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestAssetStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		asset := types.FixtureAsset("ruby")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, asset.Namespace)
 
-		err := store.UpdateAsset(ctx, asset)
+		err := s.UpdateAsset(ctx, asset)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetAssetByName(ctx, "ruby")
+		retrieved, err := s.GetAssetByName(ctx, "ruby")
 		assert.NoError(t, err)
 		assert.NotNil(t, retrieved)
 
@@ -30,121 +27,16 @@ func TestAssetStorage(t *testing.T) {
 		assert.Equal(t, asset.URL, retrieved.URL)
 		assert.Equal(t, asset.Sha512, retrieved.Sha512)
 
-		assets, continueToken, err := store.GetAssets(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		assets, err := s.GetAssets(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, assets)
 		assert.Equal(t, 1, len(assets))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating an asset in a nonexistent org should not work
 		asset.Namespace = "missing"
-		err = store.UpdateAsset(ctx, asset)
+		err = s.UpdateAsset(ctx, asset)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetAssetsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureAsset(objectName)
-
-			if err := store.UpdateAsset(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateAsset(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetAssetsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetAssetsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetAssets(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetAssets(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -4,32 +4,31 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestCheckConfigStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		check := types.FixtureCheckConfig("check1")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, check.Namespace)
 
+		pred := &store.SelectionPredicate{}
+
 		// We should receive an empty slice if no results were found
-		checks, continueToken, err := store.GetCheckConfigs(ctx, 0, "")
+		checks, err := s.GetCheckConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, checks)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateCheckConfig(ctx, check)
+		err = s.UpdateCheckConfig(ctx, check)
 		require.NoError(t, err)
 
-		retrieved, err := store.GetCheckConfigByName(ctx, "check1")
+		retrieved, err := s.GetCheckConfigByName(ctx, "check1")
 		assert.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -39,121 +38,15 @@ func TestCheckConfigStorage(t *testing.T) {
 		assert.Equal(t, check.Command, retrieved.Command)
 		assert.Equal(t, check.Stdin, retrieved.Stdin)
 
-		checks, continueToken, err = store.GetCheckConfigs(ctx, 0, "")
+		checks, err = s.GetCheckConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, checks)
 		assert.Equal(t, 1, len(checks))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a check in a nonexistent org and env should not work
 		check.Namespace = "missing"
-		err = store.UpdateCheckConfig(ctx, check)
+		err = s.UpdateCheckConfig(ctx, check)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetCheckConfigsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureCheckConfig(objectName)
-
-			if err := store.UpdateCheckConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateCheckConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetCheckConfigsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetCheckConfigsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetCheckConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetCheckConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/clusterrole_store.go
+++ b/backend/store/etcd/clusterrole_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetClusterRole(ctx context.Context, name string) (*types.Cluster
 }
 
 // ListClusterRoles ...
-func (s *Store) ListClusterRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRole, string, error) {
+func (s *Store) ListClusterRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRole, error) {
 	clusterRoles := []*types.ClusterRole{}
-	nextContinueToken, err := List(ctx, s.client, getClusterRolesPath, &clusterRoles, pageSize, continueToken)
-	return clusterRoles, nextContinueToken, err
+	err := List(ctx, s.client, getClusterRolesPath, &clusterRoles, pred)
+	return clusterRoles, err
 }
 
 // UpdateClusterRole ...

--- a/backend/store/etcd/clusterrolebinding_store.go
+++ b/backend/store/etcd/clusterrolebinding_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetClusterRoleBinding(ctx context.Context, name string) (*types.
 }
 
 // ListClusterRoleBindings ...
-func (s *Store) ListClusterRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRoleBinding, string, error) {
+func (s *Store) ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRoleBinding, error) {
 	roles := []*types.ClusterRoleBinding{}
-	nextContinueToken, err := List(ctx, s.client, getClusterRoleBindingsPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getClusterRoleBindingsPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateClusterRoleBinding ...

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -4,162 +4,54 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestEntityStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		entity := types.FixtureEntity("entity")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, entity.Namespace)
+		pred := &store.SelectionPredicate{}
 
 		// We should receive an empty slice if no results were found
-		entities, continueToken, err := store.GetEntities(ctx, 0, "")
+		entities, err := s.GetEntities(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, entities)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateEntity(ctx, entity)
+		err = s.UpdateEntity(ctx, entity)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetEntityByName(ctx, entity.Name)
+		retrieved, err := s.GetEntityByName(ctx, entity.Name)
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 		assert.Equal(t, entity.Name, retrieved.Name)
 
-		entities, continueToken, err = store.GetEntities(ctx, 0, "")
+		entities, err = s.GetEntities(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(entities))
 		assert.Equal(t, entity.Name, entities[0].Name)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.DeleteEntity(ctx, entity)
+		err = s.DeleteEntity(ctx, entity)
 		assert.NoError(t, err)
 
-		retrieved, err = store.GetEntityByName(ctx, entity.Name)
+		retrieved, err = s.GetEntityByName(ctx, entity.Name)
 		assert.Nil(t, retrieved)
 		assert.NoError(t, err)
 
 		// Nonexistent entity deletion should return no error.
-		err = store.DeleteEntity(ctx, entity)
+		err = s.DeleteEntity(ctx, entity)
 		assert.NoError(t, err)
 
 		// Updating an enity in a nonexistent org and env should not work
 		entity.Namespace = "missing"
-		err = store.UpdateEntity(ctx, entity)
+		err = s.UpdateEntity(ctx, entity)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetEntitiesPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureEntity(objectName)
-
-			if err := store.UpdateEntity(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateEntity(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetEntitiesPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetEntitiesPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetEntities(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetEntities(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/extension_registry_test.go
+++ b/backend/store/etcd/extension_registry_test.go
@@ -4,149 +4,39 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestExtensionStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		ext := types.FixtureExtension("frobber")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, ext.Namespace)
 
-		err := store.RegisterExtension(ctx, ext)
+		err := s.RegisterExtension(ctx, ext)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetExtension(ctx, "frobber")
+		retrieved, err := s.GetExtension(ctx, "frobber")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
 		assert.Equal(t, ext.Name, retrieved.Name)
 		assert.Equal(t, ext.URL, retrieved.URL)
 
-		extensions, continueToken, err := store.GetExtensions(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		extensions, err := s.GetExtensions(ctx, pred)
 		require.NoError(t, err)
 		assert.NotEmpty(t, extensions)
 		assert.Equal(t, 1, len(extensions))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating an ext in a nonexistent org should not work
 		ext.Namespace = "missing"
-		err = store.RegisterExtension(ctx, ext)
+		err = s.RegisterExtension(ctx, ext)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetExtensionsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureExtension(objectName)
-
-			ctx := context.WithValue(context.Background(), types.NamespaceKey, object.Namespace)
-			if err := store.RegisterExtension(ctx, object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			ctx = context.WithValue(context.Background(), types.NamespaceKey, object.Namespace)
-			if err := store.RegisterExtension(ctx, object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetExtensionsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetExtensionsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetExtensions(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetExtensions(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/filter_store_test.go
+++ b/backend/store/etcd/filter_store_test.go
@@ -4,32 +4,30 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestEventFilterStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		filter := types.FixtureEventFilter("filter1")
 		ctx := context.WithValue(context.Background(), types.NamespaceKey, filter.Namespace)
 
 		// We should receive an empty slice if no results were found
-		filters, continueToken, err := store.GetEventFilters(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		filters, err := s.GetEventFilters(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, filters)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateEventFilter(ctx, filter)
+		err = s.UpdateEventFilter(ctx, filter)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetEventFilterByName(ctx, "filter1")
+		retrieved, err := s.GetEventFilterByName(ctx, "filter1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +35,15 @@ func TestEventFilterStorage(t *testing.T) {
 		assert.Equal(t, filter.Action, retrieved.Action)
 		assert.Equal(t, filter.Expressions, retrieved.Expressions)
 
-		filters, continueToken, err = store.GetEventFilters(ctx, 0, "")
+		filters, err = s.GetEventFilters(ctx, pred)
 		require.NoError(t, err)
 		require.NotEmpty(t, filters)
 		assert.Equal(t, 1, len(filters))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a filter in a nonexistent namespace
 		filter.Namespace = "missing"
-		err = store.UpdateEventFilter(ctx, filter)
+		err = s.UpdateEventFilter(ctx, filter)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetEventFiltersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureEventFilter(objectName)
-
-			if err := store.UpdateEventFilter(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateEventFilter(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetEventFiltersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetEventFiltersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetEventFilters(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetEventFilters(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/handler_store_test.go
+++ b/backend/store/etcd/handler_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestHandlerStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		handler := corev2.FixtureHandler("handler1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, handler.Namespace)
 
 		// We should receive an empty slice if no results were found
-		handlers, continueToken, err := store.GetHandlers(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		handlers, err := s.GetHandlers(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, handlers)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateHandler(ctx, handler)
+		err = s.UpdateHandler(ctx, handler)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetHandlerByName(ctx, "handler1")
+		retrieved, err := s.GetHandlerByName(ctx, "handler1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +37,15 @@ func TestHandlerStorage(t *testing.T) {
 		assert.Equal(t, handler.Command, retrieved.Command)
 		assert.Equal(t, handler.Timeout, retrieved.Timeout)
 
-		handlers, continueToken, err = store.GetHandlers(ctx, 0, "")
+		handlers, err = s.GetHandlers(ctx, pred)
 		require.NoError(t, err)
 		require.NotEmpty(t, handlers)
 		assert.Equal(t, 1, len(handlers))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a handler in a nonexistent org and env should not work
 		handler.Namespace = "missing"
-		err = store.UpdateHandler(ctx, handler)
+		err = s.UpdateHandler(ctx, handler)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetHandlersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureHandler(objectName)
-
-			if err := store.UpdateHandler(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateHandler(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetHandlersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetHandlersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetHandlers(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetHandlers(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/hook_store_test.go
+++ b/backend/store/etcd/hook_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestHookConfigStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		hook := corev2.FixtureHookConfig("hook1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, hook.Namespace)
 
 		// We should receive an empty slice if no results were found
-		hooks, continueToken, err := store.GetHookConfigs(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		hooks, err := s.GetHookConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, hooks)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateHookConfig(ctx, hook)
+		err = s.UpdateHookConfig(ctx, hook)
 		require.NoError(t, err)
 
-		retrieved, err := store.GetHookConfigByName(ctx, "hook1")
+		retrieved, err := s.GetHookConfigByName(ctx, "hook1")
 		assert.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -37,121 +37,15 @@ func TestHookConfigStorage(t *testing.T) {
 		assert.Equal(t, hook.Timeout, retrieved.Timeout)
 		assert.Equal(t, hook.Stdin, retrieved.Stdin)
 
-		hooks, continueToken, err = store.GetHookConfigs(ctx, 0, "")
+		hooks, err = s.GetHookConfigs(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, hooks)
 		assert.Equal(t, 1, len(hooks))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a hook in a nonexistent org and env should not work
 		hook.Namespace = "missing"
-		err = store.UpdateHookConfig(ctx, hook)
+		err = s.UpdateHookConfig(ctx, hook)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetHookConfigsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureHookConfig(objectName)
-
-			if err := store.UpdateHookConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateHookConfig(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetHookConfigsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetHookConfigsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetHookConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetHookConfigs(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/mutator_store_test.go
+++ b/backend/store/etcd/mutator_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -15,20 +14,21 @@ import (
 )
 
 func TestMutatorStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		mutator := corev2.FixtureMutator("mutator1")
 		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, mutator.Namespace)
 
 		// We should receive an empty slice if no results were found
-		mutators, continueToken, err := store.GetMutators(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		mutators, err := s.GetMutators(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotNil(t, mutators)
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
-		err = store.UpdateMutator(ctx, mutator)
+		err = s.UpdateMutator(ctx, mutator)
 		assert.NoError(t, err)
 
-		retrieved, err := store.GetMutatorByName(ctx, "mutator1")
+		retrieved, err := s.GetMutatorByName(ctx, "mutator1")
 		require.NoError(t, err)
 		require.NotNil(t, retrieved)
 
@@ -36,121 +36,15 @@ func TestMutatorStorage(t *testing.T) {
 		assert.Equal(t, mutator.Command, retrieved.Command)
 		assert.Equal(t, mutator.Timeout, retrieved.Timeout)
 
-		mutators, continueToken, err = store.GetMutators(ctx, 0, "")
+		mutators, err = s.GetMutators(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, mutators)
 		assert.Equal(t, 1, len(mutators))
-		assert.Empty(t, continueToken)
+		assert.Empty(t, pred.Continue)
 
 		// Updating a mutator in a nonexistent org and env should not work
 		mutator.Namespace = "missing"
-		err = store.UpdateMutator(ctx, mutator)
+		err = s.UpdateMutator(ctx, mutator)
 		assert.Error(t, err)
 	})
-}
-
-func TestGetMutatorsPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		// Create a "testing" namespace in the store
-		testingNS := corev2.FixtureNamespace("testing")
-		store.UpdateNamespace(context.Background(), testingNS)
-
-		// Add 42 objects in the store: 21 in the "default" namespace and 21 in
-		// the "testing" namespace
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureMutator(objectName)
-
-			if err := store.UpdateMutator(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-
-			object.Namespace = "testing"
-			if err := store.UpdateMutator(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("objects in default namespace", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "testing")
-		t.Run("objects in testing namespace", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 10, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 1, 21)
-		})
-
-		ctx = context.Background()
-		ctx = context.WithValue(ctx, corev2.NamespaceKey, "default")
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetMutatorsPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetMutatorsPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetMutators(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetMutators(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/namespace_store_test.go
+++ b/backend/store/etcd/namespace_store_test.go
@@ -4,158 +4,66 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 func TestnamespaceStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		ctx := context.Background()
 
 		// We should receive the default namespace (set in store_test.go)
-		namespaces, _, err := store.ListNamespaces(ctx, 0, "")
+		pred := &store.SelectionPredicate{}
+		namespaces, err := s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(namespaces))
 
 		// We should be able to create a new namespace
 		namespace := types.FixtureNamespace("acme")
-		err = store.CreateNamespace(ctx, namespace)
+		err = s.CreateNamespace(ctx, namespace)
 		assert.NoError(t, err)
 
-		result, err := store.GetNamespace(ctx, namespace.Name)
+		result, err := s.GetNamespace(ctx, namespace.Name)
 		assert.NoError(t, err)
 		assert.Equal(t, namespace.Name, result.Name)
 
 		// Missing namespace
-		result, err = store.GetNamespace(ctx, "missing")
+		result, err = s.GetNamespace(ctx, "missing")
 		assert.NoError(t, err)
 		assert.Nil(t, result)
 
 		// Get all namespaces
-		namespaces, _, err = store.ListNamespaces(ctx, 0, "")
+		namespaces, err = s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, namespaces)
 		assert.Equal(t, 2, len(namespaces))
 
 		// Delete a non-empty namespace
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.Error(t, err)
 
 		// Delete a non-empty namespace w/ roles
-		require.NoError(t, store.UpdateRole(ctx, types.FixtureRole("1", namespace.Name)))
-		require.NoError(t, store.UpdateRole(ctx, types.FixtureRole("2", "asdf")))
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		require.NoError(t, s.UpdateRole(ctx, types.FixtureRole("1", namespace.Name)))
+		require.NoError(t, s.UpdateRole(ctx, types.FixtureRole("2", "asdf")))
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.Error(t, err)
 
 		// Delete an empty namespace
-		require.NoError(t, store.DeleteRole(ctx, "1"))
-		err = store.DeleteNamespace(ctx, namespace.Name)
+		require.NoError(t, s.DeleteRole(ctx, "1"))
+		err = s.DeleteNamespace(ctx, namespace.Name)
 		assert.NoError(t, err)
 
 		// Delete a missing namespace
-		err = store.DeleteNamespace(ctx, "missing")
+		err = s.DeleteNamespace(ctx, "missing")
 		assert.Error(t, err)
 
 		// Get again all namespaces
-		namespaces, _, err = store.ListNamespaces(ctx, 0, "")
+		namespaces, err = s.ListNamespaces(ctx, pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(namespaces))
 	})
-}
-
-func TestListNamespacesPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureNamespace(objectName)
-
-			if err := store.CreateNamespace(context.Background(), object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		// We get rid of the default namespace so that it doesn't
-		// interfere with our tests below.
-		if err := store.DeleteNamespace(context.Background(), "default"); err != nil {
-			t.Fatal(err)
-		}
-
-		ctx := context.Background()
-		t.Run("paginate through namespaces", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 10, 21)
-		})
-
-		t.Run("page size equals one", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 1, 21)
-		})
-
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testListNamespacesPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testListNamespacesPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.ListNamespaces(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.ListNamespaces(ctx, int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Name != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Name)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/role_store.go
+++ b/backend/store/etcd/role_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetRole(ctx context.Context, name string) (*types.Role, error) {
 }
 
 // ListRoles ...
-func (s *Store) ListRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.Role, string, error) {
+func (s *Store) ListRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Role, error) {
 	roles := []*types.Role{}
-	nextContinueToken, err := List(ctx, s.client, getRolesPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getRolesPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateRole ...

--- a/backend/store/etcd/rolebinding_store.go
+++ b/backend/store/etcd/rolebinding_store.go
@@ -49,10 +49,10 @@ func (s *Store) GetRoleBinding(ctx context.Context, name string) (*types.RoleBin
 }
 
 // ListRoleBindings ...
-func (s *Store) ListRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.RoleBinding, string, error) {
+func (s *Store) ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.RoleBinding, error) {
 	roles := []*types.RoleBinding{}
-	nextContinueToken, err := List(ctx, s.client, getRoleBindingsPath, &roles, pageSize, continueToken)
-	return roles, nextContinueToken, err
+	err := List(ctx, s.client, getRoleBindingsPath, &roles, pred)
+	return roles, err
 }
 
 // UpdateRoleBinding ...

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -4,7 +4,6 @@ package etcd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 )
 
 func TestUserStorage(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
+	testWithEtcd(t, func(s store.Store) {
 		password := "P@ssw0rd!"
 		passwordDigest, err := bcrypt.HashPassword(password)
 		require.NoError(t, err)
@@ -32,48 +31,48 @@ func TestUserStorage(t *testing.T) {
 		defer cancel()
 
 		// We should receive an empty array if no users exist
-		users, err := store.GetUsers()
+		users, err := s.GetUsers()
 		assert.NoError(t, err)
 		assert.Empty(t, users)
 
 		user := types.FixtureUser("foo")
 		user.Password = passwordDigest
-		err = store.CreateUser(user)
+		err = s.CreateUser(user)
 		assert.NoError(t, err)
 
 		// The user should be fetchable
-		result, err := store.GetUser(ctx, "foo")
+		result, err := s.GetUser(ctx, "foo")
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 
 		// Successful authentication
-		_, err = store.AuthenticateUser(ctx, "foo", password)
+		_, err = s.AuthenticateUser(ctx, "foo", password)
 		assert.NoError(t, err)
 
 		// Unsuccessful authentication with wrong password
-		_, err = store.AuthenticateUser(ctx, "foo", "foo")
+		_, err = s.AuthenticateUser(ctx, "foo", "foo")
 		assert.Error(t, err)
 
 		// User already exist
-		err = store.CreateUser(user)
+		err = s.CreateUser(user)
 		assert.Error(t, err)
 
 		mockedUser := types.FixtureUser("bar")
 		mockedUser.Password = passwordDigest
-		err = store.UpdateUser(mockedUser)
+		err = s.UpdateUser(mockedUser)
 		assert.NoError(t, err)
 
-		result, err = store.GetUser(ctx, mockedUser.Username)
+		result, err = s.GetUser(ctx, mockedUser.Username)
 		assert.NoError(t, err)
 		assert.Equal(t, mockedUser.Username, result.Username)
 
 		// Missing user
-		missingUser, err := store.GetUser(ctx, "missingUser")
+		missingUser, err := s.GetUser(ctx, "missingUser")
 		assert.NoError(t, err)
 		assert.Nil(t, missingUser)
 
 		// Get all users
-		users, err = store.GetUsers()
+		users, err = s.GetUsers()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, users)
 		assert.Equal(t, 2, len(users))
@@ -81,127 +80,44 @@ func TestUserStorage(t *testing.T) {
 		// Generate a token for the bar user
 		claims := corev2.FixtureClaims("bar", nil)
 		token, _, _ := jwt.AccessToken(claims)
-		err = store.AllowTokens(token)
+		err = s.AllowTokens(token)
 		assert.NoError(t, err)
 
 		// Disable a user that does not exist
-		err = store.DeleteUser(ctx, &types.User{Username: "Frankieie"})
+		err = s.DeleteUser(ctx, &types.User{Username: "Frankieie"})
 		assert.NoError(t, err)
 
 		// Ensure that a user with that name wasn't created
-		baduser, err := store.GetUser(ctx, "Frankieie")
+		baduser, err := s.GetUser(ctx, "Frankieie")
 		assert.NoError(t, err)
 		assert.Nil(t, baduser)
 
 		// Disable a user, which also removes all issued tokens
-		err = store.DeleteUser(ctx, mockedUser)
+		err = s.DeleteUser(ctx, mockedUser)
 		assert.NoError(t, err)
 
 		// Make sure the user is now disabled
-		disabledUser, _ := store.GetUser(ctx, mockedUser.Username)
+		disabledUser, _ := s.GetUser(ctx, mockedUser.Username)
 		assert.True(t, disabledUser.Disabled)
 
 		// Make sure the token was revoked
-		_, err = store.GetToken(claims.Subject, claims.Id)
+		_, err = s.GetToken(claims.Subject, claims.Id)
 		assert.Error(t, err)
 
 		// Authentication should be unsuccessful with a disabled user
-		_, err = store.AuthenticateUser(ctx, mockedUser.Username, password)
+		_, err = s.AuthenticateUser(ctx, mockedUser.Username, password)
 		assert.Error(t, err)
 
 		// The deleted (disabled) user should not be returned
 		// Get all users
-		users, err = store.GetUsers()
+		users, err = s.GetUsers()
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(users))
 
 		// Disabled user should appear when fetching all users
-		users, _, err = store.GetAllUsers(0, "")
+		pred := &store.SelectionPredicate{}
+		users, err = s.GetAllUsers(pred)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(users))
 	})
-}
-
-func TestGetAllUsersPagination(t *testing.T) {
-	testWithEtcd(t, func(store store.Store) {
-		for i := 1; i <= 21; i++ {
-			// We force the object name to be 2 digits "wide" in order to
-			// have a "natural" lexicographic order: 01, 02, ... instead of 1,
-			// 11, ...
-			objectName := fmt.Sprintf("%.2d", i)
-			object := corev2.FixtureUser(objectName)
-
-			if err := store.CreateUser(object); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		ctx := context.Background()
-		t.Run("paginate through users", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 10, 21)
-		})
-
-		t.Run("page size equals one", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 1, 21)
-		})
-
-		t.Run("page size bigger than set size", func(t *testing.T) {
-			testGetAllUsersPagination(t, ctx, store, 1337, 21)
-		})
-	})
-}
-
-func testGetAllUsersPagination(t *testing.T, ctx context.Context, etcd store.Store, pageSize, setSize int) {
-	nFullPages := setSize / pageSize
-	nLeftovers := setSize % pageSize
-
-	continueToken := ""
-	for i := 0; i < nFullPages; i++ {
-		objects, nextContinueToken, err := etcd.GetAllUsers(int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != pageSize {
-			t.Fatalf("Expected page %d to have %d objects but got %d", i, pageSize, len(objects))
-		}
-
-		offset := i * pageSize
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Username != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Username)
-			}
-		}
-
-		continueToken = nextContinueToken
-	}
-
-	// Check the last page, supposed to hold nLeftovers objects
-	if nLeftovers > 0 {
-		objects, nextContinueToken, err := etcd.GetAllUsers(int64(pageSize), continueToken)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(objects) != nLeftovers {
-			t.Fatalf("Expected last page with %d objects, got %d", nLeftovers, len(objects))
-		}
-
-		if nextContinueToken != "" {
-			t.Fatalf("Expected next continue token to be \"\", got %s", nextContinueToken)
-		}
-
-		offset := pageSize * nFullPages
-		for j, object := range objects {
-			n := ((offset + j) % setSize) + 1
-			expected := fmt.Sprintf("%.2d", n)
-
-			if object.Username != expected {
-				t.Fatalf("Expected %s, got %s", expected, object.Username)
-			}
-		}
-	}
 }

--- a/backend/store/etcd/watcher.go
+++ b/backend/store/etcd/watcher.go
@@ -4,111 +4,69 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/store"
+	"golang.org/x/time/rate"
 )
 
-// watcher implements the store.Watcher interface rather than clientv3.Watcher,
+// Watcher implements the store.Watcher interface rather than clientv3.Watcher,
 // so the channel returned by the Watch method only provides a single event at a
 // time instead of a list of events, and the events are ready to be consumed
-type watcher struct {
+type Watcher struct {
 	client     *clientv3.Client
-	cancel     context.CancelFunc
-	ctx        context.Context
 	key        string
 	recursive  bool
-	errChan    chan error
 	eventChan  chan *clientv3.Event
 	resultChan chan store.WatchEvent
 }
 
-// Watch returns a watcher for the given key
-func Watch(ctx context.Context, client *clientv3.Client, key string, recursive bool) store.Watcher {
+// Watch returns a Watcher for the given key
+func Watch(ctx context.Context, client *clientv3.Client, key string, recursive bool) *Watcher {
 	// Make sure we have a trailing slash if we need to watch the key and its
 	// children
 	if recursive && !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
 
-	w := createWatcher(ctx, client, key, recursive)
+	// From etcd docs:
+	// If the context is "context.Background/TODO", returned "WatchChan" will
+	// not be closed and block until event is triggered, except when server
+	// returns a non-recoverable error (e.g. ErrCompacted).
+	// For example, when context passed with "WithRequireLeader" and the
+	// connected server has no leader (e.g. due to network partition),
+	// error "etcdserver: no leader" (ErrNoLeader) will be returned,
+	// and then "WatchChan" is closed with non-nil "Err()".
+	// In order to prevent a watch stream being stuck in a partitioned node,
+	// make sure to wrap context with "WithRequireLeader".
+	ctx = clientv3.WithRequireLeader(ctx)
 
-	// Start a waitgroup to ensure the watcher is properly started
-	var startedWG sync.WaitGroup
-	startedWG.Add(1)
+	w := newWatcher(client, key, recursive)
+	w.start(ctx)
 
-	go w.run(&startedWG)
-
-	// Make sure the watcher was properly started before returning it
-	startedWG.Wait()
 	return w
 }
 
-// createWatcher creates and initializes a watcher
-func createWatcher(ctx context.Context, client *clientv3.Client, key string, recursive bool) *watcher {
-	w := &watcher{
+// newWatcher creates a new Watcher
+func newWatcher(client *clientv3.Client, key string, recursive bool) *Watcher {
+	return &Watcher{
 		client:     client,
 		key:        key,
 		recursive:  recursive,
-		errChan:    make(chan error, 1),
 		eventChan:  make(chan *clientv3.Event),
 		resultChan: make(chan store.WatchEvent),
 	}
-	w.ctx, w.cancel = context.WithCancel(ctx)
-
-	return w
 }
 
 // Result returns the resultChan
-func (w *watcher) Result() <-chan store.WatchEvent {
+func (w *Watcher) Result() <-chan store.WatchEvent {
 	return w.resultChan
 }
 
-// Stop ends all goroutines
-func (w *watcher) Stop() {
-	// Stop all goroutines
-	w.cancel()
-}
-
-// run starts a watcher and handles the result and errors coming over the
-// various channels
-func (w *watcher) run(wg *sync.WaitGroup) {
-	go w.startWatching(wg)
-
-	// Start a waitgroup to ensure the resultChan is not closed while being used
-	var resultChanWG sync.WaitGroup
-	resultChanWG.Add(1)
-	go w.processEvent(&resultChanWG)
-
-	select {
-	case err := <-w.errChan:
-		if err == context.Canceled {
-			break
-		}
-
-		errResult := store.WatchEvent{
-			Type:   store.WatchError,
-			Object: []byte(err.Error()),
-		}
-		select {
-		case w.resultChan <- errResult:
-		case <-w.ctx.Done(): // client has given up all results
-		}
-	case <-w.ctx.Done(): // client cancel
-	}
-
-	// Stop all goroutines
-	w.cancel()
-
-	// Make sure that resultChan is no longer used before closing it
-	resultChanWG.Wait()
-	close(w.resultChan)
-}
-
-// startWatching starts watching the given key and sends all etcd events
-// received to eventChan
-func (w *watcher) startWatching(wg *sync.WaitGroup) {
+// start starts watching the configured key and sends all etcd events
+// received to resultChan
+func (w *Watcher) start(ctx context.Context) {
 	opts := []clientv3.OpOption{clientv3.WithCreatedNotify()}
 	if w.recursive {
 		opts = append(opts, clientv3.WithPrefix())
@@ -116,65 +74,65 @@ func (w *watcher) startWatching(wg *sync.WaitGroup) {
 
 	logger.Debugf("starting a watcher for key %s", w.key)
 
-	watcher := clientv3.NewWatcher(w.client)
-	watcherChan := watcher.Watch(w.ctx, w.key, opts...)
+	watcherChan := w.client.Watch(ctx, w.key, opts...)
+	limiter := rate.NewLimiter(rate.Every(time.Second), 1)
 
-	// Inform the process the watcher was properly started
-	wg.Done()
+	go func() {
+		defer close(w.resultChan)
+		_ = limiter.Wait(ctx)
+		for ctx.Err() == nil {
+			for watchResponse := range watcherChan {
+				if err := watchResponse.Err(); err != nil {
+					if ctx.Err() != nil {
+						// Our context was canceled, return without error,
+						// since the consumer is probably shutting down.
+						return
+					}
+					logger.WithError(err).Info("error from watch response")
+					w.resultChan <- store.WatchEvent{
+						Type: store.WatchError,
+						Err:  err,
+					}
+					if watchResponse.Canceled {
+						// Reinstate the watcher and break to the outer loop
+						watcherChan = w.client.Watch(ctx, w.key, opts...)
+						break
+					}
+					continue
+				}
 
-	for watchResponse := range watcherChan {
-		if watchResponse.Err() != nil {
-			w.errChan <- watchResponse.Err()
-			return
-		}
-
-		for _, event := range watchResponse.Events {
-			logger.Debugf("received event of type %v for key %s", event.Type, event.Kv.Key)
-			w.event(event)
-		}
-	}
-
-	// When we reach this point, the etcd watcher chan is broken and no errors
-	// were sent via the channel and this watcher wasn't stopped, so we need to
-	// notify the main thread so other goroutine are exited too
-	w.errChan <- errors.New("etcd watcher channel was unexpectedly closed")
-}
-
-// processEvent handles incoming etcd event transmitted via eventChan,
-// transforms them into a store.WatchEvent struct and then send them back via
-// resultChan
-func (w *watcher) processEvent(wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	for {
-		select {
-		case e := <-w.eventChan:
-			typ := GetWatcherAction(e)
-			if typ == store.WatchUnknown {
-				logger.Infof("unknown etcd watch action type %q", e.Type.String())
-				continue
+				for _, event := range watchResponse.Events {
+					logger.Debugf("received event of type %v for key %s", event.Type, event.Kv.Key)
+					w.event(ctx, event)
+				}
 			}
-
-			result := store.WatchEvent{
-				Type:   typ,
-				Key:    string(e.Kv.Key),
-				Object: e.Kv.Value,
-			}
-
-			select {
-			case w.resultChan <- result:
-			case <-w.ctx.Done():
+			if w.client.Ctx().Err() != nil {
+				w.resultChan <- store.WatchEvent{
+					Type: store.WatchError,
+					Err:  errors.New("client closed unexpectedly"),
+				}
 				return
 			}
-		case <-w.ctx.Done():
-			return
 		}
-	}
+	}()
 }
 
-func (w *watcher) event(e *clientv3.Event) {
+func (w *Watcher) event(ctx context.Context, e *clientv3.Event) {
+	typ := GetWatcherAction(e)
+	if typ == store.WatchUnknown {
+		logger.Infof("unknown etcd watch action type %q", e.Type.String())
+		return
+	}
+
+	result := store.WatchEvent{
+		Type:   typ,
+		Key:    string(e.Kv.Key),
+		Object: e.Kv.Value,
+	}
+
 	select {
-	case w.eventChan <- e:
-	case <-w.ctx.Done():
+	case w.resultChan <- result:
+	case <-ctx.Done():
+		return
 	}
 }

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -91,7 +91,7 @@ func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEnt
 				entity.Name = meta.ResourceName
 			} else {
 				if err := json.Unmarshal(response.Object, &entity); err != nil {
-					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal check config from key")
+					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal entity from key")
 					continue
 				}
 			}

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -129,7 +129,7 @@ func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEv
 				tessen = *corev2.DefaultTessenConfig()
 			} else {
 				if err := json.Unmarshal(response.Object, &tessen); err != nil {
-					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal check config from key")
+					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal tessen config from key")
 					continue
 				}
 			}

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -113,7 +113,7 @@ func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEnt
 func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEventTessenConfig {
 	ch := make(chan store.WatchEventTessenConfig, 1)
 	key := tessenKeyBuilder.WithContext(ctx).Build()
-	w := Watch(ctx, s.client, key, true)
+	w := Watch(ctx, s.client, key, false)
 
 	go func() {
 		defer close(ch)

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -109,7 +109,7 @@ func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEnt
 // GetTessenConfigWatcher returns a channel that emits WatchEventTessenConfig structs notifying
 // the caller that a TessenConfig was updated. If the watcher runs into a terminal error
 // or the context passed is cancelled, then the channel will be closed. The caller must
-// restart the watcher, if needed.
+// The watcher does its best to recover from errors.
 func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEventTessenConfig {
 	ch := make(chan store.WatchEventTessenConfig, 1)
 	key := tessenKeyBuilder.WithContext(ctx).Build()

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -29,49 +28,37 @@ func GetWatcherAction(event *clientv3.Event) store.WatchActionType {
 
 // GetCheckConfigWatcher returns a channel that emits WatchEventCheckConfig structs notifying
 // the caller that a CheckConfig was updated. If the watcher runs into a terminal error
-// or the context passed is cancelled, then the channel will be closed. The caller must
-// restart the watcher, if needed.
+// or the context passed is cancelled, then the channel will be closed. The
+// watcher will do its best to recover on errors.
 func (s *Store) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEventCheckConfig {
-	ch := make(chan store.WatchEventCheckConfig)
-	watcherChan := s.client.Watch(ctx, checkKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
+	key := checkKeyBuilder.WithContext(ctx).Build()
+	w := Watch(ctx, s.client, key, true)
+	ch := make(chan store.WatchEventCheckConfig, 1)
 
 	go func() {
 		defer close(ch)
+		for response := range w.Result() {
+			if response.Type == store.WatchUnknown {
+				logger.Error("unknown etcd watch type: ", response.Type)
+				continue
+			}
 
-		for watchResponse := range watcherChan {
-			for _, event := range watchResponse.Events {
-				var (
-					watchEvent  store.WatchEventCheckConfig
-					action      store.WatchActionType
-					checkConfig *corev2.CheckConfig
-				)
+			var checkConfig corev2.CheckConfig
 
-				action = GetWatcherAction(event)
-				if action == store.WatchUnknown {
-					logger.Error("unknown etcd watch action: ", event.Type.String())
+			if response.Type == store.WatchDelete {
+				meta := store.ParseResourceKey(response.Key)
+				checkConfig.Namespace = meta.Namespace
+				checkConfig.Name = meta.ResourceName
+			} else {
+				if err := json.Unmarshal(response.Object, &checkConfig); err != nil {
+					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal check config from key")
+					continue
 				}
+			}
 
-				if action == store.WatchDelete {
-					key := store.ParseResourceKey(string(event.Kv.Key))
-					checkConfig = &corev2.CheckConfig{
-						ObjectMeta: corev2.ObjectMeta{
-							Namespace: key.Namespace,
-							Name:      key.ResourceName,
-						},
-					}
-				} else {
-					checkConfig = &corev2.CheckConfig{}
-					if err := json.Unmarshal(event.Kv.Value, checkConfig); err != nil {
-						logger.WithField("key", event.Kv.Key).WithError(err).Error("unable to unmarshal check config from key")
-					}
-				}
-
-				watchEvent = store.WatchEventCheckConfig{
-					Action:      action,
-					CheckConfig: checkConfig,
-				}
-
-				ch <- watchEvent
+			ch <- store.WatchEventCheckConfig{
+				Action:      response.Type,
+				CheckConfig: &checkConfig,
 			}
 		}
 	}()
@@ -81,46 +68,41 @@ func (s *Store) GetCheckConfigWatcher(ctx context.Context) <-chan store.WatchEve
 
 // GetEntityWatcher returns a channel that emits WatchEventEntity structs notifying
 // the caller that an Entity was updated. If the watcher runs into a terminal error
-// or the context passed is cancelled, then the channel will be closed. The caller must
-// restart the watcher, if needed.
+// or the context passed is cancelled, then the channel will be closed.
+// The watcher does its best to recover from errors.
 func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEntity {
 	ch := make(chan store.WatchEventEntity, 1)
-	wc := s.client.Watch(ctx, entityKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
+	key := entityKeyBuilder.WithContext(ctx).Build()
+	w := Watch(ctx, s.client, key, true)
+
 	go func() {
 		defer close(ch)
+		for response := range w.Result() {
+			if response.Type == store.WatchUnknown {
+				logger.Error("unknown etcd watch type: ", response.Type)
+				continue
+			}
 
-		for resp := range wc {
-			for _, event := range resp.Events {
-				action := GetWatcherAction(event)
-				if action == store.WatchUnknown {
-					logger.Errorf("unknown etcd watch action: %s", event.Type.String())
+			var entity corev2.Entity
+
+			if response.Type == store.WatchDelete {
+				meta := store.ParseResourceKey(response.Key)
+				entity.Namespace = meta.Namespace
+				entity.Name = meta.ResourceName
+			} else {
+				if err := json.Unmarshal(response.Object, &entity); err != nil {
+					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal check config from key")
 					continue
 				}
+			}
 
-				var entity corev2.Entity
-				if action != store.WatchDelete {
-					if err := json.Unmarshal(event.Kv.Value, &entity); err != nil {
-						logger.WithError(err).Error("error unmarshaling watch event")
-						continue
-					}
-				} else {
-					// Fill in the name and namespace of the deleted entity
-					parts := strings.Split(string(event.Kv.Key), "/")
-					if len(parts) > 1 {
-						entity.Name = parts[len(parts)-1]
-						entity.Namespace = parts[len(parts)-2]
-					}
-				}
-
-				watchEvent := store.WatchEventEntity{
-					Action: action,
-					Entity: &entity,
-				}
-
-				ch <- watchEvent
+			ch <- store.WatchEventEntity{
+				Action: response.Type,
+				Entity: &entity,
 			}
 		}
 	}()
+
 	return ch
 }
 
@@ -130,37 +112,34 @@ func (s *Store) GetEntityWatcher(ctx context.Context) <-chan store.WatchEventEnt
 // restart the watcher, if needed.
 func (s *Store) GetTessenConfigWatcher(ctx context.Context) <-chan store.WatchEventTessenConfig {
 	ch := make(chan store.WatchEventTessenConfig, 1)
-	wc := s.client.Watch(ctx, tessenKeyBuilder.Build(""), clientv3.WithPrefix(), clientv3.WithCreatedNotify())
+	key := tessenKeyBuilder.WithContext(ctx).Build()
+	w := Watch(ctx, s.client, key, true)
+
 	go func() {
 		defer close(ch)
+		for response := range w.Result() {
+			if response.Type == store.WatchUnknown {
+				logger.Error("unknown etcd watch type: ", response.Type)
+				continue
+			}
 
-		for resp := range wc {
-			for _, event := range resp.Events {
-				action := GetWatcherAction(event)
-				if action == store.WatchUnknown {
-					logger.Errorf("unknown etcd watch action: %s", event.Type.String())
+			var tessen corev2.TessenConfig
+
+			if response.Type == store.WatchDelete {
+				tessen = *corev2.DefaultTessenConfig()
+			} else {
+				if err := json.Unmarshal(response.Object, &tessen); err != nil {
+					logger.WithField("key", response.Key).WithError(err).Error("unable to unmarshal check config from key")
 					continue
 				}
+			}
 
-				var tessen *corev2.TessenConfig
-				if action != store.WatchDelete {
-					if err := json.Unmarshal(event.Kv.Value, &tessen); err != nil {
-						logger.WithError(err).Error("error unmarshaling watch event")
-						continue
-					}
-				} else {
-					// use default tessen config if it's deleted
-					tessen = corev2.DefaultTessenConfig()
-				}
-
-				watchEvent := store.WatchEventTessenConfig{
-					Action:       action,
-					TessenConfig: tessen,
-				}
-
-				ch <- watchEvent
+			ch <- store.WatchEventTessenConfig{
+				Action:       response.Type,
+				TessenConfig: &tessen,
 			}
 		}
 	}()
+
 	return ch
 }

--- a/backend/store/watcher.go
+++ b/backend/store/watcher.go
@@ -22,12 +22,12 @@ type WatchEvent struct {
 	Type   WatchActionType
 	Key    string
 	Object []byte
+	Err    error
 }
 
 // Watcher represents a generic watcher
 type Watcher interface {
 	Result() <-chan WatchEvent
-	Stop()
 }
 
 func (t WatchActionType) String() string {

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -306,7 +306,7 @@ func (t *Tessend) collect(now int64) *Data {
 	var entityCount, backendCount float64
 
 	// collect client count
-	entities, _, err := t.store.GetEntities(t.ctx, 0, "")
+	entities, err := t.store.GetEntities(t.ctx, &store.SelectionPredicate{})
 	if err != nil {
 		logger.WithError(err).Error("unable to retrieve client count")
 	}

--- a/testing/mockstore/assets.go
+++ b/testing/mockstore/assets.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteAssetByName(ctx context.Context, name string) error {
 }
 
 // GetAssets ...
-func (s *MockStore) GetAssets(ctx context.Context, pageSize int64, continueToken string) ([]*types.Asset, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Asset), args.String(1), args.Error(2)
+func (s *MockStore) GetAssets(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Asset, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Asset), args.Error(1)
 }
 
 // GetAssetByName ...

--- a/testing/mockstore/check_config.go
+++ b/testing/mockstore/check_config.go
@@ -14,9 +14,9 @@ func (s *MockStore) DeleteCheckConfigByName(ctx context.Context, name string) er
 }
 
 // GetCheckConfigs ...
-func (s *MockStore) GetCheckConfigs(ctx context.Context, pageSize int64, continueToken string) ([]*types.CheckConfig, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.CheckConfig), args.String(1), args.Error(2)
+func (s *MockStore) GetCheckConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*types.CheckConfig, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.CheckConfig), args.Error(1)
 }
 
 // GetCheckConfigByName ...

--- a/testing/mockstore/clusterrole.go
+++ b/testing/mockstore/clusterrole.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetClusterRole(ctx context.Context, name string) (*types.Clu
 }
 
 // ListClusterRoles ...
-func (s *MockStore) ListClusterRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRole, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.ClusterRole), args.String(1), args.Error(2)
+func (s *MockStore) ListClusterRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRole, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.ClusterRole), args.Error(1)
 }
 
 // UpdateClusterRole ...

--- a/testing/mockstore/clusterrolebinding.go
+++ b/testing/mockstore/clusterrolebinding.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetClusterRoleBinding(ctx context.Context, name string) (*ty
 }
 
 // ListClusterRoleBindings ...
-func (s *MockStore) ListClusterRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.ClusterRoleBinding, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.ClusterRoleBinding), args.String(1), args.Error(2)
+func (s *MockStore) ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.ClusterRoleBinding, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.ClusterRoleBinding), args.Error(1)
 }
 
 // UpdateClusterRoleBinding ...

--- a/testing/mockstore/entities.go
+++ b/testing/mockstore/entities.go
@@ -20,9 +20,9 @@ func (s *MockStore) DeleteEntityByName(ctx context.Context, id string) error {
 }
 
 // GetEntities ...
-func (s *MockStore) GetEntities(ctx context.Context, pageSize int64, continueToken string) ([]*types.Entity, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Entity), args.String(1), args.Error(2)
+func (s *MockStore) GetEntities(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Entity, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Entity), args.Error(1)
 }
 
 // GetEntityByName ...

--- a/testing/mockstore/events.go
+++ b/testing/mockstore/events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
 // DeleteEventByEntityCheck ...
@@ -13,15 +14,15 @@ func (s *MockStore) DeleteEventByEntityCheck(ctx context.Context, entityName, ch
 }
 
 // GetEvents ...
-func (s *MockStore) GetEvents(ctx context.Context, pageSize int64, continueToken string) ([]*corev2.Event, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*corev2.Event), args.String(1), args.Error(2)
+func (s *MockStore) GetEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
 // GetEventsByEntity ...
-func (s *MockStore) GetEventsByEntity(ctx context.Context, entityName string, pageSize int64, continueToken string) ([]*corev2.Event, string, error) {
-	args := s.Called(ctx, entityName, pageSize, continueToken)
-	return args.Get(0).([]*corev2.Event), args.String(1), args.Error(2)
+func (s *MockStore) GetEventsByEntity(ctx context.Context, entityName string, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	args := s.Called(ctx, entityName, pred)
+	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
 // GetEventByEntityCheck ...

--- a/testing/mockstore/extension.go
+++ b/testing/mockstore/extension.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -21,7 +22,7 @@ func (s *MockStore) GetExtension(ctx context.Context, name string) (*types.Exten
 	return args.Get(0).(*types.Extension), args.Error(1)
 }
 
-func (s *MockStore) GetExtensions(ctx context.Context, pageSize int64, continueToken string) ([]*types.Extension, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Extension), args.String(1), args.Error(2)
+func (s *MockStore) GetExtensions(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Extension, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Extension), args.Error(1)
 }

--- a/testing/mockstore/filters.go
+++ b/testing/mockstore/filters.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteEventFilterByName(ctx context.Context, name string) er
 }
 
 // GetEventFilters ...
-func (s *MockStore) GetEventFilters(ctx context.Context, pageSize int64, continueToken string) ([]*types.EventFilter, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.EventFilter), args.String(1), args.Error(2)
+func (s *MockStore) GetEventFilters(ctx context.Context, pred *store.SelectionPredicate) ([]*types.EventFilter, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.EventFilter), args.Error(1)
 }
 
 // GetEventFilterByName ...

--- a/testing/mockstore/handlers.go
+++ b/testing/mockstore/handlers.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteHandlerByName(ctx context.Context, name string) error 
 }
 
 // GetHandlers ...
-func (s *MockStore) GetHandlers(ctx context.Context, pageSize int64, continueToken string) ([]*types.Handler, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Handler), args.String(1), args.Error(2)
+func (s *MockStore) GetHandlers(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Handler, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Handler), args.Error(1)
 }
 
 // GetHandlerByName ...

--- a/testing/mockstore/hook_config.go
+++ b/testing/mockstore/hook_config.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteHookConfigByName(ctx context.Context, name string) err
 }
 
 // GetHookConfigs ...
-func (s *MockStore) GetHookConfigs(ctx context.Context, pageSize int64, continueToken string) ([]*types.HookConfig, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.HookConfig), args.String(1), args.Error(2)
+func (s *MockStore) GetHookConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*types.HookConfig, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.HookConfig), args.Error(1)
 }
 
 // GetHookConfigByName ...

--- a/testing/mockstore/mutators.go
+++ b/testing/mockstore/mutators.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -13,9 +14,9 @@ func (s *MockStore) DeleteMutatorByName(ctx context.Context, name string) error 
 }
 
 // GetMutators ...
-func (s *MockStore) GetMutators(ctx context.Context, pageSize int64, continueToken string) ([]*types.Mutator, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Mutator), args.String(1), args.Error(2)
+func (s *MockStore) GetMutators(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Mutator, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Mutator), args.Error(1)
 }
 
 // GetMutatorByName ...

--- a/testing/mockstore/namespaces.go
+++ b/testing/mockstore/namespaces.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -19,9 +20,9 @@ func (s *MockStore) DeleteNamespace(ctx context.Context, name string) error {
 }
 
 // ListNamespaces ...
-func (s *MockStore) ListNamespaces(ctx context.Context, pageSize int64, continueToken string) ([]*types.Namespace, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Namespace), args.String(1), args.Error(2)
+func (s *MockStore) ListNamespaces(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Namespace, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Namespace), args.Error(1)
 }
 
 // GetNamespace ...

--- a/testing/mockstore/role.go
+++ b/testing/mockstore/role.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetRole(ctx context.Context, name string) (*types.Role, erro
 }
 
 // ListRoles ...
-func (s *MockStore) ListRoles(ctx context.Context, pageSize int64, continueToken string) ([]*types.Role, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.Role), args.String(1), args.Error(2)
+func (s *MockStore) ListRoles(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Role, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.Role), args.Error(1)
 }
 
 // UpdateRole ...

--- a/testing/mockstore/rolebinding.go
+++ b/testing/mockstore/rolebinding.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -36,9 +37,9 @@ func (s *MockStore) GetRoleBinding(ctx context.Context, name string) (*types.Rol
 }
 
 // ListRoleBindings ...
-func (s *MockStore) ListRoleBindings(ctx context.Context, pageSize int64, continueToken string) ([]*types.RoleBinding, string, error) {
-	args := s.Called(ctx, pageSize, continueToken)
-	return args.Get(0).([]*types.RoleBinding), args.String(1), args.Error(2)
+func (s *MockStore) ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*types.RoleBinding, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).([]*types.RoleBinding), args.Error(1)
 }
 
 // UpdateRoleBinding ...

--- a/testing/mockstore/users.go
+++ b/testing/mockstore/users.go
@@ -3,6 +3,7 @@ package mockstore
 import (
 	"context"
 
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -40,9 +41,9 @@ func (s *MockStore) GetUsers() ([]*types.User, error) {
 }
 
 // GetAllUsers ...
-func (s *MockStore) GetAllUsers(pageSize int64, continueToken string) ([]*types.User, string, error) {
-	args := s.Called(pageSize, continueToken)
-	return args.Get(0).([]*types.User), args.String(1), args.Error(2)
+func (s *MockStore) GetAllUsers(pred *store.SelectionPredicate) ([]*types.User, error) {
+	args := s.Called(pred)
+	return args.Get(0).([]*types.User), args.Error(1)
 }
 
 // UpdateUser ...


### PR DESCRIPTION
## What is this change?

During a recent QA session, it was discovered that watchers could
fail permanently, but their consumers were using them as if they
could not. This was causing issues such as 100% CPU usage in some
components, and other components would simply fail to update until
service restart.

The problem mostly presents on backends that are using the
--no-embed-etcd mode, but can theoretically also occur on backends
that do embed etcd.

All watchers now get reinstated on a retry loop when they fail, and
all watchers now require that a leader is present, so that watchers
do not get stuck on partitions.

## Why is this change necessary?

Closes #2635 

## Does your change need a Changelog entry?

Added

## How did you verify this change?

This change is still unverified beyond automated testing, and needs to be put through a full QA cycle.