### PR TITLE
Add --no-implied-entities option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ for check hook execution.
 Protobuf will be used for serialization/deserialization unless indicated by the
 backend to use JSON.
 - Added `sensuctl dump` to dump resources to a file or STDOUT.
+- Added `--no-implied-entities` flag to backend to allow events containing
+proxy entities that do not exist to be dropped. This is useful for setups
+that sync entities from an external source-of-truth and don't want to
+allow the entity list in Sensu to deviate from it.
 
 ### Changed
 - The project now uses Go modules instead of dep for dependency management.

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -87,13 +87,14 @@ func newSessionHandler(s *Session) *handler.MessageHandler {
 // A SessionConfig contains all of the ncessary information to initialize
 // an agent session.
 type SessionConfig struct {
-	ContentType   string
-	Namespace     string
-	AgentAddr     string
-	AgentName     string
-	User          string
-	Subscriptions []string
-	RingPool      *ringv2.Pool
+	ContentType     string
+	Namespace       string
+	AgentAddr       string
+	AgentName       string
+	User            string
+	Subscriptions   []string
+	RingPool        *ringv2.Pool
+	ImpliedEntities bool
 }
 
 // NewSession creates a new Session object given the triple of a transport
@@ -346,7 +347,7 @@ func (s *Session) handleEvent(ctx context.Context, payload []byte) error {
 	// Verify if we have a source in the event and if so, use it as the entity by
 	// creating or retrieving it from the store
 	if event.HasCheck() {
-		if err := getProxyEntity(event, s.store); err != nil {
+		if err := getProxyEntity(event, s.store, s.cfg.ImpliedEntities); err != nil {
 			return err
 		}
 	}

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -43,6 +43,7 @@ const (
 	flagInsecureSkipTLSVerify = "insecure-skip-tls-verify"
 	flagDebug                 = "debug"
 	flagLogLevel              = "log-level"
+	flagNoImpliedEntities     = "no-implied-entities"
 
 	// Etcd flag constants
 	deprecatedFlagEtcdClientURLs               = "listen-client-urls"
@@ -165,6 +166,7 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 				DeregistrationHandler: viper.GetString(flagDeregistrationHandler),
 				CacheDir:              viper.GetString(flagCacheDir),
 				StateDir:              viper.GetString(flagStateDir),
+				ImpliedEntities:       viper.GetBool(flagNoImpliedEntities),
 
 				EtcdAdvertiseClientURLs:      viper.GetStringSlice(flagEtcdAdvertiseClientURLs),
 				EtcdListenClientURLs:         viper.GetStringSlice(flagEtcdClientURLs),
@@ -283,6 +285,7 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetDefault(backend.FlagKeepalivedBufferSize, 100)
 	viper.SetDefault(backend.FlagPipelinedWorkers, 100)
 	viper.SetDefault(backend.FlagPipelinedBufferSize, 100)
+	viper.SetDefault(flagNoImpliedEntities, false)
 
 	// Etcd defaults
 	viper.SetDefault(flagEtcdAdvertiseClientURLs, defaultEtcdAdvertiseClientURL)
@@ -325,6 +328,7 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	cmd.Flags().Int(backend.FlagKeepalivedBufferSize, viper.GetInt(backend.FlagKeepalivedBufferSize), "number of incoming keepalives that can be buffered")
 	cmd.Flags().Int(backend.FlagPipelinedWorkers, viper.GetInt(backend.FlagPipelinedWorkers), "number of workers spawned for handling events through the event pipeline")
 	cmd.Flags().Int(backend.FlagPipelinedBufferSize, viper.GetInt(backend.FlagPipelinedBufferSize), "number of events to handle that can be buffered")
+	cmd.Flags().Bool(flagNoImpliedEntities, viper.GetBool(flagNoImpliedEntities), "do not create a new proxy entity when an event is received for one that doesn't already exist")
 
 	// Etcd flags
 	cmd.Flags().StringSlice(flagEtcdAdvertiseClientURLs, viper.GetStringSlice(flagEtcdAdvertiseClientURLs), "list of this member's client URLs to advertise to the rest of the cluster.")

--- a/backend/config.go
+++ b/backend/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	CacheDir string
 
 	// Agentd Configuration
-	AgentHost string
-	AgentPort int
+	AgentHost       string
+	AgentPort       int
+	ImpliedEntities bool
 
 	// Apid Configuration
 	APIListenAddress string

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -80,6 +80,7 @@ type Config struct {
 	Client          *clientv3.Client
 	BufferSize      int
 	WorkerCount     int
+	ImpliedEntities bool
 }
 
 // New creates a new Eventd.


### PR DESCRIPTION
Add `--no-implied-entities` option to sensu-backend which disables the creation of entities when an event provides one that doesn't exist.

## What is this change?

Add a `--no-implied-entities` option to the backend that causes it to drop (and log) events received for entities that do not exist.

## Why is this change necessary?

Implements #3179. This option allows installations which sync entities into Sensu from an external source of truth to entirely disable the creation of entities via proxy check results submitted to the agent API.

## Does your change need a Changelog entry?

Yes, added one.

## Do you need clarification on anything?

Don't think so, it was pretty straightforward.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs are probably required.

## How did you verify this change?

Added a new unit test for the modified method.

Additionally ran within docker with a backend that has the option set as an ad hoc integration test. Received the following log as expected, and the entity was not created:
```
backend1_1  | {"component":"agentd","error":"foo does not exist and implied proxy entities are disabled","level":"error","msg":"error handling message","payload":"{\"timestamp\":1565296950,\"entity\":{\"entity_class\":\"agent\",\"system\":{\"hostname\":\"agent1\",\"os\":\"linux\",\"platform\":\"alpine\",\"platform_family\":\"alpine\",\"platform_version\":\"3.8.4\",\"network\":{\"interfaces\":[{\"name\":\"lo\",\"addresses\":[\"127.0.0.1/8\"]},{\"name\":\"eth0\",\"mac\":\"02:42:ac:12:00:05\",\"addresses\":[\"172.18.0.5/16\"]}]},\"arch\":\"amd64\"},\"subscriptions\":[\"switches\"],\"last_seen\":1565296858,\"deregister\":false,\"deregistration\":{},\"user\":\"agent\",\"redact\":[\"password\",\"passwd\",\"pass\",\"api_key\",\"api_token\",\"access_key\",\"secret_key\",\"private_key\",\"secret\"],\"metadata\":{\"name\":\"agent1\",\"namespace\":\"default\"}},\"check\":{\"handlers\":[],\"high_flap_threshold\":0,\"interval\":1,\"low_flap_threshold\":0,\"publish\":false,\"runtime_assets\":null,\"subscriptions\":[],\"proxy_entity_name\":\"foo\",\"check_hooks\":null,\"stdin\":false,\"subdue\":null,\"ttl\":0,\"timeout\":0,\"round_robin\":false,\"executed\":1565296950,\"history\":null,\"issued\":0,\"output\":\"Some error\",\"status\":2,\"total_state_change\":0,\"last_ok\":0,\"occurrences\":0,\"occurrences_watermark\":0,\"output_metric_format\":\"\",\"output_metric_handlers\":null,\"env_vars\":null,\"metadata\":{\"name\":\"test-check\",\"namespace\":\"default\"}},\"metadata\":{}}","time":"2019-08-08T20:42:30Z","type":"event"}
```
