### PR TITLE
[GraphQL] Add global id field to Mutator type

### DIFF
--- a/backend/apid/graphql/mutator.go
+++ b/backend/apid/graphql/mutator.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/graphql"
 	"github.com/sensu/sensu-go/types"
@@ -15,6 +16,11 @@ var _ schema.MutatorFieldResolvers = (*mutatorImpl)(nil)
 
 type mutatorImpl struct {
 	schema.MutatorAliases
+}
+
+// ID implements response to request for 'id' field.
+func (*mutatorImpl) ID(p graphql.ResolveParams) (string, error) {
+	return globalid.MutatorTranslator.EncodeToString(p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type


### PR DESCRIPTION
## What is this change?

Allows users to query the globally unique ID of a mutator.

## Why is this change necessary?

Unblock sensu/web#148

## Does your change need a Changelog entry?

Unlikely.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Manual.