### PR TITLE
Add support for field selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [5.6.0] - TBD
 
+### Added
+- Added fields getter functions for resources available via the REST API.
+
 ### Fixed
 - Fixed the agent `--annotations` and `--labels` flags.
 

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -106,9 +106,9 @@ func NewAsset(meta ObjectMeta) *Asset {
 // AssetFields returns a set of fields that represent that resource
 func AssetFields(r Resource) map[string]string {
 	resource := r.(*Asset)
-	fields := make(map[string]string, 3)
-	fields["asset.name"] = resource.ObjectMeta.Name
-	fields["asset.namespace"] = resource.ObjectMeta.Namespace
-	fields["asset.filters"] = strings.Join(resource.Filters, ",")
-	return fields
+	return map[string]string{
+		"asset.name":      resource.ObjectMeta.Name,
+		"asset.namespace": resource.ObjectMeta.Namespace,
+		"asset.filters":   strings.Join(resource.Filters, ","),
+	}
 }

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/sensu/sensu-go/js"
 )
@@ -100,4 +101,14 @@ func (a *Asset) URIPath() string {
 // NewAsset creates a new Asset.
 func NewAsset(meta ObjectMeta) *Asset {
 	return &Asset{ObjectMeta: meta}
+}
+
+// AssetFields returns a set of fields that represent that resource
+func AssetFields(r Resource) map[string]string {
+	resource := r.(*Asset)
+	fields := make(map[string]string, 3)
+	fields["asset.name"] = resource.ObjectMeta.Name
+	fields["asset.namespace"] = resource.ObjectMeta.Namespace
+	fields["asset.filters"] = strings.Join(resource.Filters, ",")
+	return fields
 }

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -451,4 +453,18 @@ func (c *CheckConfig) IsSubdued() bool {
 		return false
 	}
 	return subdued
+}
+
+// CheckConfigFields returns a set of fields that represent that resource
+func CheckConfigFields(r Resource) map[string]string {
+	resource := r.(*CheckConfig)
+	fields := make(map[string]string, 7)
+	fields["check.name"] = resource.ObjectMeta.Name
+	fields["check.namespace"] = resource.ObjectMeta.Namespace
+	fields["check.handlers"] = strings.Join(resource.Handlers, ",")
+	fields["check.publish"] = strconv.FormatBool(resource.Publish)
+	fields["check.round_robin"] = strconv.FormatBool(resource.RoundRobin)
+	fields["check.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
+	fields["check.subscriptions"] = strings.Join(resource.Subscriptions, ",")
+	return fields
 }

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -458,13 +458,13 @@ func (c *CheckConfig) IsSubdued() bool {
 // CheckConfigFields returns a set of fields that represent that resource
 func CheckConfigFields(r Resource) map[string]string {
 	resource := r.(*CheckConfig)
-	fields := make(map[string]string, 7)
-	fields["check.name"] = resource.ObjectMeta.Name
-	fields["check.namespace"] = resource.ObjectMeta.Namespace
-	fields["check.handlers"] = strings.Join(resource.Handlers, ",")
-	fields["check.publish"] = strconv.FormatBool(resource.Publish)
-	fields["check.round_robin"] = strconv.FormatBool(resource.RoundRobin)
-	fields["check.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
-	fields["check.subscriptions"] = strings.Join(resource.Subscriptions, ",")
-	return fields
+	return map[string]string{
+		"check.name":           resource.ObjectMeta.Name,
+		"check.namespace":      resource.ObjectMeta.Namespace,
+		"check.handlers":       strings.Join(resource.Handlers, ","),
+		"check.publish":        strconv.FormatBool(resource.Publish),
+		"check.round_robin":    strconv.FormatBool(resource.RoundRobin),
+		"check.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+		"check.subscriptions":  strings.Join(resource.Subscriptions, ","),
+	}
 }

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
+	"strings"
 
 	utilstrings "github.com/sensu/sensu-go/util/strings"
 )
@@ -168,4 +170,16 @@ func (s *entitySorter) Swap(i, j int) {
 // Less implements sort.Interface.
 func (s *entitySorter) Less(i, j int) bool {
 	return s.byFn(s.entities[i], s.entities[j])
+}
+
+// EntityFields returns a set of fields that represent that resource
+func EntityFields(r Resource) map[string]string {
+	resource := r.(*Entity)
+	fields := make(map[string]string, 5)
+	fields["entity.name"] = resource.ObjectMeta.Name
+	fields["entity.namespace"] = resource.ObjectMeta.Namespace
+	fields["entity.deregister"] = strconv.FormatBool(resource.Deregister)
+	fields["entity.entity_class"] = resource.EntityClass
+	fields["entity.subscriptions"] = strings.Join(resource.Subscriptions, ",")
+	return fields
 }

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -175,11 +175,11 @@ func (s *entitySorter) Less(i, j int) bool {
 // EntityFields returns a set of fields that represent that resource
 func EntityFields(r Resource) map[string]string {
 	resource := r.(*Entity)
-	fields := make(map[string]string, 5)
-	fields["entity.name"] = resource.ObjectMeta.Name
-	fields["entity.namespace"] = resource.ObjectMeta.Namespace
-	fields["entity.deregister"] = strconv.FormatBool(resource.Deregister)
-	fields["entity.entity_class"] = resource.EntityClass
-	fields["entity.subscriptions"] = strings.Join(resource.Subscriptions, ",")
-	return fields
+	return map[string]string{
+		"entity.name":          resource.ObjectMeta.Name,
+		"entity.namespace":     resource.ObjectMeta.Namespace,
+		"entity.deregister":    strconv.FormatBool(resource.Deregister),
+		"entity.entity_class":  resource.EntityClass,
+		"entity.subscriptions": strings.Join(resource.Subscriptions, ","),
+	}
 }

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -5,6 +5,8 @@ import (
 	fmt "fmt"
 	"net/url"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	stringsutil "github.com/sensu/sensu-go/util/strings"
@@ -348,4 +350,22 @@ func (e *Event) IsSilencedBy(entry *Silenced) bool {
 	}
 
 	return false
+}
+
+// EventFields returns a set of fields that represent that resource
+func EventFields(r Resource) map[string]string {
+	resource := r.(*Event)
+	fields := make(map[string]string, 11)
+	fields["event.name"] = resource.ObjectMeta.Name
+	fields["event.namespace"] = resource.ObjectMeta.Namespace
+	fields["event.check.handlers"] = strings.Join(resource.Check.Handlers, ",")
+	fields["event.check.publish"] = strconv.FormatBool(resource.Check.Publish)
+	fields["event.check.round_robin"] = strconv.FormatBool(resource.Check.RoundRobin)
+	fields["event.check.runtime_assets"] = strings.Join(resource.Check.RuntimeAssets, ",")
+	fields["event.check.status"] = strconv.Itoa(int(resource.Check.Status))
+	fields["event.check.subscriptions"] = strings.Join(resource.Check.Subscriptions, ",")
+	fields["event.entity.deregister"] = strconv.FormatBool(resource.Entity.Deregister)
+	fields["event.entity.entity_class"] = resource.Entity.EntityClass
+	fields["event.entity.subscriptions"] = strings.Join(resource.Entity.Subscriptions, ",")
+	return fields
 }

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -108,7 +108,7 @@ func (e *Event) IsSilenced() bool {
 	return len(e.Check.Silenced) > 0
 }
 
-// Implements dynamic.SynthesizeExtras
+// SynthesizeExtras implements dynamic.SynthesizeExtras
 func (e *Event) SynthesizeExtras() map[string]interface{} {
 	return map[string]interface{}{
 		"has_check":     e.HasCheck(),
@@ -355,17 +355,17 @@ func (e *Event) IsSilencedBy(entry *Silenced) bool {
 // EventFields returns a set of fields that represent that resource
 func EventFields(r Resource) map[string]string {
 	resource := r.(*Event)
-	fields := make(map[string]string, 11)
-	fields["event.name"] = resource.ObjectMeta.Name
-	fields["event.namespace"] = resource.ObjectMeta.Namespace
-	fields["event.check.handlers"] = strings.Join(resource.Check.Handlers, ",")
-	fields["event.check.publish"] = strconv.FormatBool(resource.Check.Publish)
-	fields["event.check.round_robin"] = strconv.FormatBool(resource.Check.RoundRobin)
-	fields["event.check.runtime_assets"] = strings.Join(resource.Check.RuntimeAssets, ",")
-	fields["event.check.status"] = strconv.Itoa(int(resource.Check.Status))
-	fields["event.check.subscriptions"] = strings.Join(resource.Check.Subscriptions, ",")
-	fields["event.entity.deregister"] = strconv.FormatBool(resource.Entity.Deregister)
-	fields["event.entity.entity_class"] = resource.Entity.EntityClass
-	fields["event.entity.subscriptions"] = strings.Join(resource.Entity.Subscriptions, ",")
-	return fields
+	return map[string]string{
+		"event.name":                 resource.ObjectMeta.Name,
+		"event.namespace":            resource.ObjectMeta.Namespace,
+		"event.check.handlers":       strings.Join(resource.Check.Handlers, ","),
+		"event.check.publish":        strconv.FormatBool(resource.Check.Publish),
+		"event.check.round_robin":    strconv.FormatBool(resource.Check.RoundRobin),
+		"event.check.runtime_assets": strings.Join(resource.Check.RuntimeAssets, ","),
+		"event.check.status":         strconv.Itoa(int(resource.Check.Status)),
+		"event.check.subscriptions":  strings.Join(resource.Check.Subscriptions, ","),
+		"event.entity.deregister":    strconv.FormatBool(resource.Entity.Deregister),
+		"event.entity.entity_class":  resource.Entity.EntityClass,
+		"event.entity.subscriptions": strings.Join(resource.Entity.Subscriptions, ","),
+	}
 }

--- a/api/core/v2/extension.go
+++ b/api/core/v2/extension.go
@@ -33,6 +33,7 @@ func FixtureExtension(name string) *Extension {
 	}
 }
 
+// NewExtension intializes an extension with the given object meta
 func NewExtension(meta ObjectMeta) *Extension {
 	return &Extension{ObjectMeta: meta}
 }
@@ -40,8 +41,8 @@ func NewExtension(meta ObjectMeta) *Extension {
 // ExtensionFields returns a set of fields that represent that resource
 func ExtensionFields(r Resource) map[string]string {
 	resource := r.(*Extension)
-	fields := make(map[string]string, 2)
-	fields["extension.name"] = resource.ObjectMeta.Name
-	fields["extension.namespace"] = resource.ObjectMeta.Namespace
-	return fields
+	return map[string]string{
+		"extension.name":      resource.ObjectMeta.Name,
+		"extension.namespace": resource.ObjectMeta.Namespace,
+	}
 }

--- a/api/core/v2/extension.go
+++ b/api/core/v2/extension.go
@@ -36,3 +36,12 @@ func FixtureExtension(name string) *Extension {
 func NewExtension(meta ObjectMeta) *Extension {
 	return &Extension{ObjectMeta: meta}
 }
+
+// ExtensionFields returns a set of fields that represent that resource
+func ExtensionFields(r Resource) map[string]string {
+	resource := r.(*Extension)
+	fields := make(map[string]string, 2)
+	fields["extension.name"] = resource.ObjectMeta.Name
+	fields["extension.namespace"] = resource.ObjectMeta.Namespace
+	return fields
+}

--- a/api/core/v2/filter.go
+++ b/api/core/v2/filter.go
@@ -108,10 +108,10 @@ func (f *EventFilter) URIPath() string {
 // EventFilterFields returns a set of fields that represent that resource
 func EventFilterFields(r Resource) map[string]string {
 	resource := r.(*EventFilter)
-	fields := make(map[string]string, 4)
-	fields["filter.name"] = resource.ObjectMeta.Name
-	fields["filter.namespace"] = resource.ObjectMeta.Namespace
-	fields["filter.action"] = resource.Action
-	fields["filter.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
-	return fields
+	return map[string]string{
+		"filter.name":           resource.ObjectMeta.Name,
+		"filter.namespace":      resource.ObjectMeta.Namespace,
+		"filter.action":         resource.Action,
+		"filter.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+	}
 }

--- a/api/core/v2/filter.go
+++ b/api/core/v2/filter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/sensu/sensu-go/js"
 	utilstrings "github.com/sensu/sensu-go/util/strings"
@@ -102,4 +103,15 @@ func FixtureDenyEventFilter(name string) *EventFilter {
 // URIPath returns the path component of a Filter URI.
 func (f *EventFilter) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s/filters/%s", url.PathEscape(f.Namespace), url.PathEscape(f.Name))
+}
+
+// EventFilterFields returns a set of fields that represent that resource
+func EventFilterFields(r Resource) map[string]string {
+	resource := r.(*EventFilter)
+	fields := make(map[string]string, 4)
+	fields["filter.name"] = resource.ObjectMeta.Name
+	fields["filter.namespace"] = resource.ObjectMeta.Namespace
+	fields["filter.action"] = resource.Action
+	fields["filter.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
+	return fields
 }

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	fmt "fmt"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -109,4 +110,17 @@ func FixtureSetHandler(name string, handlers ...string) *Handler {
 // URIPath returns the path component of a Handler URI.
 func (h *Handler) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s/handlers/%s", url.PathEscape(h.Namespace), url.PathEscape(h.Name))
+}
+
+// HandlerFields returns a set of fields that represent that resource
+func HandlerFields(r Resource) map[string]string {
+	resource := r.(*Handler)
+	fields := make(map[string]string, 6)
+	fields["handler.name"] = resource.ObjectMeta.Name
+	fields["handler.namespace"] = resource.ObjectMeta.Namespace
+	fields["handler.filters"] = strings.Join(resource.Filters, ",")
+	fields["handler.handlers"] = strings.Join(resource.Handlers, ",")
+	fields["handler.mutator"] = resource.Mutator
+	fields["handler.type"] = resource.Type
+	return fields
 }

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -115,12 +115,12 @@ func (h *Handler) URIPath() string {
 // HandlerFields returns a set of fields that represent that resource
 func HandlerFields(r Resource) map[string]string {
 	resource := r.(*Handler)
-	fields := make(map[string]string, 6)
-	fields["handler.name"] = resource.ObjectMeta.Name
-	fields["handler.namespace"] = resource.ObjectMeta.Namespace
-	fields["handler.filters"] = strings.Join(resource.Filters, ",")
-	fields["handler.handlers"] = strings.Join(resource.Handlers, ",")
-	fields["handler.mutator"] = resource.Mutator
-	fields["handler.type"] = resource.Type
-	return fields
+	return map[string]string{
+		"handler.name":      resource.ObjectMeta.Name,
+		"handler.namespace": resource.ObjectMeta.Namespace,
+		"handler.filters":   strings.Join(resource.Filters, ","),
+		"handler.handlers":  strings.Join(resource.Handlers, ","),
+		"handler.mutator":   resource.Mutator,
+		"handler.type":      resource.Type,
+	}
 }

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -152,8 +152,8 @@ func (h *Hook) URIPath() string {
 // HookConfigFields returns a set of fields that represent that resource
 func HookConfigFields(r Resource) map[string]string {
 	resource := r.(*HookConfig)
-	fields := make(map[string]string, 2)
-	fields["hook.name"] = resource.ObjectMeta.Name
-	fields["hook.namespace"] = resource.ObjectMeta.Namespace
-	return fields
+	return map[string]string{
+		"hook.name":      resource.ObjectMeta.Name,
+		"hook.namespace": resource.ObjectMeta.Namespace,
+	}
 }

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -148,3 +148,12 @@ func FixtureHookList(hookName string) *HookList {
 func (h *Hook) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s/hooks/%s", url.PathEscape(h.Namespace), url.PathEscape(h.Name))
 }
+
+// HookConfigFields returns a set of fields that represent that resource
+func HookConfigFields(r Resource) map[string]string {
+	resource := r.(*HookConfig)
+	fields := make(map[string]string, 2)
+	fields["hook.name"] = resource.ObjectMeta.Name
+	fields["hook.namespace"] = resource.ObjectMeta.Namespace
+	return fields
+}

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	fmt "fmt"
 	"net/url"
+	"strings"
 )
 
 // NewMutator creates a new Mutator.
@@ -58,4 +59,14 @@ func FixtureMutator(name string) *Mutator {
 // URIPath returns the path component of a Mutator URI.
 func (m *Mutator) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s/mutators/%s", url.PathEscape(m.Namespace), url.PathEscape(m.Name))
+}
+
+// MutatorFields returns a set of fields that represent that resource
+func MutatorFields(r Resource) map[string]string {
+	resource := r.(*Mutator)
+	fields := make(map[string]string, 3)
+	fields["mutator.name"] = resource.ObjectMeta.Name
+	fields["mutator.namespace"] = resource.ObjectMeta.Namespace
+	fields["mutator.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
+	return fields
 }

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -64,9 +64,9 @@ func (m *Mutator) URIPath() string {
 // MutatorFields returns a set of fields that represent that resource
 func MutatorFields(r Resource) map[string]string {
 	resource := r.(*Mutator)
-	fields := make(map[string]string, 3)
-	fields["mutator.name"] = resource.ObjectMeta.Name
-	fields["mutator.namespace"] = resource.ObjectMeta.Namespace
-	fields["mutator.runtime_assets"] = strings.Join(resource.RuntimeAssets, ",")
-	return fields
+	return map[string]string{
+		"mutator.name":           resource.ObjectMeta.Name,
+		"mutator.namespace":      resource.ObjectMeta.Namespace,
+		"mutator.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
+	}
 }

--- a/api/core/v2/namespace.go
+++ b/api/core/v2/namespace.go
@@ -27,7 +27,7 @@ func FixtureNamespace(name string) *Namespace {
 	}
 }
 
-// URIPath returns the path component of a Namespace URI.
+// URIPath returns the path component of a Namespace 	URI.
 func (n *Namespace) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s", url.PathEscape(n.Name))
 }
@@ -35,4 +35,12 @@ func (n *Namespace) URIPath() string {
 // GetObjectMeta only exists here to fulfil the requirements of Resource
 func (n *Namespace) GetObjectMeta() ObjectMeta {
 	return ObjectMeta{}
+}
+
+// NamespaceFields returns a set of fields that represent that resource
+func NamespaceFields(r Resource) map[string]string {
+	resource := r.(*Namespace)
+	fields := make(map[string]string, 1)
+	fields["namespace.name"] = resource.Name
+	return fields
 }

--- a/api/core/v2/namespace.go
+++ b/api/core/v2/namespace.go
@@ -27,7 +27,7 @@ func FixtureNamespace(name string) *Namespace {
 	}
 }
 
-// URIPath returns the path component of a Namespace 	URI.
+// URIPath returns the path component of a Namespace URI.
 func (n *Namespace) URIPath() string {
 	return fmt.Sprintf("/api/core/v2/namespaces/%s", url.PathEscape(n.Name))
 }
@@ -40,7 +40,7 @@ func (n *Namespace) GetObjectMeta() ObjectMeta {
 // NamespaceFields returns a set of fields that represent that resource
 func NamespaceFields(r Resource) map[string]string {
 	resource := r.(*Namespace)
-	fields := make(map[string]string, 1)
-	fields["namespace.name"] = resource.Name
-	return fields
+	return map[string]string{
+		"namespace.name": resource.Name,
+	}
 }

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -262,37 +262,37 @@ func NewRoleBinding(meta ObjectMeta) *RoleBinding {
 // ClusterRoleFields returns a set of fields that represent that resource
 func ClusterRoleFields(r Resource) map[string]string {
 	resource := r.(*ClusterRole)
-	fields := make(map[string]string, 1)
-	fields["clusterrole.name"] = resource.ObjectMeta.Name
-	return fields
+	return map[string]string{
+		"clusterrole.name": resource.ObjectMeta.Name,
+	}
 }
 
 // ClusterRoleBindingFields returns a set of fields that represent that resource
 func ClusterRoleBindingFields(r Resource) map[string]string {
 	resource := r.(*ClusterRoleBinding)
-	fields := make(map[string]string, 3)
-	fields["clusterrolebinding.name"] = resource.ObjectMeta.Name
-	fields["clusterrolebinding.role_ref.name"] = resource.RoleRef.Name
-	fields["clusterrolebinding.role_ref.type"] = resource.RoleRef.Type
-	return fields
+	return map[string]string{
+		"clusterrolebinding.name":          resource.ObjectMeta.Name,
+		"clusterrolebinding.role_ref.name": resource.RoleRef.Name,
+		"clusterrolebinding.role_ref.type": resource.RoleRef.Type,
+	}
 }
 
 // RoleFields returns a set of fields that represent that resource
 func RoleFields(r Resource) map[string]string {
 	resource := r.(*Role)
-	fields := make(map[string]string, 2)
-	fields["role.name"] = resource.ObjectMeta.Name
-	fields["role.namespace"] = resource.ObjectMeta.Namespace
-	return fields
+	return map[string]string{
+		"role.name":      resource.ObjectMeta.Name,
+		"role.namespace": resource.ObjectMeta.Namespace,
+	}
 }
 
 // RoleBindingFields returns a set of fields that represent that resource
 func RoleBindingFields(r Resource) map[string]string {
 	resource := r.(*RoleBinding)
-	fields := make(map[string]string, 4)
-	fields["rolebinding.name"] = resource.ObjectMeta.Name
-	fields["rolebinding.namespace"] = resource.ObjectMeta.Namespace
-	fields["rolebinding.role_ref.name"] = resource.RoleRef.Name
-	fields["rolebinding.role_ref.type"] = resource.RoleRef.Type
-	return fields
+	return map[string]string{
+		"rolebinding.name":          resource.ObjectMeta.Name,
+		"rolebinding.namespace":     resource.ObjectMeta.Namespace,
+		"rolebinding.role_ref.name": resource.RoleRef.Name,
+		"rolebinding.role_ref.type": resource.RoleRef.Type,
+	}
 }

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -258,3 +258,41 @@ func NewRole(meta ObjectMeta) *Role {
 func NewRoleBinding(meta ObjectMeta) *RoleBinding {
 	return &RoleBinding{ObjectMeta: meta}
 }
+
+// ClusterRoleFields returns a set of fields that represent that resource
+func ClusterRoleFields(r Resource) map[string]string {
+	resource := r.(*ClusterRole)
+	fields := make(map[string]string, 1)
+	fields["clusterrole.name"] = resource.ObjectMeta.Name
+	return fields
+}
+
+// ClusterRoleBindingFields returns a set of fields that represent that resource
+func ClusterRoleBindingFields(r Resource) map[string]string {
+	resource := r.(*ClusterRoleBinding)
+	fields := make(map[string]string, 3)
+	fields["clusterrolebinding.name"] = resource.ObjectMeta.Name
+	fields["clusterrolebinding.role_ref.name"] = resource.RoleRef.Name
+	fields["clusterrolebinding.role_ref.type"] = resource.RoleRef.Type
+	return fields
+}
+
+// RoleFields returns a set of fields that represent that resource
+func RoleFields(r Resource) map[string]string {
+	resource := r.(*Role)
+	fields := make(map[string]string, 2)
+	fields["role.name"] = resource.ObjectMeta.Name
+	fields["role.namespace"] = resource.ObjectMeta.Namespace
+	return fields
+}
+
+// RoleBindingFields returns a set of fields that represent that resource
+func RoleBindingFields(r Resource) map[string]string {
+	resource := r.(*RoleBinding)
+	fields := make(map[string]string, 4)
+	fields["rolebinding.name"] = resource.ObjectMeta.Name
+	fields["rolebinding.namespace"] = resource.ObjectMeta.Namespace
+	fields["rolebinding.role_ref.name"] = resource.RoleRef.Name
+	fields["rolebinding.role_ref.type"] = resource.RoleRef.Type
+	return fields
+}

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -123,4 +124,17 @@ func (s *silenceSorter) Swap(i, j int) {
 // Less implements sort.Interface.
 func (s *silenceSorter) Less(i, j int) bool {
 	return s.byFn(s.silences[i], s.silences[j])
+}
+
+// SilencedFields returns a set of fields that represent that resource
+func SilencedFields(r Resource) map[string]string {
+	resource := r.(*Silenced)
+	fields := make(map[string]string, 6)
+	fields["silenced.name"] = resource.ObjectMeta.Name
+	fields["silenced.namespace"] = resource.ObjectMeta.Namespace
+	fields["silenced.check"] = resource.Check
+	fields["silenced.creator"] = resource.Creator
+	fields["silenced.expire_on_resolve"] = strconv.FormatBool(resource.ExpireOnResolve)
+	fields["silenced.subscription"] = resource.Subscription
+	return fields
 }

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -129,12 +129,12 @@ func (s *silenceSorter) Less(i, j int) bool {
 // SilencedFields returns a set of fields that represent that resource
 func SilencedFields(r Resource) map[string]string {
 	resource := r.(*Silenced)
-	fields := make(map[string]string, 6)
-	fields["silenced.name"] = resource.ObjectMeta.Name
-	fields["silenced.namespace"] = resource.ObjectMeta.Namespace
-	fields["silenced.check"] = resource.Check
-	fields["silenced.creator"] = resource.Creator
-	fields["silenced.expire_on_resolve"] = strconv.FormatBool(resource.ExpireOnResolve)
-	fields["silenced.subscription"] = resource.Subscription
-	return fields
+	return map[string]string{
+		"silenced.name":              resource.ObjectMeta.Name,
+		"silenced.namespace":         resource.ObjectMeta.Namespace,
+		"silenced.check":             resource.Check,
+		"silenced.creator":           resource.Creator,
+		"silenced.expire_on_resolve": strconv.FormatBool(resource.ExpireOnResolve),
+		"silenced.subscription":      resource.Subscription,
+	}
 }

--- a/api/core/v2/tls.go
+++ b/api/core/v2/tls.go
@@ -11,7 +11,8 @@ var (
 	// PCI compliance as of Jun 30, 2018: anything under TLS 1.1 must be disabled
 	// we bump this up to TLS 1.2 so we can support the best possible ciphers
 	tlsMinVersion = uint16(tls.VersionTLS12)
-	// disable CBC suites (Lucky13 attack) this means TLS 1.1 can't work (no GCM)
+	// DefaultCipherSuites overrides the default cipher suites in order to disable
+	// CBC suites (Lucky13 attack) this means TLS 1.1 can't work (no GCM)
 	// additionally, we should only use perfect forward secrecy ciphers
 	DefaultCipherSuites = []uint16{
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,

--- a/api/core/v2/user.go
+++ b/api/core/v2/user.go
@@ -52,9 +52,9 @@ func (u *User) GetObjectMeta() ObjectMeta {
 // UserFields returns a set of fields that represent that resource
 func UserFields(r Resource) map[string]string {
 	resource := r.(*User)
-	fields := make(map[string]string, 3)
-	fields["user.username"] = resource.Username
-	fields["user.disabled"] = strconv.FormatBool(resource.Disabled)
-	fields["user.groups"] = strings.Join(resource.Groups, ",")
-	return fields
+	return map[string]string{
+		"user.username": resource.Username,
+		"user.disabled": strconv.FormatBool(resource.Disabled),
+		"user.groups":   strings.Join(resource.Groups, ","),
+	}
 }

--- a/api/core/v2/user.go
+++ b/api/core/v2/user.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	fmt "fmt"
 	"net/url"
+	"strconv"
+	"strings"
 )
 
 // FixtureUser returns a testing fixture for an Entity object.
@@ -45,4 +47,14 @@ func (u *User) URIPath() string {
 // GetObjectMeta is a dummy implementation to meet the Resource interface.
 func (u *User) GetObjectMeta() ObjectMeta {
 	return ObjectMeta{}
+}
+
+// UserFields returns a set of fields that represent that resource
+func UserFields(r Resource) map[string]string {
+	resource := r.(*User)
+	fields := make(map[string]string, 3)
+	fields["user.username"] = resource.Username
+	fields["user.disabled"] = strconv.FormatBool(resource.Disabled)
+	fields["user.groups"] = strings.Join(resource.Groups, ",")
+	return fields
 }

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -30,8 +31,8 @@ func (r *AssetsRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:assets}")
+	routes.List(r.controller.List, corev2.AssetFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:assets}", corev2.AssetFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -47,8 +47,8 @@ func (r *ChecksRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:checks}")
+	routes.List(r.controller.List, corev2.CheckConfigFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:checks}", corev2.CheckConfigFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 

--- a/backend/apid/routers/clusterrolebindings.go
+++ b/backend/apid/routers/clusterrolebindings.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -28,7 +29,7 @@ func (r *ClusterRoleBindingsRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterrolebindings}",
 	}
-	routes.List(r.controller.List)
+	routes.List(r.controller.List, corev2.ClusterRoleBindingFields)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)

--- a/backend/apid/routers/clusterroles.go
+++ b/backend/apid/routers/clusterroles.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -28,7 +29,7 @@ func (r *ClusterRolesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:clusterroles}",
 	}
-	routes.List(r.controller.List)
+	routes.List(r.controller.List, corev2.ClusterRoleFields)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:entities}")
+	routes.List(r.controller.List, corev2.EntityFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:entities}", corev2.EntityFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
@@ -32,15 +33,16 @@ func (r *EventsRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Post(r.create)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:events}")
+	routes.List(r.controller.List, corev2.EventFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:events}", corev2.EventFields)
 	routes.Path("{entity}/{check}", r.find).Methods(http.MethodGet)
 	routes.Path("{entity}/{check}", r.destroy).Methods(http.MethodDelete)
 	routes.Path("{entity}/{check}", r.createOrReplace).Methods(http.MethodPut)
 
 	// Additionaly allow a subcollection to be specified when listing events,
 	// which correspond to the entity name here
-	parent.HandleFunc(path.Join(routes.PathPrefix, "{subcollection}"), listerHandler(r.controller.List)).Methods(http.MethodGet)
+	parent.HandleFunc(path.Join(routes.PathPrefix, "{subcollection}"),
+		listerHandler(r.controller.List, corev2.EventFields)).Methods(http.MethodGet)
 }
 
 func (r *EventsRouter) find(req *http.Request) (interface{}, error) {

--- a/backend/apid/routers/extensions.go
+++ b/backend/apid/routers/extensions.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *ExtensionsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.deregister)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:extensions}")
+	routes.List(r.controller.List, corev2.ExtensionFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:extensions}", corev2.ExtensionFields)
 	routes.Put(r.register)
 }
 

--- a/backend/apid/routers/filters.go
+++ b/backend/apid/routers/filters.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *EventFiltersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:filters}")
+	routes.List(r.controller.List, corev2.EventFilterFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:filters}", corev2.EventFilterFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/handlers.go
+++ b/backend/apid/routers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *HandlersRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:handlers}")
+	routes.List(r.controller.List, corev2.HandlerFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:handlers}", corev2.HandlerFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/hooks.go
+++ b/backend/apid/routers/hooks.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *HooksRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:hooks}")
+	routes.List(r.controller.List, corev2.HookConfigFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:hooks}", corev2.HookConfigFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -92,8 +92,12 @@ func TestList(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List, corev2.CheckConfigFields))
-			router.PathPrefix("/foo").HandlerFunc(List(controller.List, corev2.CheckConfigFields))
+			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List,
+				func(r corev2.Resource) map[string]string { return map[string]string{} },
+			))
+			router.PathPrefix("/foo").HandlerFunc(List(controller.List,
+				func(r corev2.Resource) map[string]string { return map[string]string{} },
+			))
 			middleware := middlewares.Pagination{}
 			router.Use(middleware.Then)
 			router.ServeHTTP(w, r)

--- a/backend/apid/routers/lister_test.go
+++ b/backend/apid/routers/lister_test.go
@@ -92,8 +92,8 @@ func TestList(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			router := mux.NewRouter()
-			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List))
-			router.PathPrefix("/foo").HandlerFunc(List(controller.List))
+			router.PathPrefix("/foo/{subcollection}").HandlerFunc(List(controller.List, corev2.CheckConfigFields))
+			router.PathPrefix("/foo").HandlerFunc(List(controller.List, corev2.CheckConfigFields))
 			middleware := middlewares.Pagination{}
 			router.Use(middleware.Then)
 			router.ServeHTTP(w, r)

--- a/backend/apid/routers/mutators.go
+++ b/backend/apid/routers/mutators.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *MutatorsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:mutators}")
+	routes.List(r.controller.List, corev2.MutatorFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:mutators}", corev2.MutatorFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -38,7 +38,7 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:namespaces}",
 	}
-	routes.List(r.controller.List)
+	routes.List(r.controller.List, corev2.NamespaceFields)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)

--- a/backend/apid/routers/rolebindings.go
+++ b/backend/apid/routers/rolebindings.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *RoleBindingsRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:rolebindings}")
+	routes.List(r.controller.List, corev2.RoleBindingFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:rolebindings}", corev2.RoleBindingFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/roles.go
+++ b/backend/apid/routers/roles.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
@@ -31,8 +32,8 @@ func (r *RolesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.destroy)
 	routes.Get(r.find)
-	routes.List(r.controller.List)
-	routes.ListAllNamespaces(r.controller.List, "/{resource:roles}")
+	routes.List(r.controller.List, corev2.RoleFields)
+	routes.ListAllNamespaces(r.controller.List, "/{resource:roles}", corev2.RoleFields)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 }

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -167,13 +167,13 @@ func (r *ResourceRoute) Get(fn actionHandlerFunc) *mux.Route {
 }
 
 // List resources
-func (r *ResourceRoute) List(fn ListControllerFunc) *mux.Route {
-	return r.Router.HandleFunc(r.PathPrefix, listerHandler(fn)).Methods(http.MethodGet)
+func (r *ResourceRoute) List(fn ListControllerFunc, fields FieldsFunc) *mux.Route {
+	return r.Router.HandleFunc(r.PathPrefix, listerHandler(fn, fields)).Methods(http.MethodGet)
 }
 
 // ListAllNamespaces return all resources across all namespaces
-func (r *ResourceRoute) ListAllNamespaces(fn ListControllerFunc, path string) *mux.Route {
-	return r.Router.HandleFunc(path, listerHandler(fn)).Methods(http.MethodGet)
+func (r *ResourceRoute) ListAllNamespaces(fn ListControllerFunc, path string, fields FieldsFunc) *mux.Route {
+	return r.Router.HandleFunc(path, listerHandler(fn, fields)).Methods(http.MethodGet)
 }
 
 // Post creates

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-// UsersController represents the controller needs of the UsersRouter.
+// UserController represents the controller needs of the UsersRouter.
 type UserController interface {
 	List(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error)
 	Find(ctx context.Context, name string) (*types.User, error)

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -43,7 +43,7 @@ func (r *UsersRouter) Mount(parent *mux.Router) {
 		Router:     parent,
 		PathPrefix: "/{resource:users}",
 	}
-	routes.List(r.controller.List)
+	routes.List(r.controller.List, corev2.UserFields)
 	routes.Get(r.find)
 	routes.Post(r.create)
 	routes.Del(r.destroy)


### PR DESCRIPTION
## What is this change?

This PR adds functions to retrieve fields for resources that can be listed via the REST API.

It also adds an argument to the lister HTTP handler that correspond to these functions signature.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/283.

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope! I hesitated to add a method to the `Resource` interface but I decided against it because it could be considered as a breaking change; third-party code relying on it would break with this change.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not yet.

## How did you verify this change?

Manual testing.
