### PR TITLE
Deprecates client in favor of source in the agent socket

### DIFF
--- a/CHANGELOGS/unreleased/2720-add-source-agent-socket.md
+++ b/CHANGELOGS/unreleased/2720-add-source-agent-socket.md
@@ -1,0 +1,2 @@
+### Added
+- Added the 1.x `source` field as a synonym for `proxy_entity_name` in the 1.x compatible agent socket.

--- a/CHANGELOGS/unreleased/2720-add-source-agent-socket.md
+++ b/CHANGELOGS/unreleased/2720-add-source-agent-socket.md
@@ -1,2 +1,0 @@
-### Added
-- Added the 1.x `source` field as a synonym for `proxy_entity_name` in the 1.x compatible agent socket.

--- a/CHANGELOGS/unreleased/2720-rename-source-agent-socket.md
+++ b/CHANGELOGS/unreleased/2720-rename-source-agent-socket.md
@@ -1,2 +1,3 @@
 ### Changed
 - Changed the 1.x `client` field to `source` in the 1.x compatible agent socket. The `client` field is now deprecated.
+- Deprecated the agent TCP/UDP sockets in favor of the agent rest api.

--- a/CHANGELOGS/unreleased/2720-rename-source-agent-socket.md
+++ b/CHANGELOGS/unreleased/2720-rename-source-agent-socket.md
@@ -1,0 +1,2 @@
+### Changed
+- Changed the 1.x `client` field to `source` in the 1.x compatible agent socket. The `client` field is now deprecated.

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -187,6 +187,7 @@ func newStartCommand() *cobra.Command {
 			}
 
 			if !viper.GetBool(flagDisableSockets) {
+				// Agent TCP/UDP sockets are deprecated in favor of the agent rest api
 				sensuAgent.StartSocketListeners(ctx)
 			}
 

--- a/agent/event.go
+++ b/agent/event.go
@@ -5,14 +5,14 @@ import (
 
 	time "github.com/echlebek/timeproxy"
 
-	"github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types/v1"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev1 "github.com/sensu/sensu-go/types/v1"
 )
 
 // prepareEvent accepts a partial or complete event and tries to add any missing
 // attributes so it can pass validation. An error is returned if it still can't
 // pass validation after all these changes
-func prepareEvent(a *Agent, event *v2.Event) error {
+func prepareEvent(a *Agent, event *corev2.Event) error {
 	if event == nil {
 		return fmt.Errorf("an event must be provided")
 	}
@@ -55,7 +55,7 @@ func prepareEvent(a *Agent, event *v2.Event) error {
 
 // translateToEvent accepts a 1.x compatible check result
 // and attempts to translate it to a 2.x event
-func translateToEvent(a *Agent, result v1.CheckResult, event *v2.Event) error {
+func translateToEvent(a *Agent, result corev1.CheckResult, event *corev2.Event) error {
 	if result.Name == "" {
 		return fmt.Errorf("a check name must be provided")
 	}
@@ -68,9 +68,9 @@ func translateToEvent(a *Agent, result v1.CheckResult, event *v2.Event) error {
 	if result.Client == "" || result.Client == agentEntity.Name {
 		event.Entity = agentEntity
 	} else {
-		event.Entity = &v2.Entity{
-			ObjectMeta:  v2.NewObjectMeta(result.Client, agentEntity.Namespace),
-			EntityClass: v2.EntityProxyClass,
+		event.Entity = &corev2.Entity{
+			ObjectMeta:  corev2.NewObjectMeta(result.Client, agentEntity.Namespace),
+			EntityClass: corev2.EntityProxyClass,
 		}
 	}
 
@@ -79,17 +79,18 @@ func translateToEvent(a *Agent, result v1.CheckResult, event *v2.Event) error {
 		handlers = append(handlers, result.Handler)
 	}
 
-	check := &v2.Check{
-		ObjectMeta:    v2.NewObjectMeta(result.Name, agentEntity.Namespace),
-		Status:        result.Status,
-		Command:       result.Command,
-		Subscriptions: result.Subscribers,
-		Interval:      result.Interval,
-		Issued:        result.Issued,
-		Executed:      result.Executed,
-		Duration:      result.Duration,
-		Output:        result.Output,
-		Handlers:      handlers,
+	check := &corev2.Check{
+		ObjectMeta:      corev2.NewObjectMeta(result.Name, agentEntity.Namespace),
+		Status:          result.Status,
+		Command:         result.Command,
+		Subscriptions:   result.Subscribers,
+		Interval:        result.Interval,
+		Issued:          result.Issued,
+		Executed:        result.Executed,
+		Duration:        result.Duration,
+		Output:          result.Output,
+		Handlers:        handlers,
+		ProxyEntityName: result.Source,
 	}
 
 	// add config and check values to the 2.x event

--- a/agent/event.go
+++ b/agent/event.go
@@ -64,12 +64,17 @@ func translateToEvent(a *Agent, result corev1.CheckResult, event *corev2.Event) 
 		return fmt.Errorf("a check output must be provided")
 	}
 
+	source := result.Source
+	if source == "" {
+		source = result.Client
+	}
+
 	agentEntity := a.getAgentEntity()
-	if result.Client == "" || result.Client == agentEntity.Name {
+	if source == "" || source == agentEntity.Name {
 		event.Entity = agentEntity
 	} else {
 		event.Entity = &corev2.Entity{
-			ObjectMeta:  corev2.NewObjectMeta(result.Client, agentEntity.Namespace),
+			ObjectMeta:  corev2.NewObjectMeta(source, agentEntity.Namespace),
 			EntityClass: corev2.EntityProxyClass,
 		}
 	}
@@ -80,17 +85,16 @@ func translateToEvent(a *Agent, result corev1.CheckResult, event *corev2.Event) 
 	}
 
 	check := &corev2.Check{
-		ObjectMeta:      corev2.NewObjectMeta(result.Name, agentEntity.Namespace),
-		Status:          result.Status,
-		Command:         result.Command,
-		Subscriptions:   result.Subscribers,
-		Interval:        result.Interval,
-		Issued:          result.Issued,
-		Executed:        result.Executed,
-		Duration:        result.Duration,
-		Output:          result.Output,
-		Handlers:        handlers,
-		ProxyEntityName: result.Source,
+		ObjectMeta:    corev2.NewObjectMeta(result.Name, agentEntity.Namespace),
+		Status:        result.Status,
+		Command:       result.Command,
+		Subscriptions: result.Subscribers,
+		Interval:      result.Interval,
+		Issued:        result.Issued,
+		Executed:      result.Executed,
+		Duration:      result.Duration,
+		Output:        result.Output,
+		Handlers:      handlers,
 	}
 
 	// add config and check values to the 2.x event

--- a/agent/event_test.go
+++ b/agent/event_test.go
@@ -74,8 +74,30 @@ func TestTranslateToEvent(t *testing.T) {
 			},
 		},
 		{
+			Name:  "check with source",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handlers": ["slack"], "source": "foobar"}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "foobar",
+						Namespace: "test-namespace",
+					},
+					EntityClass: corev2.EntityProxyClass,
+				},
+			},
+		},
+		{
 			Name:  "check with deprecated handler attr",
-			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "slack", "client": "foobar"}`,
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "slack", "source": "foobar"}`,
 			ExpOutput: &corev2.Event{
 				Check: &corev2.Check{
 					ObjectMeta: corev2.ObjectMeta{
@@ -97,7 +119,7 @@ func TestTranslateToEvent(t *testing.T) {
 		},
 		{
 			Name:  "check with deprecated handler attr and new handlers attr",
-			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "source": "foobar"}`,
 			ExpOutput: &corev2.Event{
 				Check: &corev2.Check{
 					ObjectMeta: corev2.ObjectMeta{
@@ -118,60 +140,13 @@ func TestTranslateToEvent(t *testing.T) {
 			},
 		},
 		{
-			Name:  "check with source no client",
-			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "source": "foobar"}`,
-			ExpOutput: &corev2.Event{
-				Check: &corev2.Check{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      "check-mysql-status",
-						Namespace: "test-namespace",
-					},
-					Output:          "error!",
-					Status:          1,
-					ProxyEntityName: "foobar",
-				},
-				Entity: &corev2.Entity{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      "test-agent",
-						Namespace: "test-namespace",
-					},
-					EntityClass:   corev2.EntityAgentClass,
-					Subscriptions: []string{"default"},
-					User:          "test-user",
-					LastSeen:      time.Now().Unix(),
-				},
-			},
-		},
-		{
-			Name:  "check with source with client",
-			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "source": "foobar", "client": "test-client"}`,
-			ExpOutput: &corev2.Event{
-				Check: &corev2.Check{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      "check-mysql-status",
-						Namespace: "test-namespace",
-					},
-					Output:          "error!",
-					Status:          1,
-					ProxyEntityName: "foobar",
-				},
-				Entity: &corev2.Entity{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      "test-client",
-						Namespace: "test-namespace",
-					},
-					EntityClass: corev2.EntityProxyClass,
-				},
-			},
-		},
-		{
 			Name:     "missing name",
-			Input:    `{"output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			Input:    `{"output": "error!", "status": 1, "handler": "poop", "handlers": ["slack"], "source": "foobar"}`,
 			ExpError: true,
 		},
 		{
 			Name:     "missing output",
-			Input:    `{"name": "check-mysql-status", "status": 1, "handler": "poop", "handlers": ["slack"], "client": "foobar"}`,
+			Input:    `{"name": "check-mysql-status", "status": 1, "handler": "poop", "handlers": ["slack"], "source": "foobar"}`,
 			ExpError: true,
 		},
 	}

--- a/agent/event_test.go
+++ b/agent/event_test.go
@@ -52,7 +52,32 @@ func TestTranslateToEvent(t *testing.T) {
 			},
 		},
 		{
-			Name:  "check with client",
+			Name:  "check from docs with source existing agent",
+			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handlers": ["slack"], "source": "test-agent"}`,
+			ExpOutput: &corev2.Event{
+				Check: &corev2.Check{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "check-mysql-status",
+						Namespace: "test-namespace",
+					},
+					Output:   "error!",
+					Status:   1,
+					Handlers: []string{"slack"},
+				},
+				Entity: &corev2.Entity{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      "test-agent",
+						Namespace: "test-namespace",
+					},
+					EntityClass:   corev2.EntityAgentClass,
+					Subscriptions: []string{"default"},
+					User:          "test-user",
+					LastSeen:      time.Now().Unix(),
+				},
+			},
+		},
+		{
+			Name:  "check with deprecated client",
 			Input: `{"name": "check-mysql-status", "output": "error!", "status": 1, "handlers": ["slack"], "client": "foobar"}`,
 			ExpOutput: &corev2.Event{
 				Check: &corev2.Check{

--- a/agent/sockets.go
+++ b/agent/sockets.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
-	"github.com/sensu/sensu-go/types/v1"
+	corev1 "github.com/sensu/sensu-go/types/v1"
 )
 
 var (
 	pingRe = regexp.MustCompile(`\s+ping\s+`)
 )
+
+// Agent TCP/UDP sockets are deprecated in favor of the agent rest api
 
 // createListenSockets UDP and TCP socket listeners on port 3030 for external check
 // events.
@@ -140,7 +142,7 @@ func (a *Agent) handleTCPMessages(c net.Conn) {
 		// read again from client, add any new message to the buffer, and parse
 		// again.
 		var event types.Event
-		var result v1.CheckResult
+		var result corev1.CheckResult
 		if err = json.Unmarshal(messageBuffer.Bytes(), &result); err != nil {
 			continue
 		}
@@ -223,7 +225,7 @@ func (a *Agent) handleUDPMessages(ctx context.Context, c net.PacketConn) {
 			// message sender with the addition of the agent's entity if it is not
 			// included in the message. Any JSON errors are logged, and we return.
 			var event types.Event
-			var result v1.CheckResult
+			var result corev1.CheckResult
 			if err = json.Unmarshal(buf[:bytesRead], &result); err != nil {
 				logger.WithError(err).Error("UDP Invalid event data")
 				return

--- a/agent/sockets_test.go
+++ b/agent/sockets_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
-	"github.com/sensu/sensu-go/types/v1"
+	corev1 "github.com/sensu/sensu-go/types/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,10 +38,10 @@ func TestHandleTCPMessages(t *testing.T) {
 		assert.FailNow("failed to create TCP connection")
 	}
 
-	payload := v1.CheckResult{
+	payload := corev1.CheckResult{
 		Name:   "app_01",
 		Output: "could not connect to something",
-		Client: "proxEnt",
+		Source: "proxyEnt",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -62,6 +62,7 @@ func TestHandleTCPMessages(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
+	assert.Equal("proxyEnt", event.Check.ProxyEntityName)
 }
 
 func TestHandleUDPMessages(t *testing.T) {
@@ -90,10 +91,10 @@ func TestHandleUDPMessages(t *testing.T) {
 		assert.FailNow("failed to create UDP connection")
 	}
 
-	payload := v1.CheckResult{
+	payload := corev1.CheckResult{
 		Name:   "app_01",
 		Output: "could not connect to something",
-		Client: "proxEnt",
+		Source: "proxyEnt",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -114,6 +115,7 @@ func TestHandleUDPMessages(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
+	assert.Equal("proxyEnt", event.Check.ProxyEntityName)
 }
 
 func TestMultiWriteTimeoutTCP(t *testing.T) {
@@ -186,10 +188,10 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 		assert.FailNow("failed to create TCP connection")
 	}
 
-	payload := v1.CheckResult{
+	payload := corev1.CheckResult{
 		Name:   "app_01",
 		Output: "could not connect to something",
-		Client: "proxEnt",
+		Source: "proxyEnt",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -207,6 +209,7 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 	assert.NotNil(event.Entity)
 	assert.Equal("app_01", event.Check.Name)
 	assert.Equal(uint32(0), event.Check.Status)
+	assert.Equal("proxyEnt", event.Check.ProxyEntityName)
 }
 
 func TestReceivePingTCP(t *testing.T) {

--- a/types/v1/check.go
+++ b/types/v1/check.go
@@ -14,6 +14,7 @@ type CheckResult struct {
 	Executed    int64    `json:"executed"`
 	Duration    float64  `json:"duration"`
 	Output      string   `json:"output"`
+	Source      string   `json:"source"`
 
 	// Handler is deprecated but still supported
 	Handler string `json:"handler"`

--- a/types/v1/check.go
+++ b/types/v1/check.go
@@ -4,7 +4,7 @@ package v1
 // This is a subset of 1.x attributes, see:
 // https://docs.sensu.io/sensu-core/1.6/reference/checks/#check-attributes
 type CheckResult struct {
-	Client      string   `json:"client"`
+	Source      string   `json:"source"`
 	Status      uint32   `json:"status"`
 	Command     string   `json:"command"`
 	Subscribers []string `json:"subscribers"`
@@ -14,7 +14,9 @@ type CheckResult struct {
 	Executed    int64    `json:"executed"`
 	Duration    float64  `json:"duration"`
 	Output      string   `json:"output"`
-	Source      string   `json:"source"`
+
+	// Client is deprecated but still supported
+	Client string `json:"client"`
 
 	// Handler is deprecated but still supported
 	Handler string `json:"handler"`


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Changes the 1.x `client` field to `source` in the 1.x compatible agent socket. The `client` field is now deprecated.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2720.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Filed https://github.com/sensu/sensu-go/issues/2873 after discussing the agent socket with @cwjohnston.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1356

## How did you verify this change?

1. Run `echo '{"name": "check", "status": 1, "output": "error!", "client":"client"}' | nc localhost 3030`
- An event `client/check` is created
- `event.check.proxy_entity_name=client`
- A proxy entity `client` is created

2. Run `echo '{"name": "check", "status": 1, "output": "error!", "source":"source"}' | nc localhost 3030`
- An event `source/check` is created
- `event.check.proxy_entity_name=source`
- A proxy entity `source` is created

3. Run `echo '{"name": "check", "status": 1, "output": "error!", "source":"agent"}' | nc localhost 3030` where the agent running is named `agent`
- An event `agent/check` is created
- `event.check.proxy_entity_name` is empty
- A proxy entity is not created

4. Run `echo '{"name": "check", "status": 1, "output": "error!"}' | nc localhost 3030` where the agent running is named `agent`
- An event `agent/check` is created
- `event.check.proxy_entity_name` is empty
- A proxy entity is not created