### PR TITLE
Fix the number version with the build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,7 @@ build_binary () {
     unset GOOS
     unset GOARCH
 
+    local version_pkg="github.com/sensu/sensu-go/version"
     local version=$($VERSION_CMD -v)
     local prerelease=$($VERSION_CMD -p)
 
@@ -79,12 +80,13 @@ build_binary () {
     local cmd=$3
     local cmd_name=$4
     local ext="${@:5}"
-
+    local date=$(date --utc +%FT%T.%3NZ)
+    local buildsha=$(git rev-parse HEAD)
     local outfile="target/${goos}-${goarch}/${cmd_name}"
 
     local main_pkg="cmd/${cmd_name}"
 
-    CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build $ext -o $outfile ${REPO_PATH}/${main_pkg}
+    CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -ldflags '-X "'$version_pkg'.Version='$version'" -X "'$version_pkg'.BuildDate='$date'" -X "'$version_pkg'.BuildSHA='$buildsha'"' $ext -o $outfile ${REPO_PATH}/${main_pkg}
 
     echo $outfile
 }


### PR DESCRIPTION

Compile with a linux build environment not specify the Version , SHA and date build.
This settings is correctly set with the windows build environnement.

This pull request fix this missing settings




