### PR TITLE
Return an error when deleting an entity that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ is silenced.
 - The REST API now returns the `201 Created` success status response code for
 POST & PUT requests instead of `204 No Content`.
 
+### Fixed
+- The REST API now returns an error when trying to delete an entity that does
+not exist.
+
 ## [5.10.1] - 2019-06-25
 
 ### Fixed

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -43,8 +43,20 @@ func (s *Store) DeleteEntityByName(ctx context.Context, name string) error {
 		return errors.New("must specify name")
 	}
 
-	_, err := s.client.Delete(ctx, GetEntitiesPath(ctx, name))
-	return err
+	key := GetEntitiesPath(ctx, name)
+	resp, err := s.client.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+	if resp.Deleted == 0 {
+		return &store.ErrNotFound{Key: key}
+	} else if resp.Deleted > 1 {
+		return &store.ErrInternal{
+			Message: fmt.Sprintf("expected to delete exactly 1 key, deleted %d", resp.Deleted),
+		}
+	}
+
+	return nil
 }
 
 // GetEntityByName gets an Entity by its name.


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes the behaviour of the DELETE endpoint for entities, which would not return an error if the entity didn't exist since 5.10.1.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3097

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

Manually tested, we have a failing test case in sensu-staging that will be fixed with this patch.