### PR TITLE
API: Delete events associated with deleted entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ the sensu cluster id.
 - [Web] Avoid exception when parsing non-standard cron statements. (Eg.
 `@every 1h` or `@weekly`)
 - The resources metadata are now validated with the request URI.
+- Fixed a bug where events were not deleted when their corresponding entity was.
 
 ### Changed
 - Eventd has been refactored. Users should not perceive any changes, but a

--- a/backend/apid/actions/logger.go
+++ b/backend/apid/actions/logger.go
@@ -1,0 +1,7 @@
+package actions
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "apid",
+})

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -260,7 +260,7 @@ func (a *APId) registerRestrictedResources(router *mux.Router) {
 		routers.NewClusterRolesRouter(a.store),
 		routers.NewClusterRoleBindingsRouter(a.store),
 		routers.NewClusterRouter(actions.NewClusterController(a.cluster, a.store)),
-		routers.NewEntitiesRouter(a.store),
+		routers.NewEntitiesRouter(a.store, a.eventStore),
 		routers.NewEventFiltersRouter(a.store),
 		routers.NewEventsRouter(a.eventStore, a.bus),
 		routers.NewExtensionsRouter(a.store),

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -3,22 +3,27 @@ package routers
 import (
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
 // EntitiesRouter handles requests for /entities
 type EntitiesRouter struct {
-	handlers handlers.Handlers
+	handlers   handlers.Handlers
+	store      store.Store
+	eventStore store.EventStore
 }
 
 // NewEntitiesRouter instantiates new router for controlling entities resources
-func NewEntitiesRouter(store store.ResourceStore) *EntitiesRouter {
+func NewEntitiesRouter(store store.Store, events store.EventStore) *EntitiesRouter {
 	return &EntitiesRouter{
 		handlers: handlers.Handlers{
 			Resource: &corev2.Entity{},
 			Store:    store,
 		},
+		store:      store,
+		eventStore: events,
 	}
 }
 
@@ -29,7 +34,12 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 		PathPrefix: "/namespaces/{namespace}/{resource:entities}",
 	}
 
-	routes.Del(r.handlers.DeleteResource)
+	deleter := actions.EntityDeleter{
+		EntityStore: r.store,
+		EventStore:  r.eventStore,
+	}
+
+	routes.Del(deleter.Delete)
 	routes.Get(r.handlers.GetResource)
 	routes.List(r.handlers.ListResources, corev2.EntityFields)
 	routes.ListAllNamespaces(r.handlers.ListResources, "/{resource:entities}", corev2.EntityFields)

--- a/backend/apid/routers/entities_test.go
+++ b/backend/apid/routers/entities_test.go
@@ -6,12 +6,16 @@ import (
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestEntitiesRouter(t *testing.T) {
 	// Setup the router
 	s := &mockstore.MockStore{}
-	router := NewEntitiesRouter(s)
+	s.On("GetEventsByEntity", mock.Anything, "foo", mock.Anything).Return([]*corev2.Event{corev2.FixtureEvent("foo", "bar")}, nil)
+	s.On("DeleteEventByEntityCheck", mock.Anything, "foo", "bar").Return(nil)
+	s.On("DeleteEntityByName", mock.Anything, "foo").Return(nil)
+	router := NewEntitiesRouter(s, s)
 	parentRouter := mux.NewRouter().PathPrefix(corev2.URLPrefix).Subrouter()
 	router.Mount(parentRouter)
 
@@ -23,7 +27,11 @@ func TestEntitiesRouter(t *testing.T) {
 	tests = append(tests, listTestCases(empty)...)
 	tests = append(tests, createTestCases(empty)...)
 	tests = append(tests, updateTestCases(fixture)...)
-	tests = append(tests, deleteTestCases(fixture)...)
+	// NB: we avoid some of the generic deletion tests here since they
+	// are incompatible with the specialized deletion logic of the entity
+	// controller.
+	tests = append(tests, deleteResourceInvalidPathTestCase(fixture))
+	tests = append(tests, deleteResourceSuccessTestCase(fixture))
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
 	}


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where events were not deleted when their
associated entity was deleted via the API, the dashboard, or
sensuctl.

## Why is this change necessary?

Closes #2846 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Tested manually