### PR TITLE
Allow users to query for Handlers from the GraphQL endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added per resource counts to tessen data collection.
+- Added ability to query for `Handlers` (individual and collections) from the GraphQL query endpoint.
 
 ## [5.7.0] - 2019-05-09
 

--- a/api/core/v2/handler_test.go
+++ b/api/core/v2/handler_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -202,6 +203,40 @@ func TestHandlerValidate(t *testing.T) {
 			} else if len(test.Error) > 0 {
 				t.Fatal("expected error, got none")
 			}
+		})
+	}
+}
+
+func TestSortHandlersByName(t *testing.T) {
+	a := FixtureHandler("Abernathy")
+	b := FixtureHandler("Bernard")
+	c := FixtureHandler("Clementine")
+	d := FixtureHandler("Dolores")
+
+	testCases := []struct {
+		name     string
+		inDir    bool
+		inChecks []*Handler
+		expected []*Handler
+	}{
+		{
+			name:     "Sorts ascending",
+			inDir:    true,
+			inChecks: []*Handler{d, c, a, b},
+			expected: []*Handler{a, b, c, d},
+		},
+		{
+			name:     "Sorts descending",
+			inDir:    false,
+			inChecks: []*Handler{d, a, c, b},
+			expected: []*Handler{d, c, b, a},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sort.Sort(SortHandlersByName(tc.inChecks, tc.inDir))
+			assert.EqualValues(t, tc.expected, tc.inChecks)
 		})
 	}
 }

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -103,6 +103,48 @@ func (r *namespaceImpl) Checks(p schema.NamespaceChecksFieldResolverParams) (int
 	return res, nil
 }
 
+// Handlers implements response to request for 'handlers' field.
+func (r *namespaceImpl) Handlers(p schema.NamespaceHandlersFieldResolverParams) (interface{}, error) {
+	res := newOffsetContainer(p.Args.Offset, p.Args.Limit)
+	nsp := p.Source.(*types.Namespace)
+
+	// finds all records
+	filter := p.Args.Filter
+	results, err := loadHandlers(p.Context, nsp.Name)
+	if err != nil {
+		return res, err
+	}
+
+	records := filterHandlers(results, func(obj *types.Handler) bool {
+		if filter == "" {
+			return true
+		}
+		sobj := dynamic.Synthesize(obj)
+		matched, err := js.Evaluate(filter, sobj, nil)
+		if err != nil {
+			logger.WithError(err).Debug("unable to filter record")
+		}
+		if matched {
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return res, err
+	}
+
+	sort.Sort(types.SortHandlersByName(
+		records,
+		p.Args.OrderBy == schema.HandlerListOrders.NAME,
+	))
+
+	// paginate
+	l, h := clampSlice(p.Args.Offset, p.Args.Offset+p.Args.Limit, len(records))
+	res.Nodes = records[l:h]
+	res.PageInfo.totalCount = len(records)
+	return res, nil
+}
+
 // Silences implements response to request for 'silences' field.
 func (r *namespaceImpl) Silences(p schema.NamespaceSilencesFieldResolverParams) (interface{}, error) {
 	res := newOffsetContainer(p.Args.Offset, p.Args.Limit)

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -52,6 +52,37 @@ func TestNamespaceTypeCheckHistoryField(t *testing.T) {
 	assert.Empty(t, history)
 }
 
+func TestNamespaceTypeHandlersField(t *testing.T) {
+	client, _ := client.NewClientFactory()
+	client.On("ListHandlers", mock.Anything, mock.Anything).Return([]types.Handler{
+		*types.FixtureHandler("Abe"),
+		*types.FixtureHandler("Bernie"),
+		*types.FixtureHandler("Clem"),
+		*types.FixtureHandler("Dolly"),
+	}, nil).Once()
+
+	impl := &namespaceImpl{}
+	params := schema.NamespaceHandlersFieldResolverParams{}
+	params.Context = contextWithLoadersNoCache(context.Background(), client)
+	params.Source = types.FixtureNamespace("default")
+	params.Args.Limit = 10
+
+	// Success
+	res, err := impl.Handlers(params)
+	require.NoError(t, err)
+	assert.Len(t, res.(offsetContainer).Nodes, 4)
+
+	// Store err
+	client.On("ListHandlers", mock.Anything, mock.Anything).Return(
+		[]types.Handler{},
+		errors.New("error"),
+	)
+
+	res, err = impl.Handlers(params)
+	assert.Empty(t, res.(offsetContainer).Nodes)
+	assert.Error(t, err)
+}
+
 func TestNamespaceTypeSilencesField(t *testing.T) {
 	client, _ := client.NewClientFactory()
 	client.On("ListSilenceds", mock.Anything, "", "", mock.Anything).Return([]types.Silenced{

--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -53,6 +53,14 @@ func (r *queryImpl) Check(p schema.QueryCheckFieldResolverParams) (interface{}, 
 	return handleFetchResult(res, err)
 }
 
+// Handler implements a response to a request for the 'hander' field.
+func (r *queryImpl) Handler(p schema.QueryHandlerFieldResolverParams) (interface{}, error) {
+	ctx := contextWithNamespace(p.Context, p.Args.Namespace)
+	client := r.factory.NewWithContext(ctx)
+	res, err := client.FetchHandler(p.Args.Name)
+	return handleFetchResult(res, err)
+}
+
 // Node implements response to request for 'node' field.
 func (r *queryImpl) Node(p schema.QueryNodeFieldResolverParams) (interface{}, error) {
 	resolver := r.nodeResolver

--- a/backend/apid/graphql/query_test.go
+++ b/backend/apid/graphql/query_test.go
@@ -71,3 +71,19 @@ func TestQueryTypeCheckField(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }
+
+func TestQueryTypeHandlerField(t *testing.T) {
+	client, factory := client.NewClientFactory()
+	impl := queryImpl{factory: factory}
+
+	handler := types.FixtureHandler("a")
+	params := schema.QueryHandlerFieldResolverParams{}
+	params.Args.Namespace = handler.Namespace
+	params.Args.Name = handler.Name
+
+	// Success
+	client.On("FetchHandler", handler.Name).Return(handler, nil).Once()
+	res, err := impl.Handler(params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, res)
+}

--- a/backend/apid/graphql/schema/handler.gql.go
+++ b/backend/apid/graphql/schema/handler.gql.go
@@ -758,3 +758,408 @@ var _ObjectTypeHandlerSocketDesc = graphql.ObjectDesc{
 		"port": _ObjTypeHandlerSocketPortHandler,
 	},
 }
+
+// HandlerConnectionNodesFieldResolver implement to resolve requests for the HandlerConnection's nodes field.
+type HandlerConnectionNodesFieldResolver interface {
+	// Nodes implements response to request for nodes field.
+	Nodes(p graphql.ResolveParams) (interface{}, error)
+}
+
+// HandlerConnectionPageInfoFieldResolver implement to resolve requests for the HandlerConnection's pageInfo field.
+type HandlerConnectionPageInfoFieldResolver interface {
+	// PageInfo implements response to request for pageInfo field.
+	PageInfo(p graphql.ResolveParams) (interface{}, error)
+}
+
+//
+// HandlerConnectionFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'HandlerConnection' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type HandlerConnectionFieldResolvers interface {
+	HandlerConnectionNodesFieldResolver
+	HandlerConnectionPageInfoFieldResolver
+}
+
+// HandlerConnectionAliases implements all methods on HandlerConnectionFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type HandlerConnectionAliases struct{}
+
+// Nodes implements response to request for 'nodes' field.
+func (_ HandlerConnectionAliases) Nodes(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// PageInfo implements response to request for 'pageInfo' field.
+func (_ HandlerConnectionAliases) PageInfo(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// HandlerConnectionType A connection to a sequence of records.
+var HandlerConnectionType = graphql.NewType("HandlerConnection", graphql.ObjectKind)
+
+// RegisterHandlerConnection registers HandlerConnection object type with given service.
+func RegisterHandlerConnection(svc *graphql.Service, impl HandlerConnectionFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeHandlerConnectionDesc, impl)
+}
+func _ObjTypeHandlerConnectionNodesHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(HandlerConnectionNodesFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Nodes(frp)
+	}
+}
+
+func _ObjTypeHandlerConnectionPageInfoHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(HandlerConnectionPageInfoFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.PageInfo(frp)
+	}
+}
+
+func _ObjectTypeHandlerConnectionConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "A connection to a sequence of records.",
+		Fields: graphql1.Fields{
+			"nodes": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Name:              "nodes",
+				Type:              graphql1.NewNonNull(graphql1.NewList(graphql1.NewNonNull(graphql.OutputType("Handler")))),
+			},
+			"pageInfo": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Name:              "pageInfo",
+				Type:              graphql1.NewNonNull(graphql.OutputType("OffsetPageInfo")),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see HandlerConnectionFieldResolvers.")
+		},
+		Name: "HandlerConnection",
+	}
+}
+
+// describe HandlerConnection's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeHandlerConnectionDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeHandlerConnectionConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"nodes":    _ObjTypeHandlerConnectionNodesHandler,
+		"pageInfo": _ObjTypeHandlerConnectionPageInfoHandler,
+	},
+}
+
+// HandlerEdgeNodeFieldResolver implement to resolve requests for the HandlerEdge's node field.
+type HandlerEdgeNodeFieldResolver interface {
+	// Node implements response to request for node field.
+	Node(p graphql.ResolveParams) (interface{}, error)
+}
+
+// HandlerEdgeCursorFieldResolver implement to resolve requests for the HandlerEdge's cursor field.
+type HandlerEdgeCursorFieldResolver interface {
+	// Cursor implements response to request for cursor field.
+	Cursor(p graphql.ResolveParams) (string, error)
+}
+
+//
+// HandlerEdgeFieldResolvers represents a collection of methods whose products represent the
+// response values of the 'HandlerEdge' type.
+//
+// == Example SDL
+//
+//   """
+//   Dog's are not hooman.
+//   """
+//   type Dog implements Pet {
+//     "name of this fine beast."
+//     name:  String!
+//
+//     "breed of this silly animal; probably shibe."
+//     breed: [Breed]
+//   }
+//
+// == Example generated interface
+//
+//   // DogResolver ...
+//   type DogFieldResolvers interface {
+//     DogNameFieldResolver
+//     DogBreedFieldResolver
+//
+//     // IsTypeOf is used to determine if a given value is associated with the Dog type
+//     IsTypeOf(interface{}, graphql.IsTypeOfParams) bool
+//   }
+//
+// == Example implementation ...
+//
+//   // DogResolver implements DogFieldResolvers interface
+//   type DogResolver struct {
+//     logger logrus.LogEntry
+//     store interface{
+//       store.BreedStore
+//       store.DogStore
+//     }
+//   }
+//
+//   // Name implements response to request for name field.
+//   func (r *DogResolver) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     return dog.GetName()
+//   }
+//
+//   // Breed implements response to request for breed field.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // ... implementation details ...
+//     dog := p.Source.(DogGetter)
+//     breed := r.store.GetBreed(dog.GetBreedName())
+//     return breed
+//   }
+//
+//   // IsTypeOf is used to determine if a given value is associated with the Dog type
+//   func (r *DogResolver) IsTypeOf(p graphql.IsTypeOfParams) bool {
+//     // ... implementation details ...
+//     _, ok := p.Value.(DogGetter)
+//     return ok
+//   }
+//
+type HandlerEdgeFieldResolvers interface {
+	HandlerEdgeNodeFieldResolver
+	HandlerEdgeCursorFieldResolver
+}
+
+// HandlerEdgeAliases implements all methods on HandlerEdgeFieldResolvers interface by using reflection to
+// match name of field to a field on the given value. Intent is reduce friction
+// of writing new resolvers by removing all the instances where you would simply
+// have the resolvers method return a field.
+//
+// == Example SDL
+//
+//    type Dog {
+//      name:   String!
+//      weight: Float!
+//      dob:    DateTime
+//      breed:  [Breed]
+//    }
+//
+// == Example generated aliases
+//
+//   type DogAliases struct {}
+//   func (_ DogAliases) Name(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Weight(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Dob(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//   func (_ DogAliases) Breed(p graphql.ResolveParams) (interface{}, error) {
+//     // reflect...
+//   }
+//
+// == Example Implementation
+//
+//   type DogResolver struct { // Implements DogResolver
+//     DogAliases
+//     store store.BreedStore
+//   }
+//
+//   // NOTE:
+//   // All other fields are satisified by DogAliases but since this one
+//   // requires hitting the store we implement it in our resolver.
+//   func (r *DogResolver) Breed(p graphql.ResolveParams) interface{} {
+//     dog := v.(*Dog)
+//     return r.BreedsById(dog.BreedIDs)
+//   }
+//
+type HandlerEdgeAliases struct{}
+
+// Node implements response to request for 'node' field.
+func (_ HandlerEdgeAliases) Node(p graphql.ResolveParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// Cursor implements response to request for 'cursor' field.
+func (_ HandlerEdgeAliases) Cursor(p graphql.ResolveParams) (string, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(string)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'cursor'")
+	}
+	return ret, err
+}
+
+// HandlerEdgeType An edge in a connection.
+var HandlerEdgeType = graphql.NewType("HandlerEdge", graphql.ObjectKind)
+
+// RegisterHandlerEdge registers HandlerEdge object type with given service.
+func RegisterHandlerEdge(svc *graphql.Service, impl HandlerEdgeFieldResolvers) {
+	svc.RegisterObject(_ObjectTypeHandlerEdgeDesc, impl)
+}
+func _ObjTypeHandlerEdgeNodeHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(HandlerEdgeNodeFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Node(frp)
+	}
+}
+
+func _ObjTypeHandlerEdgeCursorHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(HandlerEdgeCursorFieldResolver)
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.Cursor(frp)
+	}
+}
+
+func _ObjectTypeHandlerEdgeConfigFn() graphql1.ObjectConfig {
+	return graphql1.ObjectConfig{
+		Description: "An edge in a connection.",
+		Fields: graphql1.Fields{
+			"cursor": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Name:              "cursor",
+				Type:              graphql1.NewNonNull(graphql1.String),
+			},
+			"node": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Name:              "node",
+				Type:              graphql.OutputType("Handler"),
+			},
+		},
+		Interfaces: []*graphql1.Interface{},
+		IsTypeOf: func(_ graphql1.IsTypeOfParams) bool {
+			// NOTE:
+			// Panic by default. Intent is that when Service is invoked, values of
+			// these fields are updated with instantiated resolvers. If these
+			// defaults are called it is most certainly programmer err.
+			// If you're see this comment then: 'Whoops! Sorry, my bad.'
+			panic("Unimplemented; see HandlerEdgeFieldResolvers.")
+		},
+		Name: "HandlerEdge",
+	}
+}
+
+// describe HandlerEdge's configuration; kept private to avoid unintentional tampering of configuration at runtime.
+var _ObjectTypeHandlerEdgeDesc = graphql.ObjectDesc{
+	Config: _ObjectTypeHandlerEdgeConfigFn,
+	FieldHandlers: map[string]graphql.FieldHandler{
+		"cursor": _ObjTypeHandlerEdgeCursorHandler,
+		"node":   _ObjTypeHandlerEdgeNodeHandler,
+	},
+}

--- a/backend/apid/graphql/schema/handler.graphql
+++ b/backend/apid/graphql/schema/handler.graphql
@@ -49,3 +49,15 @@ type HandlerSocket {
   "Port is the socket peer port."
   port: Int
 }
+
+"A connection to a sequence of records."
+type HandlerConnection {
+  nodes: [Handler!]!
+  pageInfo: OffsetPageInfo!
+}
+
+"An edge in a connection."
+type HandlerEdge {
+  node: Handler 
+  cursor: String!
+}

--- a/backend/apid/graphql/schema/namespace.graphql
+++ b/backend/apid/graphql/schema/namespace.graphql
@@ -56,6 +56,17 @@ type Namespace implements Node {
     filter: String = "",
   ): EventConnection!
 
+  "All handlers associated with the namespace."
+  handlers(
+    offset: Int = 0,
+    "Limit adds an optional limit to the number of handlers returned."
+    limit: Int = 10,
+    "Orderby adds an optional order to the records retrieved."
+    orderBy: HandlerListOrder = NAME_DESC,
+    "Filter reduces the set using the given Sensu Query Expresion predicate"
+    filter: String = "",
+  ): HandlerConnection!
+
   "All silences associated with the namespace."
   silences(
     offset: Int = 0
@@ -128,6 +139,12 @@ enum EventsListOrder {
   NEWEST
   OLDEST
   SEVERITY
+}
+
+"Describes ways in which a list of handlers can be ordered."
+enum HandlerListOrder {
+  NAME
+  NAME_DESC
 }
 
 "Describes ways in which a list of silences can be ordered."

--- a/backend/apid/graphql/schema/schema.graphql
+++ b/backend/apid/graphql/schema/schema.graphql
@@ -31,6 +31,11 @@ type Query {
   check(namespace: String!, name: String!): CheckConfig
 
   """
+  handler fetch the handler associated with the given set of arguments.
+  """
+  handler(namespace: String!, name: String!): Handler
+
+  """
   Node fetches an object given its ID.
   """
   node(

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -38,8 +38,6 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterErrCode(svc)
 	schema.RegisterEvent(svc, &eventImpl{})
 	schema.RegisterEventsListOrder(svc)
-	schema.RegisterHandler(svc, &handlerImpl{factory: clientFactory})
-	schema.RegisterHandlerSocket(svc, &handlerSocketImpl{})
 	schema.RegisterHasMetadata(svc, nil)
 	schema.RegisterIcon(svc)
 	schema.RegisterJSON(svc, jsonImpl{})
@@ -88,6 +86,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterHook(svc, &hookImpl{})
 	schema.RegisterHookConfig(svc, &hookCfgImpl{})
 	schema.RegisterHookList(svc, &hookListImpl{})
+
+	// Register handler types
+	schema.RegisterHandler(svc, &handlerImpl{factory: clientFactory})
+	schema.RegisterHandlerListOrder(svc)
+	schema.RegisterHandlerConnection(svc, &schema.HandlerConnectionAliases{})
+	schema.RegisterHandlerSocket(svc, &handlerSocketImpl{})
 
 	// Register time window
 	schema.RegisterTimeWindowDays(svc, &schema.TimeWindowDaysAliases{})

--- a/types/aliases.go
+++ b/types/aliases.go
@@ -243,6 +243,8 @@ var (
 	SortEntitiesByPredicate     = v2.SortEntitiesByPredicate
 	SortEntitiesByID            = v2.SortEntitiesByID
 	SortEntitiesByLastSeen      = v2.SortEntitiesByLastSeen
+	SortHandlersByPredicate     = v2.SortHandlersByPredicate
+	SortHandlersByName          = v2.SortHandlersByName
 	SortSilencedByPredicate     = v2.SortSilencedByPredicate
 	SortSilencedByName          = v2.SortSilencedByName
 	SortSilencedByBegin         = v2.SortSilencedByBegin


### PR DESCRIPTION
## What is this change?
This PR adds the ability to query for Handlers from the GraphQL schema to support sensu/web#89. There are two ways users can retrieve handlers. 
1. Users can retrieve a single `Handler` given a namespace and a name from the `handler` field on the root `query` type,
2. Or, users can retrieve a _collection_ of handers (`HandlerCollection`) from the `handlers` field on the `namespace` type.

##### Example Single `handler` query
<img width="1579" alt="Screen Shot 2019-05-13 at 11 49 31 AM" src="https://user-images.githubusercontent.com/3856248/57647279-60606980-7577-11e9-955f-9c0924744361.png">

##### Example Collection `handlers` query
<img width="1031" alt="Screen Shot 2019-05-13 at 11 48 55 AM" src="https://user-images.githubusercontent.com/3856248/57647314-7a9a4780-7577-11e9-89a2-7492a9fd5dc7.png">

## Why is this change necessary?
This change supports a future update in the in the [sensu/web](https://github.com/sensu/web) repo (sensu/web#89), Sensu users want the ability to view a list of handers and see the details of a particular selected handler. This change allows the Web UI to query for handlers in order to display this data to the user. 

## Does your change need a Changelog entry?
Yes, 5aae0c4

## How did you verify this change?
To manually verify this change you can run a `sensu-backend` and query the GraphQL endpoint via GraphiQL. 
1. Run a `sensu-backend` locally
2. Create a number of handlers. I did this using `sensuctl -create --file example_handlers.json` ([example_handlers.json](https://gist.github.com/wesleycyu/dd3dacaff7b993f6926717ff5fe00fa4))
3. Run the [sensu/web](https://github.com/sensu/web) application locally with the apollo dev tools Chrome extension installed. (Don't forge to update the `graphQLSchemaRef` in `package.json` to the latest commit on this PR `c29c060`)
4. Run queries to ensure that handlers are being returned correctly.

*example query:*
```
{
  handler(namespace: "default", name: "slack") {
    id
    name
    namespace
    command
    envVars
  }
  namespace(name: "default") {
    handlers {
      nodes {
        id
        name
        command
        handlers {
          id
        }
        socket {
          host
          port
        }
      }
    }
  }
}
```
