### PR TITLE
[GraphQL] Fix wrong URL bug in PutWrapped mutation

### DIFF
--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -88,7 +88,7 @@ func (r *mutationsImpl) PutWrapped(p schema.MutationPutWrappedFieldResolverParam
 		// Web UI (Checks and Handlers), but it's possible that this MAY not
 		// work for future resources.
 		suffix := "/" + url.PathEscape(ret.Value.GetObjectMeta().Name)
-		pathSubstr := strings.TrimSuffix(suffix, path)
+		pathSubstr := strings.TrimSuffix(path, suffix)
 		err = client.Post(pathSubstr, bytes)
 	}
 	if err != nil {

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -30,7 +30,7 @@ func TestMutationTypePutWrappedUpsertTrue(t *testing.T) {
 	params.Args.Upsert = true
 
 	client, factory := client.NewClientFactory()
-	client.On("Put", mock.Anything, mock.Anything).Return(nil).Once()
+	client.On("Put", "/api/core/v2/namespaces/sensu-devel/silenced/test:fred", mock.Anything).Return(nil).Once()
 	impl := mutationsImpl{factory: factory}
 
 	// Success
@@ -69,7 +69,7 @@ func TestMutationTypePutWrappedUpsertFalse(t *testing.T) {
 	params.Args.Upsert = false
 
 	client, factory := client.NewClientFactory()
-	client.On("Post", mock.Anything, mock.Anything).Return(nil).Once()
+	client.On("Post", "/api/core/v2/namespaces/sensu-devel/silenced", mock.Anything).Return(nil).Once()
 	impl := mutationsImpl{factory: factory}
 
 	// Success


### PR DESCRIPTION
## What is this change?

This change fixes a bug in the PutWrapped mutation were the wrong URL path is passed to the POST request when the mutation is called with `upsert === false`. The arguments to the `strings.TrimSuffix` method were reversed. :facepalm:

## Why is this change necessary?
Supports https://github.com/sensu/sensu-enterprise-go/issues/496

## Does your change need a Changelog entry?
Nope.

## How did you verify this change?
Manually. 