### PR TITLE
[GraphQL] Return nil when no mutator is present on handler

### DIFF
--- a/backend/apid/graphql/handler.go
+++ b/backend/apid/graphql/handler.go
@@ -29,8 +29,11 @@ func (*handlerImpl) ID(p graphql.ResolveParams) (string, error) {
 // Mutator implements response to request for 'mutator' field.
 func (r *handlerImpl) Mutator(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*types.Handler)
-	ctx := types.SetContextFromResource(p.Context, src)
+	if src.Mutator == "" {
+		return nil, nil
+	}
 
+	ctx := types.SetContextFromResource(p.Context, src)
 	client := r.factory.NewWithContext(ctx)
 	res, err := client.FetchMutator(src.Mutator)
 

--- a/backend/apid/graphql/handler_test.go
+++ b/backend/apid/graphql/handler_test.go
@@ -49,6 +49,12 @@ func TestHandlerTypeMutatorField(t *testing.T) {
 	res, err := impl.Mutator(graphql.ResolveParams{Source: handler})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
+
+	// No mutator
+	handler.Mutator = ""
+	res, err = impl.Mutator(graphql.ResolveParams{Source: handler})
+	require.NoError(t, err)
+	assert.Nil(t, res)
 }
 
 func TestHandlerTypeToJSONField(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Return `nil` when no mutator is present on source handler.

## Why is this change necessary?

Without this change, the client will attempt to list all mutators, leading to an error when trying to unmarshal the response to a single mutator.

## Does your change need a Changelog entry?

Unlikely.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No changes required.

## How did you verify this change?

Unit test & manual.