### PR TITLE
[Web] G-Zip dashboard assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed the behaviors for check `Occurrences` and `OccurrencesWatermark`.
+- [Web] Compress dashboard assets
 
 ## [5.8.0] - 2019-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed the behaviors for check `Occurrences` and `OccurrencesWatermark`.
 - Fixed a panic that could occur when seeding initial data.
 - [Web] Compress dashboard assets
+- [Web] Fixed regression where dashboard assets were no longer compressed.
 
 ## [5.8.0] - 2019-05-22
 

--- a/backend/dashboardd/dashboardd.go
+++ b/backend/dashboardd/dashboardd.go
@@ -159,7 +159,7 @@ func httpRouter(d *Dashboardd) *mux.Router {
 	r.PathPrefix("/index.json").Handler(gziphandler(listAssetsHandler(d.Assets, d.logger)))
 
 	// Serve assets
-	r.PathPrefix("/static").Handler(staticHandler(d.Assets))
+	r.PathPrefix("/static").Handler(gziphandler(staticHandler(d.Assets)))
 	r.PathPrefix("/").Handler(rootHandler(d.Assets))
 
 	return r


### PR DESCRIPTION
## What is this change?

Bundle dashboard assets are (relatively) large and would benefit from benefit from compression over the wire.

## Why is this change necessary?

I believe this regression was introduced in #2786

## Does your change need a Changelog entry?

Yes!

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Manual.