### PR TITLE
Fix event alias for timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ is silenced.
 - The REST API now returns the `201 Created` success status response code for
 POST & PUT requests instead of `204 No Content`.
 
+### Fixed
+- Fixed an aliasing regression where event timestamps from the /events API
+were not getting properly populated.
+
 ## [5.10.1] - 2019-06-25
 
 ### Fixed

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -257,10 +257,10 @@ func (s *Store) UpdateEvent(ctx context.Context, event *corev2.Event) (*corev2.E
 		persistEvent.Check = &check
 	}
 
-	if event.Timestamp == 0 {
+	if persistEvent.Timestamp == 0 {
 		// If the event is being created for the first time, it may not include
 		// a timestamp. Use the current time.
-		event.Timestamp = time.Now().Unix()
+		persistEvent.Timestamp = time.Now().Unix()
 	}
 
 	// update the history


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes an alias regression introduced in https://github.com/sensu/sensu-go/commit/37a0401c76df06547460e297e70d2e2e1aff9008 where the timestamp was not being updated for the persisted event.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3105

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Followed the steps to produced detailed in https://github.com/sensu/sensu-go/issues/3105.