### PR TITLE
Only bury check switchsets when TTL is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Added per resource counts to tessen data collection.
 
+### Fixed
+- Only bury switchsets of checks that no longer have a TTL, in order to reduce
+the number of write operations made to etcd.
+
 ## [5.7.0] - 2019-05-09
 
 ### Added

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -147,10 +147,6 @@ func (e *Eventd) startHandlers() {
 	}
 }
 
-func (e *Eventd) HandleError(err error) {
-	logger.WithError(err).Error("error monitoring event")
-}
-
 // eventKey creates a key to identify the event for liveness monitoring
 func eventKey(event *corev2.Event) string {
 	// Typically we want the entity name to be the thing we monitor, but if
@@ -230,7 +226,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 			return err
 		}
 		return e.handleUpdate(event)
-	} else {
+	} else if prevEvent != nil && prevEvent.Check.Ttl > 0 {
 		// The check TTL has been disabled, there is no longer a need to track it
 		if err := switches.Bury(context.TODO(), switchKey); err != nil {
 			// It's better to publish the event even if this fails, so

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -2,9 +2,12 @@ package eventd
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/testing/mockstore"
@@ -15,6 +18,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeSwitchSet struct {
+	mock.Mock
+}
+
+func (f *fakeSwitchSet) Alive(context.Context, string, int64) error {
+	return nil
+}
+
+func (*fakeSwitchSet) Dead(context.Context, string, int64) error {
+	return nil
+}
+
+func (*fakeSwitchSet) Bury(context.Context, string) error {
+	return nil
+}
+
+func newFakeFactory(f liveness.Interface) liveness.Factory {
+	return func(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
+		return f
+	}
+}
+
 func TestEventHandling(t *testing.T) {
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	require.NoError(t, err)
@@ -24,7 +49,7 @@ func TestEventHandling(t *testing.T) {
 	e, err := New(Config{
 		Store:           mockStore,
 		Bus:             bus,
-		LivenessFactory: fakeFactory,
+		LivenessFactory: newFakeFactory(&fakeSwitchSet{}),
 	})
 	require.NoError(t, err)
 	e.handlerCount = 5
@@ -76,25 +101,6 @@ func TestEventHandling(t *testing.T) {
 	assert.Equal(t, event.Timestamp, event.Check.LastOK)
 }
 
-type fakeSwitchSet struct {
-}
-
-func (fakeSwitchSet) Alive(context.Context, string, int64) error {
-	return nil
-}
-
-func (fakeSwitchSet) Dead(context.Context, string, int64) error {
-	return nil
-}
-
-func (fakeSwitchSet) Bury(context.Context, string) error {
-	return nil
-}
-
-func fakeFactory(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
-	return fakeSwitchSet{}
-}
-
 func TestEventMonitor(t *testing.T) {
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	require.NoError(t, err)
@@ -105,7 +111,7 @@ func TestEventMonitor(t *testing.T) {
 	require.NoError(t, err)
 	e.handlerCount = 5
 
-	e.livenessFactory = fakeFactory
+	e.livenessFactory = newFakeFactory(&fakeSwitchSet{})
 
 	require.NoError(t, e.Start())
 
@@ -217,6 +223,116 @@ func TestCheckOccurrences(t *testing.T) {
 
 			assert.Equal(t, tc.expectedOccurrences, event.Check.Occurrences)
 			assert.Equal(t, tc.expectedOccurrencesWatermark, event.Check.OccurrencesWatermark)
+		})
+	}
+}
+
+type mockSwitchSet struct {
+	mock.Mock
+}
+
+func (m *mockSwitchSet) Alive(ctx context.Context, id string, ttl int64) error {
+	args := m.Called(ctx, id, ttl)
+	return args.Error(0)
+}
+
+func (m *mockSwitchSet) Dead(ctx context.Context, id string, ttl int64) error {
+	args := m.Called(ctx, id, ttl)
+	return args.Error(0)
+}
+
+func (m *mockSwitchSet) Bury(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func TestCheckTTL(t *testing.T) {
+	ttlCheck := corev2.FixtureEvent("entity", "check")
+	ttlCheck.Check.Ttl = 120
+	nonTTLCheck := corev2.FixtureEvent("entity", "check")
+
+	type switchesFunc func(*mockSwitchSet)
+
+	tests := []struct {
+		name             string
+		msg              interface{}
+		previousEvent    *corev2.Event
+		previousEventErr error
+		switchesFunc     switchesFunc
+		wantErr          bool
+	}{
+		{
+			name:    "a check without TTL shouldn't bury its switchset",
+			msg:     nonTTLCheck,
+			wantErr: false,
+		},
+		{
+			name: "a check with TTL should update its switchset with alive",
+			msg:  ttlCheck,
+			switchesFunc: func(s *mockSwitchSet) {
+				s.On("Alive", mock.Anything, "default/check/entity", int64(120)).
+					Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "switchset alive err should be returned",
+			msg:  ttlCheck,
+			switchesFunc: func(s *mockSwitchSet) {
+				s.On("Alive", mock.Anything, "default/check/entity", int64(120)).
+					Return(errors.New("err"))
+			},
+			wantErr: true,
+		},
+		{
+			name:          "a check that just got its TTL disabled should bury its switchet",
+			msg:           nonTTLCheck,
+			previousEvent: ttlCheck,
+			switchesFunc: func(s *mockSwitchSet) {
+				s.On("Bury", mock.Anything, "default/check/entity").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:          "an error while burying the switchset should not be returned",
+			msg:           nonTTLCheck,
+			previousEvent: ttlCheck,
+			switchesFunc: func(s *mockSwitchSet) {
+				s.On("Bury", mock.Anything, "default/check/entity").Return(errors.New("err"))
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockstore.MockStore{}
+			switches := &mockSwitchSet{}
+			if tt.switchesFunc != nil {
+				tt.switchesFunc(switches)
+			}
+
+			e := &Eventd{
+				store:           store,
+				livenessFactory: newFakeFactory(switches),
+				handlerCount:    1,
+				wg:              &sync.WaitGroup{},
+			}
+			var err error
+			e.bus, err = messaging.NewWizardBus(messaging.WizardBusConfig{})
+			require.NoError(t, err)
+			require.NoError(t, e.bus.Start())
+
+			store.On("GetEventByEntityCheck", mock.Anything, "entity", "check").
+				Return(tt.previousEvent, tt.previousEventErr)
+			store.On("GetSilencedEntriesBySubscription", mock.Anything, mock.Anything).
+				Return([]*corev2.Silenced{}, nil)
+			store.On("GetSilencedEntriesByCheckName", mock.Anything, mock.Anything).
+				Return([]*corev2.Silenced{}, nil)
+			store.On("UpdateEvent", mock.Anything, mock.Anything).Return(nil)
+
+			if err := e.handleMessage(tt.msg); (err != nil) != tt.wantErr {
+				t.Errorf("Eventd.handleMessage() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -18,9 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeSwitchSet struct {
-	mock.Mock
-}
+type fakeSwitchSet struct{}
 
 func (f *fakeSwitchSet) Alive(context.Context, string, int64) error {
 	return nil


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR fixes a bug where _all_ checks that do not have a TTL would try to bury their switchset, which would result in two additional and unnecessary etcd operations (1 Put & 1 Delete) for _every_ event.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2707

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

I added a unit tests to eventd to specifically test this scenario.
