### PR TITLE
Feature/sensuctl user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ is silenced.
 - Added prometheus metrics for topics in wizard bus and agent sessions.
 - The buffer size and worker count of keepalived, eventd & pipelined can now be
 configured on sensu-backend.
+- Added the current user to the output of `sensuctl config view`.
 
 ### Changed
 - The REST API now returns the `201 Created` success status response code for

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -22,6 +22,7 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 				"api-url":   cli.Config.APIUrl(),
 				"namespace": cli.Config.Namespace(),
 				"format":    cli.Config.Format(),
+				"username":  helpers.GetCurrentUsername(cli.Config),
 			}
 
 			// Determine the format to use to output the data
@@ -61,6 +62,10 @@ func printToList(v interface{}, writer io.Writer) error {
 			{
 				Label: "Format",
 				Value: r["format"],
+			},
+			{
+				Label: "Username",
+				Value: r["username"],
 			},
 		},
 	}

--- a/cli/commands/config/view_test.go
+++ b/cli/commands/config/view_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	clienttest "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
@@ -33,8 +34,10 @@ func TestViewExec(t *testing.T) {
 	config := cli.Config.(*clienttest.MockConfig)
 	config.On("APIUrl").Return("http://127.0.0.1:8080")
 	config.On("Format").Return("none")
+	config.On("Tokens").Return(corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"))
 
 	out, err := test.RunCmd(cmd, []string{"default"})
 	assert.Regexp("Active Configuration", out)
+	assert.Regexp("admin", out)
 	assert.Nil(err, "Should not produce any errors")
 }


### PR DESCRIPTION
## What is this change?

Adds the current user to the output of `sensuctl config view`.

```
$ sensuctl config view
=== Active Configuration
API URL:   http://127.0.0.1:8080
Namespace: default
Format:    tabular
Username:  admin

$ sensuctl config view --format yaml
api-url: http://127.0.0.1:8080
format: tabular
namespace: default
username: admin

$ sensuctl config view --format json
{
  "api-url": "http://127.0.0.1:8080",
  "format": "tabular",
  "namespace": "default",
  "username": "admin"
}
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3096

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1582

## How did you verify this change?

`sensuctl config view` and unit test.