### PR TITLE
Add prometheus event processing counter to tessen data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added per resource counts to tessen data collection.
+- Added event processing counts to tessen data collection.
 
 ## [5.7.0] - 2019-05-09
 

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -21,6 +21,15 @@ const (
 	// ComponentName identifies Eventd as the component/daemon implemented in this
 	// package.
 	ComponentName = "eventd"
+
+	// EventsProcessedCounterVec is the name of the prometheus counter vec used to count events processed.
+	EventsProcessedCounterVec = "sensu_go_events_processed"
+
+	// EventsProcessedLabelName is the name of the label which stores prometheus values.
+	EventsProcessedLabelName = "status"
+
+	// EventsProcessedLabelSuccess is the name of the label used to count events processed successfully.
+	EventsProcessedLabelSuccess = "success"
 )
 
 var (
@@ -28,12 +37,13 @@ var (
 		"component": ComponentName,
 	})
 
-	eventsProcessed = prometheus.NewCounterVec(
+	// EventsProcessed counts the number of sensu go events processed.
+	EventsProcessed = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sensu_go_events_processed",
+			Name: EventsProcessedCounterVec,
 			Help: "The total number of processed events",
 		},
-		[]string{"status"},
+		[]string{EventsProcessedLabelName},
 	)
 )
 
@@ -80,7 +90,7 @@ func New(c Config, opts ...Option) (*Eventd, error) {
 		}
 	}
 
-	_ = prometheus.Register(eventsProcessed)
+	_ = prometheus.Register(EventsProcessed)
 
 	return e, nil
 }
@@ -147,6 +157,7 @@ func (e *Eventd) startHandlers() {
 	}
 }
 
+// HandleError handles event errors.
 func (e *Eventd) HandleError(err error) {
 	logger.WithError(err).Error("error monitoring event")
 }
@@ -230,16 +241,15 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 			return err
 		}
 		return e.handleUpdate(event)
-	} else {
-		// The check TTL has been disabled, there is no longer a need to track it
-		if err := switches.Bury(context.TODO(), switchKey); err != nil {
-			// It's better to publish the event even if this fails, so
-			// don't return the error here.
-			logger.WithError(err).Error("error burying switch")
-		}
+	}
+	// The check TTL has been disabled, there is no longer a need to track it
+	if err := switches.Bury(context.TODO(), switchKey); err != nil {
+		// It's better to publish the event even if this fails, so
+		// don't return the error here.
+		logger.WithError(err).Error("error burying switch")
 	}
 
-	eventsProcessed.WithLabelValues("success").Inc()
+	EventsProcessed.WithLabelValues(EventsProcessedLabelSuccess).Inc()
 
 	return e.bus.Publish(messaging.TopicEvent, event)
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   backend1:
     image: sensu/sensu:master
-    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend1 --etcd-advertise-client-urls http://backend1:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend1:2380 --state-dir /var/lib/sensu/sensu-backend/etcd1 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level info --debug
+    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend1 --etcd-advertise-client-urls http://backend1:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend1:2380 --state-dir /var/lib/sensu/sensu-backend/etcd1 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug --debug
     hostname: backend1
     restart: always
     ports:


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Instruments the prometheus metrics counter (used in `eventd` and `/metrics`) to send event processing metrics to tessen.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2910

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

https://github.com/sensu/sensu-go/issues/2911 was more complicated.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1445

## How did you verify this change?

By doing https://github.com/sensu/sensu-go/issues/2911