### PR TITLE
Refactor the storage requirements for Authorizer

### DIFF
--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -12,10 +12,20 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
+// Store is the storage requirements for the Authorizer. If you find that you
+// need functionality that is not in here, add it method by method. The god
+// type in the store package will have it.
+type Store interface {
+	ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.ClusterRoleBinding, error)
+	ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.RoleBinding, error)
+	GetRole(ctx context.Context, name string) (*corev2.Role, error)
+	GetClusterRole(ctx context.Context, name string) (*corev2.ClusterRole, error)
+}
+
 // Authorizer implements an authorizer interface using Role-Based Acccess
 // Control (RBAC)
 type Authorizer struct {
-	Store store.Store
+	Store Store
 }
 
 // RoleBinding implements the RoleBinding interface.


### PR DESCRIPTION
Using the Authorizer in the enterprise codebase is cumbersome, due
to the large API surface that must be mocked. Because of an
implementation peculiarity in our mocking library, we cannot use
the sensu-go mock store, and must therefore recreate our mocks
as necessary.

By specifying the exact API of consumers through interfaces, this
process becomes much easier.

Signed-off-by: Eric Chlebek <eric@sensu.io>