### PR TITLE
Fixed listing of silenced entries by check or subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a panic that could occur when seeding initial data.
 - [Web] Compress dashboard assets
 - [Web] Fixed regression where dashboard assets were no longer compressed.
+- Fixed listing of silenced entries by subscription or check.
 
 ## [5.8.0] - 2019-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a panic that could occur when seeding initial data.
 - [Web] Compress dashboard assets
 - [Web] Fixed regression where dashboard assets were no longer compressed.
-- Fixed listing of silenced entries by subscription or check.
+- Fixed listing of silenced entries by check or subscription.
 
 ## [5.8.0] - 2019-05-22
 

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -36,9 +36,8 @@ func (r *SilencedRouter) Mount(parent *mux.Router) {
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 
-	// Custom routes for listing by subscription and checks, for both specific
-	// namespaces and all namespaces
-	routes.Router.HandleFunc("/{resource:silenced}/subscriptions/{subscription}", listHandler(r.list)).Methods(http.MethodGet)
+	// Custom routes for listing by subscription and checks for a specific
+	// namespace, in addition to all namespaces for checks.
 	routes.Router.HandleFunc("/{resource:silenced}/checks/{check}", listHandler(r.list)).Methods(http.MethodGet)
 	routes.Router.HandleFunc(routes.PathPrefix+"/subscriptions/{subscription}", listHandler(r.list)).Methods(http.MethodGet)
 	routes.Router.HandleFunc(routes.PathPrefix+"/checks/{check}", listHandler(r.list)).Methods(http.MethodGet)

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -36,9 +36,12 @@ func (r *SilencedRouter) Mount(parent *mux.Router) {
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
 
-	// Custom
-	routes.Router.HandleFunc("subscriptions/{subscriptions}", listHandler(r.list)).Methods(http.MethodGet)
-	routes.Router.HandleFunc("checks/{check}", listHandler(r.list)).Methods(http.MethodGet)
+	// Custom routes for listing by subscription and checks, for both specific
+	// namespaces and all namespaces
+	routes.Router.HandleFunc("/{resource:silenced}/subscriptions/{subscription}", listHandler(r.list)).Methods(http.MethodGet)
+	routes.Router.HandleFunc("/{resource:silenced}/checks/{check}", listHandler(r.list)).Methods(http.MethodGet)
+	routes.Router.HandleFunc(routes.PathPrefix+"/subscriptions/{subscription}", listHandler(r.list)).Methods(http.MethodGet)
+	routes.Router.HandleFunc(routes.PathPrefix+"/checks/{check}", listHandler(r.list)).Methods(http.MethodGet)
 }
 
 func (r *SilencedRouter) list(w http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -2,6 +2,7 @@ package silenced
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"time"
 
@@ -38,6 +39,12 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// We do not support both subscription and all-namespaces flags together
+			if sub != "" && namespace == types.NamespaceTypeAll {
+				return fmt.Errorf("the subscription and %s flags are mutually exclusive", flags.AllNamespaces)
+			}
+
 			check, err := flg.GetString("check")
 			if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This fixes the `/silenced/subscriptions/:subscription` & `/silenced/checks/:check` API endpoints, and make sure the `--subscription` & `--all-namespaces` flags are not used at the same time (otherwise it tries to query `/sensu.io/silenced/:subscription`), which shouldn't be happening).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2972

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

Manually tested. Assigned https://github.com/sensu/sensu-go-qa-crucible/issues/46 to myself.
