### PR TITLE
Bugfix/websocket authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ is silenced.
 - The REST API now returns the `201 Created` success status response code for
 POST & PUT requests instead of `204 No Content`.
 
+### Fixed
+- Fixed a bug where basic authorization was not being performed on the agent websocket connection.
+
 ## [5.10.1] - 2019-06-25
 
 ### Fixed

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -43,7 +43,7 @@ type Agentd struct {
 	wg         *sync.WaitGroup
 	errChan    chan error
 	httpServer *http.Server
-	store      Store
+	store      store.Store
 	bus        messaging.MessageBus
 	tls        *types.TLSOptions
 	ringPool   *ringv2.Pool
@@ -83,7 +83,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		return nil, err
 	}
 
-	handler := middlewares.BasicAuthentication(http.HandlerFunc(a.webSocketHandler), a.store)
+	handler := middlewares.BasicAuthorization(middlewares.BasicAuthentication(http.HandlerFunc(a.webSocketHandler), a.store), a.store)
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
 		Handler:      handler,

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -24,12 +24,6 @@ var (
 	upgrader = &websocket.Upgrader{}
 )
 
-// Store specifies storage requirements for Agentd.
-type Store interface {
-	middlewares.AuthStore
-	SessionStore
-}
-
 // Agentd is the backend HTTP API.
 type Agentd struct {
 	// Host is the hostname Agentd is running on.
@@ -83,7 +77,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		return nil, err
 	}
 
-	handler := middlewares.BasicAuthorization(middlewares.BasicAuthentication(http.HandlerFunc(a.webSocketHandler), a.store), a.store)
+	handler := middlewares.BasicAuthentication(middlewares.BasicAuthorization(http.HandlerFunc(a.webSocketHandler), a.store), a.store)
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
 		Handler:      handler,

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -69,10 +69,11 @@ type SessionConfig struct {
 // connection, message bus, and store.
 // The Session is responsible for stopping itself, and does so when it
 // encounters a receive error.
-func NewSession(cfg SessionConfig, conn transport.Transport, bus messaging.MessageBus, store Store) (*Session, error) {
+func NewSession(cfg SessionConfig, conn transport.Transport, bus messaging.MessageBus, store store.Store) (*Session, error) {
 	// Validate the agent namespace
 	ctx, cancel := context.WithCancel(context.Background())
 	if _, err := store.GetNamespace(ctx, cfg.Namespace); err != nil {
+		defer cancel()
 		return nil, fmt.Errorf(
 			"could not retrieve the namespace '%s': %s", cfg.Namespace, err.Error(),
 		)

--- a/backend/apid/middlewares/authorization.go
+++ b/backend/apid/middlewares/authorization.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/sensu/sensu-go/backend/apid/actions"
@@ -8,6 +9,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/transport"
+	corev2 "github.com/sensu/sensu-go/types"
 )
 
 // Authorization is an HTTP middleware that enforces authorization
@@ -51,7 +53,9 @@ func (a Authorization) Then(next http.Handler) http.Handler {
 // BasicAuthorization performs basic authorization for entity creation via the agent websocket.
 func BasicAuthorization(next http.Handler, store store.Store) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		namespace := r.Header.Get(transport.HeaderKeyNamespace)
 		ctx := r.Context()
+		ctx = context.WithValue(ctx, corev2.NamespaceKey, namespace)
 
 		user, err := store.GetUser(ctx, r.Header.Get(transport.HeaderKeyUser))
 		if err != nil {
@@ -61,12 +65,11 @@ func BasicAuthorization(next http.Handler, store store.Store) http.Handler {
 		attrs := &authorization.Attributes{
 			APIGroup:     "core",
 			APIVersion:   "v2",
-			Namespace:    r.Header.Get(transport.HeaderKeyNamespace),
-			Resource:     "entities",
+			Namespace:    namespace,
+			Resource:     "events",
 			ResourceName: r.Header.Get(transport.HeaderKeyAgentName),
 			Verb:         "create",
 			User:         *user,
-			Websocket:    true,
 		}
 
 		auth := &rbac.Authorizer{

--- a/backend/apid/middlewares/authorization.go
+++ b/backend/apid/middlewares/authorization.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/authorization/rbac"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/transport"
 )
 
 // Authorization is an HTTP middleware that enforces authorization
@@ -41,6 +44,43 @@ func (a Authorization) Then(next http.Handler) http.Handler {
 			return
 		}
 
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// BasicAuthorization performs basic authorization for entity creation via the agent websocket.
+func BasicAuthorization(next http.Handler, store store.Store) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		user, err := store.GetUser(ctx, r.Header.Get(transport.HeaderKeyUser))
+		if err != nil {
+			writeErr(w, actions.NewErrorf(actions.PermissionDenied, "invalid user"))
+			return
+		}
+		attrs := &authorization.Attributes{
+			APIGroup:     "core",
+			APIVersion:   "v2",
+			Namespace:    r.Header.Get(transport.HeaderKeyNamespace),
+			Resource:     "entities",
+			ResourceName: r.Header.Get(transport.HeaderKeyAgentName),
+			Verb:         "create",
+			User:         *user,
+			Websocket:    true,
+		}
+
+		auth := &rbac.Authorizer{
+			Store: store,
+		}
+		authorized, err := auth.Authorize(ctx, attrs)
+		if err != nil {
+			writeErr(w, actions.NewErrorf(actions.PermissionDenied, "error authorizing session"))
+			return
+		}
+		if !authorized {
+			writeErr(w, actions.NewErrorf(actions.PermissionDenied, "session is unauthorized"))
+			return
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/backend/apid/middlewares/authorization_test.go
+++ b/backend/apid/middlewares/authorization_test.go
@@ -652,7 +652,7 @@ func TestBasicAuthorization(t *testing.T) {
 			Return(&corev2.ClusterRole{Rules: []corev2.Rule{
 				corev2.Rule{
 					Verbs:     []string{"create"},
-					Resources: []string{"entities"},
+					Resources: []string{"events"},
 				},
 			}}, nil)
 		server := httptest.NewServer(BasicAuthorization(testHandler(), stor))

--- a/backend/apid/middlewares/authorization_test.go
+++ b/backend/apid/middlewares/authorization_test.go
@@ -1,7 +1,9 @@
 package middlewares
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,14 +12,16 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
-	"github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	sensuJWT "github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/testutil"
-	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/transport"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func seedStore(t *testing.T, store store.Store) {
@@ -30,14 +34,14 @@ func seedStore(t *testing.T, store store.Store) {
 	// Add custom resources for the tests
 	// Add a ClusterRoleBinding for the ClusteRole admin and assign the
 	// local-admins group
-	localAdmins := &types.ClusterRoleBinding{
-		ObjectMeta: v2.NewObjectMeta("admin", ""),
-		RoleRef: types.RoleRef{
+	localAdmins := &corev2.ClusterRoleBinding{
+		ObjectMeta: corev2.NewObjectMeta("admin", ""),
+		RoleRef: corev2.RoleRef{
 			Type: "ClusterRole",
 			Name: "admin",
 		},
-		Subjects: []types.Subject{
-			types.Subject{
+		Subjects: []corev2.Subject{
+			corev2.Subject{
 				Type: "Group",
 				Name: "local-admins",
 			},
@@ -47,14 +51,14 @@ func seedStore(t *testing.T, store store.Store) {
 		t.Fatal("Could not add the admin ClusterRoleBinding")
 	}
 
-	admins := &types.RoleBinding{
-		ObjectMeta: v2.NewObjectMeta("admin", "default"),
-		RoleRef: types.RoleRef{
+	admins := &corev2.RoleBinding{
+		ObjectMeta: corev2.NewObjectMeta("admin", "default"),
+		RoleRef: corev2.RoleRef{
 			Type: "ClusterRole",
 			Name: "admin",
 		},
-		Subjects: []types.Subject{
-			types.Subject{
+		Subjects: []corev2.Subject{
+			corev2.Subject{
 				Type: "Group",
 				Name: "admins",
 			},
@@ -64,14 +68,14 @@ func seedStore(t *testing.T, store store.Store) {
 		t.Fatal("Could not add the admin RoleBinding")
 	}
 
-	editors := &types.RoleBinding{
-		ObjectMeta: v2.NewObjectMeta("edit", "default"),
-		RoleRef: types.RoleRef{
+	editors := &corev2.RoleBinding{
+		ObjectMeta: corev2.NewObjectMeta("edit", "default"),
+		RoleRef: corev2.RoleRef{
 			Type: "ClusterRole",
 			Name: "edit",
 		},
-		Subjects: []types.Subject{
-			types.Subject{
+		Subjects: []corev2.Subject{
+			corev2.Subject{
 				Type: "Group",
 				Name: "editors",
 			},
@@ -81,14 +85,14 @@ func seedStore(t *testing.T, store store.Store) {
 		t.Fatal("Could not add the edit RoleBinding")
 	}
 
-	viewers := &types.RoleBinding{
-		ObjectMeta: v2.NewObjectMeta("view", "default"),
-		RoleRef: types.RoleRef{
+	viewers := &corev2.RoleBinding{
+		ObjectMeta: corev2.NewObjectMeta("view", "default"),
+		RoleRef: corev2.RoleRef{
 			Type: "ClusterRole",
 			Name: "view",
 		},
-		Subjects: []types.Subject{
-			types.Subject{
+		Subjects: []corev2.Subject{
+			corev2.Subject{
 				Type: "Group",
 				Name: "viewers",
 			},
@@ -98,10 +102,10 @@ func seedStore(t *testing.T, store store.Store) {
 		t.Fatal("Could not add the view RoleBinding")
 	}
 
-	fooViewerRole := &types.Role{
-		ObjectMeta: v2.NewObjectMeta("foo-viewer", "default"),
-		Rules: []types.Rule{
-			types.Rule{
+	fooViewerRole := &corev2.Role{
+		ObjectMeta: corev2.NewObjectMeta("foo-viewer", "default"),
+		Rules: []corev2.Rule{
+			corev2.Rule{
 				Verbs:         []string{"get"},
 				Resources:     []string{"checks"},
 				ResourceNames: []string{"foo"},
@@ -112,14 +116,14 @@ func seedStore(t *testing.T, store store.Store) {
 		t.Fatal("Could not add the foo-viewer RoleBinding")
 	}
 
-	fooViewerRoleBinding := &types.RoleBinding{
-		ObjectMeta: v2.NewObjectMeta("foo-viewer", "default"),
-		RoleRef: types.RoleRef{
+	fooViewerRoleBinding := &corev2.RoleBinding{
+		ObjectMeta: corev2.NewObjectMeta("foo-viewer", "default"),
+		RoleRef: corev2.RoleRef{
 			Type: "Role",
 			Name: "foo-viewer",
 		},
-		Subjects: []types.Subject{
-			types.Subject{
+		Subjects: []corev2.Subject{
+			corev2.Subject{
 				Type: "Group",
 				Name: "foo-viewers",
 			},
@@ -546,7 +550,7 @@ func TestAuthorization(t *testing.T) {
 			}
 
 			// Inject the claims into the request context
-			claims := types.Claims{
+			claims := corev2.Claims{
 				StandardClaims: jwt.StandardClaims{Subject: "foo"},
 				Groups:         []string{tt.group},
 			}
@@ -577,5 +581,88 @@ func TestAuthorization(t *testing.T) {
 				t.Logf("Response body: %s", w.Body.String())
 			}
 		})
+	}
+}
+
+func TestBasicAuthorization(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		description  string
+		namespace    string
+		agentName    string
+		username     string
+		group        string
+		storeErr     error
+		expectedCode int
+	}{
+		{
+			description:  "Authorized request",
+			namespace:    "test-rbac",
+			username:     "authorized-user",
+			group:        "group-test-rbac",
+			expectedCode: http.StatusOK,
+		}, {
+			description:  "Unauthorized request",
+			namespace:    "super-secret",
+			username:     "unauthorized-user",
+			expectedCode: http.StatusForbidden,
+		}, {
+			description:  "Invalid user",
+			namespace:    "test-rbac",
+			username:     "nonexistent-user",
+			storeErr:     fmt.Errorf("user not found"),
+			expectedCode: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		stor := &mockstore.MockStore{}
+		user := corev2.FixtureUser(tc.username)
+		user.Groups = append(user.Groups, tc.group)
+		stor.On("GetUser", mock.Anything, tc.username).Return(user, tc.storeErr)
+		stor.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
+			Return([]*corev2.ClusterRoleBinding{&corev2.ClusterRoleBinding{
+				RoleRef: corev2.RoleRef{
+					Type: "ClusterRole",
+					Name: "cluster-admin",
+				},
+				Subjects: []corev2.Subject{
+					corev2.Subject{Type: corev2.GroupType, Name: "cluster-admins"},
+				},
+				ObjectMeta: corev2.ObjectMeta{
+					Name: "cluster-admin",
+				},
+			}}, nil)
+		stor.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
+			Return([]*corev2.RoleBinding{&corev2.RoleBinding{
+				RoleRef: corev2.RoleRef{
+					Type: "ClusterRole",
+					Name: "admin",
+				},
+				Subjects: []corev2.Subject{
+					corev2.Subject{Type: corev2.GroupType, Name: "group-test-rbac"},
+				},
+				ObjectMeta: corev2.ObjectMeta{
+					Name:      "role-test-rbac-admin",
+					Namespace: "test-rbac",
+				},
+			}}, nil)
+		stor.On("GetClusterRole", mock.Anything, "admin", mock.Anything).
+			Return(&corev2.ClusterRole{Rules: []corev2.Rule{
+				corev2.Rule{
+					Verbs:     []string{"create"},
+					Resources: []string{"entities"},
+				},
+			}}, nil)
+		server := httptest.NewServer(BasicAuthorization(testHandler(), stor))
+		defer server.Close()
+		req, _ := http.NewRequest(http.MethodPost, server.URL, bytes.NewBuffer([]byte{}))
+		req.Header.Set(transport.HeaderKeyNamespace, tc.namespace)
+		req.Header.Set(transport.HeaderKeyAgentName, tc.agentName)
+		req.Header.Set(transport.HeaderKeyUser, tc.username)
+		res, err := http.DefaultClient.Do(req)
+		assert.NoError(err)
+		assert.Equal(tc.expectedCode, res.StatusCode, tc.description)
 	}
 }

--- a/backend/authorization/interface.go
+++ b/backend/authorization/interface.go
@@ -23,6 +23,7 @@ type Attributes struct {
 	ResourceName string
 	User         types.User
 	Verb         string
+	Websocket    bool
 }
 
 // GetAttributes returns the authorization attributes stored in the given

--- a/backend/authorization/interface.go
+++ b/backend/authorization/interface.go
@@ -23,7 +23,6 @@ type Attributes struct {
 	ResourceName string
 	User         types.User
 	Verb         string
-	Websocket    bool
 }
 
 // GetAttributes returns the authorization attributes stored in the given

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -130,10 +130,6 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 			}
 		}
 
-		if attrs.Websocket && attrs.Namespace != binding.GetObjectMeta().Namespace {
-			return false
-		}
-
 		allowed, reason := ruleAllows(attrs, rule)
 		if allowed {
 			roleRef := binding.GetRoleRef()

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -18,12 +18,14 @@ type Authorizer struct {
 	Store store.Store
 }
 
+// RoleBinding implements the RoleBinding interface.
 type RoleBinding interface {
 	GetSubjects() []corev2.Subject
 	GetRoleRef() corev2.RoleRef
 	GetObjectMeta() corev2.ObjectMeta
 }
 
+// RuleVisitFunc is a function to help visit matching rules.
 type RuleVisitFunc func(RoleBinding, corev2.Rule, error) (terminate bool)
 
 // VisitRulesFor visits all of the matching rules for a given Attributes.
@@ -126,6 +128,10 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 				visitErr = err
 				return false
 			}
+		}
+
+		if attrs.Websocket && attrs.Namespace != binding.GetObjectMeta().Namespace {
+			return false
 		}
 
 		allowed, reason := ruleAllows(attrs, rule)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -82,14 +82,14 @@ func TestBackendHTTPListener(t *testing.T) {
 			}
 
 			b, err := Initialize(&Config{
-				AgentHost:        "127.0.0.1",
-				AgentPort:        agentPort,
-				APIListenAddress: fmt.Sprintf("127.0.0.1:%d", apiPort),
-				DashboardHost:    "127.0.0.1",
-				DashboardPort:    dashboardPort,
-				StateDir:         dataPath,
-				CacheDir:         cachePath,
-				TLS:              tc.tls,
+				AgentHost:                    "127.0.0.1",
+				AgentPort:                    agentPort,
+				APIListenAddress:             fmt.Sprintf("127.0.0.1:%d", apiPort),
+				DashboardHost:                "127.0.0.1",
+				DashboardPort:                dashboardPort,
+				StateDir:                     dataPath,
+				CacheDir:                     cachePath,
+				TLS:                          tc.tls,
 				EtcdAdvertiseClientURLs:      []string{clURL},
 				EtcdListenClientURLs:         []string{clURL},
 				EtcdListenPeerURLs:           []string{apURL},
@@ -125,6 +125,7 @@ func TestBackendHTTPListener(t *testing.T) {
 
 			hdr := http.Header{
 				"Authorization":                  {"Basic " + userCredentials},
+				transport.HeaderKeyUser:          {"agent"},
 				transport.HeaderKeyNamespace:     {"default"},
 				transport.HeaderKeyAgentName:     {"agent"},
 				transport.HeaderKeySubscriptions: {},


### PR DESCRIPTION
## What is this change?

Adds basic authorization middleware to the agent web socket connection.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2811

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Yes, needed to pair with @palourde and @ccressent for a bit, but they were able to clarify the missing piece for me! (it was injecting the namespace into the context)

## Have you reviewed and updated the documentation for this change? Is new documentation required?

It's a bugfix, docs should be good.

## How did you verify this change?

Integration and e2e testing. New test case is probably not required.