### PR TITLE
Sensuctl dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for check hook execution.
 - Added backwards compatible content negotiation to the websocket connection.
 Protobuf will be used for serialization/deserialization unless indicated by the
 backend to use JSON.
+- Added `sensuctl dump` to dump resources to a file or STDOUT.
 
 ### Changed
 - The project now uses Go modules instead of dep for dependency management.

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/configure"
 	"github.com/sensu/sensu-go/cli/commands/create"
 	"github.com/sensu/sensu-go/cli/commands/delete"
+	"github.com/sensu/sensu-go/cli/commands/dump"
 	"github.com/sensu/sensu-go/cli/commands/edit"
 	"github.com/sensu/sensu-go/cli/commands/entity"
 	"github.com/sensu/sensu-go/cli/commands/event"
@@ -59,6 +60,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		cluster.HelpCommand(cli),
 		edit.Command(cli),
 		tessen.HelpCommand(cli),
+		dump.Command(cli),
 	)
 
 	for _, cmd := range rootCmd.Commands() {

--- a/cli/commands/dump/LICENSE
+++ b/cli/commands/dump/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -141,7 +141,6 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			return err
 		}
 		if fp == "" {
-			_, err := fmt.Print(out)
 			return err
 		}
 		f, err := os.Create(fp)

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -145,10 +145,10 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			return err
 		}
 		f, err := os.Create(fp)
-		defer f.Close()
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 		_, err = f.WriteString(out)
 		return err
 	}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -89,10 +89,14 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		} else {
 			types := strings.Split(args[0], ",")
 			for _, t := range types {
+				length := len(actions)
 				for _, action := range All {
 					if t == action.Resource {
 						actions = append(actions, action)
 					}
+				}
+				if length == len(actions) {
+					return fmt.Errorf("invalid arg: %s", t)
 				}
 			}
 		}
@@ -120,11 +124,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			}
 
 			// execute the command and build wrapped-json or yaml lists
-			originalBytes, err := exec.Command(os.Args[0], ctlArgs...).CombinedOutput()
-			if err != nil {
-				_, _ = cmd.OutOrStdout().Write(originalBytes)
-				return fmt.Errorf("couldn't get resource: %s", err)
-			}
+			originalBytes, _ := exec.Command(os.Args[0], ctlArgs...).CombinedOutput()
 			if len(originalBytes) == 0 {
 				continue
 			}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -141,6 +141,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			return err
 		}
 		if fp == "" {
+			_, err := fmt.Print(out)
 			return err
 		}
 		f, err := os.Create(fp)

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -96,7 +96,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 					}
 				}
 				if length == len(actions) {
-					return fmt.Errorf("invalid arg: %s", t)
+					return fmt.Errorf("invalid resource type: %s", t)
 				}
 			}
 		}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -103,7 +103,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 
 		// iterate the matched actions and start building a sensuctl command
 		var out string
-		for i, a := range actions {
+		for _, a := range actions {
 			ctlArgs := []string{
 				a.Resource,
 				a.Verb,
@@ -132,7 +132,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			if len(originalBytes) == 0 {
 				continue
 			}
-			if format == "wrapped-json" || i == len(actions)-1 || out == "" {
+			if format == "wrapped-json" {
 				out = fmt.Sprintf("%s%s", out, string(originalBytes))
 			} else {
 				out = fmt.Sprintf("%s---\n%s", out, string(originalBytes))

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -89,14 +89,10 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		} else {
 			types := strings.Split(args[0], ",")
 			for _, t := range types {
-				length := len(actions)
 				for _, action := range All {
 					if t == action.Resource {
 						actions = append(actions, action)
 					}
-				}
-				if length == len(actions) {
-					return fmt.Errorf("couldn't get resource: %s", t)
 				}
 			}
 		}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -1,0 +1,120 @@
+package dump
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	utilstrings "github.com/sensu/sensu-go/util/strings"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// All is all the core resource types that sensuctl can list (non-namespaced resources are intentionally ordered first).
+	All = []string{"namespace", "cluster-role", "cluster-role-binding", "user", "asset", "check", "entity", "event", "filter", "handler", "hook", "mutator", "role", "role-binding", "silenced"}
+	// NoNamespace is all the non-namespaced core resource types that sensuctl can list.
+	NoNamespace = []string{"namespace", "cluster-role", "cluster-role-binding", "user"}
+)
+
+// Command dumps generic Sensu resources to a file or STDOUT.
+func Command(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dump [RESOURCE TYPE],[RESOURCE TYPE]... [-f FILE]",
+		Short: "dump resources to a file or STDOUT",
+		RunE:  execute(cli),
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+	helpers.AddAllNamespace(cmd.Flags())
+	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
+
+	return cmd
+}
+
+func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			_ = cmd.Help()
+			return errors.New("invalid argument(s) received")
+		}
+
+		// get the configured format or the flag override
+		format := cli.Config.Format()
+		if flag := helpers.GetChangedStringValueFlag("format", cmd.Flags()); flag != "" {
+			format = flag
+		}
+		switch format {
+		case "yaml", "wrapped-json":
+		default:
+			format = "yaml"
+		}
+
+		// parse the comma separated resource types
+		var types []string
+		if args[0] == "all" {
+			types = All
+		} else {
+			types = strings.Split(args[0], ",")
+		}
+
+		// iterate the desired types and start building a sensuctl list command
+		var out string
+		for i, t := range types {
+			ctlArgs := []string{
+				t,
+				"list",
+				"--format",
+				format,
+			}
+
+			// append --namespace or --all-namespaces flag if compatible with the resource type
+			if !utilstrings.InArray(t, NoNamespace) {
+				if ok, err := cmd.Flags().GetBool(flags.AllNamespaces); err != nil {
+					return err
+				} else if ok {
+					ctlArgs = append(ctlArgs, "--all-namespaces")
+				} else {
+					ctlArgs = append(ctlArgs, "--namespace")
+					ctlArgs = append(ctlArgs, cli.Config.Namespace())
+				}
+			}
+
+			// execute the command and build wrapped-json or yaml lists
+			originalBytes, err := exec.Command(os.Args[0], ctlArgs...).CombinedOutput()
+			if err != nil {
+				_, _ = cmd.OutOrStdout().Write(originalBytes)
+				return fmt.Errorf("couldn't get resource: %s", err)
+			}
+			if len(originalBytes) == 0 {
+				continue
+			}
+			if format == "wrapped-json" || i == len(types)-1 || out == "" {
+				out = fmt.Sprintf("%s%s", out, string(originalBytes))
+			} else {
+				out = fmt.Sprintf("%s---\n%s", out, string(originalBytes))
+			}
+		}
+
+		// write data to file or STDOUT
+		fp, err := cmd.Flags().GetString("file")
+		if err != nil {
+			return err
+		}
+		if fp == "" {
+			_, err := fmt.Print(out)
+			return err
+		}
+		f, err := os.Create(fp)
+		defer f.Close()
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(out)
+		return err
+	}
+}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -124,7 +124,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			}
 
 			// execute the command and build wrapped-json or yaml lists
-			originalBytes, _ := exec.Command(os.Args[0], ctlArgs...).CombinedOutput()
+			originalBytes, _ := exec.Command(os.Args[0], ctlArgs...).Output()
 			if len(originalBytes) == 0 {
 				continue
 			}

--- a/cli/commands/dump/dump_test.go
+++ b/cli/commands/dump/dump_test.go
@@ -28,6 +28,10 @@ func TestCommandArgs(t *testing.T) {
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
 	assert.Error(err)
+
+	out, err = test.RunCmd(cmd, []string{"check,handler,check"})
+	assert.Empty(out)
+	assert.Error(err)
 }
 
 func TestListFlags(t *testing.T) {

--- a/cli/commands/dump/dump_test.go
+++ b/cli/commands/dump/dump_test.go
@@ -1,0 +1,47 @@
+package dump
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("dump", cmd.Use)
+	assert.Regexp("dump resources", cmd.Short)
+}
+
+func TestCommandArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Error(err)
+}
+
+func TestListFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	flag := cmd.Flag("all-namespaces")
+	assert.NotNil(flag)
+
+	flag = cmd.Flag("format")
+	assert.NotNil(flag)
+
+	flag = cmd.Flag("file")
+	assert.NotNil(flag)
+}

--- a/cli/commands/dump/dump_test.go
+++ b/cli/commands/dump/dump_test.go
@@ -29,7 +29,13 @@ func TestCommandArgs(t *testing.T) {
 	assert.NotEmpty(out)
 	assert.Error(err)
 
+	// duplicate resources
 	out, err = test.RunCmd(cmd, []string{"check,handler,check"})
+	assert.Empty(out)
+	assert.Error(err)
+
+	// invalid resources
+	out, err = test.RunCmd(cmd, []string{"check,foo"})
 	assert.Empty(out)
 	assert.Error(err)
 }

--- a/cli/commands/helpers/flags.go
+++ b/cli/commands/helpers/flags.go
@@ -21,10 +21,11 @@ func AddFormatFlag(flagSet *pflag.FlagSet) {
 		"format",
 		config.DefaultFormat,
 		fmt.Sprintf(
-			`format of data returned ("%s"|"%s"|"%s")`,
+			`format of data returned ("%s"|"%s"|"%s"|"%s")`,
 			config.FormatJSON,
 			config.FormatWrappedJSON,
 			config.FormatTabular,
+			config.FormatYAML,
 		),
 	)
 }


### PR DESCRIPTION
## What is this change?

Implements `sensuctl dump`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2742

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

There was some nuance with error handling with regard to how unavailable enterprise resources might be handled.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Filing a docs issue now.

## How did you verify this change?

Filing QA crucible issues now.

examples:
```
$ sensuctl dump check
dumps all checks in the current namespace

$ sensuctl dump check --namespace dev
dumps all checks in the dev namespace

$ sensuctl dump check --all-namespaces
dumps all checks in all namespaces

$ sensuctl dump all --all-namespaces
dumps all resources in all namespaces
non-namespaced resources are prioritized first to mitigate errors when using sensuctl create (ex. namespaces must be created before resources within that namespace)

$ sensuctl dump check,foo
returns an error because foo is invalid

$ sensuctl dump check,check
returns an error because there are duplicate resource types

$ sensuctl dump all --all-namespaces --format wrapped-json
dumps all resources in all namespaces in wrapped-json format (only yaml and wrapped-json are supported due to sensuctl create)

$ sensuctl dump all --all-namespaces --file resources.yaml
dumps all resources in all namespaces to the designated file
```