### PR TITLE
Properly identify the agent in agentd session

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -81,7 +81,7 @@ func NewSession(cfg SessionConfig, conn transport.Transport, bus messaging.Messa
 	logger.WithFields(logrus.Fields{
 		"addr":          cfg.AgentAddr,
 		"namespace":     cfg.Namespace,
-		"id":            cfg.AgentName,
+		"agent":         cfg.AgentName,
 		"subscriptions": cfg.Subscriptions,
 	}).Info("agent connected")
 
@@ -135,7 +135,7 @@ func (s *Session) recvPump() {
 			case transport.ConnectionError, transport.ClosedError:
 				logger.WithFields(logrus.Fields{
 					"addr":       s.cfg.AgentAddr,
-					"id":         s.cfg.AgentName,
+					"agent":      s.cfg.AgentName,
 					"recv error": err.Error(),
 				}).Warn("stopping session")
 				return
@@ -264,7 +264,7 @@ func (s *Session) Stop() {
 		ring := s.ringPool.Get(ringv2.Path(s.cfg.Namespace, sub))
 		logger.WithFields(logrus.Fields{
 			"namespace": s.cfg.Namespace,
-			"id":        s.cfg.AgentName,
+			"agent":     s.cfg.AgentName,
 		}).Info("removing agent from ring")
 		if err := ring.Remove(s.ctx, s.cfg.AgentName); err != nil {
 			logger.WithError(err).Error("unable to remove agent from ring")

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -80,6 +80,7 @@ func NewSession(cfg SessionConfig, conn transport.Transport, bus messaging.Messa
 
 	logger.WithFields(logrus.Fields{
 		"addr":          cfg.AgentAddr,
+		"namespace":     cfg.Namespace,
 		"id":            cfg.AgentName,
 		"subscriptions": cfg.Subscriptions,
 	}).Info("agent connected")
@@ -261,7 +262,10 @@ func (s *Session) Stop() {
 	close(s.checkChannel)
 	for _, sub := range s.cfg.Subscriptions {
 		ring := s.ringPool.Get(ringv2.Path(s.cfg.Namespace, sub))
-		logger.Info("removing agent from ring")
+		logger.WithFields(logrus.Fields{
+			"namespace": s.cfg.Namespace,
+			"id":        s.cfg.AgentName,
+		}).Info("removing agent from ring")
 		if err := ring.Remove(s.ctx, s.cfg.AgentName); err != nil {
 			logger.WithError(err).Error("unable to remove agent from ring")
 		}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It makes sure we identify the agent in log entries of a session, using its ID and its namespace.

## Why is this change necessary?

Related to https://github.com/sensu/sensu-go/issues/3106

## Does your change need a Changelog entry?

I don't believe it's worth mentioning it.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.
