### PR TITLE
Wizard Bus & agent sessions instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ is silenced.
 - Added --disable-assets flag to sensu-agent.
 - Added ability to query mutators to the GraphQL service
 - Added ability to query event filters to the GraphQL service
+- Added prometheus metrics for topics in wizard bus and agent sessions.
 
 ### Changed
 - The REST API now returns the `201 Created` success status response code for

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sensu/sensu-go/backend/apid/middlewares"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/ringv2"
@@ -117,6 +118,8 @@ func (a *Agentd) Start() error {
 			logger.WithError(err).Error("failed to start http/https server")
 		}
 	}()
+
+	_ = prometheus.Register(sessionCounter)
 
 	return nil
 }

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -32,8 +32,8 @@ const (
 )
 
 var (
-	topicCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	topicCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "sensu_go_wizard_bus",
 			Help: "Number of elements in a topic",
 		},

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -5,6 +5,7 @@ package messaging
 import (
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sensu/sensu-go/backend/daemon"
 )
 
@@ -28,6 +29,16 @@ const (
 
 	// TopicTessenMetric is the topic prefix for tessen api metrics to Tessend.
 	TopicTessenMetric = "sensu:tessen-metric"
+)
+
+var (
+	topicCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "sensu_go_wizard_bus",
+			Help: "Number of elements in a topic",
+		},
+		[]string{"topic"},
+	)
 )
 
 // A Subscriber receives messages via a channel.

--- a/backend/messaging/wizard_bus.go
+++ b/backend/messaging/wizard_bus.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // WizardBus is a message bus.
@@ -38,6 +40,8 @@ func NewWizardBus(cfg WizardBusConfig, opts ...WizardOption) (*WizardBus, error)
 			return nil, err
 		}
 	}
+	_ = prometheus.Register(topicCounter)
+
 	return bus, nil
 }
 

--- a/backend/messaging/wizard_topic.go
+++ b/backend/messaging/wizard_topic.go
@@ -21,7 +21,9 @@ func (t *wizardTopic) Send(msg interface{}) {
 		subscribers = append(subscribers, subscriber)
 	}
 	t.RUnlock()
+
 	for _, subscriber := range subscribers {
+		topicCounter.WithLabelValues(t.id).Set(float64(len(subscriber.Receiver())))
 		select {
 		case subscriber.Receiver() <- msg:
 		case <-t.done:


### PR DESCRIPTION
## What is this change?

This PR adds additional prometheus metrics around topics in the Wizard Bus & agent sessions.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3099

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

We successfully tested the topics metrics in the performance testing environment. I've successfully tested the rest.