### PR TITLE
Tessend allow opt out

### DIFF
--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -89,6 +89,7 @@ type Tessend struct {
 	messageChan  chan interface{}
 	subscription messaging.Subscription
 	duration     time.Duration
+	AllowOptOut  bool
 }
 
 // Option is a functional option.
@@ -114,6 +115,7 @@ func New(c Config, opts ...Option) (*Tessend, error) {
 		bus:         c.Bus,
 		messageChan: make(chan interface{}, 1),
 		duration:    perResourceDuration,
+		AllowOptOut: true,
 	}
 	t.ctx, t.cancel = context.WithCancel(context.Background())
 	t.interrupt = make(chan *corev2.TessenConfig, 1)
@@ -406,7 +408,7 @@ func (t *Tessend) enabled(tessen *corev2.TessenConfig) bool {
 
 	wrapper := &Wrapper{}
 	err := etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
-	if err != nil {
+	if err != nil || t.AllowOptOut {
 		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out, patiently waiting for you to opt back in")
 	} else {
 		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out but a enterprise license is detected, enabling tessen.. thank you so much for your support 💚")

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -405,16 +405,12 @@ func (t *Tessend) enabled(tessen *corev2.TessenConfig) bool {
 		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted in, enabling tessen.. thank you so much for your support 💚")
 		return true
 	}
-
-	wrapper := &Wrapper{}
-	err := etcd.Get(t.ctx, t.client, licenseStorePath, wrapper)
-	if err != nil || t.AllowOptOut {
+	if t.AllowOptOut {
 		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out, patiently waiting for you to opt back in")
-	} else {
-		logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out but a enterprise license is detected, enabling tessen.. thank you so much for your support 💚")
+		return false
 	}
-
-	return err == nil
+	logger.WithField("opt-out", tessen.OptOut).Info("tessen is opted out but per the license agreement, we're enabling tessen.. thank you so much for your support 💚")
+	return true
 }
 
 // collectAndSend is a durable function to collect and send data to tessen.


### PR DESCRIPTION
## What is this change?

Adds an exportable `AllowOptOut` field to the Tessen daemon.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2967

## Does your change need a Changelog entry?

No, this doesn't change functionality.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

E2E testing. A new test case is not required at this time.