### PR TITLE
Fix check Occurrences and OccurrencesWatermark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.9.0] - TBD
+
+### Fixed
+- Fixed the behaviors for check `Occurrences` and `OccurrencesWatermark`.
+
 ## [5.8.0] - TBD
 
 ### Added

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -166,84 +166,72 @@ func TestCheckOccurrences(t *testing.T) {
 	testCases := []struct {
 		name                         string
 		status                       uint32
-		history                      corev2.CheckHistory
 		expectedOccurrences          int64
 		expectedOccurrencesWatermark int64
 	}{
 		{
 			name:                         "OK",
 			status:                       OK,
-			history:                      corev2.CheckHistory{Status: OK},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
 		},
 		{
 			name:                         "OK -> OK",
 			status:                       OK,
-			history:                      corev2.CheckHistory{Status: OK},
 			expectedOccurrences:          2,
 			expectedOccurrencesWatermark: 2,
 		},
 		{
 			name:                         "OK -> WARN",
 			status:                       WARN,
-			history:                      corev2.CheckHistory{Status: WARN},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
 		},
 		{
 			name:                         "WARN -> WARN",
 			status:                       WARN,
-			history:                      corev2.CheckHistory{Status: WARN},
 			expectedOccurrences:          2,
 			expectedOccurrencesWatermark: 2,
 		},
 		{
 			name:                         "WARN -> WARN",
 			status:                       WARN,
-			history:                      corev2.CheckHistory{Status: WARN},
 			expectedOccurrences:          3,
 			expectedOccurrencesWatermark: 3,
 		},
 		{
 			name:                         "WARN -> CRIT",
 			status:                       CRIT,
-			history:                      corev2.CheckHistory{Status: CRIT},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 3,
 		},
 		{
 			name:                         "CRIT -> CRIT",
 			status:                       CRIT,
-			history:                      corev2.CheckHistory{Status: CRIT},
 			expectedOccurrences:          2,
 			expectedOccurrencesWatermark: 3,
 		},
 		{
 			name:                         "CRIT -> CRIT",
 			status:                       CRIT,
-			history:                      corev2.CheckHistory{Status: CRIT},
 			expectedOccurrences:          3,
 			expectedOccurrencesWatermark: 3,
 		},
 		{
 			name:                         "CRIT -> CRIT",
 			status:                       CRIT,
-			history:                      corev2.CheckHistory{Status: CRIT},
 			expectedOccurrences:          4,
 			expectedOccurrencesWatermark: 4,
 		},
 		{
 			name:                         "CRIT -> OK",
 			status:                       OK,
-			history:                      corev2.CheckHistory{Status: OK},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 4,
 		},
 		{
 			name:                         "OK -> CRIT",
 			status:                       CRIT,
-			history:                      corev2.CheckHistory{Status: CRIT},
 			expectedOccurrences:          1,
 			expectedOccurrencesWatermark: 1,
 		},
@@ -257,7 +245,7 @@ func TestCheckOccurrences(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			event.Check.Status = tc.status
-			event.Check.History = append(event.Check.History, tc.history)
+			event.Check.History = append(event.Check.History, corev2.CheckHistory{Status: tc.status})
 			updateOccurrences(event)
 			assert.Equal(t, tc.expectedOccurrences, event.Check.Occurrences)
 			assert.Equal(t, tc.expectedOccurrencesWatermark, event.Check.OccurrencesWatermark)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a bug in the behavior of check `Occurrences` and `OccurrencesWatermark` which is properly defined in https://github.com/sensu/sensu-go/issues/1766#issuecomment-490687197.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1766

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1478

## How did you verify this change?

Observed how the check `Occurrences` and `OccurrencesWatermark` values changed according to the behavior defined in https://github.com/sensu/sensu-go/issues/1766#issuecomment-490687197.