### PR TITLE
Add VisitRulesFor RBAC Authorizer method

### DIFF
--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -60,6 +60,10 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 		}
 	}
 
+	if len(attrs.Namespace) == 0 {
+		return
+	}
+
 	roleBindings, err := a.Store.ListRoleBindings(ctx, &store.SelectionPredicate{})
 	if err != nil {
 		if !visitor(nil, empty, err) {


### PR DESCRIPTION
This commit adds the VisitRulesFor method for the RBAC Authorizer.
It also rewrites the Authorizer's Authorize method in terms of the
VisitRulesFor method, which proves the implementation.

This is refactoring only, and does not require any documentation changes or CHANGELOG entries.

Closes #3060 