### PR TITLE
Fix a bug in round robin check scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ not exist.
 were not getting properly populated.
 - Fixed a bug where multiple nested set handlers could be incorrectly flagged as
 deeply nested.
+- Fixed a bug where round robin proxy checks could fail to execute.
 
 ## [5.10.1] - 2019-06-25
 

--- a/backend/schedulerd/roundrobin_interval.go
+++ b/backend/schedulerd/roundrobin_interval.go
@@ -60,7 +60,6 @@ func NewRoundRobinIntervalScheduler(ctx context.Context, store store.Store, bus 
 }
 
 func (s *RoundRobinIntervalScheduler) updateRings() {
-	newCancels := make(map[string]ringCancel)
 	agentEntitiesRequest := 1
 	var proxyEntities []*corev2.Entity
 	if s.check.ProxyRequests != nil {
@@ -72,12 +71,18 @@ func (s *RoundRobinIntervalScheduler) updateRings() {
 			return
 		}
 	}
-	// Cancel any ring watchers that should no longer exist
-	for _, watcher := range s.cancels {
-		watcher.Cancel()
-	}
+	newCancels := make(map[string]ringCancel)
 	for _, sub := range s.check.Subscriptions {
 		key := ringv2.Path(s.check.Namespace, sub)
+		watcher, ok := s.cancels[key]
+		if ok {
+			if watcher.AgentEntitiesRequest == agentEntitiesRequest {
+				// don't need to recreate the watcher
+				newCancels[key] = watcher
+				continue
+			}
+			watcher.Cancel()
+		}
 
 		// Create a new watcher
 		ctx, cancel := context.WithCancel(s.ctx)
@@ -86,6 +91,12 @@ func (s *RoundRobinIntervalScheduler) updateRings() {
 		val := ringCancel{Cancel: cancel, AgentEntitiesRequest: agentEntitiesRequest}
 		go s.handleEvents(s.executor, wc, proxyEntities)
 		newCancels[key] = val
+	}
+	// clean up any remaining watchers that are no longer valid
+	for key, watcher := range s.cancels {
+		if _, ok := newCancels[key]; !ok {
+			watcher.Cancel()
+		}
 	}
 	s.cancels = newCancels
 }
@@ -130,7 +141,7 @@ func (s *RoundRobinIntervalScheduler) handleEvent(executor *CheckExecutor, event
 		s.schedule(executor, proxyEntities, event.Values)
 
 	case ringv2.EventClosing:
-		s.logger.Info("shutting down scheduler")
+		s.logger.Warn("shutting down scheduler")
 	}
 }
 


### PR DESCRIPTION
This commit fixes a bug where check schedulers can be shut
down and recreated too often. In some cases this can lead to checks
not being executed frequently enough.

The problem is caused by entity updates being treated as cause for
shutting down schedulers, when in fact, it is only necessary to do
so in the rare circumstance that entity attributes change, leading
to a different cardinality of round robin ring.

To avoid this happening, before cancelling the existing scheduler,
the cardinality of the request is inspected, and if unchanged, the
existing scheduler is left alone.

Closes #3119 

Signed-off-by: Eric Chlebek <eric@sensu.io>