### PR TITLE
Use module proxy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ environment:
   GOPATH: c:\gopath
   GOVERSION: 1.12.3
   GO111MODULE: 'on'
+  GOPROXY: 'https://proxy.golang.org'
 
   matrix:
     - GOARCH: amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
     <<: *sensu_go_build_env
     environment:
       GO111MODULE: 'on'
+      GOPROXY: 'https://proxy.golang.org'
     resource_class: large
     parallelism: 2
     steps:


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Uses the go proxy for modules, which should result in a build speedup for modules that are not cached.