### PR TITLE
Pass empty pointer to json.Unmarshal when chunking

### DIFF
--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -46,8 +46,6 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 		panic("unexpected type for objs")
 	}
 
-	newObjs := reflect.New(objsType.Elem())
-
 	for {
 		request := client.R()
 		ApplyListOptions(request, options)
@@ -61,6 +59,7 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 			return UnmarshalError(resp)
 		}
 
+		newObjs := reflect.New(objsType.Elem())
 		if err := json.Unmarshal(resp.Body(), newObjs.Interface()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This fixes a bug where we would re-use the same pointer when decoding API results while using chunking.

## Why is this change necessary?

Fixes a bug found in QA.

## Does your change need a Changelog entry?

Nope, unreleased functionality.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested, I think it's fine for now. This function uses resty so it would require a good amount of mocking/refactoring to have a proper unit test.