### PR TITLE
Append a tag to metric if an internal environment variable is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 populate, and send them to the Tessen service.
 - [Web] Adds ability to delete entities
 - [GraphQL] Adds simple auto-suggestion feature.
+- Added a tag to all Tessen metrics to differentiate internal builds.
 
 ### Changed
 - [Web] Updated embedded web assets from `275386a` ... `b0c1138`

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -241,6 +241,7 @@ func (t *Tessend) startMessageHandler() {
 					}
 					metric.Tags = append(metric.Tags, &corev2.MetricTag{Name: "hostname", Value: hostname})
 					metric.Timestamp = now
+					appendInternalTag(&metric)
 					logMetric(&metric)
 					data.Metrics.Points = append(data.Metrics.Points, &metric)
 				}
@@ -401,6 +402,7 @@ func (t *Tessend) sendPromMetrics() {
 			},
 		},
 	}
+	appendInternalTag(mp)
 	logMetric(mp)
 	data.Metrics.Points = append(data.Metrics.Points, mp)
 
@@ -545,6 +547,7 @@ func (t *Tessend) getPerResourceMetrics(now int64, data *Data) {
 		Value:     backendCount,
 		Timestamp: now,
 	}
+	appendInternalTag(mp)
 	logMetric(mp)
 	data.Metrics.Points = append(data.Metrics.Points, mp)
 
@@ -563,6 +566,7 @@ func (t *Tessend) getPerResourceMetrics(now int64, data *Data) {
 			Value:     float64(count),
 			Timestamp: now,
 		}
+		appendInternalTag(mp)
 		logMetric(mp)
 		data.Metrics.Points = append(data.Metrics.Points, mp)
 	}
@@ -581,6 +585,7 @@ func (t *Tessend) getTessenConfigMetrics(now int64, tessen *corev2.TessenConfig,
 			},
 		},
 	}
+	appendInternalTag(mp)
 	logMetric(mp)
 	data.Metrics.Points = append(data.Metrics.Points, mp)
 }
@@ -610,4 +615,14 @@ func logMetric(m *corev2.MetricPoint) {
 		"metric_name":  m.Name,
 		"metric_value": m.Value,
 	}).Debug("collected a metric for tessen")
+}
+
+// appendInternalTag tags the metric with an internal environment variable value
+func appendInternalTag(m *corev2.MetricPoint) {
+	if internalEnv := os.Getenv("SENSU_INTERNAL_ENVIRONMENT"); internalEnv != "" {
+		m.Tags = append(m.Tags, &corev2.MetricTag{
+			Name:  "sensu_internal_environment",
+			Value: internalEnv,
+		})
+	}
 }

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -162,4 +163,18 @@ func TestTessendEnabled(t *testing.T) {
 	tessen.OptOut = true
 	tessend.config = tessen
 	require.False(t, tessend.enabled())
+}
+
+func TestInternalTag(t *testing.T) {
+	mp := &corev2.MetricPoint{
+		Name:  "test_metric",
+		Value: 5,
+	}
+	appendInternalTag(mp)
+	assert.Equal(t, 0, len(mp.Tags))
+	os.Setenv("SENSU_INTERNAL_ENVIRONMENT", "foo")
+	appendInternalTag(mp)
+	assert.Equal(t, 1, len(mp.Tags))
+	assert.Equal(t, "sensu_internal_environment", mp.Tags[0].Name)
+	assert.Equal(t, "foo", mp.Tags[0].Value)
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Appends a tag `sensu_internal_environment` to each metric if the `SENSU_INTERNAL_ENVIRONMENT` environment variable is set. This differentiates internal, developmental, sandbox, etc environments in our Tessen data.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/498
Closes https://github.com/sensu/sensu-go/issues/2850

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Unit test. Verified query on Chronograph (added `"sensu_internal_environment"=''` to `WHERE` clause).