### PR TITLE
[GraphQL] Implement delete event filter mutation

### DIFF
--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -311,6 +311,30 @@ func decodeEventGID(gid string) (globalid.EventComponents, error) {
 }
 
 //
+// Implement event filter mutations
+//
+
+// DeleteEventFilter implements response to request for the 'deleteEventFilter' field.
+func (r *mutationsImpl) DeleteEventFilter(p schema.MutationDeleteEventFilterFieldResolverParams) (interface{}, error) {
+	components, _ := globalid.Decode(p.Args.Input.ID)
+	if components.Resource() != v2.EventFiltersResource {
+		return nil, errors.New("given ID must be a event filter")
+	}
+
+	ctx := setContextFromComponents(p.Context, components)
+	client := r.factory.NewWithContext(ctx)
+
+	err := client.DeleteFilter(components.Namespace(), components.UniqueComponent())
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"clientMutationId": p.Args.Input.ClientMutationID,
+		"deletedId":        components.String(),
+	}, nil
+}
+
+//
 // Implement handler mutations
 //
 

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -251,6 +251,30 @@ func TestMutationTypeDeleteMutatorField(t *testing.T) {
 	assert.Nil(t, body)
 }
 
+func TestMutationTypeDeleteEventFilterField(t *testing.T) {
+	flr := types.FixtureEventFilter("a")
+	gid := globalid.EventFilterTranslator.EncodeToString(flr)
+
+	inputs := schema.DeleteRecordInput{ID: gid}
+	params := schema.MutationDeleteEventFilterFieldResolverParams{}
+	params.Args.Input = &inputs
+
+	client, factory := client.NewClientFactory()
+	impl := mutationsImpl{factory: factory}
+
+	// Success
+	client.On("DeleteFilter", mock.Anything, mock.Anything).Return(nil).Once()
+	body, err := impl.DeleteEventFilter(params)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, body)
+
+	// Failure
+	client.On("DeleteFilter", mock.Anything, mock.Anything).Return(errors.New("err")).Once()
+	body, err = impl.DeleteEventFilter(params)
+	assert.Error(t, err)
+	assert.Nil(t, body)
+}
+
 func TestMutationTypeCreateSilenceField(t *testing.T) {
 	inputs := schema.CreateSilenceInput{
 		Namespace: "a",

--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -151,6 +151,23 @@ type MutationDeleteEventFieldResolver interface {
 	DeleteEvent(p MutationDeleteEventFieldResolverParams) (interface{}, error)
 }
 
+// MutationDeleteEventFilterFieldResolverArgs contains arguments provided to deleteEventFilter when selected
+type MutationDeleteEventFilterFieldResolverArgs struct {
+	Input *DeleteRecordInput // Input - self descriptive
+}
+
+// MutationDeleteEventFilterFieldResolverParams contains contextual info to resolve deleteEventFilter field
+type MutationDeleteEventFilterFieldResolverParams struct {
+	graphql.ResolveParams
+	Args MutationDeleteEventFilterFieldResolverArgs
+}
+
+// MutationDeleteEventFilterFieldResolver implement to resolve requests for the Mutation's deleteEventFilter field.
+type MutationDeleteEventFilterFieldResolver interface {
+	// DeleteEventFilter implements response to request for deleteEventFilter field.
+	DeleteEventFilter(p MutationDeleteEventFilterFieldResolverParams) (interface{}, error)
+}
+
 // MutationDeleteHandlerFieldResolverArgs contains arguments provided to deleteHandler when selected
 type MutationDeleteHandlerFieldResolverArgs struct {
 	Input *DeleteRecordInput // Input - self descriptive
@@ -289,6 +306,7 @@ type MutationFieldResolvers interface {
 	MutationDeleteEntityFieldResolver
 	MutationResolveEventFieldResolver
 	MutationDeleteEventFieldResolver
+	MutationDeleteEventFilterFieldResolver
 	MutationDeleteHandlerFieldResolver
 	MutationDeleteMutatorFieldResolver
 	MutationCreateSilenceFieldResolver
@@ -386,6 +404,12 @@ func (_ MutationAliases) ResolveEvent(p MutationResolveEventFieldResolverParams)
 
 // DeleteEvent implements response to request for 'deleteEvent' field.
 func (_ MutationAliases) DeleteEvent(p MutationDeleteEventFieldResolverParams) (interface{}, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	return val, err
+}
+
+// DeleteEventFilter implements response to request for 'deleteEventFilter' field.
+func (_ MutationAliases) DeleteEventFilter(p MutationDeleteEventFilterFieldResolverParams) (interface{}, error) {
 	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
 	return val, err
 }
@@ -525,6 +549,19 @@ func _ObjTypeMutationDeleteEventHandler(impl interface{}) graphql1.FieldResolveF
 	}
 }
 
+func _ObjTypeMutationDeleteEventFilterHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(MutationDeleteEventFilterFieldResolver)
+	return func(p graphql1.ResolveParams) (interface{}, error) {
+		frp := MutationDeleteEventFilterFieldResolverParams{ResolveParams: p}
+		err := mapstructure.Decode(p.Args, &frp.Args)
+		if err != nil {
+			return nil, err
+		}
+
+		return resolver.DeleteEventFilter(frp)
+	}
+}
+
 func _ObjTypeMutationDeleteHandlerHandler(impl interface{}) graphql1.FieldResolveFn {
 	resolver := impl.(MutationDeleteHandlerFieldResolver)
 	return func(p graphql1.ResolveParams) (interface{}, error) {
@@ -631,6 +668,16 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 				Name:              "deleteEvent",
 				Type:              graphql.OutputType("DeleteRecordPayload"),
 			},
+			"deleteEventFilter": &graphql1.Field{
+				Args: graphql1.FieldConfigArgument{"input": &graphql1.ArgumentConfig{
+					Description: "self descriptive",
+					Type:        graphql1.NewNonNull(graphql.InputType("DeleteRecordInput")),
+				}},
+				DeprecationReason: "",
+				Description:       "Removes given event filter.",
+				Name:              "deleteEventFilter",
+				Type:              graphql.OutputType("DeleteRecordPayload"),
+			},
 			"deleteHandler": &graphql1.Field{
 				Args: graphql1.FieldConfigArgument{"input": &graphql1.ArgumentConfig{
 					Description: "self descriptive",
@@ -726,18 +773,19 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 var _ObjectTypeMutationDesc = graphql.ObjectDesc{
 	Config: _ObjectTypeMutationConfigFn,
 	FieldHandlers: map[string]graphql.FieldHandler{
-		"createCheck":   _ObjTypeMutationCreateCheckHandler,
-		"createSilence": _ObjTypeMutationCreateSilenceHandler,
-		"deleteCheck":   _ObjTypeMutationDeleteCheckHandler,
-		"deleteEntity":  _ObjTypeMutationDeleteEntityHandler,
-		"deleteEvent":   _ObjTypeMutationDeleteEventHandler,
-		"deleteHandler": _ObjTypeMutationDeleteHandlerHandler,
-		"deleteMutator": _ObjTypeMutationDeleteMutatorHandler,
-		"deleteSilence": _ObjTypeMutationDeleteSilenceHandler,
-		"executeCheck":  _ObjTypeMutationExecuteCheckHandler,
-		"putWrapped":    _ObjTypeMutationPutWrappedHandler,
-		"resolveEvent":  _ObjTypeMutationResolveEventHandler,
-		"updateCheck":   _ObjTypeMutationUpdateCheckHandler,
+		"createCheck":       _ObjTypeMutationCreateCheckHandler,
+		"createSilence":     _ObjTypeMutationCreateSilenceHandler,
+		"deleteCheck":       _ObjTypeMutationDeleteCheckHandler,
+		"deleteEntity":      _ObjTypeMutationDeleteEntityHandler,
+		"deleteEvent":       _ObjTypeMutationDeleteEventHandler,
+		"deleteEventFilter": _ObjTypeMutationDeleteEventFilterHandler,
+		"deleteHandler":     _ObjTypeMutationDeleteHandlerHandler,
+		"deleteMutator":     _ObjTypeMutationDeleteMutatorHandler,
+		"deleteSilence":     _ObjTypeMutationDeleteSilenceHandler,
+		"executeCheck":      _ObjTypeMutationExecuteCheckHandler,
+		"putWrapped":        _ObjTypeMutationPutWrappedHandler,
+		"resolveEvent":      _ObjTypeMutationResolveEventHandler,
+		"updateCheck":       _ObjTypeMutationUpdateCheckHandler,
 	},
 }
 

--- a/backend/apid/graphql/schema/mutations.graphql
+++ b/backend/apid/graphql/schema/mutations.graphql
@@ -53,6 +53,13 @@ type Mutation {
   deleteEvent(input: DeleteRecordInput!): DeleteRecordPayload
 
   #
+  # Event Filters
+  #
+
+  "Removes given event filter."
+  deleteEventFilter(input: DeleteRecordInput!): DeleteRecordPayload
+
+  #
   # Handlers
   #
 


### PR DESCRIPTION
Requires #3085 

## What is this change?

Adds mutation for deleting event filters.

## Why is this change necessary?

So that clients can implement deletion of event filters.

## Does your change need a Changelog entry?

Sure

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No changes required.

## How did you verify this change?

Unit & manual testing.