### PR TITLE
Add functionality for deleting assets via the API and sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for check hook execution.
 - Added backwards compatible content negotiation to the websocket connection.
 Protobuf will be used for serialization/deserialization unless indicated by the
 backend to use JSON.
+- Added delete functionality for assets in the API and sensuctl.
 
 ### Changed
 - The project now uses Go modules instead of dep for dependency management.

--- a/backend/apid/routers/assets.go
+++ b/backend/apid/routers/assets.go
@@ -34,4 +34,5 @@ func (r *AssetsRouter) Mount(parent *mux.Router) {
 	routes.ListAllNamespaces(r.handlers.ListResources, "/{resource:assets}", corev2.AssetFields)
 	routes.Post(r.handlers.CreateResource)
 	routes.Put(r.handlers.CreateOrUpdateResource)
+	routes.Del(r.handlers.DeleteResource)
 }

--- a/backend/apid/routers/assets_test.go
+++ b/backend/apid/routers/assets_test.go
@@ -23,6 +23,7 @@ func TestAssetsRouter(t *testing.T) {
 	tests = append(tests, listTestCases(empty)...)
 	tests = append(tests, createTestCases(empty)...)
 	tests = append(tests, updateTestCases(fixture)...)
+	tests = append(tests, deleteTestCases(fixture)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
 	}

--- a/cli/commands/asset/delete.go
+++ b/cli/commands/asset/delete.go
@@ -1,0 +1,52 @@
+package asset
+
+import (
+	"errors"
+	"fmt"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCommand adds a command that allows user to delete assets
+func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete [NAME]",
+		Short:        "delete assets",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If no name is present print out usage
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			name := args[0]
+			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
+				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
+					return nil
+				}
+			}
+
+			asset := &corev2.Asset{
+				ObjectMeta: corev2.ObjectMeta{
+					Name:      name,
+					Namespace: cli.Config.Namespace(),
+				},
+			}
+			if err := cli.Client.Delete(asset.URIPath()); err != nil {
+				return err
+			}
+
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Deleted")
+			return err
+		},
+	}
+
+	cmd.Flags().Bool("skip-confirm", false, "skip interactive confirmation prompt")
+
+	return cmd
+}

--- a/cli/commands/asset/delete_test.go
+++ b/cli/commands/asset/delete_test.go
@@ -1,0 +1,80 @@
+package asset
+
+import (
+	"errors"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("delete", cmd.Use)
+	assert.Regexp("asset", cmd.Short)
+}
+
+func TestDeleteCommandRunEClosureWithoutName(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.Error(t, cmd.Flags().Set("timeout", "15"))
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.Regexp("Usage", out) // usage should print out
+	assert.Error(err)
+}
+
+func TestDeleteCommandRunEClosureWithFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("Delete", mock.Anything, mock.Anything).Return(nil)
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"my-asset"})
+
+	assert.Regexp("Deleted", out)
+	assert.Nil(err)
+}
+
+func TestDeleteCommandRunEClosureWithServerErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("Delete", mock.Anything, mock.Anything).Return(errors.New("oh noes"))
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"test-handler"})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("oh noes", err.Error())
+}
+
+func TestDeleteCommandRunEFailConfirm(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"test-handler"})
+	require.NoError(t, err)
+
+	assert.Contains(out, "Canceled")
+}

--- a/cli/commands/asset/help.go
+++ b/cli/commands/asset/help.go
@@ -18,6 +18,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 		ListCommand(cli),
 		InfoCommand(cli),
 		UpdateCommand(cli),
+		DeleteCommand(cli),
 	)
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds functionality for deleting assets via the API and sensuctl.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/988

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah. The generic functions and tests made this _super_ easy.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1658

## How did you verify this change?

Required by https://github.com/sensu/sensu-go-qa-crucible/pull/68
https://sensuinc.testrail.io/index.php?/cases/view/8785