### PR TITLE
Add --disable-assets flag to the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ populate, and send them to the Tessen service.
 - Added a tag to all Tessen metrics to differentiate internal builds.
 - Added a unique sensu cluster id, accessible by GET `/api/core/v2/cluster/id`.
 - Added `sensuctl cluster id` which exposes the unique sensu cluster id.
+- Added --disable-assets flag to sensu-agent.
 
 ### Changed
 - [Web] Updated embedded web assets from `275386a` ... `b0c1138`

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -745,12 +745,12 @@
   revision = "2315d5715e36303a941d907f038da7f7c44c773b"
 
 [[projects]]
-  digest = "1:55f03143250f57c5674f514c2cbacfe08fa6366a55741e0ec7f3fac1c1ce92bb"
+  digest = "1:80f6da37cbe8e63d0c910df2c5ab26b6550a97b21030fba2b5bb30f29819bccf"
   name = "github.com/sensu/lasr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ef89d3cc501cf1dc3ef065b60c9fbfa11e823967"
-  version = "v1.2.0"
+  revision = "ad0673de98cd49174a2e6b5cfea3214dafabd66c"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
@@ -1151,6 +1151,7 @@
     "github.com/coreos/etcd/pkg/transport",
     "github.com/coreos/etcd/pkg/types",
     "github.com/coreos/etcd/store",
+    "github.com/coreos/etcd/version",
     "github.com/coreos/pkg/capnslog",
     "github.com/dave/jennifer/jen",
     "github.com/dgrijalva/jwt-go",
@@ -1162,6 +1163,7 @@
     "github.com/go-resty/resty",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/jsonpb",
+    "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/proto",
     "github.com/google/uuid",
     "github.com/gorilla/mux",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -208,7 +208,7 @@ required = [
 
 [[constraint]]
   name = "github.com/sensu/lasr"
-  version = "1.2.0"
+  version = "1.2.1"
 
 [[constraint]]
   branch = "master"

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -39,6 +39,12 @@ func (a *Agent) handleCheck(ctx context.Context, payload []byte) error {
 		a.sendFailure(event, err)
 	}
 
+	if a.config.DisableAssets && len(request.Assets) > 0 {
+		err := errors.New("check requested assets, but they are disabled on this agent")
+		sendFailure(err)
+		return nil
+	}
+
 	// only schedule check execution if its not already in progress
 	// ** check hooks are part of a checks execution
 	if a.checkInProgress(request) {
@@ -90,8 +96,8 @@ func (a *Agent) executeCheck(ctx context.Context, request *v2.CheckRequest, enti
 	a.addInProgress(request)
 	defer a.removeInProgress(request)
 
-	checkConfig := request.Config
 	checkAssets := request.Assets
+	checkConfig := request.Config
 	checkHooks := request.Hooks
 
 	// Before token subsitution we retain copy of the command

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -53,6 +53,7 @@ const (
 	flagSubscriptions         = "subscriptions"
 	flagUser                  = "user"
 	flagDisableAPI            = "disable-api"
+	flagDisableAssets         = "disable-assets"
 	flagDisableSockets        = "disable-sockets"
 	flagLogLevel              = "log-level"
 	flagLabels                = "labels"
@@ -108,6 +109,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 			cfg.CacheDir = viper.GetString(flagCacheDir)
 			cfg.Deregister = viper.GetBool(flagDeregister)
 			cfg.DeregistrationHandler = viper.GetString(flagDeregistrationHandler)
+			cfg.DisableAssets = viper.GetBool(flagDisableAssets)
 			cfg.EventsAPIRateLimit = rate.Limit(viper.GetFloat64(flagEventsRateLimit))
 			cfg.EventsAPIBurstLimit = viper.GetInt(flagEventsBurstLimit)
 			cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
@@ -201,6 +203,9 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-agent"))
 	viper.SetDefault(flagDeregister, false)
 	viper.SetDefault(flagDeregistrationHandler, "")
+	viper.SetDefault(flagDisableAPI, false)
+	viper.SetDefault(flagDisableSockets, false)
+	viper.SetDefault(flagDisableAssets, false)
 	viper.SetDefault(flagEventsRateLimit, agent.DefaultEventsAPIRateLimit)
 	viper.SetDefault(flagEventsBurstLimit, agent.DefaultEventsAPIBurstLimit)
 	viper.SetDefault(flagKeepaliveInterval, agent.DefaultKeepaliveInterval)
@@ -217,8 +222,6 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	viper.SetDefault(flagStatsdEventHandlers, []string{})
 	viper.SetDefault(flagSubscriptions, []string{})
 	viper.SetDefault(flagUser, agent.DefaultUser)
-	viper.SetDefault(flagDisableAPI, false)
-	viper.SetDefault(flagDisableSockets, false)
 	viper.SetDefault(flagTrustedCAFile, "")
 	viper.SetDefault(flagInsecureSkipTLSVerify, false)
 	viper.SetDefault(flagLogLevel, "warn")
@@ -252,6 +255,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	cmd.Flags().StringSlice(flagBackendURL, viper.GetStringSlice(flagBackendURL), "ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times)")
 	cmd.Flags().Uint32(flagKeepaliveTimeout, uint32(viper.GetInt(flagKeepaliveTimeout)), "number of seconds until agent is considered dead by backend")
 	cmd.Flags().Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
+	cmd.Flags().Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	cmd.Flags().Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")
 	cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format")
 	cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")

--- a/agent/config.go
+++ b/agent/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// DisableAPI disables the events API
 	DisableAPI bool
 
+	// DisableAssets stops the agent from downloading and deploying assets
+	// in check execution.
+	DisableAssets bool
+
 	// DisableSockets disables the event sockets
 	DisableSockets bool
 

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -3,11 +3,9 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -34,20 +32,14 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cacheDir := filepath.Join(homedir, "sensu-benchmark-cache")
-
 	for i := 0; i < *flagCount; i++ {
 		name := uuid.New().String()
 
 		cfg := agent.NewConfig()
 		cfg.API.Host = agent.DefaultAPIHost
 		cfg.API.Port = agent.DefaultAPIPort
-		cfg.CacheDir = filepath.Join(cacheDir, fmt.Sprintf("sensu-agent-%d", i))
+		cfg.CacheDir = os.DevNull
+		cfg.DisableAssets = true
 		cfg.Deregister = true
 		cfg.DeregistrationHandler = ""
 		cfg.DisableAPI = true

--- a/vendor/github.com/sensu/lasr/acknack.go
+++ b/vendor/github.com/sensu/lasr/acknack.go
@@ -78,6 +78,12 @@ func (m *Message) Ack() (err error) {
 	if !atomic.CompareAndSwapInt32(&m.once, 0, 1) {
 		return ErrAckNack
 	}
+	if m.q == nil {
+		// If a user has constructed a Message outside of this package, ie,
+		// for the purposes of mocking a Q, then simply return nil here,
+		// instead of dereferencing the underlying Q and causing a panic.
+		return nil
+	}
 	return m.q.ack(m.ID)
 }
 
@@ -87,6 +93,12 @@ func (m *Message) Ack() (err error) {
 func (m *Message) Nack(retry bool) (err error) {
 	if !atomic.CompareAndSwapInt32(&m.once, 0, 1) {
 		return ErrAckNack
+	}
+	if m.q == nil {
+		// If a user has constructed a Message outside of this package, ie,
+		// for the purposes of mocking a Q, then simply return nil here,
+		// instead of dereferencing the underlying Q and causing a panic.
+		return nil
 	}
 	return m.q.nack(m.ID, retry)
 }


### PR DESCRIPTION
## What is this change?

This commit adds an agent command line flag, and ability via the
agent config file, to disable assets. In the event that an agent
is instructed to execute a check that requires an asset, the agent
will respond with a status of 3, and a message indicating that the
agent could not execute the check, because assets are disabled.

Also added is the ability to use the null device as a cache
directory. When the null device (/dev/null on nix, NUL on Windows)
is used, the agent will not attempt to create an event queue.

If --disable-assets is not set, and the cache directory is set to
the null device, then an error will occur.

These changes make the agent require no storage to operate, at the
cost of the asset and durable events API features.

## Why is this change necessary?

Closes #2287 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Automated tests.