### PR TITLE
Create generic PrintTitle function, properly check for formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed `sensuctl` color output on Windows.
+- Fixed a regression in `sensuctl cluster` json/wrapped-json output.
 
 ## [5.6.0] - 2019-04-30
 

--- a/cli/commands/cluster/health.go
+++ b/cli/commands/cluster/health.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
-	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/cli/elements/table"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
@@ -24,7 +23,7 @@ func HealthCommand(cli *cli.SensuCli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -127,16 +126,4 @@ func printAlarmsToTable(result interface{}, w io.Writer) {
 		},
 	})
 	table.Render(w, result)
-}
-
-func printTitleClusterID(v interface{}, writer io.Writer) error {
-	r, ok := v.(*etcdserverpb.ResponseHeader)
-	if !ok {
-		return fmt.Errorf("%t is not a ResponseHeader", v)
-	}
-	cfg := &list.Config{
-		Title: fmt.Sprintf("Cluster ID: %x", r.ClusterId),
-	}
-
-	return list.Print(writer, cfg)
 }

--- a/cli/commands/cluster/member-list.go
+++ b/cli/commands/cluster/member-list.go
@@ -24,7 +24,7 @@ func MemberListCommand(cli *cli.SensuCli) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("error listing cluster members: %s", err)
 			}
-			err = helpers.PrintFormatted(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), result.Header, cmd.OutOrStdout(), printTitleClusterID)
+			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/elements/list"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
@@ -57,4 +58,21 @@ func PrintFormatted(flag string, format string, v interface{}, w io.Writer, prin
 	default:
 		return printToList(v, w)
 	}
+}
+
+// PrintTitle prints a title for tabular format only.
+// Flag overrides the cli config format, if set.
+func PrintTitle(flag string, format string, title string, w io.Writer) error {
+	if flag != "" {
+		format = flag
+	}
+	// checking the formats exclusively to cover invalid formats
+	// that get defaulted to tabular
+	if format != config.FormatJSON && format != config.FormatWrappedJSON && format != config.FormatYAML {
+		cfg := &list.Config{
+			Title: title,
+		}
+		return list.Print(w, cfg)
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Implements a generic `PrintTitle` function and properly checks the configuration format. The function will print a styled title for tabular format only.

## Why is this change necessary?

Closes #2917 
Closes #2918 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nope, this was totally my fault and I knew exactly what I did wrong.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

```
$ sensuctl cluster health --format tabular
$ sensuctl cluster health --format json
$ sensuctl cluster health --format wrapped-json
$ sensuctl cluster health --format yaml
$ sensuctl cluster health --format foo
$ sensuctl cluster member-list --format tabular
$ sensuctl cluster member-list --format json
$ sensuctl cluster member-list --format wrapped-json
$ sensuctl cluster member-list --format yaml
$ sensuctl cluster member-list --format foo
```