### PR TITLE
Use unique cache key for go modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,15 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - go-pkg-cache
+            - go-mod-v1-{{ checksum "go.sum" }}
 
       # Run tests
       - run: ./build.sh unit
       - run: ./build.sh integration
       - save_cache:
-          key: go-pkg-cache
+          key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
-            - "/go/pkg"
+            - "/go/pkg/mod"
 
 workflows:
   version: 2


### PR DESCRIPTION
We should use a unique key for the go module cache that uses the cheksum of `go.sum` so when go modules are updated in a branch, it creates a new cache instead of overriding a single one that's shared across all branches. Overall, it should speed up build times because the cache will not be constantly updated when two branches use different `go.mod` files.