### PR TITLE
Refactor eventd and keepalived

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -165,6 +165,7 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize eventd
 	event, err := eventd.New(eventd.Config{
 		Store:           store,
+		EventStore:      store,
 		Bus:             bus,
 		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
 	})
@@ -206,6 +207,7 @@ func Initialize(config *Config) (*Backend, error) {
 		DeregistrationHandler: config.DeregistrationHandler,
 		Bus:             bus,
 		Store:           store,
+		EventStore:      store,
 		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
 		RingPool:        ringPool,
 	})

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -46,6 +46,7 @@ func TestEventHandling(t *testing.T) {
 	mockStore := &mockstore.MockStore{}
 	e, err := New(Config{
 		Store:           mockStore,
+		EventStore:      mockStore,
 		Bus:             bus,
 		LivenessFactory: newFakeFactory(&fakeSwitchSet{}),
 	})
@@ -105,7 +106,7 @@ func TestEventMonitor(t *testing.T) {
 	require.NoError(t, bus.Start())
 
 	mockStore := &mockstore.MockStore{}
-	e, err := New(Config{Store: mockStore, Bus: bus})
+	e, err := New(Config{Store: mockStore, EventStore: mockStore, Bus: bus})
 	require.NoError(t, err)
 	e.handlerCount = 5
 
@@ -339,6 +340,7 @@ func TestCheckTTL(t *testing.T) {
 
 			e := &Eventd{
 				store:           store,
+				eventStore:      store,
 				livenessFactory: newFakeFactory(switches),
 				handlerCount:    1,
 				wg:              &sync.WaitGroup{},

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -62,7 +62,7 @@ func TestEventdMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	e, err := New(Config{Store: store, Bus: bus, LivenessFactory: livenessFactory})
+	e, err := New(Config{Store: store, EventStore: store, Bus: bus, LivenessFactory: livenessFactory})
 	require.NoError(t, err)
 
 	if err := e.Start(); err != nil {

--- a/backend/keepalived/deregisterer_test.go
+++ b/backend/keepalived/deregisterer_test.go
@@ -20,8 +20,9 @@ func TestDeregister(t *testing.T) {
 	mockBus := &mockbus.MockBus{}
 
 	adapter := &Deregistration{
-		Store:      mockStore,
-		MessageBus: mockBus,
+		EntityStore: mockStore,
+		EventStore:  mockStore,
+		MessageBus:  mockBus,
 	}
 
 	entity := types.FixtureEntity("entity")
@@ -45,8 +46,9 @@ func TestDeregistrationHandler(t *testing.T) {
 	mockBus := &mockbus.MockBus{}
 
 	adapter := &Deregistration{
-		Store:      mockStore,
-		MessageBus: mockBus,
+		EventStore:  mockStore,
+		EntityStore: mockStore,
+		MessageBus:  mockBus,
 	}
 
 	entity := types.FixtureEntity("entity")

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -80,7 +80,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 
 	factory := liveness.EtcdFactory(context.Background(), client)
 
-	k, err := New(Config{Store: store, Bus: bus, LivenessFactory: factory})
+	k, err := New(Config{Store: store, EventStore: store, Bus: bus, LivenessFactory: factory})
 	require.NoError(t, err)
 
 	if err := k.Start(); err != nil {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -46,6 +46,7 @@ type Keepalived struct {
 	bus                   messaging.MessageBus
 	handlerCount          int
 	store                 store.Store
+	eventStore            store.EventStore
 	deregistrationHandler string
 	mu                    *sync.Mutex
 	wg                    *sync.WaitGroup
@@ -62,6 +63,7 @@ type Option func(*Keepalived) error
 // Config configures Keepalived.
 type Config struct {
 	Store                 store.Store
+	EventStore            store.EventStore
 	Bus                   messaging.MessageBus
 	LivenessFactory       liveness.Factory
 	DeregistrationHandler string
@@ -71,8 +73,9 @@ type Config struct {
 // New creates a new Keepalived.
 func New(c Config, opts ...Option) (*Keepalived, error) {
 	k := &Keepalived{
-		store: c.Store,
-		bus:   c.Bus,
+		store:      c.Store,
+		eventStore: c.EventStore,
+		bus:        c.Bus,
 		deregistrationHandler: c.DeregistrationHandler,
 		livenessFactory:       c.LivenessFactory,
 		keepaliveChan:         make(chan interface{}, 10),
@@ -372,8 +375,9 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 	}
 
 	deregisterer := &Deregistration{
-		Store:      k.store,
-		MessageBus: k.bus,
+		EntityStore: k.store,
+		EventStore:  k.eventStore,
+		MessageBus:  k.bus,
 	}
 
 	if entity.Deregister {


### PR DESCRIPTION
This commit refactors eventd and keepalived so that event storage is
decoupled from other stores.

## Why is this change necessary?

This work will support alternative event storage systems in the Sensu Go enterprise product. Closes #2999 

## Does your change need a Changelog entry?

No. No functionality has changed with this commit.

## How did you verify this change?

The change was verified with the docker-compose environment and with integration tests.