### PR TITLE
Add key separator to end of etcd key when listing events for a specific entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added functionality for the agent `--allow-list` configuration, which
 whitelists check and check hook executables.
 
+### Fixed
+- The REST API now correctly only returns events for the specific entity
+queried in the `GET /events/:entity` endpoint (#3141)
+
 ## [5.11.0] - 2019-07-10
 
 ### Added

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -44,7 +44,11 @@ func getEventWithCheckPath(ctx context.Context, entity, check string) (string, e
 
 // GetEventsPath gets the path of the event store.
 func GetEventsPath(ctx context.Context, entity string) string {
-	return eventKeyBuilder.WithContext(ctx).Build(entity)
+	b := eventKeyBuilder.WithContext(ctx)
+	if entity != "" {
+		b = b.WithExactMatch()
+	}
+	return b.Build(entity)
 }
 
 // DeleteEventByEntityCheck deletes an event by entity name and check name.

--- a/backend/store/key_builder_test.go
+++ b/backend/store/key_builder_test.go
@@ -28,3 +28,16 @@ func TestContextKeyBuilder(t *testing.T) {
 	// a different namespace that would have the same prefix, eg: acme-devel
 	assert.Equal(t, "/sensu.io/checks/acme/", builder.Build(""))
 }
+
+func TestExactMatchKeyBuilder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.NamespaceKey, "default")
+	builder := NewKeyBuilder("events").WithContext(ctx).WithExactMatch()
+
+	// Querying all events for an entity uses etcd prefixes, so we want
+	// the key to end in '/' in order not to inadvertently retrieve events from
+	// a different entity that would have the same prefix, eg: foobar
+	assert.Equal(t, "/sensu.io/events/default/entity_name/", builder.Build("entity_name"))
+}


### PR DESCRIPTION
## What is this change?

Fixes #3141 by adding the `WithExactMatch` method to `KeyBuilder` and utilising it in `GetEventsByEntity`.

## Why is this change necessary?

To prevent `GET /events/:entity` from returning events for all entities whose name begins with `:entity`.

## Does your change need a Changelog entry?

Yes, added one.

## Do you need clarification on anything?

This is just a suggested approach to address this problem. I couldn't think of any other resource types exposed via the API that are prone to the same prefix failure case, but adding the separator in the `KeyBuilder` instead of in the event store implementation seemed like the correct approach.

I don't feel strongly about the approach I've taken so if you have one you prefer feel free to reject this PR in favour of it.

## Were there any complications while making this change?

None, built and tested successfully locally with `build.sh`.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't think there's any documentation change necessary, unless you want to add a note to old documentation for this endpoint indicating that it was broken.

## How did you verify this change?

Added new unit tests for the key builder, and integration tests for the event store. Confirmed the integration test was red without the fix (the key builder test uses an undefined method without the fix present so I didn't run that) and green with it.

I also ran the reproduction steps from #3141 and confirmed the output was as expected:
```
╭─  …/sensu/sensu-go 
│
╰ sensuctl configure
? Sensu Backend URL: http://127.0.0.1:8080
? Username: admin
? Password: *********
? Namespace: default
? Preferred output format: tabular

╭─  …/sensu/sensu-go 
│
╰ sensuctl create -f entities.json

╭─  …/sensu/sensu-go 
│
╰ curl -X POST -H 'Content-Type: application/json' --data "@foo_event.json" http://127.0.0.1:3031/events   

╭─  …/sensu/sensu-go 
│
╰ curl -X POST -H 'Content-Type: application/json' --data "@foobar_event.json" http://127.0.0.1:3031/events

╭─  …/sensu/sensu-go 
│
╰ sensuctl event list
  Entity        Check                                     Output                                Status   Silenced             Timestamp            
 ──────── ───────────────── ────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── 
  agent1   keepalive         Keepalive last sent from agent1 at 2019-07-14 19:27:40 +0000 UTC        0   false      2019-07-14 15:27:40 -0400 EDT  
  foo      check-something   could not connect to it                                                 1   false      2019-07-14 15:27:42 -0400 EDT  
  foobar   check-something   could not connect to mysql                                              1   false      2019-07-14 15:27:44 -0400 EDT  

╭─  …/sensu/sensu-go 
│
╰ cat ~/.config/sensu/sensuctl/cluster | jq -r '.["access_token"]' | xargs -I{} curl -s -H "Authorization: Bearer {}" -H "Content-Type: application/json" http://localhost:8080/api/core/v2/namespaces/default/events/foo | jq -r '.[] | .entity.metadata.name'
foo

╭─  …/sensu/sensu-go 
│
╰ cat ~/.config/sensu/sensuctl/cluster | jq -r '.["access_token"]' | xargs -I{} curl -s -H "Authorization: Bearer {}" -H "Content-Type: application/json" http://localhost:8080/api/core/v2/namespaces/default/events/foobar | jq -r '.[] | .entity.metadata.name'
foobar
```