### PR TITLE
Bugfix/entity interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ backend to use JSON.
 are joined with `&&` and exclusive filter expressions are joined with `||`.
 - The REST API now correctly only returns events for the specific entity
 queried in the `GET /events/:entity` endpoint (#3141)
+- Added entity name to the interactive sensuctl survey.
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/cli/commands/entity/create.go
+++ b/cli/commands/entity/create.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
@@ -49,7 +49,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Apply given arguments to entity
-			entity := v2.NewEntity(v2.NewObjectMeta("", ""))
+			entity := corev2.NewEntity(corev2.NewObjectMeta("", ""))
 			opts.copy(entity)
 
 			if err := entity.Validate(); err != nil {

--- a/cli/commands/entity/create.go
+++ b/cli/commands/entity/create.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sensu/sensu-go/api/core/v2"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
@@ -41,7 +41,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 			opts.Namespace = cli.Config.Namespace()
 
 			if isInteractive {
-				if err := opts.administerQuestionnaire(); err != nil {
+				if err := opts.administerQuestionnaire(false); err != nil {
 					return err
 				}
 			} else {

--- a/cli/commands/entity/interactive.go
+++ b/cli/commands/entity/interactive.go
@@ -29,8 +29,31 @@ func (opts *entityOpts) withFlags(flags *pflag.FlagSet) {
 	}
 }
 
-func (opts *entityOpts) administerQuestionnaire() error {
-	qs := []*survey.Question{
+func (opts *entityOpts) administerQuestionnaire(editing bool) error {
+	var qs = []*survey.Question{}
+
+	if !editing {
+		qs = append(qs, []*survey.Question{
+			{
+				Name: "name",
+				Prompt: &survey.Input{
+					Message: "Entity Name:",
+					Default: opts.Name,
+				},
+				Validate: survey.Required,
+			},
+			{
+				Name: "namespace",
+				Prompt: &survey.Input{
+					Message: "Namespace:",
+					Default: opts.Namespace,
+				},
+				Validate: survey.Required,
+			},
+		}...)
+	}
+
+	qs = append(qs, []*survey.Question{
 		{
 			Name: "entity-class",
 			Prompt: &survey.Input{
@@ -48,15 +71,7 @@ func (opts *entityOpts) administerQuestionnaire() error {
 				Help:    "comma separated list of subscriptions",
 			},
 		},
-		{
-			Name: "namespace",
-			Prompt: &survey.Input{
-				Message: "Namespace:",
-				Default: opts.Namespace,
-			},
-			Validate: survey.Required,
-		},
-	}
+	}...)
 
 	return survey.Ask(qs, opts)
 }

--- a/cli/commands/entity/update.go
+++ b/cli/commands/entity/update.go
@@ -31,7 +31,7 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			// Administer questionnaire
 			opts := newEntityOpts()
 			opts.withEntity(entity)
-			if err := opts.administerQuestionnaire(); err != nil {
+			if err := opts.administerQuestionnaire(true); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the entity name to the interactive sensuctl survey. The name can still be passed as a command line argument.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/1961

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

`sensuctl entity create --interactive`
`sensuctl entity create foo --interactive`
`sensuctl entity update foo`