### PR TITLE
Add an `upsert` parameter to the `PutWrapped` mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ populate, and send them to the Tessen service.
 - Refactoring of the REST API.
 - Changed the identifying cluster id in TessenD from the etcd cluster id to
 the sensu cluster id.
+- [GraphQL] Updates `PutResource` mutation to accept an `upsert` boolean flag parameter. The `upsert` param defaults to `true`, but if set to `false` the mutation will return an error when attempting to create a duplicate resource.
 
 ### Fixed
 - The check state and check total_state_change properties are now more correct.

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -12,7 +12,12 @@ import (
 
 // MutationPutWrappedFieldResolverArgs contains arguments provided to putWrapped when selected
 type MutationPutWrappedFieldResolverArgs struct {
-	Raw string // Raw - self descriptive
+	Raw    string // Raw is a JSON string representation of the resource
+	Upsert bool   /*
+	Upsert is a flag that determines whether to insert a resource, or on
+	the basis of the resource already existing, UPDATE that existing
+	resource instead.
+	*/
 }
 
 // MutationPutWrappedFieldResolverParams contains contextual info to resolve putWrapped field
@@ -620,10 +625,17 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 				Type:              graphql.OutputType("ExecuteCheckPayload"),
 			},
 			"putWrapped": &graphql1.Field{
-				Args: graphql1.FieldConfigArgument{"raw": &graphql1.ArgumentConfig{
-					Description: "self descriptive",
-					Type:        graphql1.NewNonNull(graphql1.String),
-				}},
+				Args: graphql1.FieldConfigArgument{
+					"raw": &graphql1.ArgumentConfig{
+						Description: "Raw is a JSON string representation of the resource",
+						Type:        graphql1.NewNonNull(graphql1.String),
+					},
+					"upsert": &graphql1.ArgumentConfig{
+						DefaultValue: true,
+						Description:  "Upsert is a flag that determines whether to insert a resource, or on\nthe basis of the resource already existing, UPDATE that existing\nresource instead.",
+						Type:         graphql1.Boolean,
+					},
+				},
 				DeprecationReason: "",
 				Description:       "Create or overrwrite resource from given wrapped resource.",
 				Name:              "putWrapped",

--- a/backend/apid/graphql/schema/mutations.graphql
+++ b/backend/apid/graphql/schema/mutations.graphql
@@ -8,7 +8,16 @@ type Mutation {
   #
 
   "Create or overrwrite resource from given wrapped resource."
-  putWrapped(raw: String!): PutWrappedPayload!
+  putWrapped(
+    "Raw is a JSON string representation of the resource"
+    raw: String!,
+    """
+    Upsert is a flag that determines whether to insert a resource, or on
+    the basis of the resource already existing, UPDATE that existing
+    resource instead.
+    """
+    upsert: Boolean = true,
+  ): PutWrappedPayload!
 
   #
   # Checks


### PR DESCRIPTION
## What is this change?

This change updates the `PutWrapped` mutation resolver in order to conditionally call the resource POST endpoint if the user of the mutation does not want the mutation to upsert the resource they are passing as the `raw` argument of the mutation. 

Previously, the mutation would always call the resource POST endpoint, which overwrites (upserts) the resource even if the resource already exists. Since users of the mutation don't always want this behaviour, we're updating the implementation of the `PutWrapped` mutation resolver to conditionally call the POST endpoint if the `upsert` parameter is `false`. By default, the `upsert` parameter is `true` in order to maintain the original behaviour of the mutation (for backwards compatibility).

To support this change, this PR also updates the mutations schema to reflect the addition of the `upsert` argument in the `PutWrapped` mutation.

## Why is this change necessary?
This change supports a bug reported in Sensu Enterprise
> https://github.com/sensu/sensu-enterprise-go/issues/496

## Does your change need a Changelog entry?
Yes, 

## Do you need clarification on anything?
No.

## Were there any complications while making this change?
Yes. We implemented a minor hack in order to correctly call the `POST` end point for a resource

If the `upsert` parameter on this mutation is `false`, we want to return an error if the resource already exists, instead of updating the existing resource. To do this, we make a request to the POST endpoint instead of the PUT endpoint. However, since the URI path resolved from `ret.Value.URIPath()` includes the name of the resource in the path string, we need to remove the name in order to call the correct endpoint. 

Ex. 
```
POST `/api/core/v2/namespaces/default/checks` 
PUT `/api/core/v2/namespaces/default/checks/check-cpu` 
```

Here we use `strings.TrimSuffix` to remove the resource name in order to call the correct endpoint. This works for the resource we currently create from the Web UI (Checks and Handlers), but it's possible that this _may_ not work for future resources.

## Have you reviewed and updated the documentation for this change? Is new documentation required?
No documentation is required.

## How did you verify this change?
Manually and with automated tests.
