### PR TITLE
Add binding namespace to context in VisitRulesFor

### DIFF
--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -89,6 +89,8 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 			continue
 		}
 
+		ctx = store.NamespaceContext(ctx, binding.Namespace)
+
 		// Get the RoleRef that matched our user
 		rules, err := a.getRoleReferencerules(ctx, binding.RoleRef)
 		if err != nil {

--- a/backend/authorization/rbac/rbac_test.go
+++ b/backend/authorization/rbac/rbac_test.go
@@ -149,7 +149,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+				s.On("GetRole", mock.Anything, "admin").
 					Return(nil, nil)
 			},
 			want:    false,
@@ -176,7 +176,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+				s.On("GetRole", mock.Anything, "admin").
 					Return(nil, errors.New("error"))
 			},
 			wantErr: true,
@@ -206,7 +206,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+				s.On("GetRole", mock.Anything, "admin").
 					Return(&types.Role{Rules: []types.Rule{
 						types.Rule{
 							Verbs:         []string{"create"},
@@ -416,7 +416,7 @@ func TestVisitRulesFor(t *testing.T) {
 				types.Subject{Type: types.UserType, Name: "foo"},
 			},
 		}}, nil)
-	stor.On("GetRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+	stor.On("GetRole", mock.Anything, "admin").
 		Return(&types.Role{Rules: []types.Rule{
 			types.Rule{
 				Verbs:         []string{"create"},


### PR DESCRIPTION
This change is required to support a feature in the enterprise
product, and has no effect on basic auth or RBAC otherwise.

Signed-off-by: Eric Chlebek <eric@sensu.io>