### PR TITLE
Fix a regression where TotalStateChange was computed at the wrong time

### DIFF
--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -329,7 +329,6 @@ func (c *Check) MergeWith(prevCheck *Check) {
 	c.Occurrences = prevCheck.Occurrences
 	c.OccurrencesWatermark = prevCheck.OccurrencesWatermark
 	updateCheckState(c)
-	c.TotalStateChange = totalStateChange(c)
 }
 
 // FixtureCheckRequest returns a fixture for a CheckRequest object.

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -353,15 +353,17 @@ func FixtureCheckConfig(id string) *CheckConfig {
 	timeout := uint32(0)
 
 	check := &CheckConfig{
-		ObjectMeta:    NewObjectMeta(id, "default"),
-		Interval:      interval,
-		Subscriptions: []string{"linux"},
-		Command:       "command",
-		RuntimeAssets: []string{"ruby-2-4-2"},
-		CheckHooks:    []HookList{*FixtureHookList("hook1")},
-		Publish:       true,
-		Ttl:           0,
-		Timeout:       timeout,
+		ObjectMeta:        NewObjectMeta(id, "default"),
+		Interval:          interval,
+		Subscriptions:     []string{"linux"},
+		Command:           "command",
+		RuntimeAssets:     []string{"ruby-2-4-2"},
+		CheckHooks:        []HookList{*FixtureHookList("hook1")},
+		Publish:           true,
+		Ttl:               0,
+		Timeout:           timeout,
+		LowFlapThreshold:  20,
+		HighFlapThreshold: 60,
 	}
 	return check
 }

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -256,3 +256,42 @@ func TestSortCheckConfigsByName(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckMerge(t *testing.T) {
+	a := FixtureCheck("check")
+	b := FixtureCheck("check")
+
+	for i := range a.History {
+		if i%2 == 0 {
+			a.History[i].Status = 1
+		}
+	}
+
+	a.Occurrences = 1
+	a.OccurrencesWatermark = 1
+
+	b.History = nil
+	b.TotalStateChange = 0
+	b.State = ""
+	b.Occurrences = 0
+	b.OccurrencesWatermark = 0
+
+	b.MergeWith(a)
+
+	if got, want := b.TotalStateChange, uint32(98); got != want {
+		t.Errorf("bad TotalStateChange: got %d, want %d", got, want)
+	}
+
+	if got, want := b.State, EventFlappingState; got != want {
+		t.Errorf("bad State: got %s, want %s", got, want)
+	}
+
+	if got, want := b.Occurrences, int64(1); got != want {
+		t.Errorf("bad Occurrences: got %d, want %d", got, want)
+	}
+
+	if got, want := b.OccurrencesWatermark, int64(1); got != want {
+		t.Errorf("bad OccurrencesWatermark: got %d, want %d", got, want)
+	}
+
+}

--- a/api/core/v2/flapping.go
+++ b/api/core/v2/flapping.go
@@ -23,6 +23,7 @@ func isFlapping(check *Check) bool {
 // updateCheckState determines the check state based on whether the check is
 // flapping, and its status
 func updateCheckState(check *Check) {
+	check.TotalStateChange = totalStateChange(check)
 	if check == nil {
 		return
 	}

--- a/cli/commands/check/subcommands/set_low_flap_threshold_test.go
+++ b/cli/commands/check/subcommands/set_low_flap_threshold_test.go
@@ -35,6 +35,9 @@ func TestSetLowFlapThresholdCommand(t *testing.T) {
 
 		t.Run(tc.testName, func(t *testing.T) {
 			check := types.FixtureCheckConfig("checky")
+			check.LowFlapThreshold = 0
+			check.HighFlapThreshold = 0
+
 			cli := test.NewMockCLI()
 
 			client := cli.Client.(*client.MockClient)


### PR DESCRIPTION
## What is this change?
This fixes a regression introduced by an unreleased refactoring commit (#3000)

## Why is this change necessary?
Without this change, check flap detection will not work correctly.

## Does your change need a Changelog entry?
No, this is an unreleased regression.