### PR TITLE
Fix sensuctl logout message

### DIFF
--- a/cli/commands/logout/logout.go
+++ b/cli/commands/logout/logout.go
@@ -31,7 +31,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "You have been logout")
+			fmt.Fprintln(cmd.OutOrStdout(), "You have been logged out")
 			return nil
 		},
 	}

--- a/cli/commands/logout/logout_test.go
+++ b/cli/commands/logout/logout_test.go
@@ -24,7 +24,7 @@ func TestLogout(t *testing.T) {
 	config.On("Tokens").Return(tokens)
 
 	out, err := test.RunCmd(cmd, []string{})
-	assert.Regexp(t, "logout", out)
+	assert.Regexp(t, "logged out", out)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

Fixes the `sensuctl logout` confirmation message.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2450

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?
Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested