### PR TITLE
Fix error message for asset's SHA mismatch

### DIFF
--- a/asset/verifier.go
+++ b/asset/verifier.go
@@ -33,7 +33,7 @@ func (v *sha512Verifier) Verify(rs io.ReadSeeker, desiredSHA string) error {
 	}
 
 	if foundSHA := hex.EncodeToString(h.Sum(nil)); foundSHA != desiredSHA {
-		return fmt.Errorf("sha512:%s does not match specified sha512%s", desiredSHA, foundSHA)
+		return fmt.Errorf("sha512 '%s' does not match specified sha512: '%s'", desiredSHA, foundSHA)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR fixes the error message sent if an asset SHA does not match.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2454

## Does your change need a Changelog entry?

Nope!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

Manually tested
