### PR TITLE
Add EventStoreProxy

### DIFF
--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"sync/atomic"
+	"unsafe"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
+)
+
+// EventStoreProxy is a mechanism for providing an EventStore with a replaceable
+// underlying implementation. It uses an atomic so that calls are not impeded by
+// mutex overhead.
+type EventStoreProxy struct {
+	impl unsafe.Pointer
+
+	// guard against the store being garbage collected,
+	// which would cause a crash if there were no more references
+	// to it and the impl was dereferenced.
+	gcGuard EventStore
+}
+
+func NewEventStoreProxy(s EventStore) *EventStoreProxy {
+	return &EventStoreProxy{
+		impl:    unsafe.Pointer(&s),
+		gcGuard: s,
+	}
+}
+
+func (e *EventStoreProxy) do() EventStore {
+	return *((*EventStore)(atomic.LoadPointer(&e.impl)))
+}
+
+func (e *EventStoreProxy) DeleteEventByEntityCheck(ctx context.Context, entity, check string) error {
+	return e.do().DeleteEventByEntityCheck(ctx, entity, check)
+}
+
+func (e *EventStoreProxy) GetEvents(ctx context.Context, pred *SelectionPredicate) ([]*corev2.Event, error) {
+	return e.do().GetEvents(ctx, pred)
+}
+
+func (e *EventStoreProxy) GetEventsByEntity(ctx context.Context, entity string, pred *SelectionPredicate) ([]*corev2.Event, error) {
+	return e.do().GetEventsByEntity(ctx, entity, pred)
+}
+
+func (e *EventStoreProxy) GetEventByEntityCheck(ctx context.Context, entity, check string) (*types.Event, error) {
+	return e.do().GetEventByEntityCheck(ctx, entity, check)
+}
+
+func (e *EventStoreProxy) UpdateEvent(ctx context.Context, event *types.Event) (old, new *types.Event, err error) {
+	return e.do().UpdateEvent(ctx, event)
+}
+
+type closer interface {
+	Close() error
+}
+
+func (e *EventStoreProxy) UpdateEventStore(to EventStore) {
+	oldptr := atomic.SwapPointer(&e.impl, unsafe.Pointer(&to))
+	old := *((*EventStore)(oldptr))
+	if s, ok := old.(closer); ok {
+		// Attempt to close the old store
+		defer s.Close()
+	}
+	e.gcGuard = to
+}

--- a/backend/store/proxy_test.go
+++ b/backend/store/proxy_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
+)
+
+type mockEventStore struct {
+	id string
+}
+
+func (m mockEventStore) DeleteEventByEntityCheck(ctx context.Context, entity, check string) error {
+	return errors.New(m.id)
+}
+
+func (mockEventStore) GetEvents(ctx context.Context, pred *SelectionPredicate) ([]*corev2.Event, error) {
+	return nil, nil
+}
+
+func (mockEventStore) GetEventsByEntity(ctx context.Context, entity string, pred *SelectionPredicate) ([]*corev2.Event, error) {
+	return nil, nil
+}
+
+func (mockEventStore) GetEventByEntityCheck(ctx context.Context, entity, check string) (*types.Event, error) {
+	return nil, nil
+}
+
+func (mockEventStore) UpdateEvent(ctx context.Context, event *types.Event) (old, new *types.Event, err error) {
+	return nil, nil, nil
+}
+
+func TestEventStoreProxy(t *testing.T) {
+	storeA := mockEventStore{"a"}
+	storeB := mockEventStore{"b"}
+
+	proxy := NewEventStoreProxy(storeA)
+	ctx := context.Background()
+
+	err := proxy.DeleteEventByEntityCheck(ctx, "", "")
+	if got, want := err.Error(), "a"; got != want {
+		t.Fatalf("bad response from event store: got %s, want %s", got, want)
+	}
+
+	proxy.UpdateEventStore(storeB)
+
+	err = proxy.DeleteEventByEntityCheck(ctx, "", "")
+	if got, want := err.Error(), "b"; got != want {
+		t.Fatalf("bad response from event store: got %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## What is this change?

EventStoreProxy is designed to allow patching the EventStore used
by the backend.

## Why is this change necessary?

This is a strut for enterprise, so that we can support alternative event stores.

## Does your change need a Changelog entry?

Nein