### PR TITLE
Fix namespace escape issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed `sensuctl` color output on Windows.
 - Fixed a regression in `sensuctl cluster` json/wrapped-json output.
+- Fixed a regression that caused listing objects for a given namespace to also
+  include results from namespaces sharing a similar prefix.
 
 ## [5.6.0] - 2019-04-30
 

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
@@ -71,7 +72,16 @@ func (s *Store) GetEvents(ctx context.Context, pred *store.SelectionPredicate) (
 	rangeEnd := clientv3.GetPrefixRangeEnd(keyPrefix)
 	opts = append(opts, clientv3.WithRange(rangeEnd))
 
-	resp, err := s.client.Get(ctx, path.Join(keyPrefix, pred.Continue), opts...)
+	key := keyPrefix
+	if pred.Continue != "" {
+		key = path.Join(keyPrefix, pred.Continue)
+	} else {
+		if !strings.HasSuffix(key, "/") {
+			key += "/"
+		}
+	}
+
+	resp, err := s.client.Get(ctx, key, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What is this change?

If there were 2 namespaces with names like "sensu" and "sensu-dev",
querying the "sensu" namespace could also include objects from the
"sensu-dev" namespace!

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-enterprise-go/issues/418

## Does your change need a Changelog entry?

Added.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes needed.

## How did you verify this change?

Updated integration tests + manual testing.
