### PR TITLE
[GraphQL] Add ability to hook into initialization of service

### DIFF
--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -137,11 +137,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterStandardError(svc, stdErrImpl{})
 	schema.RegisterError(svc, &errImpl{})
 
-	err := svc.Regenerate()
-
+	// Run init hooks allowing consumers to extend service
 	for _, hookFn := range InitHooks {
 		hookFn(svc, cfg)
 	}
+
+	err := svc.Regenerate()
 	return &wrapper, err
 }
 

--- a/backend/apid/graphql/service_test.go
+++ b/backend/apid/graphql/service_test.go
@@ -4,13 +4,35 @@ import (
 	"testing"
 
 	client "github.com/sensu/sensu-go/backend/apid/graphql/mockclient"
+	"github.com/sensu/sensu-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewServiceSmokeTest(t *testing.T) {
+func addHook(fns ...InitHook) func() {
+	initialHooks := make([]InitHook, 0, len(InitHooks))
+	copy(initialHooks, InitHooks)
+	InitHooks = append(InitHooks, fns...)
+	return func() {
+		copy(InitHooks, initialHooks)
+	}
+}
+
+func TestNewService(t *testing.T) {
 	_, factory := client.NewClientFactory()
 	svc, err := NewService(ServiceConfig{ClientFactory: factory})
 	require.NoError(t, err)
 	assert.NotEmpty(t, svc)
+}
+
+func TestInitHooks(t *testing.T) {
+	flag := false
+	rollback := addHook(func(svc *graphql.Service, cfg ServiceConfig) {
+		flag = true
+	})
+	defer rollback()
+
+	_, err := NewService(ServiceConfig{})
+	require.NoError(t, err)
+	assert.True(t, flag)
 }

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -9,7 +9,7 @@ import (
 
 // Service ...TODO...
 type Service struct {
-	Schema graphql.Schema
+	schema graphql.Schema
 	types  *typeRegister
 }
 
@@ -113,7 +113,7 @@ func (service *Service) RegisterSchema(t SchemaDesc) {
 func (service *Service) Regenerate() error {
 	schema, err := newSchema(service.types)
 	if err == nil {
-		service.Schema = schema
+		service.schema = schema
 	}
 	return err
 }
@@ -125,7 +125,7 @@ func (service *Service) Do(
 	vars map[string]interface{},
 ) *graphql.Result {
 	params := graphql.Params{
-		Schema:         service.Schema,
+		Schema:         service.schema,
 		VariableValues: vars,
 		Context:        ctx,
 		RequestString:  q,

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -9,8 +9,8 @@ import (
 
 // Service ...TODO...
 type Service struct {
+	Schema graphql.Schema
 	types  *typeRegister
-	schema graphql.Schema
 }
 
 // NewService returns new instance of Service
@@ -113,7 +113,7 @@ func (service *Service) RegisterSchema(t SchemaDesc) {
 func (service *Service) Regenerate() error {
 	schema, err := newSchema(service.types)
 	if err == nil {
-		service.schema = schema
+		service.Schema = schema
 	}
 	return err
 }
@@ -125,7 +125,7 @@ func (service *Service) Do(
 	vars map[string]interface{},
 ) *graphql.Result {
 	params := graphql.Params{
-		Schema:         service.schema,
+		Schema:         service.Schema,
 		VariableValues: vars,
 		Context:        ctx,
 		RequestString:  q,


### PR DESCRIPTION
## What is this change?

Adds an InitHooks global to the GraphQL service so that consumers and/or 
product variants can hook into the initialization of the service and make additions
to the schema.

## Why is this change necessary?

Will allow our enterprise distribution to modify the schema.

## Does your change need a Changelog entry?

Sure.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No, not in particular.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No changes required.

## How did you verify this change?

A unit test and some manual testing upstream.