### PR TITLE
Rework watchers to avoid tight loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ POST & PUT requests instead of `204 No Content`.
 - Fixed the entity_attributes in proxy_requests so all attributes must match
 instead of only one of them.
 - Fixed a bug where events were not deleted when their corresponding entity was.
+- Fixed a bug where watchers could enter a tight loop, causing very high CPU
+  usage until sensu-backend was restarted
 
 ## [5.10.0] - 2019-06-18
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -187,13 +187,15 @@ func Initialize(config *Config) (*Backend, error) {
 	b.Daemons = append(b.Daemons, pipeline)
 
 	// Initialize eventd
-	event, err := eventd.New(eventd.Config{
-		Store:           stor,
-		EventStore:      eventStoreProxy,
-		Bus:             bus,
-		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
-		Client:          b.Client,
-	})
+	event, err := eventd.New(
+		b.ctx,
+		eventd.Config{
+			Store:           stor,
+			EventStore:      eventStoreProxy,
+			Bus:             bus,
+			LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
+			Client:          b.Client,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", event.Name(), err)
 	}
@@ -202,13 +204,15 @@ func Initialize(config *Config) (*Backend, error) {
 	ringPool := ringv2.NewPool(b.Client)
 
 	// Initialize schedulerd
-	scheduler, err := schedulerd.New(schedulerd.Config{
-		Store:       stor,
-		Bus:         bus,
-		QueueGetter: queueGetter,
-		RingPool:    ringPool,
-		Client:      b.Client,
-	})
+	scheduler, err := schedulerd.New(
+		b.ctx,
+		schedulerd.Config{
+			Store:       stor,
+			Bus:         bus,
+			QueueGetter: queueGetter,
+			RingPool:    ringPool,
+			Client:      b.Client,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", scheduler.Name(), err)
 	}
@@ -283,12 +287,14 @@ func Initialize(config *Config) (*Backend, error) {
 	b.Daemons = append(b.Daemons, api)
 
 	// Initialize tessend
-	tessen, err := tessend.New(tessend.Config{
-		Store:    stor,
-		RingPool: ringPool,
-		Client:   b.Client,
-		Bus:      bus,
-	})
+	tessen, err := tessend.New(
+		b.ctx,
+		tessend.Config{
+			Store:    stor,
+			RingPool: ringPool,
+			Client:   b.Client,
+			Bus:      bus,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", tessen.Name(), err)
 	}

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -85,7 +85,7 @@ type Config struct {
 }
 
 // New creates a new Eventd.
-func New(c Config, opts ...Option) (*Eventd, error) {
+func New(ctx context.Context, c Config, opts ...Option) (*Eventd, error) {
 	e := &Eventd{
 		store:           c.Store,
 		eventStore:      c.EventStore,
@@ -100,7 +100,7 @@ func New(c Config, opts ...Option) (*Eventd, error) {
 		Logger:          &RawLogger{},
 	}
 
-	e.ctx, e.cancel = context.WithCancel(context.Background())
+	e.ctx, e.cancel = context.WithCancel(ctx)
 	cache, err := cache.New(e.ctx, c.Client, &corev2.Silenced{}, false)
 	if err != nil {
 		return nil, err

--- a/backend/ringv2/ringv2.go
+++ b/backend/ringv2/ringv2.go
@@ -371,21 +371,21 @@ func (r *Ring) startWatchers(ctx context.Context, ch chan Event, name string, va
 				r.mu.Unlock()
 				notifyClosing(ch)
 				return
-			case response := <-itemsC:
+			case response, ok := <-itemsC:
 				if err := response.Err(); err != nil {
 					notifyError(ch, err)
 				}
-				if response.Canceled {
+				if response.Canceled || !ok {
 					// The watcher needs to be reinstated
 					r.startWatchers(ctx, ch, name, values, interval, cron)
 					return
 				}
 				notifyAddRemove(ch, response)
-			case response := <-nextC:
+			case response, ok := <-nextC:
 				if err := response.Err(); err != nil {
 					notifyError(ch, err)
 				}
-				if response.Canceled {
+				if response.Canceled || !ok {
 					// The watcher needs to be reinstated
 					r.startWatchers(ctx, ch, name, values, interval, cron)
 					return

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -108,12 +108,9 @@ func (c *CheckWatcher) startWatcher() {
 	for {
 		select {
 		case watchEvent, ok := <-watchChan:
-			if !ok {
-				// The watchChan has closed. Restart the watcher.
-				watchChan = c.store.GetCheckConfigWatcher(c.ctx)
-				continue
+			if ok {
+				c.handleWatchEvent(watchEvent)
 			}
-			c.handleWatchEvent(watchEvent)
 		case <-c.ctx.Done():
 			c.mu.Lock()
 			defer c.mu.Unlock()

--- a/backend/schedulerd/schedulerd.go
+++ b/backend/schedulerd/schedulerd.go
@@ -40,7 +40,7 @@ type Config struct {
 }
 
 // New creates a new Schedulerd.
-func New(c Config, opts ...Option) (*Schedulerd, error) {
+func New(ctx context.Context, c Config, opts ...Option) (*Schedulerd, error) {
 	s := &Schedulerd{
 		store:       c.Store,
 		queueGetter: c.QueueGetter,
@@ -48,7 +48,7 @@ func New(c Config, opts ...Option) (*Schedulerd, error) {
 		errChan:     make(chan error, 1),
 		ringPool:    c.RingPool,
 	}
-	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.ctx, s.cancel = context.WithCancel(ctx)
 	cache, err := cache.New(s.ctx, c.Client, &corev2.Entity{}, true)
 	if err != nil {
 		return nil, err

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -32,7 +32,7 @@ func TestSchedulerd(t *testing.T) {
 	// Mock a default namespace
 	require.NoError(t, st.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
 
-	schedulerd, err := New(Config{
+	schedulerd, err := New(context.Background(), Config{
 		Store:       st,
 		QueueGetter: queue.NewMemoryGetter(),
 		Bus:         bus,

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -195,7 +195,6 @@ func (r *Resource) start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case event := <-r.watcher:
-			fmt.Println("received event")
 			r.updates = append(r.updates, event)
 		case <-ticker.C:
 			if len(r.updates) > 0 {

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -195,6 +195,7 @@ func (r *Resource) start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case event := <-r.watcher:
+			fmt.Println("received event")
 			r.updates = append(r.updates, event)
 		case <-ticker.C:
 			if len(r.updates) > 0 {

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -94,7 +94,6 @@ func TestEntityCacheIntegration(t *testing.T) {
 
 	newEntity := corev2.FixtureEntity("new")
 	newEntity.EntityClass = corev2.EntityProxyClass
-	fmt.Println("update...")
 	if err := store.UpdateEntity(ctx, newEntity); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -97,7 +97,6 @@ func TestEntityCacheIntegration(t *testing.T) {
 	if err := store.UpdateEntity(ctx, newEntity); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println("updated")
 	<-watcher
 
 	got := cache.Get("default")

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -94,10 +94,11 @@ func TestEntityCacheIntegration(t *testing.T) {
 
 	newEntity := corev2.FixtureEntity("new")
 	newEntity.EntityClass = corev2.EntityProxyClass
+	fmt.Println("update...")
 	if err := store.UpdateEntity(ctx, newEntity); err != nil {
 		t.Fatal(err)
 	}
-
+	fmt.Println("updated")
 	<-watcher
 
 	got := cache.Get("default")

--- a/backend/store/etcd/watcher.go
+++ b/backend/store/etcd/watcher.go
@@ -14,6 +14,8 @@ import (
 // so the channel returned by the Watch method only provides a single event at a
 // time instead of a list of events, and the events are ready to be consumed
 type Watcher struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
 	client     *clientv3.Client
 	key        string
 	recursive  bool
@@ -32,27 +34,15 @@ func Watch(ctx context.Context, client *clientv3.Client, key string, recursive b
 		key += "/"
 	}
 
-	// From etcd docs:
-	// If the context is "context.Background/TODO", returned "WatchChan" will
-	// not be closed and block until event is triggered, except when server
-	// returns a non-recoverable error (e.g. ErrCompacted).
-	// For example, when context passed with "WithRequireLeader" and the
-	// connected server has no leader (e.g. due to network partition),
-	// error "etcdserver: no leader" (ErrNoLeader) will be returned,
-	// and then "WatchChan" is closed with non-nil "Err()".
-	// In order to prevent a watch stream being stuck in a partitioned node,
-	// make sure to wrap context with "WithRequireLeader".
-	ctx = clientv3.WithRequireLeader(ctx)
-
-	w := newWatcher(client, key, recursive, opts...)
-	w.start(ctx)
+	w := newWatcher(ctx, client, key, recursive, opts...)
+	go w.start()
 
 	return w
 }
 
 // newWatcher creates a new Watcher
-func newWatcher(client *clientv3.Client, key string, recursive bool, opts ...clientv3.OpOption) *Watcher {
-	return &Watcher{
+func newWatcher(ctx context.Context, client *clientv3.Client, key string, recursive bool, opts ...clientv3.OpOption) *Watcher {
+	wc := &Watcher{
 		client:     client,
 		key:        key,
 		recursive:  recursive,
@@ -60,6 +50,8 @@ func newWatcher(client *clientv3.Client, key string, recursive bool, opts ...cli
 		resultChan: make(chan store.WatchEvent),
 		opts:       opts,
 	}
+	wc.ctx, wc.cancel = context.WithCancel(ctx)
+	return wc
 }
 
 // Result returns the resultChan
@@ -67,59 +59,90 @@ func (w *Watcher) Result() <-chan store.WatchEvent {
 	return w.resultChan
 }
 
-// start starts watching the configured key and sends all etcd events
-// received to resultChan
-func (w *Watcher) start(ctx context.Context) {
+func (w *Watcher) start() {
+	// Define the client options for this watcher
 	opts := []clientv3.OpOption{clientv3.WithCreatedNotify()}
 	if w.recursive {
 		opts = append(opts, clientv3.WithPrefix())
 	}
-
 	opts = append(opts, w.opts...)
 
-	logger.Debugf("starting a watcher for key %s", w.key)
+	// Create a channel to be notified if the watch channel is closed
+	watchChanStopped := make(chan struct{})
 
-	watcherChan := w.client.Watch(ctx, w.key, opts...)
+	// Create a cancellable context for our watcher
+	ctx, cancel := context.WithCancel(w.ctx)
+
+	// Start the watcher
+	logger.Debugf("starting a watcher for key %s", w.key)
+	go w.watch(ctx, opts, watchChanStopped)
+
+	// Initialize a rate limiter
 	limiter := rate.NewLimiter(rate.Every(time.Second), 1)
 
-	go func() {
-		defer close(w.resultChan)
-		_ = limiter.Wait(ctx)
-		for ctx.Err() == nil {
-			select {
-			case watchResponse, ok := <-watcherChan:
-				if err := watchResponse.Err(); err != nil {
-					logger.WithError(err).Info("error from watch response")
-					w.resultChan <- store.WatchEvent{
-						Type: store.WatchError,
-						Err:  err,
-					}
+RetryLoop:
+	for {
+		select {
+		case <-watchChanStopped:
+			// The watch channel is broken, so let's make sure to close the watcher
+			// first by cancelling its context, to prevent any possible memory leak
+			cancel()
 
-					// If the watch failed or if the channel is still open then
-					// just recreate the watcher since it can fail to close its
-					// channel or set Canceled to true. That's the only thing I
-					// tried that ended up working to avoid spinning
-					// indefinitely...
-					if watchResponse.Canceled || ok {
-						// Reinstate the watcher
-						watcherChan = w.client.Watch(ctx, w.key, opts...)
-					}
-				} else {
-					for _, event := range watchResponse.Events {
-						logger.Debugf("received event of type %v for key %s", event.Type, event.Kv.Key)
-						w.event(ctx, event)
-					}
-				}
+			// Now, we don't want to reconnect too quickly so wait for a moment
+			_ = limiter.Wait(w.ctx)
 
-			case <-w.client.Ctx().Done():
-				w.resultChan <- store.WatchEvent{
-					Type: store.WatchError,
-					Err:  w.client.Ctx().Err(),
-				}
-				return
-			}
+			// Re-create a cancellable context for our watcher
+			ctx, cancel = context.WithCancel(w.ctx)
+
+			// Re-create a channel to be notified if the watch channel is closed
+			watchChanStopped = make(chan struct{})
+
+			// Restart the watcher
+			logger.Debugf("restarting the watcher for key %s", w.key)
+			go w.watch(ctx, opts, watchChanStopped)
+		case <-w.ctx.Done():
+			// The consumer has cancelled this watcher, we need to exit
+			logger.Debugf("stopping the watcher for key %s", w.key)
+			break RetryLoop
 		}
-	}()
+	}
+
+	// Use both parent and current watcher context's cancellable functions to reap
+	// all goroutines. At this point the consumer has stopped the watcher so we
+	// should stop everything. It's also fine to double cancel.
+	cancel()
+	w.cancel()
+	close(w.resultChan)
+}
+
+func (w *Watcher) watch(ctx context.Context, opts []clientv3.OpOption, watchChanStopped chan struct{}) {
+	// Wrap the context with WithRequireLeader so ErrNoLeader is returned and the
+	// WatchChan is closed if the etcd server has no leader
+	ctx = clientv3.WithRequireLeader(ctx)
+
+	watchChan := w.client.Watch(ctx, w.key, opts...)
+
+	// Loop over the watchChan channel to receive watch responses. The loop will
+	// exit if the channel is closed.
+	for watchResponse := range watchChan {
+		if watchResponse.Err() != nil {
+			// We received an error from the channel, so let's assume it's no longer
+			// functional and exit this goroutine so we can try to re-create the
+			// watcher
+			logger.WithError(watchResponse.Err()).Info("error from watch response")
+			break
+		}
+
+		for _, event := range watchResponse.Events {
+			logger.Debugf("received event of type %v for key %s", event.Type, event.Kv.Key)
+			w.event(ctx, event)
+		}
+	}
+
+	// At this point, the watch channel has been closed by its consumer or is
+	// broken, therefore we should notify the main thread that this goroutine has
+	// exited
+	close(watchChanStopped)
 }
 
 func (w *Watcher) event(ctx context.Context, e *clientv3.Event) {

--- a/backend/store/etcd/watcher.go
+++ b/backend/store/etcd/watcher.go
@@ -80,7 +80,6 @@ func (w *Watcher) start() {
 
 	// Start the watcher
 	logger.Debugf("starting a watcher for key %s", w.key)
-	resultChanWG.Add(1)
 	w.watch(ctx, opts, watchChanStopped, &resultChanWG)
 
 	// Initialize a rate limiter
@@ -106,7 +105,6 @@ func (w *Watcher) start() {
 
 				// Restart the watcher
 				logger.Debugf("restarting the watcher for key %s", w.key)
-				resultChanWG.Add(1)
 				w.watch(ctx, opts, watchChanStopped, &resultChanWG)
 			case <-w.ctx.Done():
 				// The consumer has cancelled this watcher, we need to exit
@@ -131,6 +129,8 @@ func (w *Watcher) watch(ctx context.Context, opts []clientv3.OpOption, watchChan
 	// Wrap the context with WithRequireLeader so ErrNoLeader is returned and the
 	// WatchChan is closed if the etcd server has no leader
 	ctx = clientv3.WithRequireLeader(ctx)
+
+	resultChanWG.Add(1)
 
 	watchChan := w.client.Watch(ctx, w.key, opts...)
 

--- a/backend/store/etcd/watcher_test.go
+++ b/backend/store/etcd/watcher_test.go
@@ -95,18 +95,6 @@ func TestWatcher(t *testing.T) {
 	})
 }
 
-func TestEtcdClientClosed(t *testing.T) {
-	testWithEtcdStore(t, func(s *Store) {
-		w := Watch(context.Background(), s.client, checkKeyBuilder.Build(""), true)
-
-		// Close the etcd client
-		if err := w.client.Close(); err != nil {
-			t.Fatal(err)
-		}
-		expectType(t, w, store.WatchError)
-	})
-}
-
 func expectType(t *testing.T, w store.Watcher, typ store.WatchActionType) {
 	t.Helper()
 

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -104,7 +104,7 @@ type Config struct {
 }
 
 // New creates a new TessenD.
-func New(c Config, opts ...Option) (*Tessend, error) {
+func New(ctx context.Context, c Config, opts ...Option) (*Tessend, error) {
 	t := &Tessend{
 		interval:    corev2.DefaultTessenInterval,
 		store:       c.Store,
@@ -117,7 +117,7 @@ func New(c Config, opts ...Option) (*Tessend, error) {
 		duration:    perResourceDuration,
 		AllowOptOut: true,
 	}
-	t.ctx, t.cancel = context.WithCancel(context.Background())
+	t.ctx, t.cancel = context.WithCancel(ctx)
 	t.interrupt = make(chan *corev2.TessenConfig, 1)
 	key := ringv2.Path("global", "backends")
 	t.ring = c.RingPool.Get(key)

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -3,6 +3,7 @@
 package tessend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -42,12 +43,14 @@ func newTessendTest(t *testing.T) *Tessend {
 	s.On("GetTessenConfigWatcher", mock.Anything).Return(ch)
 	s.On("GetClusterID", mock.Anything).Return("foo", fmt.Errorf("foo"))
 
-	tessend, err := New(Config{
-		Store:    s,
-		Client:   client,
-		RingPool: ringv2.NewPool(client),
-		Bus:      bus,
-	})
+	tessend, err := New(
+		context.Background(),
+		Config{
+			Store:    s,
+			Client:   client,
+			RingPool: ringv2.NewPool(client),
+			Bus:      bus,
+		})
 	tessend.duration = 5 * time.Millisecond
 	tessend.config = corev2.DefaultTessenConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
## What is this change?

This small change is the result of many hours of fighting with etcd watchers in a staging environment.

In a nutshell, it alters 2 abstractions we've built on top of etcd watchers, `etcd.Watcher` (in `/backend/store`, yes the name is unfortunate) and `ringv2.Ring`, so that they can better detect when an etcd watcher dies.

We also don't `range` over those etcd watcher channels anymore; we `for { select { } }` instead, which allows us to avoid cases where we would end up ranging over a closed channel.

## Why is this change necessary?

Mostly addresses #3012 and #2635.
~There are still improvements that could be made, see #3092.~
Closes https://github.com/sensu/sensu-go/issues/3092
Closes https://github.com/sensu/sensu-go/issues/3012

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

Even after spending that much time with etcd watchers, I'm still not 100% sure of the correct, foolproof way to manage their life cycle.

Also, I tried to refactor `Ring.startWatchers()` and `Watcher.start()` so that they share a common abstraction for etcd watchers, but that didn't work out. I'm wondering if I'm missing subtleties between the 2 that justifies the 2 separate implementations?

## Were there any complications while making this change?

- we started with no way to reproduce the problem

  That was unfortunate and that considerably slowed down progress at the beginning. Eventually found a way to reproduce by overloading the backend by creating a lot of proxy entities (took up to an hour to do) and then ultimately found a way to reproduce by simply disconnecting backends from each other.

- hard to iterate fast with staging
  
  I ended up writing shell scripts to help with the task; they might make a good addition to `sensu-staging` after a cleanup.

- couldn't refactor watcher/ring to use 1 implementation
  
  I just kept breaking everything and I'm wondering if there is actually a subtle reason why they each have their abstraction over etcd watchers.

- CPU usage can still be higher than normal 
  
  While a backend is disconnected from the cluster, its CPU usage still goes up, though not nearly has high as before, and it comes back down to normal once it reconnects. This is 100% coming from the goroutine spawned by `Watcher.start()`, but I've been unable
to address that without breaking `Watcher` altogether... #3092 tracks this specific case.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This is an internal change that requires no documentation addition or change.
[This comment I made during my investigation](https://github.com/sensu/sensu-go/issues/3012#issuecomment-501851111) may be helpful in the future.

## How did you verify this change?

- Pass all unit tests for watcher and ring
- Pass all integration tests for watcher and ring
- Pass automated QA tests in a staging environment
- Many hours overloading or disconnecting cluster members and observing/profiling their CPU usage
