### PR TITLE
Fix tabular output of sensuctl filter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ failures and reconnect faster.
 - The default handshake timeout for the WebSocket connection negotiation has
 been lowered from 45 to 15 seconds and is now configurable.
 
+### Fixed
+- Fixed the tabular output of `sensuctl filter list` so inclusive filter expressions
+are joined with `&&` and exclusive filter expressions are joined with `||`.
+
 ## [5.11.0] - 2019-07-10
 
 ### Added

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -89,7 +90,20 @@ func printToTable(results interface{}, writer io.Writer) {
 				if !ok {
 					return cli.TypeError
 				}
-				return strings.Join(filter.Expressions, " && ")
+				var expressions []string
+				var sep string
+				switch action := filter.Action; action {
+				case types.EventFilterActionAllow:
+					sep = " && "
+				case types.EventFilterActionDeny:
+					sep = " || "
+				default:
+					sep = ", "
+				}
+				for _, exp := range filter.Expressions {
+					expressions = append(expressions, fmt.Sprintf("(%s)", exp))
+				}
+				return strings.Join(expressions, sep)
 			},
 		},
 	})


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes the tabular output of `sensuctl filter list` so inclusive filter expressions are joined with `&&` and exclusive filter expressions are joined with `||`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3038

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yup, this behavior is in line with the docs.

## How did you verify this change?

```
$ sensuctl filter list
       Name         Action                                                           Expressions                                                           
 ───────────────── ──────── ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
  two-expressions   allow    (event.check.occurrences == 5 && event.check.status != 0) && (event.is_resolution && event.check.occurrences_watermark >= 5)  
$ sensuctl filter list
       Name         Action                                                           Expressions                                                           
 ───────────────── ──────── ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
  two-expressions   deny     (event.check.occurrences == 5 && event.check.status != 0) || (event.is_resolution && event.check.occurrences_watermark >= 5)  
```