### PR TITLE
Use latest docker tag instead of master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a panic that could occur when seeding initial data.
 - [Web] Compress dashboard assets
 - [Web] Fixed regression where dashboard assets were no longer compressed.
+- The docker-compose.yaml file now refers to the sensu/sensu:latest image.
 
 ## [5.8.0] - 2019-05-22
 

--- a/build.sh
+++ b/build.sh
@@ -207,8 +207,8 @@ docker_build() {
         build_binary linux amd64 $cmd $cmd_name $ext
     done
 
-    # build the docker image with master tag
-    docker build --label build.sha=${build_sha} -t sensu/sensu:master .
+    # build the docker image with latest tag
+    docker build --label build.sha=${build_sha} -t sensu/sensu:latest .
 }
 
 test_dashboard() {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   backend1:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend1 --etcd-advertise-client-urls http://backend1:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend1:2380 --state-dir /var/lib/sensu/sensu-backend/etcd1 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug --debug
     hostname: backend1
     restart: always
@@ -13,7 +13,7 @@ services:
       - "6060:6060"
       - "3000:3000"
   backend2:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend2 --etcd-advertise-client-urls http://backend2:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend2:2380 --state-dir /var/lib/sensu/sensu-backend/etcd2 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug
     hostname: backend2
     restart: always
@@ -23,7 +23,7 @@ services:
       - "18080:8080"
       - "18081:8081"
   backend3:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --name backend3 --etcd-advertise-client-urls http://backend3:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend3:2380 --state-dir /var/lib/sensu/sensu-backend/etcd3 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug
     hostname: backend3
     restart: always
@@ -33,7 +33,7 @@ services:
       - "28080:8080"
       - "28081:8081"
   agent1:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend1:8081 --subscriptions switches --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent1
     restart: always
@@ -42,7 +42,7 @@ services:
       - backend2
       - backend3
   agent2:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions switches --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent2
     restart: always
@@ -51,7 +51,7 @@ services:
       - backend2
       - backend3
   agent3:
-   image: sensu/sensu:master
+   image: sensu/sensu:latest
    command: sensu-agent start --backend-url ws://backend3:8081 --subscriptions rbac,roundrobin --log-level warn --namespace devops --keepalive-interval 5 --keepalive-timeout 10
    hostname: agent3
    restart: always
@@ -60,7 +60,7 @@ services:
      - backend2
      - backend3
   agent4:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions schedules,rbac,roundrobin,proxy --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent4
     restart: always
@@ -69,7 +69,7 @@ services:
       - backend2
       - backend3
   agent5:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions schedules,rbac,roundrobin,proxy --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent5
     restart: always
@@ -78,7 +78,7 @@ services:
       - backend2
       - backend3
   agent6:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions schedules,rbac,roundrobin,proxy --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent6
     restart: always
@@ -87,7 +87,7 @@ services:
       - backend2
       - backend3
   agent7:
-    image: sensu/sensu:master
+    image: sensu/sensu:latest
     command: sensu-agent start --backend-url ws://backend2:8081 --subscriptions schedules,rbac,roundrobin,proxy --log-level warn --keepalive-interval 5 --keepalive-timeout 10
     hostname: agent7
     restart: always


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This change replaces the deprecated `master` tag for our Docker images, which is referred by the [docker-compose.yaml](https://github.com/sensu/sensu-go/blob/master/docker-compose.yaml) file.


## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2963

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope.

## How did you verify this change?

Manually tested.
