### PR TITLE
Bugfix for annotations & labels flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.6.0] - TBD
 
+### Fixed
+- Fixed the agent `--annotations` and `--labels` flags.
+
 ## [5.5.1] - 2019-04-15
 
 ### Changed

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -25,6 +25,9 @@ import (
 
 var (
 	logger *logrus.Entry
+
+	annotations map[string]string
+	labels      map[string]string
 )
 
 const (
@@ -164,6 +167,20 @@ func newStartCommand() *cobra.Command {
 			cfg.Redact = viper.GetStringSlice(flagRedact)
 			cfg.Subscriptions = viper.GetStringSlice(flagSubscriptions)
 
+			// Workaround for https://github.com/sensu/sensu-go/issues/2357. Detect if
+			// the flags for labels and annotations were changed. If so, use their
+			// values since flags take precedence over config
+			if flag := cmd.Flags().Lookup(flagLabels); flag != nil {
+				if flag.Changed {
+					cfg.Labels = labels
+				}
+			}
+			if flag := cmd.Flags().Lookup(flagAnnotations); flag != nil {
+				if flag.Changed {
+					cfg.Labels = annotations
+				}
+			}
+
 			sensuAgent, err := agent.NewAgent(cfg)
 			if err != nil {
 				return err
@@ -279,8 +296,8 @@ func newStartCommand() *cobra.Command {
 	cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format")
 	cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
 	cmd.Flags().String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug]")
-	cmd.Flags().StringToString(flagLabels, viper.GetStringMapString(flagLabels), "entity labels map")
-	cmd.Flags().StringToString(flagAnnotations, viper.GetStringMapString(flagAnnotations), "entity annotations map")
+	cmd.Flags().StringToStringVar(&labels, flagLabels, nil, "entity labels map")
+	cmd.Flags().StringToStringVar(&annotations, flagAnnotations, nil, "entity annotations map")
 
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc)
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -170,15 +170,11 @@ func newStartCommand() *cobra.Command {
 			// Workaround for https://github.com/sensu/sensu-go/issues/2357. Detect if
 			// the flags for labels and annotations were changed. If so, use their
 			// values since flags take precedence over config
-			if flag := cmd.Flags().Lookup(flagLabels); flag != nil {
-				if flag.Changed {
-					cfg.Labels = labels
-				}
+			if flag := cmd.Flags().Lookup(flagLabels); flag != nil && flag.Changed {
+				cfg.Labels = labels
 			}
-			if flag := cmd.Flags().Lookup(flagAnnotations); flag != nil {
-				if flag.Changed {
-					cfg.Labels = annotations
-				}
+			if flag := cmd.Flags().Lookup(flagAnnotations); flag != nil && flag.Changed {
+				cfg.Annotations = annotations
 			}
 
 			sensuAgent, err := agent.NewAgent(cfg)


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR fixes the `--annotations` & `--labels` flags with a workaround, since the actual problem in viper is still present: https://github.com/spf13/viper/issues/608.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2357

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

Manually tested:

#### Labels
```bash
$ sensu-agent start --labels foo=bar
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.labels'
{
  "foo": "bar"
}

# Now use a config file with:
# labels:
#   baz: qux
$ sensu-agent start -c agent.yml
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.labels'
{
  "baz": "qux"
}

# Now mix the config file with labels flag, which should have precedence over the config
$ sensu-agent start -c agent.yml --labels foo=bar
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.labels'
{
  "foo": "bar"
}
```

#### Annotations
```bash
$ sensu-agent start --annotations foo=bar
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.annotations'
{
  "foo": "bar"
}

# Now use a config file with:
# annotations:
#   baz: qux
$ sensu-agent start -c agent.yml
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.annotations'
{
  "baz": "qux"
}

# Now mix the config file with annotations flag, which should have precedence over the config
$ sensu-agent start -c agent.yml --annotations foo=bar
$ sensuctl entity info whisky.local --format json | jq -r '.metadata.annotations'
{
  "foo": "bar"
}
```
