### PR TITLE
Multiple nested set handlers should not be flagged as deeply nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ POST & PUT requests instead of `204 No Content`.
 ### Fixed
 - Fixed an aliasing regression where event timestamps from the /events API
 were not getting properly populated.
+- Fixed a bug where multiple nested set handlers could be incorrectly flagged as
+deeply nested.
 
 ## [5.10.1] - 2019-06-25
 

--- a/backend/pipelined/handle.go
+++ b/backend/pipelined/handle.go
@@ -157,8 +157,7 @@ func (p *Pipelined) expandHandlers(ctx context.Context, handlers []string, level
 		}
 
 		if handler.Type == "set" {
-			level++
-			setHandlers, err := p.expandHandlers(ctx, handler.Handlers, level)
+			setHandlers, err := p.expandHandlers(ctx, handler.Handlers, level+1)
 
 			if err != nil {
 				logger.


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR fixes a bug where set handlers could be incorrectly marked as too deeply nested if multiple nested set handlers are provided.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3109

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

I've refactored the unit tests to make sure this use case was properly tested.