### PR TITLE
Implement POST /api/core/v2/tessen/metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - [Web] Adds ability to delete entities
+- Added POST `/api/core/v2/tessen/metrics`.
 
 ### Changed
 - [Web] Updated embedded web assets from `275386a` ... `b0c1138`

--- a/backend/apid/actions/tessen.go
+++ b/backend/apid/actions/tessen.go
@@ -54,3 +54,24 @@ func (c TessenController) Get(ctx context.Context) (*corev2.TessenConfig, error)
 
 	return config, nil
 }
+
+// TessenMetricController exposes actions which a viewer can perform
+type TessenMetricController struct {
+	bus messaging.MessageBus
+}
+
+// NewTessenMetricController returns a new TessenMetricController
+func NewTessenMetricController(bus messaging.MessageBus) TessenMetricController {
+	return TessenMetricController{
+		bus: bus,
+	}
+}
+
+// Publish publishes the metrics to the message bus used by TessenD
+func (c TessenMetricController) Publish(ctx context.Context, metrics []corev2.MetricPoint) error {
+	if err := c.bus.Publish(messaging.TopicTessenMetric, metrics); err != nil {
+		return NewError(InternalErr, err)
+	}
+
+	return nil
+}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -104,7 +104,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 	router := mux.NewRouter().UseEncodedPath()
 	router.NotFoundHandler = middlewares.SimpleLogger{}.Then(http.HandlerFunc(notFoundHandler))
 	router.Handle("/metrics", promhttp.Handler())
-	registerUnauthenticatedResources(router, a.store, a.cluster, a.etcdClientTLSConfig, a.clusterVersion)
+	registerUnauthenticatedResources(router, a.store, a.cluster, a.etcdClientTLSConfig, a.clusterVersion, a.bus)
 	a.registerGraphQLService(router, c.URL, tlsClientConfig)
 	registerAuthenticationResources(router, a.store, a.Authenticator)
 	a.registerRestrictedResources(router)
@@ -190,6 +190,7 @@ func registerUnauthenticatedResources(
 	cluster clientv3.Cluster,
 	etcdClientTLSConfig *tls.Config,
 	clusterVersion string,
+	bus messaging.MessageBus,
 ) {
 	mountRouters(
 		NewSubrouter(
@@ -199,6 +200,7 @@ func registerUnauthenticatedResources(
 		),
 		routers.NewHealthRouter(actions.NewHealthController(store, cluster, etcdClientTLSConfig)),
 		routers.NewVersionRouter(actions.NewVersionController(clusterVersion)),
+		routers.NewTessenMetricRouter(actions.NewTessenMetricController(bus)),
 	)
 }
 

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -25,6 +25,9 @@ const (
 
 	// TopicTessen is the topic prefix for tessen api events to Tessend.
 	TopicTessen = "sensu:tessen"
+
+	// TopicTessenMetric is the topic prefix for tessen api metrics to Tessend.
+	TopicTessenMetric = "sensu:tessen-metric"
 )
 
 // A Subscriber receives messages via a channel.


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the POST `/api/core/v2/tessen/metrics` API endpoint.

## Why is this change necessary?

Closes #2982 

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs are not required.

## How did you verify this change?

Unit/integration coverage. E2E tested with POST the following []corev2.MetricPoint on `/api/core/v2/tessen/metrics`.
```
[
    {
        "name": "cpu.idle_percentage",
        "value": 61,
        "timestamp": 1525462242,
        "tags": [
            {
                "name": "name0",
                "value": "value0"
            },
            {
                "name": "name1",
                "value": "value1"
            }
        ]
    },
    {
        "name": "mem.sys",
        "value": 104448,
        "timestamp": 1525462242,
        "tags": []
    }
]
```
