### PR TITLE
Trace GraphQL query executions

### DIFF
--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/graphql"
+	"github.com/sensu/sensu-go/graphql/tracing"
 )
 
 type InitHook func(*graphql.Service, ServiceConfig)
@@ -152,6 +153,10 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	for _, hookFn := range InitHooks {
 		hookFn(svc, cfg)
 	}
+
+	// Configure tracing
+	tracer := tracing.NewPrometheusTracer()
+	svc.RegisterMiddleware(tracer)
 
 	err := svc.Regenerate()
 	return &wrapper, err

--- a/backend/apid/graphql/tracing.go
+++ b/backend/apid/graphql/tracing.go
@@ -1,0 +1,12 @@
+package graphql
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sensu/sensu-go/graphql/tracing"
+)
+
+func init() {
+	if err := prometheus.Register(tracing.Collector); err != nil {
+		logger.WithError(err).Error("unable to register tracer")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf // indirect
 	github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7
-	github.com/gogo/protobuf v1.1.1
+	github.com/gogo/protobuf v1.2.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.1.0
@@ -69,7 +69,7 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v0.8.0
 	github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612
-	github.com/prometheus/common v0.0.0-20170908161822-2f17f4a9d485 // indirect
+	github.com/prometheus/common v0.0.0-20170908161822-2f17f4a9d485
 	github.com/prometheus/procfs v0.0.0-20170703101242-e645f4e5aaa8 // indirect
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
 	github.com/robfig/cron v0.0.0-20171101201047-2315d5715e36

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/gorilla/websocket v1.2.0
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c
-	github.com/graphql-go/graphql v0.0.0-20180119225129-1c504cfe6f63
+	github.com/graphql-go/graphql v0.7.9-0.20190403165646-199d20bbfed7
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v0.0.0-20160910222444-6b7015e65d36 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7 h1:lbvF7dIiXWPjUxm0
 github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7/go.mod h1:xMECeum3O2uZ1/noW5020CuR+OfNI3xjv3MVVCNVGYI=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -102,6 +103,8 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/libp2p/go-reuseport v0.0.0-20180416043609-15a1cd37f050 h1:i8wqdGSimubK0zh8C4vQAK317oOElW0nkyQRZd6xNNE=
@@ -218,6 +221,7 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20170927054726-6dc17368e09b h1:3X+R0qq1+64izd8es+EttB6qcY+JDlVmAhpRXl7gpzU=
 golang.org/x/time v0.0.0-20170927054726-6dc17368e09b/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/genproto v0.0.0-20170918111702-1e559d0a00ee h1:kgfN7j3GYevqPqse0VojTFu/nJjf/Sv9T0TwRC5Vw08=
 google.golang.org/genproto v0.0.0-20170918111702-1e559d0a00ee/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.13.0 h1:bHIbVsCwmvbArgCJmLdgOdHFXlKqTOVjbibbS19cXHc=

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c h1:94S+uo
 github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c/go.mod h1:jk4jk0c5ZISbKaMe8WsVopGB5/15GvGHMdMdPtwlRp4=
 github.com/graphql-go/graphql v0.0.0-20180119225129-1c504cfe6f63 h1:SzyRVZObOKxxmgJOiso84rXeQYhsq8/a7RDZryUe6xg=
 github.com/graphql-go/graphql v0.0.0-20180119225129-1c504cfe6f63/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
+github.com/graphql-go/graphql v0.7.9-0.20190403165646-199d20bbfed7/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v0.0.0-20160910222444-6b7015e65d36 h1:cwTrrTEhz13khQS3/UZMLFWwiqlcsdp/2sxFmSjAWeQ=

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -9,7 +9,8 @@ import (
 // Middleware is an interface for extending a service with operations that
 // wrap existing functionality.
 type Middleware interface {
-	// Init is used to help you initialize the extension
+	// Init is called at the beginning of an execution. Helpful for initializing
+	// anything used during the execution of the query.
 	Init(context.Context, *graphql.Params) context.Context
 
 	// Name returns the name of the extension (make sure it's custom)

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -1,0 +1,35 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/graphql-go/graphql"
+)
+
+// Middleware is an interface for extending a service with operations that
+// wrap existing functionality.
+type Middleware interface {
+	// Init is used to help you initialize the extension
+	Init(context.Context, *graphql.Params) context.Context
+
+	// Name returns the name of the extension (make sure it's custom)
+	Name() string
+
+	// ParseDidStart is being called before starting parsing
+	ParseDidStart(context.Context) (context.Context, graphql.ParseFinishFunc)
+
+	// ValidationDidStart is called just before validation begins
+	ValidationDidStart(context.Context) (context.Context, graphql.ValidationFinishFunc)
+
+	// ExecutionDidStart notifies about the start of the execution
+	ExecutionDidStart(context.Context) (context.Context, graphql.ExecutionFinishFunc)
+
+	// ResolveFieldDidStart notifies about the start of the resolving of a field
+	ResolveFieldDidStart(context.Context, *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc)
+
+	// HasResult returns if the extension wants to add data to the result
+	HasResult() bool
+
+	// GetResult returns the data that the extension wants to add to the result
+	GetResult(context.Context) interface{}
+}

--- a/graphql/tracing/prometheus.go
+++ b/graphql/tracing/prometheus.go
@@ -1,0 +1,139 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	time "github.com/echlebek/timeproxy"
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sensu/sensu-go/util/strings"
+)
+
+const (
+	KeyParse        = "parse"
+	KeyValidate     = "validate"
+	KeyExecuteQuery = "execute_query"
+	KeyExecuteField = "execute_field"
+)
+
+var (
+	Collector = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "graphql_duration_seconds",
+			Help: "Time spent in GraphQL operations, in seconds",
+		},
+		[]string{"key", "platform_key"},
+	)
+
+	noopParse    = func(_ error) {}
+	noopValidate = func(_ []gqlerrors.FormattedError) {}
+	noopQuery    = func(_ *graphql.Result) {}
+	noopField    = func(_ interface{}, _ error) {}
+
+	platformKeys = map[string]string{
+		KeyParse:        "graphql.parse",
+		KeyValidate:     "graphql.validate",
+		KeyExecuteQuery: "graphql.execute",
+		KeyExecuteField: "graphql.execute",
+	}
+)
+
+// PrometheusTracer is a GraphQL middleware that collects metrics for query
+// parsing, validation, and field execution.
+type PrometheusTracer struct {
+	// AllowList contains the metrics that will be collected. Defaults to
+	// []string{KeyExecuteField}
+	AllowList []string
+}
+
+// NewPrometheusTracer instantiates new tracer.
+func NewPrometheusTracer() *PrometheusTracer {
+	return &PrometheusTracer{
+		AllowList: []string{
+			KeyExecuteField,
+		},
+	}
+}
+
+// Init is used to initialize the extension
+func (t *PrometheusTracer) Init(ctx context.Context, p *graphql.Params) context.Context {
+	return ctx
+}
+
+// Name returns the name of the extension
+func (c *PrometheusTracer) Name() string {
+	return "tracer.prometheus"
+}
+
+// ParseDidStart is called before starting parsing
+func (c *PrometheusTracer) ParseDidStart(ctx context.Context) (context.Context, graphql.ParseFinishFunc) {
+	if !strings.InArray(KeyParse, c.AllowList) {
+		return ctx, noopParse
+	}
+	t := time.Now()
+	return ctx, func(_ error) {
+		dur := msecSince(t)
+		fmt.Printf("dur: %v", dur)
+		met := Collector.WithLabelValues(KeyParse, platformKeys[KeyParse])
+		met.Observe(dur)
+	}
+}
+
+// ValidationDidStart is called just before the validation begins
+func (c *PrometheusTracer) ValidationDidStart(ctx context.Context) (context.Context, graphql.ValidationFinishFunc) {
+	if !strings.InArray(KeyValidate, c.AllowList) {
+		return ctx, noopValidate
+	}
+	t := time.Now()
+	return ctx, func(_ []gqlerrors.FormattedError) {
+		dur := msecSince(t)
+		met := Collector.WithLabelValues(KeyValidate, platformKeys[KeyValidate])
+		met.Observe(dur)
+	}
+}
+
+// ExecutionDidStart notifies about the start of the execution
+func (c *PrometheusTracer) ExecutionDidStart(ctx context.Context) (context.Context, graphql.ExecutionFinishFunc) {
+	if !strings.InArray(KeyExecuteQuery, c.AllowList) {
+		return ctx, noopQuery
+	}
+	t := time.Now()
+	return ctx, func(_ *graphql.Result) {
+		dur := msecSince(t)
+		met := Collector.WithLabelValues(KeyExecuteQuery, platformKeys[KeyExecuteQuery])
+		met.Observe(dur)
+	}
+}
+
+// ResolveFieldDidStart notifies about the start of the resolving of a field
+func (c *PrometheusTracer) ResolveFieldDidStart(ctx context.Context, i *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc) {
+	if !strings.InArray(KeyExecuteField, c.AllowList) {
+		return ctx, noopField
+	}
+	t := time.Now()
+	return ctx, func(_ interface{}, _ error) {
+		dur := msecSince(t)
+		key := i.ParentType.Name() + "." + i.FieldName
+		met := Collector.WithLabelValues(KeyExecuteField, key)
+		met.Observe(dur)
+	}
+}
+
+func (c *PrometheusTracer) GetResult(ctx context.Context) interface{} {
+	return nil
+}
+
+func (c *PrometheusTracer) HasResult() bool {
+	return false
+}
+
+func (c *PrometheusTracer) Collector() prometheus.Collector {
+	return Collector
+}
+
+func msecSince(t time.Time) float64 {
+	dur := time.Since(t)
+	return float64(dur) / float64(time.Millisecond)
+}

--- a/graphql/tracing/prometheus.go
+++ b/graphql/tracing/prometheus.go
@@ -81,7 +81,7 @@ func (c *PrometheusTracer) ParseDidStart(ctx context.Context) (context.Context, 
 
 // ValidationDidStart is called just before the validation begins
 func (c *PrometheusTracer) ValidationDidStart(ctx context.Context) (context.Context, graphql.ValidationFinishFunc) {
-	if !strings.InArray(KeyValidate, c.AllowList) {
+	if !utilstrings.InArray(KeyValidate, c.AllowList) {
 		return ctx, noopValidate
 	}
 	t := time.Now()
@@ -94,7 +94,7 @@ func (c *PrometheusTracer) ValidationDidStart(ctx context.Context) (context.Cont
 
 // ExecutionDidStart notifies about the start of the execution
 func (c *PrometheusTracer) ExecutionDidStart(ctx context.Context) (context.Context, graphql.ExecutionFinishFunc) {
-	if !strings.InArray(KeyExecuteQuery, c.AllowList) {
+	if !utilstrings.InArray(KeyExecuteQuery, c.AllowList) {
 		return ctx, noopQuery
 	}
 	t := time.Now()
@@ -107,7 +107,7 @@ func (c *PrometheusTracer) ExecutionDidStart(ctx context.Context) (context.Conte
 
 // ResolveFieldDidStart notifies about the start of the resolving of a field
 func (c *PrometheusTracer) ResolveFieldDidStart(ctx context.Context, i *graphql.ResolveInfo) (context.Context, graphql.ResolveFieldFinishFunc) {
-	if !strings.InArray(KeyExecuteField, c.AllowList) {
+	if !utilstrings.InArray(KeyExecuteField, c.AllowList) {
 		return ctx, noopField
 	}
 	t := time.Now()

--- a/graphql/tracing/prometheus.go
+++ b/graphql/tracing/prometheus.go
@@ -7,7 +7,7 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/gqlerrors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sensu/sensu-go/util/strings"
+	utilstrings "github.com/sensu/sensu-go/util/strings"
 )
 
 const (
@@ -68,7 +68,7 @@ func (c *PrometheusTracer) Name() string {
 
 // ParseDidStart is called before starting parsing
 func (c *PrometheusTracer) ParseDidStart(ctx context.Context) (context.Context, graphql.ParseFinishFunc) {
-	if !strings.InArray(KeyParse, c.AllowList) {
+	if !utilstrings.InArray(KeyParse, c.AllowList) {
 		return ctx, noopParse
 	}
 	t := time.Now()

--- a/graphql/tracing/prometheus.go
+++ b/graphql/tracing/prometheus.go
@@ -2,7 +2,6 @@ package tracing
 
 import (
 	"context"
-	"fmt"
 
 	time "github.com/echlebek/timeproxy"
 	"github.com/graphql-go/graphql"
@@ -75,7 +74,6 @@ func (c *PrometheusTracer) ParseDidStart(ctx context.Context) (context.Context, 
 	t := time.Now()
 	return ctx, func(_ error) {
 		dur := msecSince(t)
-		fmt.Printf("dur: %v", dur)
 		met := Collector.WithLabelValues(KeyParse, platformKeys[KeyParse])
 		met.Observe(dur)
 	}

--- a/graphql/tracing/prometheus_test.go
+++ b/graphql/tracing/prometheus_test.go
@@ -1,0 +1,243 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/echlebek/crock"
+	time "github.com/echlebek/timeproxy"
+	"github.com/gogo/protobuf/proto"
+	"github.com/graphql-go/graphql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrometheusTracerParseDidStart(t *testing.T) {
+	mockTime, cleanup := mockTime()
+	defer cleanup()
+
+	trace := NewPrometheusTracer()
+	trace.AllowList = []string{KeyParse}
+
+	_, fn := trace.ParseDidStart(context.Background())
+	mockTime.Set(time.Now().Add(7 * time.Millisecond))
+	fn(nil)
+
+	got := mustGather(t, trace.Collector())
+	assert.Contains(t, got, `
+  label: <
+    name: "key"
+    value: "parse"
+  >
+  label: <
+    name: "platform_key"
+    value: "graphql.parse"
+  >
+  summary: <
+    sample_count: 1
+    sample_sum: 7
+    quantile: <
+      quantile: 0.5
+      value: 7
+    >
+    quantile: <
+      quantile: 0.9
+      value: 7
+    >
+    quantile: <
+      quantile: 0.99
+      value: 7
+    >
+  >`)
+
+	trace.AllowList = []string{}
+	_, fn = trace.ParseDidStart(context.Background())
+	fn(nil)
+
+	got = mustGather(t, trace.Collector())
+	assert.Contains(t, got, "sample_count: 1")
+}
+
+func TestPrometheusTracerValidateDidStart(t *testing.T) {
+	mockTime, cleanup := mockTime()
+	defer cleanup()
+
+	trace := NewPrometheusTracer()
+	trace.AllowList = []string{KeyValidate}
+
+	_, fn := trace.ValidationDidStart(context.Background())
+	mockTime.Set(time.Now().Add(540 * time.Millisecond))
+	fn(nil)
+
+	got := mustGather(t, trace.Collector())
+	assert.Contains(t, got, `
+  label: <
+    name: "key"
+    value: "validate"
+  >
+  label: <
+    name: "platform_key"
+    value: "graphql.validate"
+  >
+  summary: <
+    sample_count: 1
+    sample_sum: 540
+    quantile: <
+      quantile: 0.5
+      value: 540
+    >
+    quantile: <
+      quantile: 0.9
+      value: 540
+    >
+    quantile: <
+      quantile: 0.99
+      value: 540
+    >
+  >`)
+
+	trace.AllowList = []string{}
+	_, fn = trace.ValidationDidStart(context.Background())
+	fn(nil)
+
+	got = mustGather(t, trace.Collector())
+	assert.Contains(t, got, "sample_count: 1")
+}
+
+func TestPrometheusTracerExecutionDidStart(t *testing.T) {
+	mockTime, cleanup := mockTime()
+	defer cleanup()
+
+	trace := NewPrometheusTracer()
+	trace.AllowList = []string{KeyExecuteQuery}
+
+	_, fn := trace.ExecutionDidStart(context.Background())
+	mockTime.Set(time.Now().Add(720 * time.Millisecond))
+	fn(nil)
+
+	got := mustGather(t, trace.Collector())
+	assert.Contains(t, got, `
+  label: <
+    name: "key"
+    value: "execute_query"
+  >
+  label: <
+    name: "platform_key"
+    value: "graphql.execute"
+  >
+  summary: <
+    sample_count: 1
+    sample_sum: 720
+    quantile: <
+      quantile: 0.5
+      value: 720
+    >
+    quantile: <
+      quantile: 0.9
+      value: 720
+    >
+    quantile: <
+      quantile: 0.99
+      value: 720
+    >
+  >`)
+
+	trace.AllowList = []string{}
+	_, fn = trace.ExecutionDidStart(context.Background())
+	fn(nil)
+
+	got = mustGather(t, trace.Collector())
+	assert.Contains(t, got, "sample_count: 1")
+}
+
+func TestPrometheusTracerFieldDidStart(t *testing.T) {
+	mockTime, cleanup := mockTime()
+	defer cleanup()
+
+	trace := NewPrometheusTracer()
+	trace.AllowList = []string{KeyExecuteField}
+
+	info := &graphql.ResolveInfo{
+		FieldName:  "interval",
+		ParentType: &checkType{},
+	}
+
+	_, fn := trace.ResolveFieldDidStart(context.Background(), info)
+	mockTime.Set(time.Now().Add(1530 * time.Millisecond))
+	fn(nil, nil)
+
+	got := mustGather(t, trace.Collector())
+	assert.Contains(t, got, `
+  label: <
+    name: "key"
+    value: "execute_field"
+  >
+  label: <
+    name: "platform_key"
+    value: "Check.interval"
+  >
+  summary: <
+    sample_count: 1
+    sample_sum: 1530
+    quantile: <
+      quantile: 0.5
+      value: 1530
+    >
+    quantile: <
+      quantile: 0.9
+      value: 1530
+    >
+    quantile: <
+      quantile: 0.99
+      value: 1530
+    >
+  >`)
+
+	trace.AllowList = []string{}
+	_, fn = trace.ResolveFieldDidStart(context.Background(), info)
+	fn(nil, nil)
+
+	got = mustGather(t, trace.Collector())
+	assert.Contains(t, got, "sample_count: 1")
+}
+
+func mockTime() (*crock.Time, func()) {
+	mockTime := crock.NewTime(time.Unix(0, 0))
+	time.TimeProxy = mockTime
+	return mockTime, func() {
+		time.TimeProxy = time.RealTime{}
+	}
+}
+
+func mustGather(t *testing.T, collector prometheus.Collector) string {
+	reg := prometheus.NewRegistry()
+	err := reg.Register(collector)
+	if err != nil {
+		t.Error("unable to register tracer")
+		t.FailNow()
+	}
+	metricFamilies, err := reg.Gather()
+	if err != nil {
+		t.Errorf("unexpected behavior of custom test registry.\n%#v", metricFamilies)
+		t.FailNow()
+	}
+	if len(metricFamilies) == 0 {
+		return ""
+	}
+	return proto.MarshalTextString(metricFamilies[0])
+}
+
+type checkType struct{}
+
+func (*checkType) Name() string {
+	return "Check"
+}
+func (*checkType) Description() string {
+	return ""
+}
+func (*checkType) String() string {
+	return ""
+}
+func (*checkType) Error() error {
+	return nil
+}


### PR DESCRIPTION
## What is this change?

* Updates `graphql-go/graphql` module for it's "Extensions" feature. "Extensions" are in essence middleware that allow an implementer to wrap query executions and provide functionality, see: https://github.com/graphql-go/graphql/pull/448.
* Introduces a GraphQL middleware that captures the duration it took to perform different operations within a query execution. Parsing, validation, resolving field, and total resolver time are observed. Implementation borrows heavily from [Ruby implementation](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/tracing/prometheus_tracing.rb).
* Observations are written to a Prometheus summary.

## Why is this change necessary?

Will allow us to get detailed metrics on GraphQL query performance.

## Does your change need a Changelog entry?

Sure.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Hubris.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe any will be required.

## How did you verify this change?

Unit tests