### PR TITLE
Add limitd, entitylimiter middleware, and header in list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Added LimitD, a backend daemon that collects and maintains a history of the total entity count.
+- Added EntityLimiter, an API middleware that appends a `Warning` header to all API responses if
+the cluster exceeds the free entity limit, on average.
+- Added the entity limit warning header to all `sensuctl` tabular `list` commands.
+
 ## [5.6.0] - TBD
 
 ### Added

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -29,6 +29,7 @@ import (
 type APId struct {
 	Authenticator *authentication.Authenticator
 	HTTPServer    *http.Server
+	EntityLimiter *limiter.EntityLimiter
 
 	stopping            chan struct{}
 	running             *atomic.Value
@@ -73,6 +74,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		cluster:             c.Cluster,
 		etcdClientTLSConfig: c.EtcdClientTLSConfig,
 		Authenticator:       c.Authenticator,
+		EntityLimiter:       c.EntityLimiter,
 	}
 
 	// prepare TLS configs (both server and client)

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -110,7 +110,7 @@ func TestCheckTypeSilencesField(t *testing.T) {
 		*types.FixtureSilenced("unix:my-check"),
 		*types.FixtureSilenced("fred:my-check"),
 		*types.FixtureSilenced("unix:not-my-check"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &checkImpl{}
 	params := graphql.ResolveParams{}
@@ -132,7 +132,7 @@ func TestCheckTypeRuntimeAssetsField(t *testing.T) {
 		*types.FixtureAsset("one"),
 		*types.FixtureAsset("two"),
 		*types.FixtureAsset("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	// return associated silence
 	impl := &checkImpl{}
@@ -150,7 +150,7 @@ func TestCheckConfigTypeIsSilencedField(t *testing.T) {
 	client.On("ListSilenceds", mock.Anything, "", "", mock.Anything).Return([]types.Silenced{
 		*types.FixtureSilenced("*:my-check"),
 		*types.FixtureSilenced("unix:not-my-check"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &checkCfgImpl{}
 	params := graphql.ResolveParams{}
@@ -175,7 +175,7 @@ func TestCheckConfigTypeSilencesField(t *testing.T) {
 		*types.FixtureSilenced("unix:different-check"),
 		*types.FixtureSilenced("unrelated:my-check"),
 		*types.FixtureSilenced("*:another-check"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &checkCfgImpl{}
 	params := graphql.ResolveParams{}
@@ -197,7 +197,7 @@ func TestCheckConfigTypeRuntimeAssetsField(t *testing.T) {
 		*types.FixtureAsset("one"),
 		*types.FixtureAsset("two"),
 		*types.FixtureAsset("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	// return associated silence
 	impl := &checkCfgImpl{}
@@ -223,7 +223,7 @@ func TestCheckConfigTypeHandlersField(t *testing.T) {
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
 		*types.FixtureHandler("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestCheckTypeHandlersField(t *testing.T) {
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
 		*types.FixtureHandler("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestCheckConfigTypeOutputMetricHandlersField(t *testing.T) {
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
 		*types.FixtureHandler("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	res, err := impl.OutputMetricHandlers(params)
 	require.NoError(t, err)
@@ -292,7 +292,7 @@ func TestCheckTypeOutputMetricHandlersField(t *testing.T) {
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
 		*types.FixtureHandler("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	res, err := impl.OutputMetricHandlers(params)
 	require.NoError(t, err)

--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -35,7 +35,7 @@ func loadAssetsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListAssets(key.String(), client.ListOptions{})
+			records, _, err := c.ListAssets(key.String(), client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -64,7 +64,7 @@ func loadCheckConfigsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListChecks(key.String(), client.ListOptions{})
+			records, _, err := c.ListChecks(key.String(), client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -93,7 +93,7 @@ func loadEntitiesBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListEntities(key.String(), client.ListOptions{})
+			records, _, err := c.ListEntities(key.String(), client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -122,7 +122,7 @@ func loadEventsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListEvents(key.String(), client.ListOptions{})
+			records, _, err := c.ListEvents(key.String(), client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -151,7 +151,7 @@ func loadHandlersBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListHandlers(key.String(), client.ListOptions{})
+			records, _, err := c.ListHandlers(key.String(), client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -180,7 +180,7 @@ func loadNamespacesBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for range keys {
-			records, err := c.ListNamespaces(client.ListOptions{})
+			records, _, err := c.ListNamespaces(client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -209,7 +209,7 @@ func loadSilencedsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListSilenceds(key.String(), "", "", client.ListOptions{})
+			records, _, err := c.ListSilenceds(key.String(), "", "", client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -22,7 +22,7 @@ func TestEntityTypeRelatedField(t *testing.T) {
 		*source,
 		*types.FixtureEntity("a"),
 		*types.FixtureEntity("b"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	params := schema.EntityRelatedFieldResolverParams{}
 	params.Context = contextWithLoaders(context.Background(), client)
@@ -45,7 +45,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 		*types.FixtureEvent(entity.Name, "a"),
 		*types.FixtureEvent(entity.Name, "b"),
 		*types.FixtureEvent(entity.Name, "c"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	// params
 	params := graphql.ResolveParams{}
@@ -64,7 +64,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 	client.On("ListEvents", "sensu", mock.Anything).Return([]types.Event{
 		*types.FixtureEvent(entity.Name, "a"),
 		*failingEv,
-	}, nil).Once()
+	}, "", nil).Once()
 
 	// exit status: 2
 	// params.Context = contextWithLoaders(context.Background(), client)
@@ -96,7 +96,7 @@ func TestEntityTypeEventsField(t *testing.T) {
 		*types.FixtureEvent(entity.Name, "a"),
 		*types.FixtureEvent(entity.Name, "b"),
 		*types.FixtureEvent(entity.Name, "c"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	// params
 	params := schema.EntityEventsFieldResolverParams{}
@@ -120,7 +120,7 @@ func TestEntityTypeSilencesField(t *testing.T) {
 		*types.FixtureSilenced("www:*"),
 		*types.FixtureSilenced("unix:my-check"),
 		*types.FixtureSilenced("entity:unrelated:*"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &entityImpl{}
 	params := graphql.ResolveParams{}
@@ -142,7 +142,7 @@ func TestEntityTypeIsSilencedField(t *testing.T) {
 		*types.FixtureSilenced("entity:en:*"),
 		*types.FixtureSilenced("ou:my-check"),
 		*types.FixtureSilenced("entity:unrelated:*"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &entityImpl{}
 	params := graphql.ResolveParams{}

--- a/backend/apid/graphql/event_test.go
+++ b/backend/apid/graphql/event_test.go
@@ -62,7 +62,7 @@ func TestEventTypeIsSilencedField(t *testing.T) {
 		*types.FixtureSilenced("*:my-check"),
 		*types.FixtureSilenced("unix:not-my-check"),
 		*types.FixtureSilenced("entity:my-entity:*"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &eventImpl{}
 	params := graphql.ResolveParams{}
@@ -89,7 +89,7 @@ func TestEventTypeSilencesField(t *testing.T) {
 		*types.FixtureSilenced("entity:my-entity:my-check"),     // match
 		*types.FixtureSilenced("entity:my-entity:not-my-check"), // not match
 		*types.FixtureSilenced("not-my-subscription:*"),         // not match
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &eventImpl{}
 	params := graphql.ResolveParams{}

--- a/backend/apid/graphql/handler_test.go
+++ b/backend/apid/graphql/handler_test.go
@@ -28,7 +28,7 @@ func TestHandlerTypeHandlersField(t *testing.T) {
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
 		*types.FixtureHandler("three"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -29,7 +29,7 @@ func TestNamespaceTypeCheckHistoryField(t *testing.T) {
 		*types.FixtureEvent("a", "b"),
 		*types.FixtureEvent("b", "c"),
 		*types.FixtureEvent("c", "d"),
-	}, nil).Once()
+	}, "", nil).Once()
 	impl := &namespaceImpl{}
 
 	// Params
@@ -45,7 +45,7 @@ func TestNamespaceTypeCheckHistoryField(t *testing.T) {
 	assert.Len(t, history, 30)
 
 	// store err
-	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{}, errors.New("test"))
+	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{}, "", errors.New("test"))
 	history, err = impl.CheckHistory(params)
 	require.NotNil(t, history)
 	assert.Error(t, err)
@@ -58,7 +58,7 @@ func TestNamespaceTypeSilencesField(t *testing.T) {
 		*types.FixtureSilenced("a:b"),
 		*types.FixtureSilenced("b:c"),
 		*types.FixtureSilenced("c:d"),
-	}, nil).Once()
+	}, "", nil).Once()
 
 	impl := &namespaceImpl{}
 	params := schema.NamespaceSilencesFieldResolverParams{}
@@ -71,7 +71,7 @@ func TestNamespaceTypeSilencesField(t *testing.T) {
 	assert.NotEmpty(t, res)
 
 	// Store err
-	client.On("ListSilenceds", mock.Anything, "", "", mock.Anything).Return([]types.Silenced{}, errors.New("abc"))
+	client.On("ListSilenceds", mock.Anything, "", "", mock.Anything).Return([]types.Silenced{}, "", errors.New("abc"))
 	res, err = impl.Silences(params)
 	assert.Empty(t, res)
 	assert.Error(t, err)

--- a/backend/apid/graphql/viewer_test.go
+++ b/backend/apid/graphql/viewer_test.go
@@ -54,7 +54,7 @@ func TestViewerTypeNamespacesField(t *testing.T) {
 	params.Context = contextWithLoadersNoCache(context.Background(), client)
 
 	// Success
-	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{*nsp}, nil).Once()
+	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{*nsp}, "", nil).Once()
 	res, err := impl.Namespaces(params)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)

--- a/backend/apid/middlewares/entity_limiter.go
+++ b/backend/apid/middlewares/entity_limiter.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+
+	"github.com/sensu/sensu-go/backend/limiter"
+)
+
+// HeaderWarning is the header key for entity limit warnings
+const HeaderWarning = "Warning"
+
+// EntityLimiter is an HTTP middleware that surfaces warnings
+// about entity limits.
+type EntityLimiter struct {
+	Limiter *limiter.EntityLimiter
+}
+
+// Then middleware
+func (e EntityLimiter) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entityLimit := e.Limiter.Limit()
+		entityCount := math.Floor(average(e.Limiter.CountHistory()))
+		if entityCount > float64(entityLimit) {
+			w.Header().Set(HeaderWarning, fmt.Sprintf("You have exceeded the entity limit of %d for the free tier of Sensu Go: %d entities", entityLimit, int(entityCount)))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func average(history []int) float64 {
+	var total float64
+	for _, value := range history {
+		total += float64(value)
+	}
+	return total / float64(len(history))
+}

--- a/backend/apid/middlewares/entity_limiter.go
+++ b/backend/apid/middlewares/entity_limiter.go
@@ -22,7 +22,7 @@ func (e EntityLimiter) Then(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !e.Limiter.License() {
 			entityLimit := e.Limiter.Limit()
-			entityCount := math.Floor(average(e.Limiter.CountHistory()))
+			entityCount := math.Floor(Average(e.Limiter.CountHistory()))
 			if entityCount > float64(entityLimit) {
 				w.Header().Set(HeaderWarning, fmt.Sprintf("You have exceeded the entity limit of %d for the free tier of Sensu Go: %d entities", entityLimit, int(entityCount)))
 			}
@@ -31,7 +31,8 @@ func (e EntityLimiter) Then(next http.Handler) http.Handler {
 	})
 }
 
-func average(history []int) float64 {
+// Average calculates the average value of a count history.
+func Average(history []int) float64 {
 	var total float64
 	for _, value := range history {
 		total += float64(value)

--- a/backend/apid/middlewares/entity_limiter.go
+++ b/backend/apid/middlewares/entity_limiter.go
@@ -20,18 +20,15 @@ type EntityLimiter struct {
 // Then middleware
 func (e EntityLimiter) Then(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		e.LimitHeader(w)
+		if !e.Limiter.License() {
+			entityLimit := e.Limiter.Limit()
+			entityCount := math.Floor(average(e.Limiter.CountHistory()))
+			if entityCount > float64(entityLimit) {
+				w.Header().Set(HeaderWarning, fmt.Sprintf("You have exceeded the entity limit of %d for the free tier of Sensu Go: %d entities", entityLimit, int(entityCount)))
+			}
+		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-// LimitHeader calculates if the entity limit has been reached and appends a warning header.
-func (e EntityLimiter) LimitHeader(w http.ResponseWriter) {
-	entityLimit := e.Limiter.Limit()
-	entityCount := math.Floor(average(e.Limiter.CountHistory()))
-	if entityCount > float64(entityLimit) {
-		w.Header().Set(HeaderWarning, fmt.Sprintf("You have exceeded the entity limit of %d for the free tier of Sensu Go: %d entities", entityLimit, int(entityCount)))
-	}
 }
 
 func average(history []int) float64 {

--- a/backend/apid/middlewares/entity_limiter_test.go
+++ b/backend/apid/middlewares/entity_limiter_test.go
@@ -1,0 +1,56 @@
+package middlewares
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/limiter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddlewareEntityLimit(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		description string
+		entities    int
+		header      bool
+	}{
+		{
+			description: "Entities over limit",
+			entities:    1500,
+			header:      true,
+		}, {
+			description: "Entities under limit",
+			entities:    500,
+			header:      false,
+		}, {
+			description: "Entities at limit",
+			entities:    1000,
+			header:      false,
+		},
+	}
+
+	mware := EntityLimiter{
+		Limiter: limiter.NewEntityLimiter(),
+	}
+	server := httptest.NewServer(mware.Then(testHandler()))
+	defer server.Close()
+
+	for _, tc := range tests {
+		for i := 0; i < 12; i++ {
+			mware.Limiter.AddCount(tc.entities)
+		}
+		req, _ := http.NewRequest(http.MethodPost, server.URL+"/health", bytes.NewBuffer([]byte{}))
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(err)
+		assert.Equal(http.StatusOK, res.StatusCode, tc.description)
+		if tc.header {
+			assert.Contains(res.Header.Get(HeaderWarning), "You have exceeded the entity limit", tc.description)
+		} else {
+			assert.Empty(res.Header.Get(HeaderWarning), tc.description)
+		}
+	}
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -223,7 +223,7 @@ func Initialize(config *Config) (*Backend, error) {
 	}
 	authenticator.AddProvider(basic)
 
-	entityLimiter := limiter.NewEntityLimiter()
+	entityLimiter := limiter.NewEntityLimiter(b.ctx, b.Client)
 
 	// Initialize apid
 	api, err := apid.New(apid.Config{

--- a/backend/limitd/LICENSE
+++ b/backend/limitd/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/limitd/limitd.go
+++ b/backend/limitd/limitd.go
@@ -74,7 +74,7 @@ func (t *Limitd) Err() <-chan error {
 
 // Name returns the daemon name.
 func (t *Limitd) Name() string {
-	return "limitd"
+	return componentName
 }
 
 // start starts a loop to periodically update entity count and history.

--- a/backend/limitd/limitd.go
+++ b/backend/limitd/limitd.go
@@ -1,0 +1,105 @@
+package limitd
+
+import (
+	"context"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/limiter"
+	"github.com/sensu/sensu-go/backend/store/etcd"
+)
+
+const (
+	// componentName identifies LimitD as the component/daemon implemented in this package.
+	componentName = "limitd"
+
+	// interval is the interval, in seconds, that LimitD will update the entity count.
+	interval = 300 * time.Second
+)
+
+// Limitd is the limit daemon.
+type Limitd struct {
+	interval      time.Duration
+	client        *clientv3.Client
+	ctx           context.Context
+	cancel        context.CancelFunc
+	errChan       chan error
+	entityLimiter *limiter.EntityLimiter
+}
+
+// Option is a functional option.
+type Option func(*Limitd) error
+
+// Config configures Limitd.
+type Config struct {
+	Client        *clientv3.Client
+	EntityLimiter *limiter.EntityLimiter
+}
+
+// New creates a new Limitd.
+func New(c Config, opts ...Option) (*Limitd, error) {
+	t := &Limitd{
+		interval:      interval,
+		client:        c.Client,
+		errChan:       make(chan error, 1),
+		entityLimiter: c.EntityLimiter,
+	}
+	t.ctx, t.cancel = context.WithCancel(context.Background())
+
+	return t, nil
+}
+
+// Start the limit daemon.
+func (t *Limitd) Start() error {
+	if err := t.ctx.Err(); err != nil {
+		return err
+	}
+
+	go t.start()
+
+	return nil
+}
+
+// Stop the limit daemon.
+func (t *Limitd) Stop() error {
+	t.cancel()
+	close(t.errChan)
+	return nil
+}
+
+// Err returns a channel on which to listen for terminal errors.
+func (t *Limitd) Err() <-chan error {
+	return t.errChan
+}
+
+// Name returns the daemon name.
+func (t *Limitd) Name() string {
+	return "limitd"
+}
+
+// start starts a loop to periodically update entity count and history.
+func (t *Limitd) start() {
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+	t.count()
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case <-ticker.C:
+			t.count()
+		}
+	}
+}
+
+// count collects the total number of entities and adds the entry
+// to the entity limiter history.
+func (t *Limitd) count() {
+	entities, err := etcd.Count(t.ctx, t.client, etcd.GetEntitiesPath(t.ctx, ""))
+	if err != nil {
+		logger.WithError(err).Error("unable to retrieve entity count")
+		return
+	}
+	logger.WithField("entities", entities).Debug("counted total number of entities")
+	t.entityLimiter.AddCount(int(entities))
+}

--- a/backend/limitd/limitd_test.go
+++ b/backend/limitd/limitd_test.go
@@ -3,6 +3,7 @@
 package limitd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/etcd"
@@ -23,7 +24,7 @@ func newLimitdTest(t *testing.T) *Limitd {
 
 	limitd, err := New(Config{
 		Client:        client,
-		EntityLimiter: limiter.NewEntityLimiter(),
+		EntityLimiter: limiter.NewEntityLimiter(context.Background(), client),
 	})
 	require.NoError(t, err)
 	return limitd

--- a/backend/limitd/limitd_test.go
+++ b/backend/limitd/limitd_test.go
@@ -1,0 +1,37 @@
+// +build integration,!race
+
+package limitd
+
+import (
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sensu/sensu-go/backend/limiter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLimitdTest(t *testing.T) *Limitd {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	limitd, err := New(Config{
+		Client:        client,
+		EntityLimiter: limiter.NewEntityLimiter(),
+	})
+	require.NoError(t, err)
+	return limitd
+}
+
+func TestLimitd(t *testing.T) {
+	limitd := newLimitdTest(t)
+	require.NoError(t, limitd.Start())
+	assert.NoError(t, limitd.Stop())
+	assert.Equal(t, limitd.Name(), "limitd")
+}

--- a/backend/limitd/limitd_test.go
+++ b/backend/limitd/limitd_test.go
@@ -33,5 +33,5 @@ func TestLimitd(t *testing.T) {
 	limitd := newLimitdTest(t)
 	require.NoError(t, limitd.Start())
 	assert.NoError(t, limitd.Stop())
-	assert.Equal(t, limitd.Name(), "limitd")
+	assert.Equal(t, limitd.Name(), componentName)
 }

--- a/backend/limitd/logger.go
+++ b/backend/limitd/logger.go
@@ -3,5 +3,5 @@ package limitd
 import "github.com/sirupsen/logrus"
 
 var logger = logrus.WithFields(logrus.Fields{
-	"component": "limitd",
+	"component": componentName,
 })

--- a/backend/limitd/logger.go
+++ b/backend/limitd/logger.go
@@ -1,0 +1,7 @@
+package limitd
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "limitd",
+})

--- a/backend/limiter/LICENSE
+++ b/backend/limiter/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/backend/limiter/limiter.go
+++ b/backend/limiter/limiter.go
@@ -50,11 +50,7 @@ func (e *EntityLimiter) Limit() int {
 // License returns a bool indicating the presence of a license.
 func (e *EntityLimiter) License() bool {
 	wrapper := &tessend.Wrapper{}
-	err := etcd.Get(e.ctx, e.client, tessend.LicenseStorePath, wrapper)
-	if err != nil {
-		return false
-	}
-	return true
+	return etcd.Get(e.ctx, e.client, tessend.LicenseStorePath, wrapper) == nil
 }
 
 // CountHistory returns the count history.

--- a/backend/limiter/limiter.go
+++ b/backend/limiter/limiter.go
@@ -1,0 +1,55 @@
+package limiter
+
+import (
+	"sync"
+)
+
+const (
+	// entityLimit is the limit of the total number of entities in a cluster.
+	entityLimit = 1000
+
+	// entityHistorySize is the maximum number of counts the entity history should store.
+	entityHistorySize = 12
+)
+
+// Limiter specifies the Limiter interface.
+type Limiter interface {
+	Limit() int
+	CountHistory() []int
+	AddCount(int)
+}
+
+// EntityLimiter contains the entity count history.
+type EntityLimiter struct {
+	entityCountHistory []int
+	mu                 sync.Mutex
+}
+
+// NewEntityLimiter instantiates a new EntityLimiter.
+func NewEntityLimiter() *EntityLimiter {
+	return &EntityLimiter{
+		entityCountHistory: []int{},
+	}
+}
+
+// Limit returns the entity limit.
+func (e *EntityLimiter) Limit() int {
+	return entityLimit
+}
+
+// CountHistory returns the count history.
+func (e *EntityLimiter) CountHistory() []int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.entityCountHistory
+}
+
+// AddCount appends a new entity count to the entity history.
+func (e *EntityLimiter) AddCount(i int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.entityCountHistory = append(e.entityCountHistory, i)
+	if len(e.entityCountHistory) > entityHistorySize {
+		e.entityCountHistory = e.entityCountHistory[1:]
+	}
+}

--- a/backend/limiter/limiter_test.go
+++ b/backend/limiter/limiter_test.go
@@ -1,0 +1,22 @@
+package limiter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+	limiter := NewEntityLimiter()
+	assert.NotEmpty(t, limiter)
+	assert.Equal(t, entityLimit, limiter.Limit())
+	assert.Equal(t, 0, len(limiter.CountHistory()))
+	for i := 0; i < 12; i++ {
+		limiter.AddCount(i)
+	}
+	assert.Equal(t, 12, len(limiter.CountHistory()))
+	assert.Equal(t, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, limiter.CountHistory())
+	limiter.AddCount(99)
+	assert.Equal(t, 12, len(limiter.CountHistory()))
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 99}, limiter.CountHistory())
+}

--- a/backend/limiter/limiter_test.go
+++ b/backend/limiter/limiter_test.go
@@ -1,13 +1,24 @@
 package limiter
 
 import (
+	"context"
 	"testing"
 
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLimiter(t *testing.T) {
-	limiter := NewEntityLimiter()
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client, err := e.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	limiter := NewEntityLimiter(context.Background(), client)
 	assert.NotEmpty(t, limiter)
 	assert.Equal(t, entityLimit, limiter.Limit())
 	assert.Equal(t, 0, len(limiter.CountHistory()))

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -5,7 +5,8 @@ import (
 )
 
 const (
-	licenseStorePath = "/sensu.io/api/enterprise/licensing/v2/license"
+	// LicenseStorePath is the enterprise path to the license.
+	LicenseStorePath = "/sensu.io/api/enterprise/licensing/v2/license"
 )
 
 // Data is the payload sent to tessen

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -307,7 +307,7 @@ func (t *Tessend) enabled(tessen *corev2.TessenConfig) bool {
 	}
 
 	wrapper := &Wrapper{}
-	err := etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
+	err := etcd.Get(t.ctx, t.client, LicenseStorePath, wrapper)
 	if err != nil {
 		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out, patiently waiting for you to opt back in")
 	} else {
@@ -376,7 +376,7 @@ func (t *Tessend) getDataPayload() *Data {
 
 	// collect license information
 	wrapper := &Wrapper{}
-	err = etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
+	err = etcd.Get(t.ctx, t.client, LicenseStorePath, wrapper)
 	if err != nil {
 		logger.WithError(err).Debug("unable to retrieve license")
 	}

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -11,8 +11,9 @@ import (
 var assetsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "assets")
 
 // ListAssets fetches a list of asset resources from the backend
-func (client *RestClient) ListAssets(namespace string, options ListOptions) ([]corev2.Asset, error) {
+func (client *RestClient) ListAssets(namespace string, options ListOptions) ([]corev2.Asset, string, error) {
 	var assets []corev2.Asset
+	var header string
 
 	path := assetsPath(namespace)
 	request := client.R()
@@ -21,15 +22,17 @@ func (client *RestClient) ListAssets(namespace string, options ListOptions) ([]c
 
 	res, err := request.Get(path)
 	if err != nil {
-		return assets, err
+		return assets, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return assets, UnmarshalError(res)
+		return assets, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &assets)
-	return assets, err
+	return assets, header, err
 }
 
 // FetchAsset fetches an asset resource from the backend

--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -95,8 +95,9 @@ func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
 }
 
 // ListChecks fetches all checks from configured Sensu instance
-func (client *RestClient) ListChecks(namespace string, options ListOptions) ([]corev2.CheckConfig, error) {
+func (client *RestClient) ListChecks(namespace string, options ListOptions) ([]corev2.CheckConfig, string, error) {
 	var checks []corev2.CheckConfig
+	var header string
 
 	path := checksPath(namespace)
 	request := client.R()
@@ -105,15 +106,17 @@ func (client *RestClient) ListChecks(namespace string, options ListOptions) ([]c
 
 	res, err := request.Get(path)
 	if err != nil {
-		return checks, err
+		return checks, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return checks, UnmarshalError(res)
+		return checks, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &checks)
-	return checks, err
+	return checks, header, err
 }
 
 // AddCheckHook associates an existing hook with an existing check

--- a/cli/client/clusterrole.go
+++ b/cli/client/clusterrole.go
@@ -27,12 +27,14 @@ func (client *RestClient) FetchClusterRole(name string) (*types.ClusterRole, err
 }
 
 // ListClusterRoles within the namespace
-func (client *RestClient) ListClusterRoles(options ListOptions) ([]corev2.ClusterRole, error) {
+func (client *RestClient) ListClusterRoles(options ListOptions) ([]corev2.ClusterRole, string, error) {
+	var header string
 	clusterRoles := []corev2.ClusterRole{}
 
-	if err := client.List(clusterRolesPath(), &clusterRoles, options); err != nil {
-		return clusterRoles, err
+	header, err := client.List(clusterRolesPath(), &clusterRoles, options)
+	if err != nil {
+		return clusterRoles, header, err
 	}
 
-	return clusterRoles, nil
+	return clusterRoles, header, nil
 }

--- a/cli/client/clusterrolebinding.go
+++ b/cli/client/clusterrolebinding.go
@@ -26,13 +26,15 @@ func (client *RestClient) FetchClusterRoleBinding(name string) (*types.ClusterRo
 	return clusterRoleBinding, nil
 }
 
-// ListClusterRoleBinding in the cluster
-func (client *RestClient) ListClusterRoleBindings(options ListOptions) ([]corev2.ClusterRoleBinding, error) {
+// ListClusterRoleBindings in the cluster
+func (client *RestClient) ListClusterRoleBindings(options ListOptions) ([]corev2.ClusterRoleBinding, string, error) {
+	var header string
 	clusterRoleBindings := []corev2.ClusterRoleBinding{}
 
-	if err := client.List(clusterRoleBindingsPath(), &clusterRoleBindings, options); err != nil {
-		return clusterRoleBindings, err
+	header, err := client.List(clusterRoleBindingsPath(), &clusterRoleBindings, options)
+	if err != nil {
+		return clusterRoleBindings, header, err
 	}
 
-	return clusterRoleBindings, nil
+	return clusterRoleBindings, header, nil
 }

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -33,8 +33,9 @@ func (client *RestClient) FetchEntity(name string) (*types.Entity, error) {
 }
 
 // ListEntities fetches all entities from configured Sensu instance
-func (client *RestClient) ListEntities(namespace string, options ListOptions) ([]corev2.Entity, error) {
+func (client *RestClient) ListEntities(namespace string, options ListOptions) ([]corev2.Entity, string, error) {
 	var entities []corev2.Entity
+	var header string
 
 	path := entitiesPath(namespace)
 	request := client.R()
@@ -43,15 +44,17 @@ func (client *RestClient) ListEntities(namespace string, options ListOptions) ([
 
 	res, err := request.Get(path)
 	if err != nil {
-		return entities, err
+		return entities, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return entities, UnmarshalError(res)
+		return entities, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &entities)
-	return entities, err
+	return entities, header, err
 }
 
 // UpdateEntity updates given entity on configured Sensu instance

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -29,8 +29,9 @@ func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error)
 }
 
 // ListEvents fetches events from Sensu API
-func (client *RestClient) ListEvents(namespace string, options ListOptions) ([]corev2.Event, error) {
+func (client *RestClient) ListEvents(namespace string, options ListOptions) ([]corev2.Event, string, error) {
 	var events []corev2.Event
+	var header string
 
 	path := eventsPath(namespace)
 	request := client.R()
@@ -39,15 +40,17 @@ func (client *RestClient) ListEvents(namespace string, options ListOptions) ([]c
 
 	res, err := request.Get(path)
 	if err != nil {
-		return events, err
+		return events, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return nil, UnmarshalError(res)
+		return nil, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &events)
-	return events, err
+	return events, header, err
 }
 
 // DeleteEvent deletes an event.

--- a/cli/client/extension.go
+++ b/cli/client/extension.go
@@ -11,8 +11,9 @@ import (
 var extPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "extensions")
 
 // ListExtensions retrieves a list of extension resources from the backend
-func (client *RestClient) ListExtensions(namespace string, options ListOptions) ([]corev2.Extension, error) {
+func (client *RestClient) ListExtensions(namespace string, options ListOptions) ([]corev2.Extension, string, error) {
 	var extensions []corev2.Extension
+	var header string
 
 	path := extPath(namespace)
 	request := client.R()
@@ -21,15 +22,17 @@ func (client *RestClient) ListExtensions(namespace string, options ListOptions) 
 
 	res, err := request.Get(path)
 	if err != nil {
-		return extensions, err
+		return extensions, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return extensions, fmt.Errorf("%v", res.String())
+		return extensions, header, fmt.Errorf("%v", res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &extensions)
-	return extensions, err
+	return extensions, header, err
 }
 
 // DeregisterExtension deregisters an extension resource from the backend

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -55,8 +55,9 @@ func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 }
 
 // ListFilters fetches all filters from configured Sensu instance
-func (client *RestClient) ListFilters(namespace string, options ListOptions) ([]corev2.EventFilter, error) {
+func (client *RestClient) ListFilters(namespace string, options ListOptions) ([]corev2.EventFilter, string, error) {
 	var filters []corev2.EventFilter
+	var header string
 
 	path := filtersPath(namespace)
 	request := client.R()
@@ -65,15 +66,17 @@ func (client *RestClient) ListFilters(namespace string, options ListOptions) ([]
 
 	res, err := request.Get(path)
 	if err != nil {
-		return filters, err
+		return filters, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return filters, UnmarshalError(res)
+		return filters, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &filters)
-	return filters, err
+	return filters, header, err
 }
 
 // UpdateFilter updates an existing filter with fields from a new one.

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -11,8 +11,9 @@ import (
 var handlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
 
 // ListHandlers fetches all handlers from configured Sensu instance
-func (client *RestClient) ListHandlers(namespace string, options ListOptions) ([]corev2.Handler, error) {
+func (client *RestClient) ListHandlers(namespace string, options ListOptions) ([]corev2.Handler, string, error) {
 	var handlers []corev2.Handler
+	var header string
 
 	path := handlersPath(namespace)
 	request := client.R()
@@ -21,15 +22,17 @@ func (client *RestClient) ListHandlers(namespace string, options ListOptions) ([
 
 	res, err := request.Get(path)
 	if err != nil {
-		return handlers, err
+		return handlers, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return handlers, UnmarshalError(res)
+		return handlers, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &handlers)
-	return handlers, err
+	return handlers, header, err
 }
 
 // CreateHandler creates new handler on configured Sensu instance

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -73,8 +73,9 @@ func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
 }
 
 // ListHooks fetches all hooks from configured Sensu instance
-func (client *RestClient) ListHooks(namespace string, options ListOptions) ([]corev2.HookConfig, error) {
+func (client *RestClient) ListHooks(namespace string, options ListOptions) ([]corev2.HookConfig, string, error) {
 	var hooks []corev2.HookConfig
+	var header string
 
 	path := hooksPath(namespace)
 	request := client.R()
@@ -83,13 +84,15 @@ func (client *RestClient) ListHooks(namespace string, options ListOptions) ([]co
 
 	res, err := request.Get(path)
 	if err != nil {
-		return hooks, err
+		return hooks, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return hooks, UnmarshalError(res)
+		return hooks, header, UnmarshalError(res)
 	}
 
 	err = json.Unmarshal(res.Body(), &hooks)
-	return hooks, err
+	return hooks, header, err
 }

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -46,7 +46,7 @@ type GenericClient interface {
 	// Get retrieves the key at the given path and stores it into obj
 	Get(path string, obj interface{}) error
 	// List retrieves all keys with the given path prefix and stores them into objs
-	List(path string, objs interface{}, options ListOptions) error
+	List(path string, objs interface{}, options ListOptions) (string, error)
 	// Post creates the given obj at the specified path
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
@@ -69,7 +69,7 @@ type AssetAPIClient interface {
 	CreateAsset(*types.Asset) error
 	UpdateAsset(*types.Asset) error
 	FetchAsset(string) (*types.Asset, error)
-	ListAssets(string, ListOptions) ([]types.Asset, error)
+	ListAssets(string, ListOptions) ([]types.Asset, string, error)
 }
 
 // CheckAPIClient client methods for checks
@@ -78,7 +78,7 @@ type CheckAPIClient interface {
 	DeleteCheck(string, string) error
 	ExecuteCheck(*types.AdhocRequest) error
 	FetchCheck(string) (*types.CheckConfig, error)
-	ListChecks(string, ListOptions) ([]types.CheckConfig, error)
+	ListChecks(string, ListOptions) ([]types.CheckConfig, string, error)
 	UpdateCheck(*types.CheckConfig) error
 
 	AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error
@@ -90,7 +90,7 @@ type ClusterRoleAPIClient interface {
 	CreateClusterRole(*types.ClusterRole) error
 	DeleteClusterRole(string) error
 	FetchClusterRole(string) (*types.ClusterRole, error)
-	ListClusterRoles(ListOptions) ([]types.ClusterRole, error)
+	ListClusterRoles(ListOptions) ([]types.ClusterRole, string, error)
 }
 
 // ClusterRoleBindingAPIClient client methods for cluster role bindings
@@ -98,7 +98,7 @@ type ClusterRoleBindingAPIClient interface {
 	CreateClusterRoleBinding(*types.ClusterRoleBinding) error
 	DeleteClusterRoleBinding(string) error
 	FetchClusterRoleBinding(string) (*types.ClusterRoleBinding, error)
-	ListClusterRoleBindings(ListOptions) ([]types.ClusterRoleBinding, error)
+	ListClusterRoleBindings(ListOptions) ([]types.ClusterRoleBinding, string, error)
 }
 
 // EntityAPIClient client methods for entities
@@ -106,7 +106,7 @@ type EntityAPIClient interface {
 	CreateEntity(entity *types.Entity) error
 	DeleteEntity(string, string) error
 	FetchEntity(ID string) (*types.Entity, error)
-	ListEntities(string, ListOptions) ([]types.Entity, error)
+	ListEntities(string, ListOptions) ([]types.Entity, string, error)
 	UpdateEntity(entity *types.Entity) error
 }
 
@@ -115,14 +115,14 @@ type FilterAPIClient interface {
 	CreateFilter(*types.EventFilter) error
 	DeleteFilter(string, string) error
 	FetchFilter(string) (*types.EventFilter, error)
-	ListFilters(string, ListOptions) ([]types.EventFilter, error)
+	ListFilters(string, ListOptions) ([]types.EventFilter, string, error)
 	UpdateFilter(*types.EventFilter) error
 }
 
 // EventAPIClient client methods for events
 type EventAPIClient interface {
 	FetchEvent(string, string) (*types.Event, error)
-	ListEvents(string, ListOptions) ([]corev2.Event, error)
+	ListEvents(string, ListOptions) ([]corev2.Event, string, error)
 
 	// DeleteEvent deletes the event identified by entity, check.
 	DeleteEvent(namespace, entity, check string) error
@@ -132,7 +132,7 @@ type EventAPIClient interface {
 
 // ExtensionAPIClient client methods for extensions
 type ExtensionAPIClient interface {
-	ListExtensions(namespace string, options ListOptions) ([]types.Extension, error)
+	ListExtensions(namespace string, options ListOptions) ([]types.Extension, string, error)
 	RegisterExtension(*types.Extension) error
 	DeregisterExtension(name, namespace string) error
 }
@@ -141,7 +141,7 @@ type ExtensionAPIClient interface {
 type HandlerAPIClient interface {
 	CreateHandler(*types.Handler) error
 	DeleteHandler(string, string) error
-	ListHandlers(string, ListOptions) ([]types.Handler, error)
+	ListHandlers(string, ListOptions) ([]types.Handler, string, error)
 	FetchHandler(string) (*types.Handler, error)
 	UpdateHandler(*types.Handler) error
 }
@@ -157,13 +157,13 @@ type HookAPIClient interface {
 	UpdateHook(*types.HookConfig) error
 	DeleteHook(string, string) error
 	FetchHook(string) (*types.HookConfig, error)
-	ListHooks(string, ListOptions) ([]types.HookConfig, error)
+	ListHooks(string, ListOptions) ([]types.HookConfig, string, error)
 }
 
 // MutatorAPIClient client methods for mutators
 type MutatorAPIClient interface {
 	CreateMutator(*types.Mutator) error
-	ListMutators(string, ListOptions) ([]types.Mutator, error)
+	ListMutators(string, ListOptions) ([]types.Mutator, string, error)
 	DeleteMutator(string, string) error
 	FetchMutator(string) (*types.Mutator, error)
 	UpdateMutator(*types.Mutator) error
@@ -174,7 +174,7 @@ type NamespaceAPIClient interface {
 	CreateNamespace(*types.Namespace) error
 	UpdateNamespace(*types.Namespace) error
 	DeleteNamespace(string) error
-	ListNamespaces(ListOptions) ([]types.Namespace, error)
+	ListNamespaces(ListOptions) ([]types.Namespace, string, error)
 	FetchNamespace(string) (*types.Namespace, error)
 }
 
@@ -184,7 +184,7 @@ type UserAPIClient interface {
 	CreateUser(*types.User) error
 	DisableUser(string) error
 	FetchUser(string) (*types.User, error)
-	ListUsers(ListOptions) ([]types.User, error)
+	ListUsers(ListOptions) ([]types.User, string, error)
 	ReinstateUser(string) error
 	RemoveGroupFromUser(string, string) error
 	RemoveAllGroupsFromUser(string) error
@@ -197,7 +197,7 @@ type RoleAPIClient interface {
 	CreateRole(*types.Role) error
 	DeleteRole(string, string) error
 	FetchRole(string) (*types.Role, error)
-	ListRoles(string, ListOptions) ([]types.Role, error)
+	ListRoles(string, ListOptions) ([]types.Role, string, error)
 }
 
 // RoleBindingAPIClient client methods for role bindings
@@ -205,7 +205,7 @@ type RoleBindingAPIClient interface {
 	CreateRoleBinding(*types.RoleBinding) error
 	DeleteRoleBinding(string, string) error
 	FetchRoleBinding(string) (*types.RoleBinding, error)
-	ListRoleBindings(string, ListOptions) ([]types.RoleBinding, error)
+	ListRoleBindings(string, ListOptions) ([]types.RoleBinding, string, error)
 }
 
 // SilencedAPIClient client methods for silenced
@@ -218,7 +218,7 @@ type SilencedAPIClient interface {
 
 	// ListSilenceds lists all silenced entries, optionally constraining by
 	// subscription or check.
-	ListSilenceds(namespace, subscription, check string, options ListOptions) ([]types.Silenced, error)
+	ListSilenceds(namespace, subscription, check string, options ListOptions) ([]types.Silenced, string, error)
 
 	// FetchSilenced fetches the silenced entry by ID.
 	FetchSilenced(id string) (*types.Silenced, error)
@@ -230,7 +230,7 @@ type SilencedAPIClient interface {
 // ClusterMemberClient specifies client methods for cluster membership management
 type ClusterMemberClient interface {
 	// MemberList lists cluster members
-	MemberList() (*clientv3.MemberListResponse, error)
+	MemberList() (*clientv3.MemberListResponse, string, error)
 
 	// MemberAdd adds a cluster member
 	MemberAdd(peerAddrs []string) (*clientv3.MemberAddResponse, error)

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -11,8 +11,9 @@ import (
 var mutatorsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "mutators")
 
 // ListMutators fetches all mutators from the configured Sensu instance
-func (client *RestClient) ListMutators(namespace string, options ListOptions) ([]corev2.Mutator, error) {
+func (client *RestClient) ListMutators(namespace string, options ListOptions) ([]corev2.Mutator, string, error) {
 	var mutators []corev2.Mutator
+	var header string
 
 	path := mutatorsPath(namespace)
 	request := client.R()
@@ -21,15 +22,17 @@ func (client *RestClient) ListMutators(namespace string, options ListOptions) ([
 
 	res, err := request.Get(path)
 	if err != nil {
-		return mutators, err
+		return mutators, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return mutators, fmt.Errorf("%v", res.String())
+		return mutators, header, fmt.Errorf("%v", res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &mutators)
-	return mutators, err
+	return mutators, header, err
 }
 
 // CreateMutator creates new mutator on the configured Sensu instance

--- a/cli/client/namespace.go
+++ b/cli/client/namespace.go
@@ -57,8 +57,9 @@ func (client *RestClient) DeleteNamespace(namespace string) error {
 }
 
 // ListNamespaces fetches all namespaces from configured Sensu instance
-func (client *RestClient) ListNamespaces(options ListOptions) ([]corev2.Namespace, error) {
+func (client *RestClient) ListNamespaces(options ListOptions) ([]corev2.Namespace, string, error) {
 	var namespaces []corev2.Namespace
+	var header string
 
 	path := namespacesPath()
 	request := client.R()
@@ -67,15 +68,17 @@ func (client *RestClient) ListNamespaces(options ListOptions) ([]corev2.Namespac
 
 	res, err := request.Get(path)
 	if err != nil {
-		return namespaces, err
+		return namespaces, header, err
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	if res.StatusCode() >= 400 {
-		return namespaces, fmt.Errorf("%v", res.String())
+		return namespaces, header, fmt.Errorf("%v", res.String())
 	}
 
 	err = json.Unmarshal(res.Body(), &namespaces)
-	return namespaces, err
+	return namespaces, header, err
 }
 
 // FetchNamespace fetches an namespace by name

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -27,12 +27,14 @@ func (client *RestClient) FetchRole(name string) (*types.Role, error) {
 }
 
 // ListRoles lists the roles within the given namespace.
-func (client *RestClient) ListRoles(namespace string, options ListOptions) ([]corev2.Role, error) {
+func (client *RestClient) ListRoles(namespace string, options ListOptions) ([]corev2.Role, string, error) {
+	var header string
 	roles := []corev2.Role{}
 
-	if err := client.List(rolesPath(namespace), &roles, options); err != nil {
-		return roles, err
+	header, err := client.List(rolesPath(namespace), &roles, options)
+	if err != nil {
+		return roles, header, err
 	}
 
-	return roles, nil
+	return roles, header, nil
 }

--- a/cli/client/rolebinding.go
+++ b/cli/client/rolebinding.go
@@ -27,12 +27,14 @@ func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, err
 }
 
 // ListRoleBindings lists the role bindings within the given namespace.
-func (client *RestClient) ListRoleBindings(namespace string, options ListOptions) ([]corev2.RoleBinding, error) {
+func (client *RestClient) ListRoleBindings(namespace string, options ListOptions) ([]corev2.RoleBinding, string, error) {
+	var header string
 	roleBindings := []corev2.RoleBinding{}
 
-	if err := client.List(roleBindingsPath(namespace), &roleBindings, options); err != nil {
-		return roleBindings, err
+	header, err := client.List(roleBindingsPath(namespace), &roleBindings, options)
+	if err != nil {
+		return roleBindings, header, err
 	}
 
-	return roleBindings, nil
+	return roleBindings, header, nil
 }

--- a/cli/client/testing/mock_asset_client.go
+++ b/cli/client/testing/mock_asset_client.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ListAssets for use with mock lib
-func (c *MockClient) ListAssets(namespace string, options client.ListOptions) ([]corev2.Asset, error) {
+func (c *MockClient) ListAssets(namespace string, options client.ListOptions) ([]corev2.Asset, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Asset), args.Error(1)
+	return args.Get(0).([]corev2.Asset), args.Get(1).(string), args.Error(2)
 }
 
 // FetchAsset for use with mock lib

--- a/cli/client/testing/mock_check_client.go
+++ b/cli/client/testing/mock_check_client.go
@@ -38,9 +38,9 @@ func (c *MockClient) FetchCheck(name string) (*types.CheckConfig, error) {
 }
 
 // ListChecks for use with mock lib
-func (c *MockClient) ListChecks(namespace string, options client.ListOptions) ([]corev2.CheckConfig, error) {
+func (c *MockClient) ListChecks(namespace string, options client.ListOptions) ([]corev2.CheckConfig, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.CheckConfig), args.Error(1)
+	return args.Get(0).([]corev2.CheckConfig), args.Get(1).(string), args.Error(2)
 }
 
 // AddCheckHook for use with mock lib

--- a/cli/client/testing/mock_cluster_client.go
+++ b/cli/client/testing/mock_cluster_client.go
@@ -2,21 +2,25 @@ package testing
 
 import "github.com/coreos/etcd/clientv3"
 
-func (c *MockClient) MemberList() (*clientv3.MemberListResponse, error) {
+// MemberList ...
+func (c *MockClient) MemberList() (*clientv3.MemberListResponse, string, error) {
 	args := c.Called()
-	return args.Get(0).(*clientv3.MemberListResponse), args.Error(1)
+	return args.Get(0).(*clientv3.MemberListResponse), args.Get(1).(string), args.Error(2)
 }
 
+// MemberAdd ...
 func (c *MockClient) MemberAdd(peerAddrs []string) (*clientv3.MemberAddResponse, error) {
 	args := c.Called(peerAddrs)
 	return args.Get(0).(*clientv3.MemberAddResponse), args.Error(1)
 }
 
+// MemberUpdate ...
 func (c *MockClient) MemberUpdate(id uint64, peerAddrs []string) (*clientv3.MemberUpdateResponse, error) {
 	args := c.Called(id, peerAddrs)
 	return args.Get(0).(*clientv3.MemberUpdateResponse), args.Error(1)
 }
 
+// MemberRemove ...
 func (c *MockClient) MemberRemove(id uint64) (*clientv3.MemberRemoveResponse, error) {
 	args := c.Called(id)
 	return args.Get(0).(*clientv3.MemberRemoveResponse), args.Error(1)

--- a/cli/client/testing/mock_clusterrole_client.go
+++ b/cli/client/testing/mock_clusterrole_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteClusterRole(name string) error {
 }
 
 // ListClusterRoles ...
-func (c *MockClient) ListClusterRoles(options client.ListOptions) ([]corev2.ClusterRole, error) {
+func (c *MockClient) ListClusterRoles(options client.ListOptions) ([]corev2.ClusterRole, string, error) {
 	args := c.Called(options)
-	return args.Get(0).([]corev2.ClusterRole), args.Error(1)
+	return args.Get(0).([]corev2.ClusterRole), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_clusterrolebinding_client.go
+++ b/cli/client/testing/mock_clusterrolebinding_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteClusterRoleBinding(name string) error {
 }
 
 // ListClusterRoleBindings ...
-func (c *MockClient) ListClusterRoleBindings(options client.ListOptions) ([]corev2.ClusterRoleBinding, error) {
+func (c *MockClient) ListClusterRoleBindings(options client.ListOptions) ([]corev2.ClusterRoleBinding, string, error) {
 	args := c.Called(options)
-	return args.Get(0).([]corev2.ClusterRoleBinding), args.Error(1)
+	return args.Get(0).([]corev2.ClusterRoleBinding), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_entity_client.go
+++ b/cli/client/testing/mock_entity_client.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ListEntities for use with mock lib
-func (c *MockClient) ListEntities(namespace string, options client.ListOptions) ([]corev2.Entity, error) {
+func (c *MockClient) ListEntities(namespace string, options client.ListOptions) ([]corev2.Entity, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Entity), args.Error(1)
+	return args.Get(0).([]corev2.Entity), args.Get(1).(string), args.Error(2)
 }
 
 // FetchEntity for use with mock lib

--- a/cli/client/testing/mock_event_client.go
+++ b/cli/client/testing/mock_event_client.go
@@ -14,9 +14,9 @@ func (c *MockClient) FetchEvent(entity, check string) (*types.Event, error) {
 }
 
 // ListEvents for use with mock lib
-func (c *MockClient) ListEvents(namespace string, options client.ListOptions) ([]corev2.Event, error) {
+func (c *MockClient) ListEvents(namespace string, options client.ListOptions) ([]corev2.Event, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Event), args.Error(1)
+	return args.Get(0).([]corev2.Event), args.Get(1).(string), args.Error(2)
 }
 
 // DeleteEvent for use with mock lib

--- a/cli/client/testing/mock_extension_client.go
+++ b/cli/client/testing/mock_extension_client.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ListExtensions ...
-func (c *MockClient) ListExtensions(namespace string, options client.ListOptions) ([]corev2.Extension, error) {
+func (c *MockClient) ListExtensions(namespace string, options client.ListOptions) ([]corev2.Extension, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Extension), args.Error(1)
+	return args.Get(0).([]corev2.Extension), args.Get(1).(string), args.Error(2)
 }
 
 // RegisterExtension ...

--- a/cli/client/testing/mock_filter_client.go
+++ b/cli/client/testing/mock_filter_client.go
@@ -26,9 +26,9 @@ func (c *MockClient) FetchFilter(name string) (*types.EventFilter, error) {
 }
 
 // ListFilters for use with mock lib
-func (c *MockClient) ListFilters(namespace string, options client.ListOptions) ([]corev2.EventFilter, error) {
+func (c *MockClient) ListFilters(namespace string, options client.ListOptions) ([]corev2.EventFilter, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.EventFilter), args.Error(1)
+	return args.Get(0).([]corev2.EventFilter), args.Get(1).(string), args.Error(2)
 }
 
 // UpdateFilter for use with mock lib

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -18,9 +18,9 @@ func (c *MockClient) Get(path string, obj interface{}) error {
 }
 
 // List ...
-func (c *MockClient) List(path string, objs interface{}, options client.ListOptions) error {
+func (c *MockClient) List(path string, objs interface{}, options client.ListOptions) (string, error) {
 	args := c.Called(path, objs, options)
-	return args.Error(0)
+	return args.Get(0).(string), args.Error(1)
 }
 
 // Post ...

--- a/cli/client/testing/mock_handler_client.go
+++ b/cli/client/testing/mock_handler_client.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ListHandlers for use with mock package
-func (c *MockClient) ListHandlers(namespace string, options client.ListOptions) ([]corev2.Handler, error) {
+func (c *MockClient) ListHandlers(namespace string, options client.ListOptions) ([]corev2.Handler, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Handler), args.Error(1)
+	return args.Get(0).([]corev2.Handler), args.Get(1).(string), args.Error(2)
 }
 
 // CreateHandler for use with mock package

--- a/cli/client/testing/mock_hook_client.go
+++ b/cli/client/testing/mock_hook_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) FetchHook(name string) (*types.HookConfig, error) {
 }
 
 // ListHooks for use with mock lib
-func (c *MockClient) ListHooks(namespace string, options client.ListOptions) ([]corev2.HookConfig, error) {
+func (c *MockClient) ListHooks(namespace string, options client.ListOptions) ([]corev2.HookConfig, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.HookConfig), args.Error(1)
+	return args.Get(0).([]corev2.HookConfig), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_mutator_client.go
+++ b/cli/client/testing/mock_mutator_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) UpdateMutator(m *types.Mutator) error {
 }
 
 // ListMutators for use with mock lib
-func (c *MockClient) ListMutators(namespace string, options client.ListOptions) ([]corev2.Mutator, error) {
+func (c *MockClient) ListMutators(namespace string, options client.ListOptions) ([]corev2.Mutator, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Mutator), args.Error(1)
+	return args.Get(0).([]corev2.Mutator), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_namespace_client.go
+++ b/cli/client/testing/mock_namespace_client.go
@@ -26,9 +26,9 @@ func (c *MockClient) DeleteNamespace(namespace string) error {
 }
 
 // ListNamespaces for use with mock lib
-func (c *MockClient) ListNamespaces(options client.ListOptions) ([]corev2.Namespace, error) {
+func (c *MockClient) ListNamespaces(options client.ListOptions) ([]corev2.Namespace, string, error) {
 	args := c.Called(options)
-	return args.Get(0).([]corev2.Namespace), args.Error(1)
+	return args.Get(0).([]corev2.Namespace), args.Get(1).(string), args.Error(2)
 }
 
 // FetchNamespace for use with mock lib

--- a/cli/client/testing/mock_role_client.go
+++ b/cli/client/testing/mock_role_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteRole(namespace, name string) error {
 }
 
 // ListRoles ...
-func (c *MockClient) ListRoles(namespace string, options client.ListOptions) ([]corev2.Role, error) {
+func (c *MockClient) ListRoles(namespace string, options client.ListOptions) ([]corev2.Role, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Role), args.Error(1)
+	return args.Get(0).([]corev2.Role), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_rolebinding_client.go
+++ b/cli/client/testing/mock_rolebinding_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteRoleBinding(namespace, name string) error {
 }
 
 // ListRoleBindings ...
-func (c *MockClient) ListRoleBindings(namespace string, options client.ListOptions) ([]corev2.RoleBinding, error) {
+func (c *MockClient) ListRoleBindings(namespace string, options client.ListOptions) ([]corev2.RoleBinding, string, error) {
 	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.RoleBinding), args.Error(1)
+	return args.Get(0).([]corev2.RoleBinding), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_silenced_client.go
+++ b/cli/client/testing/mock_silenced_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) FetchSilenced(id string) (*types.Silenced, error) {
 }
 
 // ListSilenceds for use with mock lib
-func (c *MockClient) ListSilenceds(namespace, sub, check string, options client.ListOptions) ([]corev2.Silenced, error) {
+func (c *MockClient) ListSilenceds(namespace, sub, check string, options client.ListOptions) ([]corev2.Silenced, string, error) {
 	args := c.Called(namespace, sub, check, options)
-	return args.Get(0).([]corev2.Silenced), args.Error(1)
+	return args.Get(0).([]corev2.Silenced), args.Get(1).(string), args.Error(2)
 }

--- a/cli/client/testing/mock_user_client.go
+++ b/cli/client/testing/mock_user_client.go
@@ -32,9 +32,9 @@ func (c *MockClient) FetchUser(username string) (*types.User, error) {
 }
 
 // ListUsers for use with mock lib
-func (c *MockClient) ListUsers(options client.ListOptions) ([]corev2.User, error) {
+func (c *MockClient) ListUsers(options client.ListOptions) ([]corev2.User, string, error) {
 	args := c.Called(options)
-	return args.Get(0).([]corev2.User), args.Error(1)
+	return args.Get(0).([]corev2.User), args.Get(1).(string), args.Error(2)
 }
 
 // ReinstateUser for use with mock lib

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -74,8 +74,9 @@ func (client *RestClient) FetchUser(username string) (*types.User, error) {
 }
 
 // ListUsers fetches all users from configured Sensu instance
-func (client *RestClient) ListUsers(options ListOptions) ([]corev2.User, error) {
+func (client *RestClient) ListUsers(options ListOptions) ([]corev2.User, string, error) {
 	var users []corev2.User
+	var header string
 
 	path := usersPath()
 	request := client.R()
@@ -84,15 +85,17 @@ func (client *RestClient) ListUsers(options ListOptions) ([]corev2.User, error) 
 
 	res, err := request.Get(path)
 	if err != nil {
-		return users, err
+		return users, header, err
 	}
 
 	if res.StatusCode() >= 400 {
-		return users, UnmarshalError(res)
+		return users, header, UnmarshalError(res)
 	}
 
+	header = EntityLimitHeader(res.Header())
+
 	err = json.Unmarshal(res.Body(), &users)
-	return users, err
+	return users, header, err
 }
 
 // ReinstateUser reinstates a disabled user on configured Sensu instance

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -38,7 +38,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch assets from API
-			results, err := cli.Client.ListAssets(namespace, opts)
+			results, header, err := cli.Client.ListAssets(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/asset/list_test.go
+++ b/cli/commands/asset/list_test.go
@@ -36,7 +36,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	client.On("ListAssets", mock.Anything, mock.Anything).Return([]types.Asset{
 		*types.FixtureAsset("one"),
 		*types.FixtureAsset("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -55,7 +55,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListAssets", "", mock.Anything).Return([]types.Asset{
 		*types.FixtureAsset("one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.AllNamespaces, "t"))
@@ -73,7 +73,7 @@ func TestListCommandRunEClosureWithJSON(t *testing.T) {
 	client.On("ListAssets", mock.Anything, mock.Anything).Return([]types.Asset{
 		*types.FixtureAsset("one"),
 		*types.FixtureAsset("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -87,7 +87,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListAssets", mock.Anything, mock.Anything).Return([]types.Asset{}, errors.New("fire"))
+	client.On("ListAssets", mock.Anything, mock.Anything).Return([]types.Asset{}, "", errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -38,7 +38,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch checks from the API
-			results, err := cli.Client.ListChecks(namespace, opts)
+			results, header, err := cli.Client.ListChecks(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{
 		*types.FixtureCheckConfig("name-one"),
 		*types.FixtureCheckConfig("name-two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListChecks", "", mock.Anything).Return([]types.CheckConfig{
 		*types.FixtureCheckConfig("name-one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -70,7 +70,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	check.RuntimeAssets = []string{"asset-one"}
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{*check}, nil)
+	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{*check}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -94,7 +94,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{}, errors.New("my-err"))
+	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{}, "", errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -113,7 +113,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	checkConfig.Command = "echo foo && exit 1"
 	client.On("ListChecks", "", mock.Anything).Return([]types.CheckConfig{
 		*checkConfig,
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))

--- a/cli/commands/cluster/health.go
+++ b/cli/commands/cluster/health.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
-	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/cli/elements/table"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
@@ -24,7 +23,7 @@ func HealthCommand(cli *cli.SensuCli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -127,16 +126,4 @@ func printAlarmsToTable(result interface{}, w io.Writer) {
 		},
 	})
 	table.Render(w, result)
-}
-
-func printTitleClusterID(v interface{}, writer io.Writer) error {
-	r, ok := v.(*etcdserverpb.ResponseHeader)
-	if !ok {
-		return fmt.Errorf("%t is not a ResponseHeader", v)
-	}
-	cfg := &list.Config{
-		Title: fmt.Sprintf("Cluster ID: %x", r.ClusterId),
-	}
-
-	return list.Print(writer, cfg)
 }

--- a/cli/commands/cluster/member-list.go
+++ b/cli/commands/cluster/member-list.go
@@ -20,11 +20,15 @@ func MemberListCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "list cluster members",
 		SilenceUsage: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := cli.Client.MemberList()
+			result, header, err := cli.Client.MemberList()
 			if err != nil {
 				return fmt.Errorf("error listing cluster members: %s", err)
 			}
-			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -25,7 +25,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListClusterRoles(opts)
+			results, header, err := cli.Client.ListClusterRoles(opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrole/list_test.go
+++ b/cli/commands/clusterrole/list_test.go
@@ -27,7 +27,7 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{
 		*types.FixtureClusterRole("one"),
 		*types.FixtureClusterRole("two"),
-	}, nil)
+	}, "", nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -42,7 +42,7 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{
 		*types.FixtureClusterRole("one"),
 		*types.FixtureClusterRole("two"),
-	}, nil)
+	}, "", nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -55,7 +55,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{}, errors.New("fire"))
+	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{}, "", errors.New("fire"))
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Empty(out)

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -25,7 +25,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListClusterRoleBindings(opts)
+			results, header, err := cli.Client.ListClusterRoleBindings(opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -37,7 +37,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch handlers from API
-			results, err := cli.Client.ListEntities(namespace, opts)
+			results, header, err := cli.Client.ListEntities(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -133,7 +133,8 @@ func TestListCommandRunEntityLimitHeader(t *testing.T) {
 	assert.Nil(err)
 
 	// Tabular should contain header
-	cmd.Flags().Set("format", "tabular")
+	err = cmd.Flags().Set("format", "tabular")
+	assert.Nil(err)
 	out, err = test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -38,7 +38,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch events from API
-			results, err := cli.Client.ListEvents(namespace, opts)
+			results, header, err := cli.Client.ListEvents(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/event/list_test.go
+++ b/cli/commands/event/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{
 		*types.FixtureEvent("1", "something"),
 		*types.FixtureEvent("2", "funny"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -51,7 +51,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListEvents", "", mock.Anything).Return([]types.Event{
 		*types.FixtureEvent("1", "something"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -69,7 +69,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{
 		*types.FixtureEvent("1", "something"),
 		*types.FixtureEvent("2", "funny"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "none"))
@@ -89,7 +89,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := newConfiguredCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{}, errors.New("fun-msg"))
+	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{}, "", errors.New("fun-msg"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -48,7 +48,7 @@ func runList(config string, c client.APIClient, namespace, format string) func(*
 			return err
 		}
 
-		extensions, err := c.ListExtensions(namespace, opts)
+		extensions, _, err := c.ListExtensions(namespace, opts)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/extension/list_test.go
+++ b/cli/commands/extension/list_test.go
@@ -34,7 +34,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	client.On("ListExtensions", mock.Anything, mock.Anything).Return([]types.Extension{
 		*types.FixtureExtension("one"),
 		*types.FixtureExtension("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -53,7 +53,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListExtensions", "default", mock.Anything).Return([]types.Extension{
 		*types.FixtureExtension("one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -70,7 +70,7 @@ func TestListCommandRunEClosureWithJSON(t *testing.T) {
 	client.On("ListExtensions", mock.Anything, mock.Anything).Return([]types.Extension{
 		*types.FixtureExtension("one"),
 		*types.FixtureExtension("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -84,7 +84,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListExtensions", mock.Anything, mock.Anything).Return([]types.Extension{}, errors.New("fire"))
+	client.On("ListExtensions", mock.Anything, mock.Anything).Return([]types.Extension{}, "", errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -36,7 +36,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch filters from the API
-			results, err := cli.Client.ListFilters(namespace, opts)
+			results, header, err := cli.Client.ListFilters(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/filter/list_test.go
+++ b/cli/commands/filter/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListFilters", mock.Anything, mock.Anything).Return([]types.EventFilter{
 		*types.FixtureEventFilter("name-one"),
 		*types.FixtureEventFilter("name-two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListFilters", "", mock.Anything).Return([]types.EventFilter{
 		*types.FixtureEventFilter("name-one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -69,7 +69,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	filter := types.FixtureEventFilter("name-one")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListFilters", mock.Anything, mock.Anything).Return([]types.EventFilter{*filter}, nil)
+	client.On("ListFilters", mock.Anything, mock.Anything).Return([]types.EventFilter{*filter}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -88,7 +88,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListFilters", mock.Anything, mock.Anything).Return([]types.EventFilter{}, errors.New("my-err"))
+	client.On("ListFilters", mock.Anything, mock.Anything).Return([]types.EventFilter{}, "", errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -105,7 +105,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	filter := types.FixtureEventFilter("name-one")
 	filter.Expressions = append(filter.Expressions, "10 > 0")
-	client.On("ListFilters", "", mock.Anything).Return([]types.EventFilter{*filter}, nil)
+	client.On("ListFilters", "", mock.Anything).Return([]types.EventFilter{*filter}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -38,7 +38,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch handlers from API
-			results, err := cli.Client.ListHandlers(namespace, opts)
+			results, header, err := cli.Client.ListHandlers(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/handler/list_test.go
+++ b/cli/commands/handler/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListHandlers", mock.Anything, mock.Anything).Return([]types.Handler{
 		*types.FixtureHandler("one"),
 		*types.FixtureHandler("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -49,7 +49,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHandlers", "", mock.Anything).Return([]types.Handler{
 		*types.FixtureHandler("one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.AllNamespaces, "t"))
@@ -68,7 +68,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 		*types.FixtureSetHandler("one", "two", "three"),
 		*types.FixtureSocketHandler("two", "tcp"),
 		*types.FixtureHandler("three"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -83,7 +83,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHandlers", mock.Anything, mock.Anything).Return([]types.Handler{}, errors.New("fire"))
+	client.On("ListHandlers", mock.Anything, mock.Anything).Return([]types.Handler{}, "", errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
@@ -57,4 +58,24 @@ func PrintFormatted(flag string, format string, v interface{}, w io.Writer, prin
 	default:
 		return printToList(v, w)
 	}
+}
+
+// PrintTitle prints a string as a title in tabular format only.
+// Flag overrides the cli config format if set.
+func PrintTitle(flag string, format string, title string, w io.Writer) error {
+	if title == "" {
+		return nil
+	}
+	if flag != "" {
+		format = flag
+	}
+	// ensure tabular format and invalid formats (which default to tabular) print the title
+	if format == config.FormatJSON || format == config.FormatWrappedJSON || format == config.FormatYAML {
+		return nil
+	}
+	cfg := &list.Config{
+		Title: title,
+	}
+
+	return list.Print(w, cfg)
 }

--- a/cli/commands/hook/list.go
+++ b/cli/commands/hook/list.go
@@ -36,7 +36,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch hooks from the API
-			results, err := cli.Client.ListHooks(namespace, opts)
+			results, header, err := cli.Client.ListHooks(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/hook/list_test.go
+++ b/cli/commands/hook/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{
 		*types.FixtureHookConfig("name-one"),
 		*types.FixtureHookConfig("name-two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListHooks", "", mock.Anything).Return([]types.HookConfig{
 		*types.FixtureHookConfig("name-one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -69,7 +69,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	hook := types.FixtureHookConfig("name-one")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{*hook}, nil)
+	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{*hook}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -89,7 +89,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{}, errors.New("my-err"))
+	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{}, "", errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -108,7 +108,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	hookConfig.Command = "echo foo && exit 1"
 	client.On("ListHooks", "", mock.Anything).Return([]types.HookConfig{
 		*hookConfig,
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -37,7 +37,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch mutators from the API
-			results, err := cli.Client.ListMutators(namespace, opts)
+			results, header, err := cli.Client.ListMutators(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/mutator/list_test.go
+++ b/cli/commands/mutator/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{
 		*types.FixtureMutator("name-one"),
 		*types.FixtureMutator("name-two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListMutators", "", mock.Anything).Return([]types.Mutator{
 		*types.FixtureMutator("name-one"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -69,7 +69,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	mutator := types.FixtureMutator("name-one")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{*mutator}, nil)
+	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{*mutator}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -88,7 +88,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{}, errors.New("my-err"))
+	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{}, "", errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -105,7 +105,7 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	mutator := types.FixtureMutator("name-one")
 	mutator.Command = "echo foo && exit 1"
-	client.On("ListMutators", "", mock.Anything).Return([]types.Mutator{*mutator}, nil)
+	client.On("ListMutators", "", mock.Anything).Return([]types.Mutator{*mutator}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))

--- a/cli/commands/namespace/list.go
+++ b/cli/commands/namespace/list.go
@@ -30,7 +30,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch namespaces from API
-			results, err := cli.Client.ListNamespaces(opts)
+			results, header, err := cli.Client.ListNamespaces(opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/namespace/list_test.go
+++ b/cli/commands/namespace/list_test.go
@@ -31,7 +31,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{
 		*types.FixtureNamespace("one"),
 		*types.FixtureNamespace("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -45,7 +45,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{}, errors.New("fire"))
+	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{}, "", errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -31,7 +31,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListRoles(namespace, opts)
+			results, header, err := cli.Client.ListRoles(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -27,7 +27,7 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{
 		*types.FixtureRole("one", "default"),
 		*types.FixtureRole("two", "default"),
-	}, nil)
+	}, "", nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -42,7 +42,7 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{
 		*types.FixtureRole("one", "default"),
 		*types.FixtureRole("two", "default"),
-	}, nil)
+	}, "", nil)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -55,7 +55,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{}, errors.New("fire"))
+	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{}, "", errors.New("fire"))
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Empty(out)

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -31,7 +31,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListRoleBindings(namespace, opts)
+			results, header, err := cli.Client.ListRoleBindings(namespace, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -49,7 +49,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
-			results, err := cli.Client.ListSilenceds(namespace, sub, check, opts)
+			results, header, err := cli.Client.ListSilenceds(namespace, sub, check, opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/silenced/list_test.go
+++ b/cli/commands/silenced/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{
 		*types.FixtureSilenced("foo:bar"),
 		*types.FixtureSilenced("bar:foo"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -52,7 +52,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 	client := cli.Client.(*client.MockClient)
 	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{
 		*types.FixtureSilenced("foo:bar"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -74,7 +74,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	silenced.Namespace = "defaultnamespace"
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{*silenced}, nil)
+	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{*silenced}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -104,7 +104,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{}, errors.New("my-err"))
+	client.On("ListSilenceds", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]types.Silenced{}, "", errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -32,7 +32,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch users from API
-			results, err := cli.Client.ListUsers(opts)
+			results, header, err := cli.Client.ListUsers(opts)
+			if err != nil {
+				return err
+			}
+
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), header, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/user/list_test.go
+++ b/cli/commands/user/list_test.go
@@ -33,7 +33,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	client.On("ListUsers", mock.Anything).Return([]types.User{
 		*types.FixtureUser("one"),
 		*types.FixtureUser("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -47,7 +47,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListUsers", mock.Anything).Return([]types.User{}, errors.New("fire"))
+	client.On("ListUsers", mock.Anything).Return([]types.User{}, "", errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -66,7 +66,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	client.On("ListUsers", mock.Anything).Return([]types.User{
 		*types.FixtureUser("one"),
 		*types.FixtureUser("two"),
-	}, nil)
+	}, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -97,7 +97,7 @@ func TestListCommandRunEClosureWithJSONOutput(t *testing.T) {
 	}
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListUsers", mock.Anything).Return(testUsers, nil)
+	client.On("ListUsers", mock.Anything).Return(testUsers, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -125,7 +125,7 @@ func TestListCommandRunEClosureWithYAMLOutput(t *testing.T) {
 	}
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListUsers", mock.Anything).Return(testUsers, nil)
+	client.On("ListUsers", mock.Anything).Return(testUsers, "", nil)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "yaml"))


### PR DESCRIPTION
**WARNING:** this one behemoth of a release branch

Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

This feature branch contains the addition of the `LimitD` daemon and `EntityLimiter` middleware in order to enforce the free entity limit. This branch also adds functionality to all `sensuctl` tabular `list` commands to print the `Warning` header if a user has exceeded the limit. 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/367
Closes https://github.com/sensu/sensu-enterprise-go/issues/366
Closes https://github.com/sensu/sensu-enterprise-go/issues/391

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

I had to touch some GraphQL stuff because a function was refactored to additionally return a response header. I think what I did should be sufficient, but would love @jamesdphillips or someone with a little more GraphQL knowledge to doublecheck.

## Were there any complications while making this change?

Some refactoring was required in the CLI in order to display the header for all `list` commands. I decided _not_ to completely gut the CLI code at this time, however a more generic refactor is probably due.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Looking through the docs and filing an issue now.

## How did you verify this change?

Header is not printed, as the entity limit has not been reached.
```
$ sensuctl check list
  Name   Command   Interval   Cron   Timeout   TTL   Subscriptions   Handlers   Assets   Hooks   Publish?   Stdin?   Metric Format   Metric Handlers  
 ────── ───────── ────────── ────── ───────── ───── ─────────────── ────────── ──────── ─────── ────────── ──────── ─────────────── ───────────────── 
  foo    foo             60                0     0   foo                                         true       false                                     
$ sensuctl check list --format json
[
  {
    "command": "foo",
    "handlers": [],
    "high_flap_threshold": 0,
    "interval": 60,
    "low_flap_threshold": 0,
    "publish": true,
    "runtime_assets": [],
    "subscriptions": [
      "foo"
    ],
    "proxy_entity_name": "",
    "check_hooks": null,
    "stdin": false,
    "subdue": null,
    "ttl": 0,
    "timeout": 0,
    "round_robin": false,
    "output_metric_format": "",
    "output_metric_handlers": [],
    "env_vars": null,
    "metadata": {
      "name": "foo",
      "namespace": "default"
    }
  }
]
```
Header is printed after 1001 entities have been added.

**entities.sh**
```
for i in {0..1001}
do
    sensuctl entity create entity$i --entity-class proxy
done
```
```
$ sh entities.sh
$ sensuctl check list
=== You have exceeded the entity limit of 1000 for the free tier of Sensu Go: 1001 entities
  Name   Command   Interval   Cron   Timeout   TTL   Subscriptions   Handlers   Assets   Hooks   Publish?   Stdin?   Metric Format   Metric Handlers  
 ────── ───────── ────────── ────── ───────── ───── ─────────────── ────────── ──────── ─────── ────────── ──────── ─────────────── ───────────────── 
  foo    foo             60                0     0   foo                                         true       false                                     

$ sensuctl check list --format json
[
  {
    "command": "foo",
    "handlers": [],
    "high_flap_threshold": 0,
    "interval": 60,
    "low_flap_threshold": 0,
    "publish": true,
    "runtime_assets": [],
    "subscriptions": [
      "foo"
    ],
    "proxy_entity_name": "",
    "check_hooks": null,
    "stdin": false,
    "subdue": null,
    "ttl": 0,
    "timeout": 0,
    "round_robin": false,
    "output_metric_format": "",
    "output_metric_handlers": [],
    "env_vars": null,
    "metadata": {
      "name": "foo",
      "namespace": "default"
    }
  }
]
```

Writing TestRail cases now.. will update this PR with links shortly.