### PR TITLE
[GraphQL] Ensures that all types are registered

### DIFF
--- a/graphql/integration/service_test.go
+++ b/graphql/integration/service_test.go
@@ -26,6 +26,9 @@ func TestExerciseService(t *testing.T) {
 	schema.RegisterLocale(svc)
 	schema.RegisterSchema(svc)
 
+	schema.RegisterErr(svc, nil)
+	schema.RegisterStdErr(svc, &schema.StdErrAliases{})
+
 	err := svc.Regenerate()
 	require.NoError(t, err)
 

--- a/graphql/integration/testdata/schema-kitchen-sink.graphql
+++ b/graphql/integration/testdata/schema-kitchen-sink.graphql
@@ -33,6 +33,7 @@ type Foo implements Bar {
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Url
   seven: [Bar]
+  eight: Err
 }
 
 type AnnotatedObject @onObject(arg: "value") {
@@ -56,7 +57,7 @@ Feed includes all stuff and things.
 """
 union Feed = Foo | QueryRoot
 
-"AnnotatedUnion i dont care"
+"AnnotatedUnion .. for the union"
 union AnnotatedUnion @onUnion = A | B
 
 scalar CustomScalar
@@ -121,3 +122,12 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @include(if: Boolean!)
   on FIELD
   | FRAGMENT_SPREAD
+
+interface Err {
+  message: String!
+}
+
+type StdErr implements Err {
+  message: String!
+  code: Int!
+}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -89,9 +89,9 @@ func (service *Service) RegisterUnion(t UnionDesc, impl UnionTypeResolver) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
 		newTypes := make([]*graphql.Object, len(cfg.Types))
-		for _, t := range cfg.Types {
+		for i, t := range cfg.Types {
 			objType := m[t.PrivateName].(*graphql.Object)
-			newTypes = append(newTypes, objType)
+			newTypes[i] = objType
 		}
 		cfg.Types = newTypes
 


### PR DESCRIPTION
## What is this change?

Ensures that all types are registered.

## Why is this change necessary?

Types that are not directly referenced by the root Schema type or any of
their children are not immediately registered with the schema. As such to
ensure that ALL types are available we append any that are missing.

For example, consider the following:

```graphql
interface Err {
  message: String!
}

type InputErr implements Err {
  message: String!
  code: Int!
  input: String
}

type StdErr implement Err {
  message: String!
}

type MutationRoot {
  shutdown(node: String!) {
    err: Err
  }
}

# When the schema object is initialized, it walks the graph resolving each dependency and
# registering each type in it's lookup table. However, in the case below, the StdErr and InputErr
# objects are never directly referenced by either the Schema root or MutationRoot objects. This 
# means that at runtime the schema is unable to resolve either of the Err types.
# 
# As a result we must take the additional step (see commit 5f09c0e) of registering types
# missing in the schema's lookup table.
schema {
  mutation: MutationRoot
}
```

## Does your change need a Changelog entry?

I would say no.

I am marking this as a regression as I tried to fix but only exacerbated the issue in #2847.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

When updating the integration test, I found another small issue with the union type.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

An integration test and manual testing.