### PR TITLE
Pass the JWT claims to the Refresh authentication method

### DIFF
--- a/api/core/v2/provider.go
+++ b/api/core/v2/provider.go
@@ -9,7 +9,7 @@ type AuthProvider interface {
 	// Authenticate attempts to authenticate a user with its username and password
 	Authenticate(ctx context.Context, username, password string) (*Claims, error)
 	// Refresh renews the user claims with the provider claims
-	Refresh(ctx context.Context, providerClaims AuthProviderClaims) (*Claims, error)
+	Refresh(ctx context.Context, claims *Claims) (*Claims, error)
 
 	// GetObjectMeta returns the object metadata for the provider
 	GetObjectMeta() ObjectMeta

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -224,7 +224,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Refresh the user claims
-	claims, err := a.authenticator.Refresh(r.Context(), accessClaims.Provider)
+	claims, err := a.authenticator.Refresh(r.Context(), accessClaims)
 	if err != nil {
 		logger.WithError(err).Error("could not refresh user claims")
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)

--- a/backend/authentication/authenticator.go
+++ b/backend/authentication/authenticator.go
@@ -44,16 +44,16 @@ func (a *Authenticator) Authenticate(ctx context.Context, username, password str
 // Refresh is called when a new access token is requested with a refresh token.
 // The provider should attempt to update the user identity to reflect any changes
 // since the access token was last refreshed
-func (a *Authenticator) Refresh(ctx context.Context, claims corev2.AuthProviderClaims) (*corev2.Claims, error) {
+func (a *Authenticator) Refresh(ctx context.Context, claims *corev2.Claims) (*corev2.Claims, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
 	// Retrieve the right provider with the provider ID specified in the claims
-	if provider, ok := a.providers[claims.ProviderID]; ok {
+	if provider, ok := a.providers[claims.Provider.ProviderID]; ok {
 		user, err := provider.Refresh(ctx, claims)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"could not refresh user %q with provider %q: %s", claims.UserID, provider.Type(), err,
+				"could not refresh user %q with provider %q: %s", claims.Provider.UserID, provider.Type(), err,
 			)
 		}
 
@@ -61,7 +61,7 @@ func (a *Authenticator) Refresh(ctx context.Context, claims corev2.AuthProviderC
 	}
 
 	return nil, fmt.Errorf(
-		"could not refresh user %q with missing provider ID %q", claims.UserID, claims.ProviderID,
+		"could not refresh user %q with missing provider ID %q", claims.Provider.UserID, claims.Provider.ProviderID,
 	)
 }
 

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -44,24 +44,24 @@ func (p *Provider) Authenticate(ctx context.Context, username, password string) 
 }
 
 // Refresh the claims of a user
-func (p *Provider) Refresh(ctx context.Context, providerClaims corev2.AuthProviderClaims) (*corev2.Claims, error) {
-	user, err := p.Store.GetUser(ctx, providerClaims.UserID)
+func (p *Provider) Refresh(ctx context.Context, claims *corev2.Claims) (*corev2.Claims, error) {
+	user, err := p.Store.GetUser(ctx, claims.Provider.UserID)
 	if err != nil {
 		return nil, err
 	}
 	if user == nil {
-		return nil, fmt.Errorf("user %q does not exist", providerClaims.UserID)
+		return nil, fmt.Errorf("user %q does not exist", claims.Provider.UserID)
 	}
 
-	claims, err := jwt.NewClaims(user)
+	newClaims, err := jwt.NewClaims(user)
 	if err != nil {
 		return nil, err
 	}
 
 	// Set the provider claims
-	claims.Provider = p.claims(user.Username)
+	newClaims.Provider = p.claims(user.Username)
 
-	return claims, nil
+	return newClaims, nil
 }
 
 // GetObjectMeta returns the provider metadata


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR changes the signature of the `Refresh` method of the `AuthProvider` interface so all the JWT claims are passed to the authentication provider, not just a subset of it and therefore allow the providers to return the same claims if required.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/590

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Unit & integration tests.