### PR TITLE
Remove encoded protobuf payloads from log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ are joined with `&&` and exclusive filter expressions are joined with `||`.
 - The REST API now correctly only returns events for the specific entity
 queried in the `GET /events/:entity` endpoint (#3141)
 
+### Removed
+- Removed encoded protobuf payloads from log messages (when decoded, they can reveal
+redacted secrets).
+
 ## [5.11.1] - 2019-07-18
 
 ### Fixed

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,9 +108,10 @@ func NewAgent(config *Config) (*Agent, error) {
 
 func (a *Agent) sendMessage(msg *transport.Message) {
 	logger.WithFields(logrus.Fields{
-		"type":    msg.Type,
-		"payload": agentd.PayloadString(a.contentType, msg.Payload),
-	}).Debug("sending message")
+		"type":         msg.Type,
+		"content_type": a.contentType,
+		"payload_size": len(msg.Payload),
+	}).Info("sending message")
 	a.sendq <- msg
 }
 
@@ -248,9 +249,10 @@ func (a *Agent) receiveLoop(ctx context.Context, cancel context.CancelFunc, conn
 
 		go func(msg *transport.Message) {
 			logger.WithFields(logrus.Fields{
-				"type":    msg.Type,
-				"payload": agentd.PayloadString(a.contentType, msg.Payload),
-			}).Debug("message received")
+				"type":         msg.Type,
+				"content_type": a.contentType,
+				"payload_size": len(msg.Payload),
+			}).Info("message received")
 			err := a.handler.Handle(ctx, msg.Type, msg.Payload)
 			if err != nil {
 				logger.WithError(err).Error("error handling message")

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -2,7 +2,6 @@ package agentd
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -225,7 +224,7 @@ func (s *Session) sendPump() {
 	for {
 		select {
 		case msg := <-s.sendq:
-			logger.WithField("message", PayloadString(s.cfg.ContentType, msg.Payload)).Debug("session - sending message")
+			logger.WithField("payload_size", len(msg.Payload)).Debug("session - sending message")
 			err := s.conn.Send(msg)
 			if err != nil {
 				switch err := err.(type) {
@@ -356,13 +355,4 @@ func (s *Session) handleEvent(ctx context.Context, payload []byte) error {
 	event.Entity.Subscriptions = addEntitySubscription(event.Entity.Name, event.Entity.Subscriptions)
 
 	return s.bus.Publish(messaging.TopicEventRaw, event)
-}
-
-// PayloadString returns the string representation of a protobuf
-// or JSON serialized payload.
-func PayloadString(contentType string, msgPayload []byte) string {
-	if contentType == ProtobufSerializationHeader {
-		return base64.StdEncoding.EncodeToString(msgPayload)
-	}
-	return string(msgPayload)
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Removes encoded protobuf payloads from log messages (when decoded, they can reveal redacted secrets).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3158

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1623

## How did you verify this change?

Reviewed logs in e2e testing. See https://github.com/sensu/sensu-go-qa-crucible/pull/65.