### PR TITLE
Add a DeleteHandler mutation on the GraphQL endpoint

### DIFF
--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -265,6 +265,27 @@ func decodeEventGID(gid string) (globalid.EventComponents, error) {
 }
 
 //
+// Implement handler mutations
+//
+
+// DeleteHandler implements response to request for the 'deleteHandler' field.
+func (r *mutationsImpl) DeleteHandler(p schema.MutationDeleteHandlerFieldResolverParams) (interface{}, error) {
+	components, _ := globalid.Decode(p.Args.Input.ID)
+	ctx := setContextFromComponents(p.Context, components)
+
+	client := r.factory.NewWithContext(ctx)
+
+	err := client.DeleteHandler(components.Namespace(), components.UniqueComponent())
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"clientMutationId": p.Args.Input.ClientMutationID,
+		"deletedId":        components.String(),
+	}, nil
+}
+
+//
 // Implement silenced mutations
 //
 

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -163,6 +163,30 @@ func TestMutationTypeDeleteEventField(t *testing.T) {
 	assert.Nil(t, body)
 }
 
+func TestMutationTypeDeleteHandlerField(t *testing.T) {
+	hd := types.FixtureHandler("a")
+	gid := globalid.HandlerTranslator.EncodeToString(hd)
+
+	inputs := schema.DeleteRecordInput{ID: gid}
+	params := schema.MutationDeleteHandlerFieldResolverParams{}
+	params.Args.Input = &inputs
+
+	client, factory := client.NewClientFactory()
+	impl := mutationsImpl{factory: factory}
+
+	// Success
+	client.On("DeleteHandler", mock.Anything, mock.Anything).Return(nil).Once()
+	body, err := impl.DeleteHandler(params)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, body)
+
+	// Failure
+	client.On("DeleteHandler", mock.Anything, mock.Anything).Return(errors.New("err")).Once()
+	body, err = impl.DeleteHandler(params)
+	assert.Error(t, err)
+	assert.Nil(t, body)
+}
+
 func TestMutationTypeCreateSilenceField(t *testing.T) {
 	inputs := schema.CreateSilenceInput{
 		Namespace: "a",

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -146,6 +146,23 @@ type MutationDeleteEventFieldResolver interface {
 	DeleteEvent(p MutationDeleteEventFieldResolverParams) (interface{}, error)
 }
 
+// MutationDeleteHandlerFieldResolverArgs contains arguments provided to deleteHandler when selected
+type MutationDeleteHandlerFieldResolverArgs struct {
+	Input *DeleteRecordInput // Input - self descriptive
+}
+
+// MutationDeleteHandlerFieldResolverParams contains contextual info to resolve deleteHandler field
+type MutationDeleteHandlerFieldResolverParams struct {
+	graphql.ResolveParams
+	Args MutationDeleteHandlerFieldResolverArgs
+}
+
+// MutationDeleteHandlerFieldResolver implement to resolve requests for the Mutation's deleteHandler field.
+type MutationDeleteHandlerFieldResolver interface {
+	// DeleteHandler implements response to request for deleteHandler field.
+	DeleteHandler(p MutationDeleteHandlerFieldResolverParams) (interface{}, error)
+}
+
 // MutationCreateSilenceFieldResolverArgs contains arguments provided to createSilence when selected
 type MutationCreateSilenceFieldResolverArgs struct {
 	Input *CreateSilenceInput // Input - self descriptive
@@ -250,6 +267,7 @@ type MutationFieldResolvers interface {
 	MutationDeleteEntityFieldResolver
 	MutationResolveEventFieldResolver
 	MutationDeleteEventFieldResolver
+	MutationDeleteHandlerFieldResolver
 	MutationCreateSilenceFieldResolver
 	MutationDeleteSilenceFieldResolver
 }
@@ -345,6 +363,12 @@ func (_ MutationAliases) ResolveEvent(p MutationResolveEventFieldResolverParams)
 
 // DeleteEvent implements response to request for 'deleteEvent' field.
 func (_ MutationAliases) DeleteEvent(p MutationDeleteEventFieldResolverParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// DeleteHandler implements response to request for 'deleteHandler' field.
+func (_ MutationAliases) DeleteHandler(p MutationDeleteHandlerFieldResolverParams) (interface{}, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
 	return val, err
 }
@@ -472,6 +496,19 @@ func _ObjTypeMutationDeleteEventHandler(impl interface{}) graphql1.FieldResolveF
 	}
 }
 
+func _ObjTypeMutationDeleteHandlerHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(MutationDeleteHandlerFieldResolver)
+	return func(p graphql1.ResolveParams) (interface{}, error) {
+		frp := MutationDeleteHandlerFieldResolverParams{ResolveParams: p}
+		err := mapstructure.Decode(p.Args, &frp.Args)
+		if err != nil {
+			return nil, err
+		}
+
+		return resolver.DeleteHandler(frp)
+	}
+}
+
 func _ObjTypeMutationCreateSilenceHandler(impl interface{}) graphql1.FieldResolveFn {
 	resolver := impl.(MutationCreateSilenceFieldResolver)
 	return func(p graphql1.ResolveParams) (interface{}, error) {
@@ -552,6 +589,16 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 				Name:              "deleteEvent",
 				Type:              graphql.OutputType("DeleteRecordPayload"),
 			},
+			"deleteHandler": &graphql1.Field{
+				Args: graphql1.FieldConfigArgument{"input": &graphql1.ArgumentConfig{
+					Description: "self descriptive",
+					Type:        graphql1.NewNonNull(graphql.InputType("DeleteRecordInput")),
+				}},
+				DeprecationReason: "",
+				Description:       "Removes given handler.",
+				Name:              "deleteHandler",
+				Type:              graphql.OutputType("DeleteRecordPayload"),
+			},
 			"deleteSilence": &graphql1.Field{
 				Args: graphql1.FieldConfigArgument{"input": &graphql1.ArgumentConfig{
 					Description: "self descriptive",
@@ -625,6 +672,7 @@ var _ObjectTypeMutationDesc = graphql.ObjectDesc{
 		"deleteCheck":   _ObjTypeMutationDeleteCheckHandler,
 		"deleteEntity":  _ObjTypeMutationDeleteEntityHandler,
 		"deleteEvent":   _ObjTypeMutationDeleteEventHandler,
+		"deleteHandler": _ObjTypeMutationDeleteHandlerHandler,
 		"deleteSilence": _ObjTypeMutationDeleteSilenceHandler,
 		"executeCheck":  _ObjTypeMutationExecuteCheckHandler,
 		"putWrapped":    _ObjTypeMutationPutWrappedHandler,

--- a/backend/apid/graphql/schema/mutations.graphql
+++ b/backend/apid/graphql/schema/mutations.graphql
@@ -44,6 +44,13 @@ type Mutation {
   deleteEvent(input: DeleteRecordInput!): DeleteRecordPayload
 
   #
+  # Handlers
+  #
+
+  "Removes given handler."
+  deleteHandler(input: DeleteRecordInput!): DeleteRecordPayload
+
+  #
   # Silences
   #
 

--- a/backend/apid/graphql/schema/namespace.gql.go
+++ b/backend/apid/graphql/schema/namespace.gql.go
@@ -160,7 +160,8 @@ type NamespaceHandlersFieldResolverArgs struct {
 	Eg.
 
 	type:pipe
-	type:socket
+	type:tcp
+	type:udp
 	type:set
 	*/
 }
@@ -681,7 +682,7 @@ func _ObjectTypeNamespaceConfigFn() graphql1.ObjectConfig {
 					},
 					"filters": &graphql1.ArgumentConfig{
 						DefaultValue: []interface{}{},
-						Description:  "Filters reduces the set using given arbitrary expression[s]; expressions\ntake on the form KEY: VALUE. The accepted key(s) are: type.\n\nEg.\n\ntype:pipe\ntype:socket\ntype:set",
+						Description:  "Filters reduces the set using given arbitrary expression[s]; expressions\ntake on the form KEY: VALUE. The accepted key(s) are: type.\n\nEg.\n\ntype:pipe\ntype:tcp\ntype:udp\ntype:set",
 						Type:         graphql1.NewList(graphql1.NewNonNull(graphql1.String)),
 					},
 					"limit": &graphql1.ArgumentConfig{


### PR DESCRIPTION
## What is this change?
This change updates the GraphQL schema with a `deleteHandler` mutation to support the `sensu/sensu-enterprise-go/444` issue ([link](https://github.com/sensu/sensu-enterprise-go/issues/444)) which allows users to delete a handler resource via the Web UI.

## Why is this change necessary?
This is the first PR to address `sensu/sensu-enterprise-go/444` ([link](https://github.com/sensu/sensu-enterprise-go/issues/444))
> As a user, I can delete a handler through the web UI.

## Does your change need a Changelog entry?
Yes, 058cddd

## How did you verify this change?
Unit and manual. Create a Handler, use the GraphQL endpoint to delete the Handler with the following operation:
```
mutation {
  deleteHandler(input: {
    id: "srn:handlers:sensu-devel:slack"
  }) {
    clientMutationId
  }
}
````
