### PR TITLE
Feature/cluster id hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Added the message bus to Tessend in order to track Tessen configuration changes from the API.
 - Added a performance optimizing `Count()` function to the generic store.
+- Added a hexadecimal Cluster ID title to the `sensuctl cluster health` and
+`sensuctl cluster member-list` commands in tabular format.
+- Added a `Header` field to the `HealthResponse` type returned by `/health`.
 
 ## [5.5.1] - 2019-04-15
 

--- a/api/core/v2/health.go
+++ b/api/core/v2/health.go
@@ -22,12 +22,19 @@ type HealthResponse struct {
 	Alarms []*etcdserverpb.AlarmMember
 	// ClusterHealth is the list of health status for every cluster member.
 	ClusterHealth []*ClusterHealth
+	// Header is the response header for the entire cluster response.
+	Header *etcdserverpb.ResponseHeader
 }
 
 // FixtureHealthResponse returns a HealthResponse fixture for testing.
 func FixtureHealthResponse(healthy bool) *HealthResponse {
 	var err string
-	healthResponse := &HealthResponse{}
+	healthResponse := &HealthResponse{
+		Header: &etcdserverpb.ResponseHeader{
+			ClusterId: uint64(4255616304056076734),
+		},
+	}
+
 	clusterHealth := []*ClusterHealth{}
 	clusterHealth = append(clusterHealth, &ClusterHealth{
 		MemberID: uint64(12345),

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -7,15 +7,12 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
-	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/sensu/sensu-go/types"
 )
 
 // GetClusterHealth retrieves the cluster health
 func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, etcdClientTLSConfig *tls.Config) *types.HealthResponse {
-	healthResponse := &types.HealthResponse{
-		Header: &etcdserverpb.ResponseHeader{},
-	}
+	healthResponse := &types.HealthResponse{}
 
 	// Do a get op against every cluster member. Collect the  memberIDs and
 	// op errors into a response map, and return this map as etcd health

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/sensu/sensu-go/types"
 )
 
 // GetClusterHealth retrieves the cluster health
 func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, etcdClientTLSConfig *tls.Config) *types.HealthResponse {
-	healthResponse := &types.HealthResponse{}
+	healthResponse := &types.HealthResponse{
+		Header: &etcdserverpb.ResponseHeader{},
+	}
 
 	// Do a get op against every cluster member. Collect the  memberIDs and
 	// op errors into a response map, and return this map as etcd health
@@ -22,6 +25,7 @@ func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, 
 		logger.WithError(err).Warning("could not get the cluster member list")
 		return healthResponse
 	}
+	healthResponse.Header = mList.Header
 
 	for _, member := range mList.Members {
 		health := &types.ClusterHealth{

--- a/cli/commands/cluster/health.go
+++ b/cli/commands/cluster/health.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/cli/elements/table"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
@@ -20,6 +21,10 @@ func HealthCommand(cli *cli.SensuCli) *cobra.Command {
 		SilenceUsage: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			result, err := cli.Client.Health()
+			if err != nil {
+				return err
+			}
+			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
 			if err != nil {
 				return err
 			}
@@ -122,4 +127,16 @@ func printAlarmsToTable(result interface{}, w io.Writer) {
 		},
 	})
 	table.Render(w, result)
+}
+
+func printTitleClusterID(v interface{}, writer io.Writer) error {
+	r, ok := v.(*etcdserverpb.ResponseHeader)
+	if !ok {
+		return fmt.Errorf("%t is not a ResponseHeader", v)
+	}
+	cfg := &list.Config{
+		Title: fmt.Sprintf("Cluster ID: %x", r.ClusterId),
+	}
+
+	return list.Print(writer, cfg)
 }

--- a/cli/commands/cluster/health_test.go
+++ b/cli/commands/cluster/health_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
@@ -25,8 +26,13 @@ func TestHealthCommand(t *testing.T) {
 
 func TestHealthCommandAlarmCorrupt(t *testing.T) {
 	assert := assert.New(t)
+	clusterID := uint64(4255616304056076734)
 
-	healthResponse := &types.HealthResponse{}
+	healthResponse := &types.HealthResponse{
+		Header: &etcdserverpb.ResponseHeader{
+			ClusterId: clusterID,
+		},
+	}
 	clusterHealth := []*types.ClusterHealth{}
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
@@ -59,21 +65,28 @@ func TestHealthCommandAlarmCorrupt(t *testing.T) {
 	out, err := test.RunCmd(cmd, []string{})
 	require.NoError(t, err)
 
-	assert.Contains(out, "ID")         // heading
-	assert.Contains(out, "Name")       // heading
-	assert.Contains(out, "Error")      // heading
-	assert.Contains(out, "Healthy")    // heading
-	assert.Contains(out, "Alarm Type") // Heading
-	assert.Contains(out, "true")       // healthy cluster member
-	assert.Contains(out, "false")      // unhealthy cluster member
-	assert.Contains(out, "error")      // cluster error
-	assert.Contains(out, "CORRUPT")    // alarm type
+	assert.Contains(out, "ID")                         // heading
+	assert.Contains(out, "Name")                       // heading
+	assert.Contains(out, "Error")                      // heading
+	assert.Contains(out, "Healthy")                    // heading
+	assert.Contains(out, "Alarm Type")                 // Heading
+	assert.Contains(out, "true")                       // healthy cluster member
+	assert.Contains(out, "false")                      // unhealthy cluster member
+	assert.Contains(out, "error")                      // cluster error
+	assert.Contains(out, "CORRUPT")                    // alarm type
+	assert.Contains(out, "Cluster ID")                 // cluster id title
+	assert.Contains(out, fmt.Sprintf("%x", clusterID)) // cluster id hex
 }
 
 func TestHealthCommandAlarmNoSpace(t *testing.T) {
 	assert := assert.New(t)
+	clusterID := uint64(4255616304056076734)
 
-	healthResponse := &types.HealthResponse{}
+	healthResponse := &types.HealthResponse{
+		Header: &etcdserverpb.ResponseHeader{
+			ClusterId: clusterID,
+		},
+	}
 	clusterHealth := []*types.ClusterHealth{}
 	clusterHealth = append(clusterHealth, &types.ClusterHealth{
 		MemberID: uint64(12345),
@@ -100,12 +113,14 @@ func TestHealthCommandAlarmNoSpace(t *testing.T) {
 	out, err := test.RunCmd(cmd, []string{})
 	require.NoError(t, err)
 
-	assert.Contains(out, "ID")         // heading
-	assert.Contains(out, "Name")       // heading
-	assert.Contains(out, "Error")      // heading
-	assert.Contains(out, "Healthy")    // heading
-	assert.Contains(out, "Alarm Type") // Heading
-	assert.Contains(out, "false")      // unhealthy cluster member
-	assert.Contains(out, "error")      // cluster error
-	assert.Contains(out, "NOSPACE")    // alarm type
+	assert.Contains(out, "ID")                         // heading
+	assert.Contains(out, "Name")                       // heading
+	assert.Contains(out, "Error")                      // heading
+	assert.Contains(out, "Healthy")                    // heading
+	assert.Contains(out, "Alarm Type")                 // Heading
+	assert.Contains(out, "false")                      // unhealthy cluster member
+	assert.Contains(out, "error")                      // cluster error
+	assert.Contains(out, "NOSPACE")                    // alarm type
+	assert.Contains(out, "Cluster ID")                 // cluster id title
+	assert.Contains(out, fmt.Sprintf("%x", clusterID)) // cluster id hex
 }

--- a/cli/commands/cluster/member-list.go
+++ b/cli/commands/cluster/member-list.go
@@ -24,6 +24,10 @@ func MemberListCommand(cli *cli.SensuCli) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error listing cluster members: %s", err)
 			}
+			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
+			if err != nil {
+				return err
+			}
 			return helpers.Print(cmd, cli.Config.Format(), printMemberListToTable, nil, result)
 		},
 	}


### PR DESCRIPTION
## What is this change?

Surfaces the hexadecimal cluster id in `sensuctl cluster health` and `sensuctl cluster member-list`. Adds the cluster response header to the `/health` data type and response.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2870.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1390

## How did you verify this change?
Updated the following test cases
- https://sensuinc.testrail.io/index.php?/cases/view/149
- https://sensuinc.testrail.io/index.php?/cases/view/151
- https://sensuinc.testrail.io/index.php?/cases/view/3842
- https://sensuinc.testrail.io/index.php?/cases/view/5514

**_Before:_**
```
(release-5.5.1)$ curl http://127.0.0.1:8080/health | jq .
{
  "Alarms": null,
  "ClusterHealth": [
    {
      "MemberID": 9882886658148555000,
      "Name": "default",
      "Err": "",
      "Healthy": true
    }
  ]
}
```

```
(release-5.5.1)$ sensuctl cluster health
         ID            Name     Error   Healthy  
 ────────────────── ────────── ─────── ───────── 
  ac6007e1e32e2d19   backend3           true     
  d39305853d0fb740   backend1           true     
  e01784ae8c57bedb   backend2           true     
(release-5.5.1)$ sensuctl cluster member-list
         ID            Name          Peer URLs             Client URLs       
 ────────────────── ────────── ────────────────────── ────────────────────── 
  ac6007e1e32e2d19   backend3   http://backend3:2380   http://backend3:2379  
  d39305853d0fb740   backend1   http://backend1:2380   http://backend1:2379  
  e01784ae8c57bedb   backend2   http://backend2:2380   http://backend2:2379
```

**_After:_**
```
(release-5.6.0)$ curl http://127.0.0.1:8080/health | jq .
{
  "Alarms": null,
  "ClusterHealth": [
    {
      "MemberID": 9882886658148555000,
      "Name": "default",
      "Err": "",
      "Healthy": true
    }
  ],
  "Header": {
    "cluster_id": 4255616304056077000,
    "member_id": 9882886658148555000,
    "raft_term": 26
  }
}
```

```
(release-5.6.0)$ sensuctl cluster health
=== Cluster ID: 11605770c9b38c21
         ID            Name     Error   Healthy  
 ────────────────── ────────── ─────── ───────── 
  ac6007e1e32e2d19   backend3           true     
  d39305853d0fb740   backend1           true     
  e01784ae8c57bedb   backend2           true     
(release-5.6.0)$ sensuctl cluster member-list
=== Cluster ID: 11605770c9b38c21
         ID            Name          Peer URLs             Client URLs       
 ────────────────── ────────── ────────────────────── ────────────────────── 
  ac6007e1e32e2d19   backend3   http://backend3:2380   http://backend3:2379  
  d39305853d0fb740   backend1   http://backend1:2380   http://backend1:2379  
  e01784ae8c57bedb   backend2   http://backend2:2380   http://backend2:2379  
```