### PR TITLE
[GraphQL] Ensure only events associated with an entity are returned

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -61,7 +61,7 @@ func (r *entityImpl) Events(p schema.EntityEventsFieldResolverParams) (interface
 		return []interface{}{}, err
 	}
 	records := filterEvents(results, func(obj *types.Event) bool {
-		return matches(obj)
+		return obj.Entity.Name == src.Name && matches(obj)
 	})
 
 	// sort records

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -96,19 +96,20 @@ func TestEntityTypeEventsField(t *testing.T) {
 	client.On("ListEvents", mock.Anything, mock.Anything).Return([]types.Event{
 		*types.FixtureEvent(entity.Name, "a"),
 		*types.FixtureEvent(entity.Name, "b"),
-		*types.FixtureEvent(entity.Name, "c"),
+		*types.FixtureEvent("no-entity", "c"),
 	}, nil).Once()
 
 	// params
 	params := schema.EntityEventsFieldResolverParams{}
 	params.Context = contextWithLoadersNoCache(context.Background(), client)
+	params.Args.Filters = []string{}
 	params.Source = entity
 
 	// return all events
 	impl := &entityImpl{}
 	evs, err := impl.Events(params)
 	require.NoError(t, err)
-	assert.Len(t, evs, 3)
+	assert.Len(t, evs, 2)
 }
 
 func TestEntityTypeSilencesField(t *testing.T) {


### PR DESCRIPTION
## What is this change?

Fixes a regression on the `Entity` type's `events` field, where events that are not directly related to the entity would be included in the result.

Introduced in #2951.

## Why is this change necessary?

It's a regression to core functionality.

## Does your change need a Changelog entry?

Regression was introduced prior to the last release.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Improved unit tests and manual testing.