### PR TITLE
Configurable buffer size & worker count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ is silenced.
 - Added --disable-assets flag to sensu-agent.
 - Added ability to query mutators to the GraphQL service
 - Added ability to query event filters to the GraphQL service
+- The buffer size and worker count of keepalived, eventd & pipelined can now be
+configured on sensu-backend.
 
 ### Changed
 - The REST API now returns the `201 Created` success status response code for

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sensu/sensu-go/rpc"
 	"github.com/sensu/sensu-go/system"
 	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/viper"
 )
 
 // Backend represents the backend server, which is used to hold the datastore
@@ -180,6 +181,8 @@ func Initialize(config *Config) (*Backend, error) {
 		Bus:                     bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
+		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
+		WorkerCount:             viper.GetInt(FlagPipelinedWorkers),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", pipeline.Name(), err)
@@ -193,6 +196,8 @@ func Initialize(config *Config) (*Backend, error) {
 		Bus:             bus,
 		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
 		Client:          b.Client,
+		BufferSize:      viper.GetInt(FlagEventdBufferSize),
+		WorkerCount:     viper.GetInt(FlagEventdWorkers),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", event.Name(), err)
@@ -236,6 +241,8 @@ func Initialize(config *Config) (*Backend, error) {
 		EventStore:            stor,
 		LivenessFactory:       liveness.EtcdFactory(b.ctx, b.Client),
 		RingPool:              ringPool,
+		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -277,12 +277,12 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetDefault(flagTrustedCAFile, "")
 	viper.SetDefault(flagInsecureSkipTLSVerify, false)
 	viper.SetDefault(flagLogLevel, "warn")
-	viper.SetDefault(backend.FlagEventdWorkers, 1000)
-	viper.SetDefault(backend.FlagEventdBufferSize, 2000)
-	viper.SetDefault(backend.FlagKeepalivedWorkers, 1000)
-	viper.SetDefault(backend.FlagKeepalivedBufferSize, 2000)
-	viper.SetDefault(backend.FlagPipelinedWorkers, 1000)
-	viper.SetDefault(backend.FlagPipelinedBufferSize, 2000)
+	viper.SetDefault(backend.FlagEventdWorkers, 100)
+	viper.SetDefault(backend.FlagEventdBufferSize, 100)
+	viper.SetDefault(backend.FlagKeepalivedWorkers, 100)
+	viper.SetDefault(backend.FlagKeepalivedBufferSize, 100)
+	viper.SetDefault(backend.FlagPipelinedWorkers, 100)
+	viper.SetDefault(backend.FlagPipelinedBufferSize, 100)
 
 	// Etcd defaults
 	viper.SetDefault(flagEtcdAdvertiseClientURLs, defaultEtcdAdvertiseClientURL)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -277,6 +277,12 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetDefault(flagTrustedCAFile, "")
 	viper.SetDefault(flagInsecureSkipTLSVerify, false)
 	viper.SetDefault(flagLogLevel, "warn")
+	viper.SetDefault(backend.FlagEventdWorkers, 1000)
+	viper.SetDefault(backend.FlagEventdBufferSize, 2000)
+	viper.SetDefault(backend.FlagKeepalivedWorkers, 1000)
+	viper.SetDefault(backend.FlagKeepalivedBufferSize, 2000)
+	viper.SetDefault(backend.FlagPipelinedWorkers, 1000)
+	viper.SetDefault(backend.FlagPipelinedBufferSize, 2000)
 
 	// Etcd defaults
 	viper.SetDefault(flagEtcdAdvertiseClientURLs, defaultEtcdAdvertiseClientURL)
@@ -313,6 +319,12 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
 	cmd.Flags().Bool(flagDebug, false, "enable debugging and profiling features")
 	cmd.Flags().String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug]")
+	cmd.Flags().Int(backend.FlagEventdWorkers, viper.GetInt(backend.FlagEventdWorkers), "number of workers spawned for processing incoming events")
+	cmd.Flags().Int(backend.FlagEventdBufferSize, viper.GetInt(backend.FlagEventdBufferSize), "number of incoming events that can be buffered")
+	cmd.Flags().Int(backend.FlagKeepalivedWorkers, viper.GetInt(backend.FlagKeepalivedWorkers), "number of workers spawned for processing incoming keepalives")
+	cmd.Flags().Int(backend.FlagKeepalivedBufferSize, viper.GetInt(backend.FlagKeepalivedBufferSize), "number of incoming keepalives that can be buffered")
+	cmd.Flags().Int(backend.FlagPipelinedWorkers, viper.GetInt(backend.FlagPipelinedWorkers), "number of workers spawned for handling events through the event pipeline")
+	cmd.Flags().Int(backend.FlagPipelinedBufferSize, viper.GetInt(backend.FlagPipelinedBufferSize), "number of events to handle that can be buffered")
 
 	// Etcd flags
 	cmd.Flags().StringSlice(flagEtcdAdvertiseClientURLs, viper.GetStringSlice(flagEtcdAdvertiseClientURLs), "list of this member's client URLs to advertise to the rest of the cluster.")

--- a/backend/config.go
+++ b/backend/config.go
@@ -14,6 +14,19 @@ const (
 
 	// DefaultEtcdPeerURL is the default URL to listen for Etcd peers (single-node cluster only)
 	DefaultEtcdPeerURL = "http://127.0.0.1:2380"
+
+	// FlagEventdWorkers defines the number of workers for eventd
+	FlagEventdWorkers = "eventd-workers"
+	// FlagEventdBufferSize defines the buffer size for eventd
+	FlagEventdBufferSize = "eventd-buffer-size"
+	// FlagKeepalivedWorkers defines the number of workers for keepalived
+	FlagKeepalivedWorkers = "keepalived-workers"
+	// FlagKeepalivedBufferSize defines buffer size for keepalived
+	FlagKeepalivedBufferSize = "keepalived-buffer-size"
+	// FlagPipelinedWorkers defines the number of workers for pipelined
+	FlagPipelinedWorkers = "pipelined-workers"
+	// FlagPipelinedBufferSize defines the buffer size for pipelined
+	FlagPipelinedBufferSize = "pipelined-buffer-size"
 )
 
 // Config specifies a Backend configuration.

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -24,10 +24,6 @@ const (
 	// package.
 	ComponentName = "eventd"
 
-	// DefaultHandlerCount is the number of goroutines that will be allocated
-	// for processing incoming events.
-	DefaultHandlerCount = 1000
-
 	// EventsProcessedCounterVec is the name of the prometheus counter vec used to count events processed.
 	EventsProcessedCounterVec = "sensu_go_events_processed"
 
@@ -60,7 +56,7 @@ type Eventd struct {
 	store           store.Store
 	eventStore      store.EventStore
 	bus             messaging.MessageBus
-	handlerCount    int
+	workerCount     int
 	livenessFactory liveness.Factory
 	eventChan       chan interface{}
 	subscription    messaging.Subscription
@@ -82,19 +78,28 @@ type Config struct {
 	Bus             messaging.MessageBus
 	LivenessFactory liveness.Factory
 	Client          *clientv3.Client
+	BufferSize      int
+	WorkerCount     int
 }
 
 // New creates a new Eventd.
 func New(c Config, opts ...Option) (*Eventd, error) {
+	if c.BufferSize == 0 {
+		c.BufferSize = 1
+	}
+	if c.WorkerCount == 0 {
+		c.WorkerCount = 1
+	}
+
 	e := &Eventd{
 		store:           c.Store,
 		eventStore:      c.EventStore,
 		bus:             c.Bus,
-		handlerCount:    DefaultHandlerCount,
+		workerCount:     c.WorkerCount,
 		livenessFactory: c.LivenessFactory,
 		errChan:         make(chan error, 1),
 		shutdownChan:    make(chan struct{}, 1),
-		eventChan:       make(chan interface{}, 100),
+		eventChan:       make(chan interface{}, c.BufferSize),
 		wg:              &sync.WaitGroup{},
 		mu:              &sync.Mutex{},
 		Logger:          &RawLogger{},
@@ -125,7 +130,7 @@ func (e *Eventd) Receiver() chan<- interface{} {
 
 // Start eventd.
 func (e *Eventd) Start() error {
-	e.wg.Add(e.handlerCount)
+	e.wg.Add(e.workerCount)
 	sub, err := e.bus.Subscribe(messaging.TopicEventRaw, "eventd", e)
 	e.subscription = sub
 	if err != nil {
@@ -137,7 +142,7 @@ func (e *Eventd) Start() error {
 }
 
 func (e *Eventd) startHandlers() {
-	for i := 0; i < e.handlerCount; i++ {
+	for i := 0; i < e.workerCount; i++ {
 		go func() {
 			defer e.wg.Done()
 

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -54,7 +54,7 @@ func newEventd(store store.Store, bus messaging.MessageBus, livenessFactory live
 		wg:              &sync.WaitGroup{},
 		mu:              &sync.Mutex{},
 		Logger:          &RawLogger{},
-		handlerCount:    5,
+		workerCount:     5,
 		silencedCache:   &cache.Resource{},
 	}
 }
@@ -252,7 +252,7 @@ func TestCheckTTL(t *testing.T) {
 				store:           store,
 				eventStore:      store,
 				livenessFactory: newFakeFactory(switches),
-				handlerCount:    1,
+				workerCount:     1,
 				wg:              &sync.WaitGroup{},
 				Logger:          &RawLogger{},
 				silencedCache:   &cache.Resource{},

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -73,12 +73,12 @@ type Config struct {
 // New creates a new Keepalived.
 func New(c Config, opts ...Option) (*Keepalived, error) {
 	k := &Keepalived{
-		store:      c.Store,
-		eventStore: c.EventStore,
-		bus:        c.Bus,
+		store:                 c.Store,
+		eventStore:            c.EventStore,
+		bus:                   c.Bus,
 		deregistrationHandler: c.DeregistrationHandler,
 		livenessFactory:       c.LivenessFactory,
-		keepaliveChan:         make(chan interface{}, 10),
+		keepaliveChan:         make(chan interface{}, 1000),
 		handlerCount:          DefaultHandlerCount,
 		mu:                    &sync.Mutex{},
 		errChan:               make(chan error, 1),

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -58,7 +58,11 @@ func newKeepalivedTest(t *testing.T) *keepalivedTest {
 	deregisterer := &mockDeregisterer{}
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	require.NoError(t, err)
-	k, err := New(Config{Store: store, Bus: bus, LivenessFactory: fakeFactory})
+	k, err := New(Config{
+		Store:           store,
+		Bus:             bus,
+		LivenessFactory: fakeFactory,
+	})
 	require.NoError(t, err)
 	test := &keepalivedTest{
 		MessageBus:   bus,

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -62,7 +62,7 @@ func New(c Config, options ...Option) (*Pipelined, error) {
 		running:           &atomic.Value{},
 		wg:                &sync.WaitGroup{},
 		errChan:           make(chan error, 1),
-		eventChan:         make(chan interface{}, 100),
+		eventChan:         make(chan interface{}, 1000),
 		executor:          command.NewExecutor(),
 		assetGetter:       c.AssetGetter,
 	}

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -13,12 +13,6 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
-const (
-	// PipelineCount specifies how many pipelines (goroutines) are
-	// in action.
-	PipelineCount int = 10
-)
-
 // ExtensionExecutorGetterFunc gets an ExtensionExecutor. Used to decouple
 // Pipelined from gRPC.
 type ExtensionExecutorGetterFunc func(*types.Extension) (rpc.ExtensionExecutor, error)
@@ -39,6 +33,7 @@ type Pipelined struct {
 	bus               messaging.MessageBus
 	extensionExecutor ExtensionExecutorGetterFunc
 	executor          command.Executor
+	workerCount       int
 }
 
 // Config configures a Pipelined.
@@ -47,6 +42,8 @@ type Config struct {
 	Bus                     messaging.MessageBus
 	ExtensionExecutorGetter ExtensionExecutorGetterFunc
 	AssetGetter             asset.Getter
+	BufferSize              int
+	WorkerCount             int
 }
 
 // Option is a functional option used to configure Pipelined.
@@ -54,6 +51,13 @@ type Option func(*Pipelined) error
 
 // New creates a new Pipelined with supplied Options applied.
 func New(c Config, options ...Option) (*Pipelined, error) {
+	if c.BufferSize == 0 {
+		c.BufferSize = 1
+	}
+	if c.WorkerCount == 0 {
+		c.WorkerCount = 1
+	}
+
 	p := &Pipelined{
 		store:             c.Store,
 		bus:               c.Bus,
@@ -62,7 +66,8 @@ func New(c Config, options ...Option) (*Pipelined, error) {
 		running:           &atomic.Value{},
 		wg:                &sync.WaitGroup{},
 		errChan:           make(chan error, 1),
-		eventChan:         make(chan interface{}, 1000),
+		eventChan:         make(chan interface{}, c.BufferSize),
+		workerCount:       c.WorkerCount,
 		executor:          command.NewExecutor(),
 		assetGetter:       c.AssetGetter,
 	}
@@ -88,7 +93,7 @@ func (p *Pipelined) Start() error {
 	}
 	p.subscription = sub
 
-	p.createPipelines(PipelineCount, p.eventChan)
+	p.createPipelines(p.workerCount, p.eventChan)
 
 	return nil
 }


### PR DESCRIPTION
## What is this change?

This PR introduces configurable buffer size & worker count for keepalived, eventd & pipelined.

More specifically, it allows an operator to configure the `sensu:event-raw`, `sensu:event` & `sensu:keepalive` topics of Wizard Bus in order to determine the buffer size and the number of workers that consume these topics.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3098

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1575

## How did you verify this change?

I manually tested this change and we successfully used this change on the performance testing environment.
