### PR TITLE
Fix/arm overflow int

### DIFF
--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -38,7 +38,7 @@ const (
 
 	// DefaultQuotaBackendBytes is the default database size limit for etcd
 	// databases (4 GB)
-	DefaultQuotaBackendBytes = 1 << 32
+	DefaultQuotaBackendBytes int64 = (1 << 32)
 )
 
 func init() {


### PR DESCRIPTION
The last tag and master failed to compiled on ARM architecture with 
`backend/cmd/start.go:290:18: constant 4294967296 overflows int` error


