### PR TITLE
Refactor authentication into its own API

### DIFF
--- a/api/core/v2/token.go
+++ b/api/core/v2/token.go
@@ -1,6 +1,15 @@
 package v2
 
-import jwt "github.com/dgrijalva/jwt-go"
+import (
+	"errors"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+var (
+	ErrInvalidToken = errors.New("invalid access or refresh token")
+	ErrUnauthorized = errors.New("unauthorized")
+)
 
 // Claims represents the JWT claims
 type Claims struct {

--- a/backend/api/authentication.go
+++ b/backend/api/authentication.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
+	"github.com/sensu/sensu-go/backend/authentication/providers/basic"
+	"github.com/sensu/sensu-go/backend/store"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// AuthenticationClient is a type that can be used to interact with the
+// backend's authentication services.
+type AuthenticationClient struct {
+	store store.TokenStore
+	auth  *authentication.Authenticator
+}
+
+func NewAuthenticationClient(store store.TokenStore, auth *authentication.Authenticator) *AuthenticationClient {
+	return &AuthenticationClient{
+		store: store,
+		auth:  auth,
+	}
+}
+
+// CreateAccessToken creates a new access token, given a valid username and password.
+func (a *AuthenticationClient) CreateAccessToken(ctx context.Context, username, password string) (*corev2.Tokens, error) {
+	claims, err := a.auth.Authenticate(ctx, username, password)
+	if err != nil {
+		return nil, corev2.ErrUnauthorized
+	}
+
+	// Add the 'system:users' group to this user
+	claims.Groups = append(claims.Groups, "system:users")
+
+	// Create an access token and its signed version
+	token, tokenString, err := jwt.AccessToken(claims)
+	if err != nil {
+		return nil, fmt.Errorf("error creating access token: %s", err)
+	}
+
+	// Create a refresh token and its signed version
+	refreshClaims := &v2.Claims{StandardClaims: v2.StandardClaims(claims.Subject)}
+	refreshToken, refreshTokenString, err := jwt.RefreshToken(refreshClaims)
+	if err != nil {
+		return nil, fmt.Errorf("error creating access token: %s", err)
+	}
+
+	// Add the tokens in the access list
+	if err := a.store.AllowTokens(token, refreshToken); err != nil {
+		return nil, err
+	}
+
+	result := &corev2.Tokens{
+		Access:    tokenString,
+		ExpiresAt: claims.ExpiresAt,
+		Refresh:   refreshTokenString,
+	}
+
+	return result, nil
+
+}
+
+// TestCreds detects if the username and password are valid.
+func (a *AuthenticationClient) TestCreds(ctx context.Context, username, password string) error {
+	// Authenticate against the basic provider
+	providers := a.auth.Providers()
+
+	if basic, ok := providers[basic.Type]; ok {
+		if _, err := basic.Authenticate(ctx, username, password); err == nil {
+			return nil
+		}
+		return errors.New("basic provider is disabled")
+	}
+
+	return errors.New("invalid username and/or password")
+}
+
+// Logout logs a user out. The context must carry the user's access and refresh
+// claims, with the following context key-values:
+//
+// corev2.AccessTokenClaims -> *corev2.Claims
+// corev2.RefreshTokenClaims -> *corev2.Claims
+func (a *AuthenticationClient) Logout(ctx context.Context) error {
+	var accessClaims, refreshClaims *corev2.Claims
+
+	// Get the access token claims
+	if value := ctx.Value(corev2.AccessTokenClaims); value != nil {
+		accessClaims = value.(*v2.Claims)
+	} else {
+		return corev2.ErrInvalidToken
+	}
+
+	// Get the refresh token claims
+	if value := ctx.Value(corev2.RefreshTokenClaims); value != nil {
+		refreshClaims = value.(*v2.Claims)
+	} else {
+		return corev2.ErrInvalidToken
+	}
+
+	// Remove the access & refresh tokens from the access list
+	return a.store.RevokeTokens(accessClaims, refreshClaims)
+}
+
+// RefreshAccessToken refreshes an access token. The context must carry the
+// user's access and refresh claims, as well as the previous token value,
+// with the following context key-values:
+//
+// corev2.AccessTokenClaims -> *corev2.Claims
+// corev2.RefreshTokenClaims -> *corev2.Claims
+// corev2.RefreshTokenString -> string
+func (a *AuthenticationClient) RefreshAccessToken(ctx context.Context) (*corev2.Tokens, error) {
+	var accessClaims, refreshClaims *v2.Claims
+
+	// Get the access token claims
+	if value := ctx.Value(v2.AccessTokenClaims); value != nil {
+		accessClaims = value.(*v2.Claims)
+	} else {
+		return nil, corev2.ErrInvalidToken
+	}
+
+	// Get the refresh token claims
+	if value := ctx.Value(v2.RefreshTokenClaims); value != nil {
+		refreshClaims = value.(*v2.Claims)
+	} else {
+		return nil, corev2.ErrInvalidToken
+	}
+
+	// Get the refresh token string
+	var refreshTokenString string
+	if value := ctx.Value(v2.RefreshTokenString); value != nil {
+		refreshTokenString = value.(string)
+	} else {
+		return nil, corev2.ErrInvalidToken
+	}
+
+	// Make sure the refresh token is authorized in the access list
+	if _, err := a.store.GetToken(refreshClaims.Subject, refreshClaims.Id); err != nil {
+		switch err := err.(type) {
+		case *store.ErrNotFound:
+			return nil, err
+		default:
+			return nil, fmt.Errorf("unexpected error while authorizing refresh token ID %q: %s", refreshClaims.Id, err)
+		}
+	}
+
+	// Revoke the old access token from the access list
+	if err := a.store.RevokeTokens(accessClaims); err != nil {
+		return nil, err
+	}
+
+	// Ensure backward compatibility by filling the provider claims if missing
+	if accessClaims.Provider.ProviderID == "" || accessClaims.Provider.UserID == "" {
+		accessClaims.Provider.ProviderID = basic.Type
+		accessClaims.Provider.UserID = accessClaims.Subject
+	}
+
+	// Ensure backward compatibility with Sensu Go 5.1.1, since the provider type
+	// was used in the provider ID
+	if accessClaims.Provider.ProviderID == "basic/default" {
+		accessClaims.Provider.ProviderID = basic.Type
+	}
+
+	// Refresh the user claims
+	claims, err := a.auth.Refresh(ctx, accessClaims.Provider)
+	if err != nil {
+		return nil, corev2.ErrUnauthorized
+	}
+
+	// Ensure the 'system:users' group is present
+	claims.Groups = append(claims.Groups, "system:users")
+
+	// Issue a new access token
+	accessToken, accessTokenString, err := jwt.AccessToken(claims)
+	if err != nil {
+		return nil, err
+	}
+
+	// store the new access token in the access list
+	if err := a.store.AllowTokens(accessToken); err != nil {
+		return nil, err
+	}
+
+	return &corev2.Tokens{
+		Access:    accessTokenString,
+		ExpiresAt: accessClaims.ExpiresAt,
+		Refresh:   refreshTokenString,
+	}, nil
+}

--- a/backend/api/authentication_test.go
+++ b/backend/api/authentication_test.go
@@ -1,0 +1,323 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
+	"github.com/sensu/sensu-go/backend/authentication/providers/basic"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/mock"
+)
+
+func defaultAuth(store store.Store) *authentication.Authenticator {
+	auth := &authentication.Authenticator{}
+	provider := &basic.Provider{Store: store, ObjectMeta: corev2.ObjectMeta{Name: basic.Type}}
+	auth.AddProvider(provider)
+	return auth
+}
+
+func defaultStore() store.Store {
+	return &mockstore.MockStore{}
+}
+
+func contextWithClaims(claims *corev2.Claims) context.Context {
+	refreshClaims := &corev2.Claims{StandardClaims: corev2.StandardClaims(claims.Subject)}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, corev2.AccessTokenClaims, claims)
+	ctx = context.WithValue(ctx, corev2.RefreshTokenClaims, refreshClaims)
+	return ctx
+}
+
+func TestCreateAccessToken(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Username      string
+		Password      string
+		Store         func() store.Store
+		Authenticator func(store.Store) *authentication.Authenticator
+		Context       func() context.Context
+		WantError     bool
+		Error         error
+	}{
+		{
+			Name:          "no credentials",
+			Store:         defaultStore,
+			Authenticator: defaultAuth,
+			Context:       context.Background,
+			WantError:     true,
+			Error:         corev2.ErrUnauthorized,
+		},
+		{
+			Name:     "invalid credentials",
+			Username: "foo",
+			Password: "P@ssw0rd!",
+			Store: func() store.Store {
+				user := corev2.FixtureUser("foo")
+				store := &mockstore.MockStore{}
+				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, errors.New("error"))
+				return store
+			},
+			Authenticator: defaultAuth,
+			Context:       context.Background,
+			WantError:     true,
+			Error:         corev2.ErrUnauthorized,
+		},
+		{
+			Name:     "success",
+			Username: "foo",
+			Password: "P@ssw0rd!",
+			Context:  context.Background,
+			Store: func() store.Store {
+				store := &mockstore.MockStore{}
+				user := corev2.FixtureUser("foo")
+				store.On("AllowTokens", mock.AnythingOfType("[]*jwt.Token")).Return(nil)
+				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, nil)
+				return store
+			},
+			Authenticator: defaultAuth,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			store := test.Store()
+			authn := NewAuthenticationClient(store, test.Authenticator(store))
+			tokens, err := authn.CreateAccessToken(test.Context(), test.Username, test.Password)
+			if test.WantError && err == nil {
+				t.Fatal("want error, got nil")
+				if test.Error != nil && test.Error != err {
+					t.Fatalf("bad error: got %v, want %v", err, test.Error)
+				}
+			}
+			if !test.WantError && err != nil {
+				t.Fatal(err)
+			}
+			if tokens != nil {
+				if err := tokens.Validate(); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestTestCreds(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Username      string
+		Password      string
+		Store         func() store.Store
+		Authenticator func(store.Store) *authentication.Authenticator
+		Context       func() context.Context
+		WantError     bool
+		Error         error
+	}{
+		{
+			Name:          "no credentials",
+			Store:         defaultStore,
+			Authenticator: defaultAuth,
+			Context:       context.Background,
+			WantError:     true,
+			Error:         corev2.ErrUnauthorized,
+		},
+		{
+			Name:     "invalid credentials",
+			Username: "foo",
+			Password: "P@ssw0rd!",
+			Store: func() store.Store {
+				user := corev2.FixtureUser("foo")
+				store := &mockstore.MockStore{}
+				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, errors.New("error"))
+				return store
+			},
+			Authenticator: defaultAuth,
+			Context:       context.Background,
+			WantError:     true,
+			Error:         corev2.ErrUnauthorized,
+		},
+		{
+			Name:     "success",
+			Username: "foo",
+			Password: "P@ssw0rd!",
+			Context:  context.Background,
+			Store: func() store.Store {
+				store := &mockstore.MockStore{}
+				user := corev2.FixtureUser("foo")
+				store.On("AllowTokens", mock.AnythingOfType("[]*jwt.Token")).Return(nil)
+				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, nil)
+				return store
+			},
+			Authenticator: defaultAuth,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			store := test.Store()
+			authn := NewAuthenticationClient(store, test.Authenticator(store))
+			err := authn.TestCreds(test.Context(), test.Username, test.Password)
+			if test.WantError && err == nil {
+				t.Fatal("want error, got nil")
+				if test.Error != nil && test.Error != err {
+					t.Fatalf("bad error: got %v, want %v", err, test.Error)
+				}
+			}
+			if !test.WantError && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestLogout(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Store         func() store.Store
+		Authenticator func(store.Store) *authentication.Authenticator
+		Context       func(*corev2.Claims) context.Context
+		WantError     bool
+		Error         error
+	}{
+		{
+			Name:          "invalid token",
+			Store:         defaultStore,
+			Authenticator: defaultAuth,
+			Context:       func(*corev2.Claims) context.Context { return context.Background() },
+			WantError:     true,
+			Error:         corev2.ErrInvalidToken,
+		},
+		{
+			Name: "not whitelisted",
+			Store: func() store.Store {
+				store := &mockstore.MockStore{}
+				store.On("RevokeTokens", mock.AnythingOfType("[]*v2.Claims")).Return(fmt.Errorf("error"))
+				return store
+			},
+			Authenticator: defaultAuth,
+			Context:       contextWithClaims,
+			WantError:     true,
+		},
+		{
+			Name: "success",
+			Store: func() store.Store {
+				store := &mockstore.MockStore{}
+				store.On("RevokeTokens", mock.AnythingOfType("[]*v2.Claims")).Return(nil)
+				return store
+			},
+			Authenticator: defaultAuth,
+			Context:       contextWithClaims,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			claims := corev2.FixtureClaims("foo", nil)
+			ctx := test.Context(claims)
+			store := test.Store()
+			authenticator := test.Authenticator(store)
+			auth := NewAuthenticationClient(store, authenticator)
+			err := auth.Logout(ctx)
+			if err == nil && test.WantError {
+				t.Fatal("got non-nil error")
+			}
+			if err != nil && !test.WantError {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestRefreshAccessToken(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Store         func() store.Store
+		Authenticator func(store.Store) *authentication.Authenticator
+		Context       func(*corev2.Claims) context.Context
+		WantError     bool
+		Error         error
+	}{
+		{
+			Name: "not whitelisted",
+			Store: func() store.Store {
+				st := &mockstore.MockStore{}
+				user := &corev2.User{Username: "foo"}
+				st.On(
+					"GetToken",
+					mock.AnythingOfType("string"),
+					mock.AnythingOfType("string"),
+				).Return(&corev2.Claims{}, &store.ErrNotFound{})
+				st.On("GetUser",
+					mock.Anything,
+					mock.AnythingOfType("string")).Return(user, nil)
+				return st
+			},
+			Authenticator: defaultAuth,
+			Context:       contextWithClaims,
+			WantError:     true,
+			Error:         corev2.ErrUnauthorized,
+		},
+		{
+			Name: "cannot whitelist access token",
+			Store: func() store.Store {
+				st := &mockstore.MockStore{}
+				user := &corev2.User{Username: "foo"}
+				st.On("AllowTokens", mock.AnythingOfType("[]*jwt.Token")).Return(fmt.Errorf("error"))
+				st.On("RevokeTokens", mock.AnythingOfType("[]*v2.Claims")).Return(nil)
+				st.On("GetToken",
+					mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&corev2.Claims{}, nil)
+				st.On("GetUser",
+					mock.Anything, mock.AnythingOfType("string")).Return(user, nil)
+				return st
+			},
+			Authenticator: defaultAuth,
+			Context:       contextWithClaims,
+			WantError:     true,
+		},
+		{
+			Name: "success",
+			Store: func() store.Store {
+				st := &mockstore.MockStore{}
+				user := &corev2.User{Username: "foo"}
+				st.On("AllowTokens", mock.AnythingOfType("[]*jwt.Token")).Return(nil)
+				st.On("RevokeTokens", mock.AnythingOfType("[]*v2.Claims")).Return(nil)
+				st.On("GetToken",
+					mock.AnythingOfType("string"), mock.AnythingOfType("string"),
+				).Return(&types.Claims{}, nil)
+				st.On("GetUser",
+					mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("string"),
+				).Return(user, nil)
+				return st
+			},
+			Authenticator: defaultAuth,
+			Context: func(claims *corev2.Claims) context.Context {
+				ctx := contextWithClaims(claims)
+				_, refreshTokenString, _ := jwt.RefreshToken(ctx.Value(corev2.RefreshTokenClaims).(*corev2.Claims))
+				ctx = context.WithValue(ctx, corev2.RefreshTokenString, refreshTokenString)
+				return ctx
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			claims := corev2.FixtureClaims("foo", nil)
+			ctx := test.Context(claims)
+			store := test.Store()
+			authenticator := test.Authenticator(store)
+			auth := NewAuthenticationClient(store, authenticator)
+			_, err := auth.RefreshAccessToken(ctx)
+			if err == nil && test.WantError {
+				t.Fatal("got non-nil error")
+			}
+			if err != nil && !test.WantError {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is this change?

This change extracts business logic from the authentication router and places it in its own type. The intent is that this type will be reused by dashboardd, so that it doesn't need to reverse proxy requests. This is the first of many such changes.

## Why is this change necessary?

These changes are in support of #2566

## Does your change need a Changelog entry?

No