### PR TITLE
Create a special canned check for load testing

### DIFF
--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -86,8 +86,16 @@ func NewCheck(c *CheckConfig) *Check {
 	return check
 }
 
+const undocumentedTestCheckName = "!sensu_test_check!"
+
 // Validate returns an error if the check does not pass validation tests.
 func (c *Check) Validate() error {
+	if c.Name == undocumentedTestCheckName {
+		// undocumented test check, the agent will use this name to return
+		// a canned response. It is not possible to use this name according
+		// to the normal validation rules, so it shouldn't impact anyone.
+		return nil
+	}
 	if err := ValidateName(c.Name); err != nil {
 		return errors.New("check name " + err.Error())
 	}
@@ -198,6 +206,12 @@ func (c *CheckConfig) MarshalJSON() ([]byte, error) {
 
 // Validate returns an error if the check does not pass validation tests.
 func (c *CheckConfig) Validate() error {
+	if c.Name == undocumentedTestCheckName {
+		// undocumented test check, the agent will use this name to return
+		// a canned response. It is not possible to use this name according
+		// to the normal validation rules, so it shouldn't impact anyone.
+		return nil
+	}
 	if err := ValidateName(c.Name); err != nil {
 		return errors.New("check name " + err.Error())
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -14,6 +14,34 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const undocumentedTestCheckName = "!sensu_test_check!"
+
+const cannedResponseText = `
+                         .'loo:,
+                        ,KNMMWNWX
+                  ..    ,000OkxkW'
+                 ,o,.   .O0KOOOk0:
+                 dkl.    :OO0kkkk;
+                 :ko     .lOOOOkx
+              'OXX0:       'xWMdkd;o,.
+              cMMMM; .,lkXN;oWNOk,;MMMMWXx:
+              oMMMM:KNWMMMMl'.cl .NMMMMMMMMX
+              NMMMWkMMMMMMMMWxxKONMMMMMMMMMM
+             oMMMMMMMMMMMMMMMNW0NMMMMMMMMMMM.
+             KMMMMMMMMMMMMMMWMWWMMMMMMMMMMMMN
+             oKXXKKKKXMMMMMMMMMWMMMMMMMMMMMMM.
+                     'MMMMMMMMMMMMMMMMMMMMMMMk
+                     .MMMMMMMMWMMMMMMMMMMMMMMM
+                      WMMMMMMMMMMWNMMMMMMMMMMN
+                      WMMMMMMMMMWX0kO0WMMMMMMO
+                     .MMMMMMMMMMMNX0kkWMMMMWO'
+                     ;MMMMMMMMMMMMWXNNMMMMW.
+`
+
+var cannedResponse = &ExecutionResponse{
+	Output: cannedResponseText,
+}
+
 // Executor ...
 type Executor interface {
 	Execute(context.Context, ExecutionRequest) (*ExecutionResponse, error)
@@ -87,6 +115,9 @@ func NewExecutor() Executor {
 // timeout, optionally writing to STDIN, capturing its combined output
 // (STDOUT/ERR) and exit status.
 func (e *ExecutionRequest) Execute(ctx context.Context, execution ExecutionRequest) (*ExecutionResponse, error) {
+	if execution.Name == undocumentedTestCheckName {
+		return cannedResponse, nil
+	}
 	resp := &ExecutionResponse{}
 	logger := logrus.WithFields(logrus.Fields{"component": "command"})
 	// Using a platform specific shell to "cheat", as the shell


### PR DESCRIPTION
When a user specifies a check called !sensu_test_check! then
agents will respond with an event that contains an ASCII image of
Rick Astley.

Signed-off-by: Eric Chlebek <eric@sensu.io>