### PR TITLE
Add chunk-size option to sensuctl (pagination)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added event processing counts to tessen data collection.
 - Added ability to query for `Handlers` (individual and collections) from the GraphQL query endpoint.
 - --etcd-cipher-suites option is now available for sensu-backend.
+- Added the `--chunk-size` flag to `sensuctl * list` sub-commands
 
 ### Changed
 - eventd and keepalived now use 1000 handlers for events.

--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -35,7 +35,7 @@ func loadAssetsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListAssets(key.String(), client.ListOptions{})
+			records, err := c.ListAssets(key.String(), &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -64,7 +64,7 @@ func loadCheckConfigsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListChecks(key.String(), client.ListOptions{})
+			records, err := c.ListChecks(key.String(), &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -93,7 +93,7 @@ func loadEntitiesBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListEntities(key.String(), client.ListOptions{})
+			records, err := c.ListEntities(key.String(), &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -122,7 +122,7 @@ func loadEventsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListEvents(key.String(), client.ListOptions{})
+			records, err := c.ListEvents(key.String(), &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -151,7 +151,7 @@ func loadHandlersBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListHandlers(key.String(), client.ListOptions{})
+			records, err := c.ListHandlers(key.String(), &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -180,7 +180,7 @@ func loadNamespacesBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for range keys {
-			records, err := c.ListNamespaces(client.ListOptions{})
+			records, err := c.ListNamespaces(&client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}
@@ -209,7 +209,7 @@ func loadSilencedsBatchFn(c client.APIClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for _, key := range keys {
-			records, err := c.ListSilenceds(key.String(), "", "", client.ListOptions{})
+			records, err := c.ListSilenceds(key.String(), "", "", &client.ListOptions{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -11,7 +11,7 @@ import (
 var assetsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "assets")
 
 // ListAssets fetches a list of asset resources from the backend
-func (client *RestClient) ListAssets(namespace string, options ListOptions) ([]corev2.Asset, error) {
+func (client *RestClient) ListAssets(namespace string, options *ListOptions) ([]corev2.Asset, error) {
 	var assets []corev2.Asset
 
 	path := assetsPath(namespace)

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -14,22 +14,11 @@ var assetsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "assets")
 func (client *RestClient) ListAssets(namespace string, options *ListOptions) ([]corev2.Asset, error) {
 	var assets []corev2.Asset
 
-	path := assetsPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(assetsPath(namespace), &assets, options); err != nil {
 		return assets, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return assets, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &assets)
-	return assets, err
+	return assets, nil
 }
 
 // FetchAsset fetches an asset resource from the backend

--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -98,22 +98,11 @@ func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
 func (client *RestClient) ListChecks(namespace string, options *ListOptions) ([]corev2.CheckConfig, error) {
 	var checks []corev2.CheckConfig
 
-	path := checksPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(checksPath(namespace), &checks, options); err != nil {
 		return checks, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return checks, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &checks)
-	return checks, err
+	return checks, nil
 }
 
 // AddCheckHook associates an existing hook with an existing check

--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -95,7 +95,7 @@ func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
 }
 
 // ListChecks fetches all checks from configured Sensu instance
-func (client *RestClient) ListChecks(namespace string, options ListOptions) ([]corev2.CheckConfig, error) {
+func (client *RestClient) ListChecks(namespace string, options *ListOptions) ([]corev2.CheckConfig, error) {
 	var checks []corev2.CheckConfig
 
 	path := checksPath(namespace)

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-resty/resty"
@@ -165,5 +166,13 @@ func ApplyListOptions(request *resty.Request, options *ListOptions) {
 
 	if options.LabelSelector != "" {
 		request.SetQueryParam("labelSelector", options.LabelSelector)
+	}
+
+	if options.ChunkSize > 0 {
+		request.SetQueryParam("limit", strconv.Itoa(options.ChunkSize))
+	}
+
+	if options.ContinueToken != "" {
+		request.SetQueryParam("continue", options.ContinueToken)
 	}
 }

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -158,7 +158,7 @@ func (client *RestClient) configure() {
 
 // ApplyListOptions mutates the given request to make it carry the semantics of
 // the given options.
-func ApplyListOptions(request *resty.Request, options ListOptions) {
+func ApplyListOptions(request *resty.Request, options *ListOptions) {
 	if options.FieldSelector != "" {
 		request.SetQueryParam("fieldSelector", options.FieldSelector)
 	}

--- a/cli/client/clusterrole.go
+++ b/cli/client/clusterrole.go
@@ -27,7 +27,7 @@ func (client *RestClient) FetchClusterRole(name string) (*types.ClusterRole, err
 }
 
 // ListClusterRoles within the namespace
-func (client *RestClient) ListClusterRoles(options ListOptions) ([]corev2.ClusterRole, error) {
+func (client *RestClient) ListClusterRoles(options *ListOptions) ([]corev2.ClusterRole, error) {
 	clusterRoles := []corev2.ClusterRole{}
 
 	if err := client.List(clusterRolesPath(), &clusterRoles, options); err != nil {

--- a/cli/client/clusterrolebinding.go
+++ b/cli/client/clusterrolebinding.go
@@ -27,7 +27,7 @@ func (client *RestClient) FetchClusterRoleBinding(name string) (*types.ClusterRo
 }
 
 // ListClusterRoleBinding in the cluster
-func (client *RestClient) ListClusterRoleBindings(options ListOptions) ([]corev2.ClusterRoleBinding, error) {
+func (client *RestClient) ListClusterRoleBindings(options *ListOptions) ([]corev2.ClusterRoleBinding, error) {
 	clusterRoleBindings := []corev2.ClusterRoleBinding{}
 
 	if err := client.List(clusterRoleBindingsPath(), &clusterRoleBindings, options); err != nil {

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -36,22 +36,11 @@ func (client *RestClient) FetchEntity(name string) (*types.Entity, error) {
 func (client *RestClient) ListEntities(namespace string, options *ListOptions) ([]corev2.Entity, error) {
 	var entities []corev2.Entity
 
-	path := entitiesPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(entitiesPath(namespace), &entities, options); err != nil {
 		return entities, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return entities, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &entities)
-	return entities, err
+	return entities, nil
 }
 
 // UpdateEntity updates given entity on configured Sensu instance

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -33,7 +33,7 @@ func (client *RestClient) FetchEntity(name string) (*types.Entity, error) {
 }
 
 // ListEntities fetches all entities from configured Sensu instance
-func (client *RestClient) ListEntities(namespace string, options ListOptions) ([]corev2.Entity, error) {
+func (client *RestClient) ListEntities(namespace string, options *ListOptions) ([]corev2.Entity, error) {
 	var entities []corev2.Entity
 
 	path := entitiesPath(namespace)

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -29,7 +29,7 @@ func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error)
 }
 
 // ListEvents fetches events from Sensu API
-func (client *RestClient) ListEvents(namespace string, options ListOptions) ([]corev2.Event, error) {
+func (client *RestClient) ListEvents(namespace string, options *ListOptions) ([]corev2.Event, error) {
 	var events []corev2.Event
 
 	path := eventsPath(namespace)

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -32,22 +32,11 @@ func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error)
 func (client *RestClient) ListEvents(namespace string, options *ListOptions) ([]corev2.Event, error) {
 	var events []corev2.Event
 
-	path := eventsPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(eventsPath(namespace), &events, options); err != nil {
 		return events, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return nil, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &events)
-	return events, err
+	return events, nil
 }
 
 // DeleteEvent deletes an event.

--- a/cli/client/extension.go
+++ b/cli/client/extension.go
@@ -11,7 +11,7 @@ import (
 var extPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "extensions")
 
 // ListExtensions retrieves a list of extension resources from the backend
-func (client *RestClient) ListExtensions(namespace string, options ListOptions) ([]corev2.Extension, error) {
+func (client *RestClient) ListExtensions(namespace string, options *ListOptions) ([]corev2.Extension, error) {
 	var extensions []corev2.Extension
 
 	path := extPath(namespace)

--- a/cli/client/extension.go
+++ b/cli/client/extension.go
@@ -14,22 +14,11 @@ var extPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "extensions")
 func (client *RestClient) ListExtensions(namespace string, options *ListOptions) ([]corev2.Extension, error) {
 	var extensions []corev2.Extension
 
-	path := extPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(extPath(namespace), &extensions, options); err != nil {
 		return extensions, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return extensions, fmt.Errorf("%v", res.String())
-	}
-
-	err = json.Unmarshal(res.Body(), &extensions)
-	return extensions, err
+	return extensions, nil
 }
 
 // DeregisterExtension deregisters an extension resource from the backend

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -58,22 +58,11 @@ func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 func (client *RestClient) ListFilters(namespace string, options *ListOptions) ([]corev2.EventFilter, error) {
 	var filters []corev2.EventFilter
 
-	path := filtersPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(filtersPath(namespace), &filters, options); err != nil {
 		return filters, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return filters, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &filters)
-	return filters, err
+	return filters, nil
 }
 
 // UpdateFilter updates an existing filter with fields from a new one.

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -55,7 +55,7 @@ func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 }
 
 // ListFilters fetches all filters from configured Sensu instance
-func (client *RestClient) ListFilters(namespace string, options ListOptions) ([]corev2.EventFilter, error) {
+func (client *RestClient) ListFilters(namespace string, options *ListOptions) ([]corev2.EventFilter, error) {
 	var filters []corev2.EventFilter
 
 	path := filtersPath(namespace)

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -36,7 +36,7 @@ func (client *RestClient) Get(path string, obj interface{}) error {
 }
 
 // List sends a GET request for all objects at the given path
-func (client *RestClient) List(path string, objs interface{}, options ListOptions) error {
+func (client *RestClient) List(path string, objs interface{}, options *ListOptions) error {
 	request := client.R()
 
 	ApplyListOptions(request, options)

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -3,7 +3,9 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
+	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -35,22 +37,44 @@ func (client *RestClient) Get(path string, obj interface{}) error {
 	return nil
 }
 
-// List sends a GET request for all objects at the given path
+// List sends a GET request for all objects at the given path.
+// The options parameter allows for enhancing the request with field/label
+// selectors (filtering), pagination, ...
 func (client *RestClient) List(path string, objs interface{}, options *ListOptions) error {
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
-		return err
+	objsType := reflect.TypeOf(objs)
+	if objsType.Kind() != reflect.Ptr || objsType.Elem().Kind() != reflect.Slice {
+		panic("unexpected type for objs")
 	}
 
-	if res.StatusCode() >= 400 {
-		return UnmarshalError(res)
+	newObjs := reflect.New(objsType.Elem())
+
+	for {
+		request := client.R()
+		ApplyListOptions(request, options)
+
+		resp, err := request.Get(path)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode() >= 400 {
+			return UnmarshalError(resp)
+		}
+
+		if err := json.Unmarshal(resp.Body(), newObjs.Interface()); err != nil {
+			return err
+		}
+
+		o := reflect.ValueOf(objs).Elem()
+		o.Set(reflect.AppendSlice(o, newObjs.Elem()))
+
+		options.ContinueToken = resp.Header().Get(v2.PaginationContinueHeader)
+		if options.ContinueToken == "" {
+			break
+		}
 	}
 
-	return json.Unmarshal(res.Body(), objs)
+	return nil
 }
 
 // Post sends a POST request with obj as the payload to the given path

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -14,22 +14,11 @@ var handlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
 func (client *RestClient) ListHandlers(namespace string, options *ListOptions) ([]corev2.Handler, error) {
 	var handlers []corev2.Handler
 
-	path := handlersPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(handlersPath(namespace), &handlers, options); err != nil {
 		return handlers, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return handlers, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &handlers)
-	return handlers, err
+	return handlers, nil
 }
 
 // CreateHandler creates new handler on configured Sensu instance

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -11,7 +11,7 @@ import (
 var handlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
 
 // ListHandlers fetches all handlers from configured Sensu instance
-func (client *RestClient) ListHandlers(namespace string, options ListOptions) ([]corev2.Handler, error) {
+func (client *RestClient) ListHandlers(namespace string, options *ListOptions) ([]corev2.Handler, error) {
 	var handlers []corev2.Handler
 
 	path := handlersPath(namespace)

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -76,20 +76,9 @@ func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
 func (client *RestClient) ListHooks(namespace string, options *ListOptions) ([]corev2.HookConfig, error) {
 	var hooks []corev2.HookConfig
 
-	path := hooksPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(hooksPath(namespace), &hooks, options); err != nil {
 		return hooks, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return hooks, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &hooks)
-	return hooks, err
+	return hooks, nil
 }

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -73,7 +73,7 @@ func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
 }
 
 // ListHooks fetches all hooks from configured Sensu instance
-func (client *RestClient) ListHooks(namespace string, options ListOptions) ([]corev2.HookConfig, error) {
+func (client *RestClient) ListHooks(namespace string, options *ListOptions) ([]corev2.HookConfig, error) {
 	var hooks []corev2.HookConfig
 
 	path := hooksPath(namespace)

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -46,7 +46,7 @@ type GenericClient interface {
 	// Get retrieves the key at the given path and stores it into obj
 	Get(path string, obj interface{}) error
 	// List retrieves all keys with the given path prefix and stores them into objs
-	List(path string, objs interface{}, options ListOptions) error
+	List(path string, objs interface{}, options *ListOptions) error
 	// Post creates the given obj at the specified path
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
@@ -69,7 +69,7 @@ type AssetAPIClient interface {
 	CreateAsset(*types.Asset) error
 	UpdateAsset(*types.Asset) error
 	FetchAsset(string) (*types.Asset, error)
-	ListAssets(string, ListOptions) ([]types.Asset, error)
+	ListAssets(string, *ListOptions) ([]types.Asset, error)
 }
 
 // CheckAPIClient client methods for checks
@@ -78,7 +78,7 @@ type CheckAPIClient interface {
 	DeleteCheck(string, string) error
 	ExecuteCheck(*types.AdhocRequest) error
 	FetchCheck(string) (*types.CheckConfig, error)
-	ListChecks(string, ListOptions) ([]types.CheckConfig, error)
+	ListChecks(string, *ListOptions) ([]types.CheckConfig, error)
 	UpdateCheck(*types.CheckConfig) error
 
 	AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error
@@ -90,7 +90,7 @@ type ClusterRoleAPIClient interface {
 	CreateClusterRole(*types.ClusterRole) error
 	DeleteClusterRole(string) error
 	FetchClusterRole(string) (*types.ClusterRole, error)
-	ListClusterRoles(ListOptions) ([]types.ClusterRole, error)
+	ListClusterRoles(*ListOptions) ([]types.ClusterRole, error)
 }
 
 // ClusterRoleBindingAPIClient client methods for cluster role bindings
@@ -98,7 +98,7 @@ type ClusterRoleBindingAPIClient interface {
 	CreateClusterRoleBinding(*types.ClusterRoleBinding) error
 	DeleteClusterRoleBinding(string) error
 	FetchClusterRoleBinding(string) (*types.ClusterRoleBinding, error)
-	ListClusterRoleBindings(ListOptions) ([]types.ClusterRoleBinding, error)
+	ListClusterRoleBindings(*ListOptions) ([]types.ClusterRoleBinding, error)
 }
 
 // EntityAPIClient client methods for entities
@@ -106,7 +106,7 @@ type EntityAPIClient interface {
 	CreateEntity(entity *types.Entity) error
 	DeleteEntity(string, string) error
 	FetchEntity(ID string) (*types.Entity, error)
-	ListEntities(string, ListOptions) ([]types.Entity, error)
+	ListEntities(string, *ListOptions) ([]types.Entity, error)
 	UpdateEntity(entity *types.Entity) error
 }
 
@@ -115,14 +115,14 @@ type FilterAPIClient interface {
 	CreateFilter(*types.EventFilter) error
 	DeleteFilter(string, string) error
 	FetchFilter(string) (*types.EventFilter, error)
-	ListFilters(string, ListOptions) ([]types.EventFilter, error)
+	ListFilters(string, *ListOptions) ([]types.EventFilter, error)
 	UpdateFilter(*types.EventFilter) error
 }
 
 // EventAPIClient client methods for events
 type EventAPIClient interface {
 	FetchEvent(string, string) (*types.Event, error)
-	ListEvents(string, ListOptions) ([]corev2.Event, error)
+	ListEvents(string, *ListOptions) ([]corev2.Event, error)
 
 	// DeleteEvent deletes the event identified by entity, check.
 	DeleteEvent(namespace, entity, check string) error
@@ -132,7 +132,7 @@ type EventAPIClient interface {
 
 // ExtensionAPIClient client methods for extensions
 type ExtensionAPIClient interface {
-	ListExtensions(namespace string, options ListOptions) ([]types.Extension, error)
+	ListExtensions(namespace string, options *ListOptions) ([]types.Extension, error)
 	RegisterExtension(*types.Extension) error
 	DeregisterExtension(name, namespace string) error
 }
@@ -141,7 +141,7 @@ type ExtensionAPIClient interface {
 type HandlerAPIClient interface {
 	CreateHandler(*types.Handler) error
 	DeleteHandler(string, string) error
-	ListHandlers(string, ListOptions) ([]types.Handler, error)
+	ListHandlers(string, *ListOptions) ([]types.Handler, error)
 	FetchHandler(string) (*types.Handler, error)
 	UpdateHandler(*types.Handler) error
 }
@@ -157,13 +157,13 @@ type HookAPIClient interface {
 	UpdateHook(*types.HookConfig) error
 	DeleteHook(string, string) error
 	FetchHook(string) (*types.HookConfig, error)
-	ListHooks(string, ListOptions) ([]types.HookConfig, error)
+	ListHooks(string, *ListOptions) ([]types.HookConfig, error)
 }
 
 // MutatorAPIClient client methods for mutators
 type MutatorAPIClient interface {
 	CreateMutator(*types.Mutator) error
-	ListMutators(string, ListOptions) ([]types.Mutator, error)
+	ListMutators(string, *ListOptions) ([]types.Mutator, error)
 	DeleteMutator(string, string) error
 	FetchMutator(string) (*types.Mutator, error)
 	UpdateMutator(*types.Mutator) error
@@ -174,7 +174,7 @@ type NamespaceAPIClient interface {
 	CreateNamespace(*types.Namespace) error
 	UpdateNamespace(*types.Namespace) error
 	DeleteNamespace(string) error
-	ListNamespaces(ListOptions) ([]types.Namespace, error)
+	ListNamespaces(*ListOptions) ([]types.Namespace, error)
 	FetchNamespace(string) (*types.Namespace, error)
 }
 
@@ -184,7 +184,7 @@ type UserAPIClient interface {
 	CreateUser(*types.User) error
 	DisableUser(string) error
 	FetchUser(string) (*types.User, error)
-	ListUsers(ListOptions) ([]types.User, error)
+	ListUsers(*ListOptions) ([]types.User, error)
 	ReinstateUser(string) error
 	RemoveGroupFromUser(string, string) error
 	RemoveAllGroupsFromUser(string) error
@@ -197,7 +197,7 @@ type RoleAPIClient interface {
 	CreateRole(*types.Role) error
 	DeleteRole(string, string) error
 	FetchRole(string) (*types.Role, error)
-	ListRoles(string, ListOptions) ([]types.Role, error)
+	ListRoles(string, *ListOptions) ([]types.Role, error)
 }
 
 // RoleBindingAPIClient client methods for role bindings
@@ -205,7 +205,7 @@ type RoleBindingAPIClient interface {
 	CreateRoleBinding(*types.RoleBinding) error
 	DeleteRoleBinding(string, string) error
 	FetchRoleBinding(string) (*types.RoleBinding, error)
-	ListRoleBindings(string, ListOptions) ([]types.RoleBinding, error)
+	ListRoleBindings(string, *ListOptions) ([]types.RoleBinding, error)
 }
 
 // SilencedAPIClient client methods for silenced
@@ -218,7 +218,7 @@ type SilencedAPIClient interface {
 
 	// ListSilenceds lists all silenced entries, optionally constraining by
 	// subscription or check.
-	ListSilenceds(namespace, subscription, check string, options ListOptions) ([]types.Silenced, error)
+	ListSilenceds(namespace, subscription, check string, options *ListOptions) ([]types.Silenced, error)
 
 	// FetchSilenced fetches the silenced entry by ID.
 	FetchSilenced(id string) (*types.Silenced, error)

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -12,6 +12,14 @@ import (
 type ListOptions struct {
 	FieldSelector string
 	LabelSelector string
+
+	// ContinueToken is the current pagination token.
+	ContinueToken string
+
+	// ChunkSize is the number of objects to fetch per page when taking
+	// advantage of the API's pagination capabilities. ChunkSize <= 0 means
+	// fetch everything all at once; do not use pagination.
+	ChunkSize int
 }
 
 // APIClient client methods across the Sensu API

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
@@ -14,22 +13,11 @@ var mutatorsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "mutators")
 func (client *RestClient) ListMutators(namespace string, options *ListOptions) ([]corev2.Mutator, error) {
 	var mutators []corev2.Mutator
 
-	path := mutatorsPath(namespace)
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(mutatorsPath(namespace), &mutators, options); err != nil {
 		return mutators, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return mutators, fmt.Errorf("%v", res.String())
-	}
-
-	err = json.Unmarshal(res.Body(), &mutators)
-	return mutators, err
+	return mutators, nil
 }
 
 // CreateMutator creates new mutator on the configured Sensu instance

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -11,7 +11,7 @@ import (
 var mutatorsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "mutators")
 
 // ListMutators fetches all mutators from the configured Sensu instance
-func (client *RestClient) ListMutators(namespace string, options ListOptions) ([]corev2.Mutator, error) {
+func (client *RestClient) ListMutators(namespace string, options *ListOptions) ([]corev2.Mutator, error) {
 	var mutators []corev2.Mutator
 
 	path := mutatorsPath(namespace)

--- a/cli/client/namespace.go
+++ b/cli/client/namespace.go
@@ -60,22 +60,11 @@ func (client *RestClient) DeleteNamespace(namespace string) error {
 func (client *RestClient) ListNamespaces(options *ListOptions) ([]corev2.Namespace, error) {
 	var namespaces []corev2.Namespace
 
-	path := namespacesPath()
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(namespacesPath(), &namespaces, options); err != nil {
 		return namespaces, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return namespaces, fmt.Errorf("%v", res.String())
-	}
-
-	err = json.Unmarshal(res.Body(), &namespaces)
-	return namespaces, err
+	return namespaces, nil
 }
 
 // FetchNamespace fetches an namespace by name

--- a/cli/client/namespace.go
+++ b/cli/client/namespace.go
@@ -57,7 +57,7 @@ func (client *RestClient) DeleteNamespace(namespace string) error {
 }
 
 // ListNamespaces fetches all namespaces from configured Sensu instance
-func (client *RestClient) ListNamespaces(options ListOptions) ([]corev2.Namespace, error) {
+func (client *RestClient) ListNamespaces(options *ListOptions) ([]corev2.Namespace, error) {
 	var namespaces []corev2.Namespace
 
 	path := namespacesPath()

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -27,7 +27,7 @@ func (client *RestClient) FetchRole(name string) (*types.Role, error) {
 }
 
 // ListRoles lists the roles within the given namespace.
-func (client *RestClient) ListRoles(namespace string, options ListOptions) ([]corev2.Role, error) {
+func (client *RestClient) ListRoles(namespace string, options *ListOptions) ([]corev2.Role, error) {
 	roles := []corev2.Role{}
 
 	if err := client.List(rolesPath(namespace), &roles, options); err != nil {

--- a/cli/client/rolebinding.go
+++ b/cli/client/rolebinding.go
@@ -27,7 +27,7 @@ func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, err
 }
 
 // ListRoleBindings lists the role bindings within the given namespace.
-func (client *RestClient) ListRoleBindings(namespace string, options ListOptions) ([]corev2.RoleBinding, error) {
+func (client *RestClient) ListRoleBindings(namespace string, options *ListOptions) ([]corev2.RoleBinding, error) {
 	roleBindings := []corev2.RoleBinding{}
 
 	if err := client.List(roleBindingsPath(namespace), &roleBindings, options); err != nil {

--- a/cli/client/silenced.go
+++ b/cli/client/silenced.go
@@ -35,7 +35,7 @@ func (client *RestClient) DeleteSilenced(namespace, name string) error {
 }
 
 // ListSilenceds fetches all silenced entries from configured Sensu instance
-func (client *RestClient) ListSilenceds(namespace, sub, check string, options ListOptions) ([]corev2.Silenced, error) {
+func (client *RestClient) ListSilenceds(namespace, sub, check string, options *ListOptions) ([]corev2.Silenced, error) {
 	if sub != "" && check != "" {
 		name, err := types.SilencedName(sub, check)
 		if err != nil {

--- a/cli/client/testing/mock_asset_client.go
+++ b/cli/client/testing/mock_asset_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ListAssets for use with mock lib
-func (c *MockClient) ListAssets(namespace string, options client.ListOptions) ([]corev2.Asset, error) {
+func (c *MockClient) ListAssets(namespace string, options *client.ListOptions) ([]corev2.Asset, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Asset), args.Error(1)
 }

--- a/cli/client/testing/mock_check_client.go
+++ b/cli/client/testing/mock_check_client.go
@@ -38,7 +38,7 @@ func (c *MockClient) FetchCheck(name string) (*types.CheckConfig, error) {
 }
 
 // ListChecks for use with mock lib
-func (c *MockClient) ListChecks(namespace string, options client.ListOptions) ([]corev2.CheckConfig, error) {
+func (c *MockClient) ListChecks(namespace string, options *client.ListOptions) ([]corev2.CheckConfig, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.CheckConfig), args.Error(1)
 }

--- a/cli/client/testing/mock_clusterrole_client.go
+++ b/cli/client/testing/mock_clusterrole_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteClusterRole(name string) error {
 }
 
 // ListClusterRoles ...
-func (c *MockClient) ListClusterRoles(options client.ListOptions) ([]corev2.ClusterRole, error) {
+func (c *MockClient) ListClusterRoles(options *client.ListOptions) ([]corev2.ClusterRole, error) {
 	args := c.Called(options)
 	return args.Get(0).([]corev2.ClusterRole), args.Error(1)
 }

--- a/cli/client/testing/mock_clusterrolebinding_client.go
+++ b/cli/client/testing/mock_clusterrolebinding_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteClusterRoleBinding(name string) error {
 }
 
 // ListClusterRoleBindings ...
-func (c *MockClient) ListClusterRoleBindings(options client.ListOptions) ([]corev2.ClusterRoleBinding, error) {
+func (c *MockClient) ListClusterRoleBindings(options *client.ListOptions) ([]corev2.ClusterRoleBinding, error) {
 	args := c.Called(options)
 	return args.Get(0).([]corev2.ClusterRoleBinding), args.Error(1)
 }

--- a/cli/client/testing/mock_entity_client.go
+++ b/cli/client/testing/mock_entity_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ListEntities for use with mock lib
-func (c *MockClient) ListEntities(namespace string, options client.ListOptions) ([]corev2.Entity, error) {
+func (c *MockClient) ListEntities(namespace string, options *client.ListOptions) ([]corev2.Entity, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Entity), args.Error(1)
 }

--- a/cli/client/testing/mock_event_client.go
+++ b/cli/client/testing/mock_event_client.go
@@ -14,7 +14,7 @@ func (c *MockClient) FetchEvent(entity, check string) (*types.Event, error) {
 }
 
 // ListEvents for use with mock lib
-func (c *MockClient) ListEvents(namespace string, options client.ListOptions) ([]corev2.Event, error) {
+func (c *MockClient) ListEvents(namespace string, options *client.ListOptions) ([]corev2.Event, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Event), args.Error(1)
 }

--- a/cli/client/testing/mock_extension_client.go
+++ b/cli/client/testing/mock_extension_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ListExtensions ...
-func (c *MockClient) ListExtensions(namespace string, options client.ListOptions) ([]corev2.Extension, error) {
+func (c *MockClient) ListExtensions(namespace string, options *client.ListOptions) ([]corev2.Extension, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Extension), args.Error(1)
 }

--- a/cli/client/testing/mock_filter_client.go
+++ b/cli/client/testing/mock_filter_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) FetchFilter(name string) (*types.EventFilter, error) {
 }
 
 // ListFilters for use with mock lib
-func (c *MockClient) ListFilters(namespace string, options client.ListOptions) ([]corev2.EventFilter, error) {
+func (c *MockClient) ListFilters(namespace string, options *client.ListOptions) ([]corev2.EventFilter, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.EventFilter), args.Error(1)
 }

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -18,7 +18,7 @@ func (c *MockClient) Get(path string, obj interface{}) error {
 }
 
 // List ...
-func (c *MockClient) List(path string, objs interface{}, options client.ListOptions) error {
+func (c *MockClient) List(path string, objs interface{}, options *client.ListOptions) error {
 	args := c.Called(path, objs, options)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_handler_client.go
+++ b/cli/client/testing/mock_handler_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ListHandlers for use with mock package
-func (c *MockClient) ListHandlers(namespace string, options client.ListOptions) ([]corev2.Handler, error) {
+func (c *MockClient) ListHandlers(namespace string, options *client.ListOptions) ([]corev2.Handler, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Handler), args.Error(1)
 }

--- a/cli/client/testing/mock_hook_client.go
+++ b/cli/client/testing/mock_hook_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) FetchHook(name string) (*types.HookConfig, error) {
 }
 
 // ListHooks for use with mock lib
-func (c *MockClient) ListHooks(namespace string, options client.ListOptions) ([]corev2.HookConfig, error) {
+func (c *MockClient) ListHooks(namespace string, options *client.ListOptions) ([]corev2.HookConfig, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.HookConfig), args.Error(1)
 }

--- a/cli/client/testing/mock_mutator_client.go
+++ b/cli/client/testing/mock_mutator_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) UpdateMutator(m *types.Mutator) error {
 }
 
 // ListMutators for use with mock lib
-func (c *MockClient) ListMutators(namespace string, options client.ListOptions) ([]corev2.Mutator, error) {
+func (c *MockClient) ListMutators(namespace string, options *client.ListOptions) ([]corev2.Mutator, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Mutator), args.Error(1)
 }

--- a/cli/client/testing/mock_namespace_client.go
+++ b/cli/client/testing/mock_namespace_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteNamespace(namespace string) error {
 }
 
 // ListNamespaces for use with mock lib
-func (c *MockClient) ListNamespaces(options client.ListOptions) ([]corev2.Namespace, error) {
+func (c *MockClient) ListNamespaces(options *client.ListOptions) ([]corev2.Namespace, error) {
 	args := c.Called(options)
 	return args.Get(0).([]corev2.Namespace), args.Error(1)
 }

--- a/cli/client/testing/mock_role_client.go
+++ b/cli/client/testing/mock_role_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteRole(namespace, name string) error {
 }
 
 // ListRoles ...
-func (c *MockClient) ListRoles(namespace string, options client.ListOptions) ([]corev2.Role, error) {
+func (c *MockClient) ListRoles(namespace string, options *client.ListOptions) ([]corev2.Role, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.Role), args.Error(1)
 }

--- a/cli/client/testing/mock_rolebinding_client.go
+++ b/cli/client/testing/mock_rolebinding_client.go
@@ -26,7 +26,7 @@ func (c *MockClient) DeleteRoleBinding(namespace, name string) error {
 }
 
 // ListRoleBindings ...
-func (c *MockClient) ListRoleBindings(namespace string, options client.ListOptions) ([]corev2.RoleBinding, error) {
+func (c *MockClient) ListRoleBindings(namespace string, options *client.ListOptions) ([]corev2.RoleBinding, error) {
 	args := c.Called(namespace, options)
 	return args.Get(0).([]corev2.RoleBinding), args.Error(1)
 }

--- a/cli/client/testing/mock_silenced_client.go
+++ b/cli/client/testing/mock_silenced_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) FetchSilenced(id string) (*types.Silenced, error) {
 }
 
 // ListSilenceds for use with mock lib
-func (c *MockClient) ListSilenceds(namespace, sub, check string, options client.ListOptions) ([]corev2.Silenced, error) {
+func (c *MockClient) ListSilenceds(namespace, sub, check string, options *client.ListOptions) ([]corev2.Silenced, error) {
 	args := c.Called(namespace, sub, check, options)
 	return args.Get(0).([]corev2.Silenced), args.Error(1)
 }

--- a/cli/client/testing/mock_user_client.go
+++ b/cli/client/testing/mock_user_client.go
@@ -32,7 +32,7 @@ func (c *MockClient) FetchUser(username string) (*types.User, error) {
 }
 
 // ListUsers for use with mock lib
-func (c *MockClient) ListUsers(options client.ListOptions) ([]corev2.User, error) {
+func (c *MockClient) ListUsers(options *client.ListOptions) ([]corev2.User, error) {
 	args := c.Called(options)
 	return args.Get(0).([]corev2.User), args.Error(1)
 }

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -77,22 +77,11 @@ func (client *RestClient) FetchUser(username string) (*types.User, error) {
 func (client *RestClient) ListUsers(options *ListOptions) ([]corev2.User, error) {
 	var users []corev2.User
 
-	path := usersPath()
-	request := client.R()
-
-	ApplyListOptions(request, options)
-
-	res, err := request.Get(path)
-	if err != nil {
+	if err := client.List(usersPath(), &users, options); err != nil {
 		return users, err
 	}
 
-	if res.StatusCode() >= 400 {
-		return users, UnmarshalError(res)
-	}
-
-	err = json.Unmarshal(res.Body(), &users)
-	return users, err
+	return users, nil
 }
 
 // ReinstateUser reinstates a disabled user on configured Sensu instance

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -74,7 +74,7 @@ func (client *RestClient) FetchUser(username string) (*types.User, error) {
 }
 
 // ListUsers fetches all users from configured Sensu instance
-func (client *RestClient) ListUsers(options ListOptions) ([]corev2.User, error) {
+func (client *RestClient) ListUsers(options *ListOptions) ([]corev2.User, error) {
 	var users []corev2.User
 
 	path := usersPath()

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -56,6 +56,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -38,7 +38,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch assets from API
-			results, err := cli.Client.ListAssets(namespace, opts)
+			results, err := cli.Client.ListAssets(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -56,6 +56,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -38,7 +38,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch checks from the API
-			results, err := cli.Client.ListChecks(namespace, opts)
+			results, err := cli.Client.ListChecks(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -42,6 +42,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddFormatFlag(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -25,7 +25,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListClusterRoles(opts)
+			results, err := cli.Client.ListClusterRoles(&opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -42,6 +42,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddFormatFlag(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -25,7 +25,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListClusterRoleBindings(opts)
+			results, err := cli.Client.ListClusterRoleBindings(&opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -37,7 +37,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch handlers from API
-			results, err := cli.Client.ListEntities(namespace, opts)
+			results, err := cli.Client.ListEntities(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/entity/list.go
+++ b/cli/commands/entity/list.go
@@ -55,6 +55,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -56,6 +56,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -38,7 +38,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch events from API
-			results, err := cli.Client.ListEvents(namespace, opts)
+			results, err := cli.Client.ListEvents(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -29,6 +29,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddFormatFlag(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -48,7 +48,7 @@ func runList(config string, c client.APIClient, namespace, format string) func(*
 			return err
 		}
 
-		extensions, err := c.ListExtensions(namespace, opts)
+		extensions, err := c.ListExtensions(namespace, &opts)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -54,6 +54,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -36,7 +36,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch filters from the API
-			results, err := cli.Client.ListFilters(namespace, opts)
+			results, err := cli.Client.ListFilters(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/flags/flags.go
+++ b/cli/commands/flags/flags.go
@@ -17,4 +17,8 @@ const (
 	// LabelSelector is used to provide a label expression that will be used as
 	// a filter, typically when listing resources.
 	LabelSelector = "label-selector"
+
+	// ChunkSize is used to specify that a list of objects is to be fetched in
+	// chunks of the given size, using the API's pagination capabilities.
+	ChunkSize = "chunk-size"
 )

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -56,6 +56,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -38,7 +38,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch handlers from API
-			results, err := cli.Client.ListHandlers(namespace, opts)
+			results, err := cli.Client.ListHandlers(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/helpers/flags.go
+++ b/cli/commands/helpers/flags.go
@@ -49,6 +49,11 @@ func AddLabelSelectorFlag(flagSet *pflag.FlagSet) {
 	flagSet.String(flags.LabelSelector, "", "Only select resources matching this label selector (enterprise only)")
 }
 
+// AddChunkSizeFlag adds the '--chunk-size' flag to the given command
+func AddChunkSizeFlag(flagSet *pflag.FlagSet) {
+	flagSet.Int(flags.ChunkSize, 0, "Return large lists in chunks of the given size rather than all at once")
+}
+
 // FlagHasChanged determines if the user has set the value of a flag,
 // or left it to default
 func FlagHasChanged(name string, flagset *pflag.FlagSet) bool {
@@ -99,8 +104,14 @@ func ListOptionsFromFlags(flagSet *pflag.FlagSet) (client.ListOptions, error) {
 		return opts, err
 	}
 
+	chunkSize, err := flagSet.GetInt(flags.ChunkSize)
+	if err != nil {
+		chunkSize = 0
+	}
+
 	opts.FieldSelector = fieldSelector
 	opts.LabelSelector = labelSelector
+	opts.ChunkSize = chunkSize
 
 	return opts, nil
 }

--- a/cli/commands/hook/list.go
+++ b/cli/commands/hook/list.go
@@ -54,6 +54,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/hook/list.go
+++ b/cli/commands/hook/list.go
@@ -36,7 +36,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch hooks from the API
-			results, err := cli.Client.ListHooks(namespace, opts)
+			results, err := cli.Client.ListHooks(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -37,7 +37,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch mutators from the API
-			results, err := cli.Client.ListMutators(namespace, opts)
+			results, err := cli.Client.ListMutators(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/mutator/list.go
+++ b/cli/commands/mutator/list.go
@@ -55,6 +55,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/namespace/list.go
+++ b/cli/commands/namespace/list.go
@@ -47,6 +47,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddFormatFlag(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/namespace/list.go
+++ b/cli/commands/namespace/list.go
@@ -30,7 +30,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch namespaces from API
-			results, err := cli.Client.ListNamespaces(opts)
+			results, err := cli.Client.ListNamespaces(&opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -31,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListRoles(namespace, opts)
+			results, err := cli.Client.ListRoles(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -49,6 +49,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -49,6 +49,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -31,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListRoleBindings(namespace, opts)
+			results, err := cli.Client.ListRoleBindings(namespace, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -68,6 +68,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddAllNamespace(flags)
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	_ = flags.StringP("subscription", "s", "", "name of the silenced subscription")
 	_ = flags.StringP("check", "c", "", "name of the silenced check")

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -49,7 +49,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
-			results, err := cli.Client.ListSilenceds(namespace, sub, check, opts)
+			results, err := cli.Client.ListSilenceds(namespace, sub, check, &opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -32,7 +32,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch users from API
-			results, err := cli.Client.ListUsers(opts)
+			results, err := cli.Client.ListUsers(&opts)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/user/list.go
+++ b/cli/commands/user/list.go
@@ -50,6 +50,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 	helpers.AddFormatFlag(cmd.Flags())
 	helpers.AddFieldSelectorFlag(cmd.Flags())
 	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }


### PR DESCRIPTION
## What is this change?

This change is somewhat of a pale version of what I had originally envisioned.
It is nonetheless a step toward having a better behaving `sensuctl` on
installations with large number of objects, greatly reducing if not completely
removing potential timeouts during API calls.

The idea is to introduce a new `--chunk-size` flag on `list` sub-commands to
tell the client to internally use the API's pagination capability to retrieve
chunks of at most `chunk-size` objects. The sum of these chunks corresponds to
the same result set that would have been retrieved in one go, without the
`--chunk-size` flag.

## Why is this change necessary?

Alleviates problems when trying to list large number of resources.
Closes #2904.

## Does your change need a Changelog entry?

Yes, added.

## Were there any complications while making this change?

The original intention was to stream the chunks to the output, as to be able to
start displaying results as soon as the first chunk arrives. This would have lead
to a pretty constant memory usage and more "responsiveness" in the output.

As it turns out, receiving a resource set as a collection of independent chunks
raises a few questions:

-   With `tabular` output, the header may need to be repeated
    This is in order to keep proper table alignment in the output. This might be
    indesirable for users trying to parse that output (they should use one of the
    structured outputs for that though). `kubectl` repeats the header, though that
    sometimes confuse people. See <https://github.com/kubernetes/kubernetes/issues/65727>.

-   With `json` or `yaml` output, we need to "stream" to the output
    Each chunk is an array of objects. Simply printing them as they come changes
    the output to become an array of array of objects with the current printing
    methods we have. This is not desirable because it makes the output of `list`
    and `list --chunk-size x` different and breaks operations like dumping the
    checks in a json file (e.g. `sensuctl check list --format json --chunk-size
      500 > my-checks.json`) and loading them elsewhere (`sensuctl create -f
      my-checks.json`).

As a consequence, right now, we reassemble all the chunks before printing
everything in one go. That still fixes potential timeouts when querying the API
for large object sets, but it doesn't change the ballooning memory usage of
`sensuctl` or the delay before showing some output.

Ideally, we would rework or add to the `Print*()` helpers in order for them to
support a more streaming way of printing objects. With that out of the way, we
would be able to either:

-   change `cli.Client` so that it can stream its response object set to its caller
-   move the pagination logic out of `cli.Client` and into `cli.Commands`, in
    order for the commands to "print as they query"

## Have you reviewed and updated the documentation for this change? Is new documentation required?

The `sensuctl` reference needs to be updated. This is tracked here: https://github.com/sensu/sensu-docs/issues/1467.

## How did you verify this change?

- manual testing on local sensu instance
- checked against the `cli.commands` tests

Testing this feature uncovered a bug in the Namespace and User pagination: https://github.com/sensu/sensu-go/pull/2960.
