### PR TITLE
Return 201 Created on POST & PUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 is silenced.
 - Added --disable-assets flag to sensu-agent.
 
+### Changed
+- The REST API now returns the `201 Created` success status response code for
+POST & PUT requests instead of `204 No Content`.
+
 ### Fixed
 - Fixed a bug where events were not deleted when their corresponding entity was.
 

--- a/backend/apid/routers/checks_test.go
+++ b/backend/apid/routers/checks_test.go
@@ -117,7 +117,7 @@ func TestChecksRouterCustomRoutes(t *testing.T) {
 			controllerFunc: func(c *mockCheckController) {
 				c.On("AddCheckHook", mock.Anything, "check1", mock.AnythingOfType("v2.HookList")).Return(nil)
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 		{
 			name:   "it deletes a check hook from a check",

--- a/backend/apid/routers/events_test.go
+++ b/backend/apid/routers/events_test.go
@@ -156,7 +156,7 @@ func TestEventsRouter(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 		{
 			name:           "it returns 400 if the payload to update is not decodable",
@@ -206,7 +206,7 @@ func TestEventsRouter(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 		{
 			name:   "it returns 404 if the event to delete does not exist",

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -280,7 +280,7 @@ var createResourceSuccessTestCase = func(resource corev2.Resource) routerTestCas
 	typ := reflect.TypeOf(resource).String()
 
 	return routerTestCase{
-		name:   "it returns 204 if the resource was created",
+		name:   "it returns 201 if the resource was created",
 		method: http.MethodPost,
 		path:   resource.URIPath(),
 		body:   marshal(resource),
@@ -289,7 +289,7 @@ var createResourceSuccessTestCase = func(resource corev2.Resource) routerTestCas
 				Return(nil).
 				Once()
 		},
-		wantStatusCode: http.StatusNoContent,
+		wantStatusCode: http.StatusCreated,
 	}
 }
 
@@ -367,7 +367,7 @@ var updateResourceSuccessTestCase = func(resource corev2.Resource) routerTestCas
 	typ := reflect.TypeOf(resource).String()
 
 	return routerTestCase{
-		name:   "it returns 204 if the resource was updated",
+		name:   "it returns 201 if the resource was updated",
 		method: http.MethodPut,
 		path:   resource.URIPath(),
 		body:   marshal(resource),
@@ -376,7 +376,7 @@ var updateResourceSuccessTestCase = func(resource corev2.Resource) routerTestCas
 				Return(nil).
 				Once()
 		},
-		wantStatusCode: http.StatusNoContent,
+		wantStatusCode: http.StatusCreated,
 	}
 }
 

--- a/backend/apid/routers/lister.go
+++ b/backend/apid/routers/lister.go
@@ -53,7 +53,7 @@ func List(list ListControllerFunc, fields FieldsFunc) http.HandlerFunc {
 			w.Header().Set(corev2.PaginationContinueHeader, encodedContinue)
 		}
 
-		RespondWith(w, results)
+		RespondWith(w, r, results)
 	}
 }
 

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -16,13 +16,17 @@ type errorBody struct {
 }
 
 // RespondWith given writer and resource, marshal to JSON and write response.
-func RespondWith(w http.ResponseWriter, resources interface{}) {
+func RespondWith(w http.ResponseWriter, r *http.Request, resources interface{}) {
 	// Set content-type to JSON
 	w.Header().Set("Content-Type", "application/json")
 
 	// If no resource(s) are present return a 204 response code
 	if resources == nil {
-		w.WriteHeader(http.StatusNoContent)
+		if r.Method == http.MethodPost || r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusCreated)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
 		return
 	}
 
@@ -124,7 +128,7 @@ func actionHandler(action actionHandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		RespondWith(w, resources)
+		RespondWith(w, r, resources)
 	}
 }
 
@@ -132,13 +136,13 @@ func actionHandler(action actionHandlerFunc) http.HandlerFunc {
 // TODO(palourde): Add pagination to silenced entries
 func listHandler(fn listHandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		records, err := fn(w, r)
+		resources, err := fn(w, r)
 		if err != nil {
 			WriteError(w, err)
 			return
 		}
 
-		RespondWith(w, records)
+		RespondWith(w, r, resources)
 	}
 }
 

--- a/backend/apid/routers/silenced_test.go
+++ b/backend/apid/routers/silenced_test.go
@@ -128,7 +128,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 		{
 			name:           "it returns 400 if the payload to update is not decodable",
@@ -166,7 +166,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 	}
 	for _, tt := range tests {

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -165,7 +165,7 @@ func TestUsersRouter(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 		{
 			name:           "it returns 400 if the payload to update is not decodable",
@@ -203,7 +203,7 @@ func TestUsersRouter(t *testing.T) {
 					Return(nil).
 					Once()
 			},
-			wantStatusCode: http.StatusNoContent,
+			wantStatusCode: http.StatusCreated,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR changes the success status response code for POST & PUT requests from `204 No Content` to `201 Created`.

In a perfect world, we would make a distinction for PUT requests between a resource creation (201) or update (200 or 204) but this information is not currently available to the HTTP handlers, at least not without a major refactoring.

**N.B.** This change will require a PR to sensu-enterprise-go once merged!

## Why is this change necessary?

This request came from Alex while discussing the API documentation.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

See https://github.com/sensu/sensu-docs/issues/1558

## How did you verify this change?

Unit tests.
