### PR TITLE
Fix deleted proxy entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ backend to use JSON.
 are joined with `&&` and exclusive filter expressions are joined with `||`.
 - The REST API now correctly only returns events for the specific entity
 queried in the `GET /events/:entity` endpoint (#3141)
+- The backend now drops events for entities that have been deleted (#3178)
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -48,10 +48,51 @@ func (a *Agent) getEntities(event *types.Event) {
 	if event.Entity != nil && event.HasCheck() && event.Entity.Name != a.config.AgentName {
 		// Identify the event's source as the provided entity so it can be properly
 		// handled by the backend
-		event.Check.ProxyEntityName = event.Entity.Name
+		// Only do this if the entity name isn't empty, as we use empty entity names
+		// to signify to the backend that the check was submitted via the agent API,
+		// not the result of a previously scheduled check. This is important as it
+		// allows the backend to differentiate between events received for
+		// prevously scheduled checks for since-deleted entities, and events submitted
+		// via the agent API which should create a new entity if one doesn't exist.
+		if event.Entity.Name != "" {
+			event.Check.ProxyEntityName = event.Entity.Name
+		}
 	}
 
-	// From this point we make sure that the agent's entity is used in the event
+	// From this point we make sure that the agent's entity data is used in the event
 	// so we provide details like the namespace to the backend
-	event.Entity = a.getAgentEntity()
+	agentEntity := a.getAgentEntity()
+
+	// If we are dealing with a proxy entity, don't add the Agent's name to it.
+	// Having the agent's entity embedded within the event prevents the detection
+	// (and subsequent dropping) of events submitted for deleted entities, as well
+	// as properly handling malformed events where the proxy_entity_name field
+	// doesn't match the entity name embedded in the event.
+	if event.HasCheck() && event.Check.ProxyEntityName != "" {
+		// This may apply in different ways which require slightly different handling:
+		//   1. Proxy-style entity is provided in the JSON payload of the API
+		//      (ie: { "entity_class": "proxy", "metadata": { "namespace": "default", "name": "foo" }}
+		//   2. No entity is provided in the payload
+		//
+		// Case 1
+		if event.Entity == nil {
+			// Copy the necessary entity attributes to pass validation
+			event.Entity = &types.Entity{
+				ObjectMeta: types.ObjectMeta{
+					Namespace: agentEntity.Namespace,
+				},
+			}
+			// Case 2
+		} else {
+			// Namespace is needed by the backend, everything else in the event is looked
+			// up from the store, or if the entity is being created, set from defaults,
+			// so we don't need to modify anything else.
+			if event.Entity.Namespace == "" {
+				event.Entity.Namespace = agentEntity.Namespace
+			}
+		}
+	} else {
+		// Send as the agent's entity directly
+		event.Entity = agentEntity
+	}
 }

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -81,6 +81,7 @@ func (a *Agent) getEntities(event *types.Event) {
 				ObjectMeta: types.ObjectMeta{
 					Namespace: agentEntity.Namespace,
 				},
+				EntityClass: "proxy",
 			}
 			// Case 2
 		} else {
@@ -90,6 +91,7 @@ func (a *Agent) getEntities(event *types.Event) {
 			if event.Entity.Namespace == "" {
 				event.Entity.Namespace = agentEntity.Namespace
 			}
+			event.EntityClass = "proxy"
 		}
 	} else {
 		// Send as the agent's entity directly

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -91,7 +91,7 @@ func (a *Agent) getEntities(event *types.Event) {
 			if event.Entity.Namespace == "" {
 				event.Entity.Namespace = agentEntity.Namespace
 			}
-			event.EntityClass = "proxy"
+			event.Entity.EntityClass = "proxy"
 		}
 	} else {
 		// Send as the agent's entity directly

--- a/agent/entity_test.go
+++ b/agent/entity_test.go
@@ -48,11 +48,11 @@ func TestGetEntities(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		name              string
-		agent             *Agent
-		event             *types.Event
-		expectedAgentName string
-		expectedSource    string
+		name               string
+		agent              *Agent
+		event              *types.Event
+		expectedEntityName string
+		expectedSource     string
 	}{
 		{
 			name: "The provided event has no entity",
@@ -62,19 +62,41 @@ func TestGetEntities(t *testing.T) {
 			event: &types.Event{
 				Check: types.FixtureCheck("check_cpu"),
 			},
-			expectedAgentName: "foo",
-			expectedSource:    "",
+			expectedEntityName: "foo",
+			expectedSource:     "",
 		},
 		{
-			name: "The provided event has an entity",
+			name: "The provided proxy event has no entity",
+			agent: &Agent{
+				entity: types.FixtureEntity("foo"),
+			},
+			event: &types.Event{
+				Check: types.FixtureProxyCheck("check_cpu", "bar"),
+			},
+			expectedEntityName: "",
+			expectedSource:     "bar",
+		},
+		{
+			name: "The provided event has a proxy entity",
 			agent: &Agent{
 				config: &Config{
 					AgentName: "agent_entity",
 				},
 			},
-			event:             types.FixtureEvent("proxy_entity", "check_cpu"),
-			expectedAgentName: "agent_entity",
-			expectedSource:    "proxy_entity",
+			event:              types.FixtureProxyEvent("proxy_entity", "check_cpu"),
+			expectedEntityName: "",
+			expectedSource:     "proxy_entity",
+		},
+		{
+			name: "The provided event has a non-proxy entity",
+			agent: &Agent{
+				config: &Config{
+					AgentName: "agent_entity",
+				},
+			},
+			event:              types.FixtureEvent("regular_entity", "check_cpu"),
+			expectedEntityName: "regular_entity",
+			expectedSource:     "regular_entity",
 		},
 	}
 
@@ -83,7 +105,7 @@ func TestGetEntities(t *testing.T) {
 			tc.agent.systemInfo = &types.System{}
 
 			tc.agent.getEntities(tc.event)
-			assert.Equal(tc.expectedAgentName, tc.event.Entity.Name)
+			assert.Equal(tc.expectedEntityName, tc.event.Entity.Name)
 			assert.Equal(tc.expectedSource, tc.event.Check.ProxyEntityName)
 		})
 	}

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -64,6 +64,14 @@ func FixtureCheck(id string) *Check {
 	return c
 }
 
+// FixtureProxyCheck returns a fixture for a proxy check object, associated with
+// the given entity.
+func FixtureProxyCheck(id string, proxyEntityName string) *Check {
+	c := FixtureCheck(id)
+	c.ProxyEntityName = proxyEntityName
+	return c
+}
+
 // NewCheck creates a new Check. It copies the fields from CheckConfig that
 // match with Check's fields.
 //

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -131,6 +131,14 @@ func FixtureEntity(name string) *Entity {
 	}
 }
 
+// FixtureProxyEntity returns a testing fixture for an proxy Entity object.
+func FixtureProxyEntity(name string) *Entity {
+	e := FixtureEntity(name)
+	e.EntityClass = "proxy"
+	e.ObjectMeta.Name = ""
+	return e
+}
+
 //
 // Sorting
 

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -133,6 +133,16 @@ func FixtureEvent(entityName, checkID string) *Event {
 	}
 }
 
+// FixtureProxyEvent returns a testing fixture for an Event object for a proxy Entity.
+func FixtureProxyEvent(entityName, checkID string) *Event {
+	return &Event{
+		ObjectMeta: NewObjectMeta("", "default"),
+		Timestamp:  time.Now().Unix(),
+		Entity:     FixtureProxyEntity(entityName),
+		Check:      FixtureProxyCheck(checkID, entityName),
+	}
+}
+
 // NewEvent creates a new Event.
 func NewEvent(meta ObjectMeta) *Event {
 	return &Event{ObjectMeta: meta}

--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -7,6 +7,12 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+type ErrDeletedEntity string
+
+func (e ErrDeletedEntity) Error() string {
+	return fmt.Sprintf("%s was deleted after this event was scheduled, dropping event", string(e))
+}
+
 // addEntitySubscription appends the entity subscription (using the format
 // "entity:entityName") to the subscriptions of an entity
 func addEntitySubscription(entityName string, subscriptions []string) []string {
@@ -17,7 +23,7 @@ func addEntitySubscription(entityName string, subscriptions []string) []string {
 // getProxyEntity verifies if a proxy entity name was provided in the given event and if
 // so, retrieves the corresponding entity in the store in order to replace the
 // event's entity with it. In case no entity exists, we create an entity with
-// the proxy class
+// the proxy class only if the event doesn't already have an entity attached.
 func getProxyEntity(event *types.Event, s SessionStore) error {
 	ctx := context.WithValue(context.Background(), types.NamespaceKey, event.Entity.Namespace)
 
@@ -29,8 +35,26 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 			return fmt.Errorf("could not query the store for a proxy entity: %s", err)
 		}
 
-		// Check if an entity was found for this proxy entity. If not, we need to create it
+		// Check if an entity was found for this proxy entity.
+		// If not, we may need to create it.
+		// There are a few possible scenarios here:
+		//   1: Entity exists in event and in store (normal case, doesn't reach this point)
+		//   2: Entity exists in event and not in store (ie: a proxy check was scheduled
+		//      for this entity, and the entity was deleted between when the check was scheduled
+		//      and when the result was received). We should not create a new entity in this case.
+		//   3: Entity does not exist in event or the store (ie: check was not scheduled by
+		//      the backend, but was instead submitted via the agent's API). We should
+		//      create a new entity in this case.
 		if entity == nil {
+			// case 2: event has an entity but it doesn't exist in the store anymore
+			// because it was deleted.
+			if event.Entity != nil {
+				return ErrDeletedEntity(event.Check.ProxyEntityName)
+			}
+
+			// case 3: event has no entity, and neither does the store. This event was
+			// submitted via the agent API, not scheduled by the backend, so we can
+			// safely create an entity for it.
 			entity = &types.Entity{
 				EntityClass:   types.EntityProxyClass,
 				Subscriptions: addEntitySubscription(event.Check.ProxyEntityName, []string{}),

--- a/backend/agentd/entity_test.go
+++ b/backend/agentd/entity_test.go
@@ -16,7 +16,8 @@ func TestGetProxyEntity(t *testing.T) {
 	assert := assert.New(t)
 
 	store := &mockstore.MockStore{}
-	store.On("GetEntityByName", mock.Anything, "bar").Return(types.FixtureEntity("bar"), nil)
+	store.On("GetEntityByName", mock.Anything, "bar").Return(types.FixtureProxyEntity("bar"), nil)
+	store.On("GetEntityByName", mock.Anything, "foo").Return(types.FixtureProxyEntity("foo"), nil)
 
 	var nilEntity *types.Entity
 	store.On("GetEntityByName", mock.Anything, "baz").Return(nilEntity, nil)
@@ -46,7 +47,7 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "bar",
 				},
-				Entity: types.FixtureEntity("foo"),
+				Entity: types.FixtureProxyEntity("bar"),
 			},
 			expectedError:  false,
 			expectedEntity: "bar",
@@ -58,10 +59,21 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "baz",
 				},
-				Entity: types.FixtureEntity("foo"),
+				Entity: types.FixtureProxyEntity("baz"),
 			},
 			expectedError:  false,
 			expectedEntity: "baz",
+		},
+		{
+			name: "The event has an entity, but no corresponding entity matches it (likely because it was deleted)",
+			event: &types.Event{
+				ObjectMeta: v2.NewObjectMeta("", "default"),
+				Check: &types.Check{
+					ProxyEntityName: "missing",
+				},
+				Entity: types.FixtureProxyEntity("missing"),
+			},
+			expectedError: true,
 		},
 		{
 			name: "The proxy entity can't be queried",
@@ -70,7 +82,7 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "quux",
 				},
-				Entity: types.FixtureEntity("foo"),
+				Entity: types.FixtureProxyEntity("quux"),
 			},
 			expectedError: true,
 		},
@@ -81,7 +93,18 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "qux",
 				},
-				Entity: types.FixtureEntity("foo"),
+				Entity: types.FixtureProxyEntity("qux"),
+			},
+			expectedError: true,
+		},
+		{
+			name: "The proxy entity doesn't match the entity embedded in the event",
+			event: &types.Event{
+				ObjectMeta: v2.NewObjectMeta("", "default"),
+				Check: &types.Check{
+					ProxyEntityName: "foo",
+				},
+				Entity: types.FixtureProxyEntity("bar"),
 			},
 			expectedError: true,
 		},

--- a/backend/agentd/entity_test.go
+++ b/backend/agentd/entity_test.go
@@ -16,8 +16,9 @@ func TestGetProxyEntity(t *testing.T) {
 	assert := assert.New(t)
 
 	store := &mockstore.MockStore{}
-	store.On("GetEntityByName", mock.Anything, "bar").Return(types.FixtureProxyEntity("bar"), nil)
-	store.On("GetEntityByName", mock.Anything, "foo").Return(types.FixtureProxyEntity("foo"), nil)
+	store.On("GetEntityByName", mock.Anything, "bar").Return(types.FixtureEntity("bar"), nil)
+	store.On("GetEntityByName", mock.Anything, "foo").Return(types.FixtureEntity("foo"), nil)
+	store.On("GetEntityByName", mock.Anything, "broken").Return(types.FixtureEntity("not_broken"), nil)
 
 	var nilEntity *types.Entity
 	store.On("GetEntityByName", mock.Anything, "baz").Return(nilEntity, nil)
@@ -71,7 +72,7 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "missing",
 				},
-				Entity: types.FixtureProxyEntity("missing"),
+				Entity: types.FixtureEntity("missing"),
 			},
 			expectedError: true,
 		},
@@ -104,7 +105,18 @@ func TestGetProxyEntity(t *testing.T) {
 				Check: &types.Check{
 					ProxyEntityName: "foo",
 				},
-				Entity: types.FixtureProxyEntity("bar"),
+				Entity: types.FixtureEntity("bar"),
+			},
+			expectedError: true,
+		},
+		{
+			name: "The entity store returned an incorrect entity, which does not match the one in the event",
+			event: &types.Event{
+				ObjectMeta: v2.NewObjectMeta("", "default"),
+				Check: &types.Check{
+					ProxyEntityName: "foo",
+				},
+				Entity: types.FixtureEntity("broken"),
 			},
 			expectedError: true,
 		},

--- a/testing/testutil/errors.go
+++ b/testing/testutil/errors.go
@@ -1,6 +1,9 @@
 package testutil
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // CompareError ensures that the provided err is expected
 func CompareError(err error, expected bool, t *testing.T) {
@@ -9,6 +12,23 @@ func CompareError(err error, expected bool, t *testing.T) {
 	if expected && err == nil {
 		t.Fatal("expected error, got none")
 	} else if !expected && err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+}
+
+// CompareErrorType ensures that the provided err is of the expected type.
+// No comparison of error values is done.
+func CompareErrorType(err error, expected reflect.Type, t *testing.T) {
+	t.Helper()
+
+	if expected != nil {
+		if err == nil {
+			t.Fatal("expected error, got none")
+		}
+		if reflect.TypeOf(err) != expected {
+			t.Fatalf("expected error of type %s, got %T", expected.Name(), err)
+		}
+	} else if expected == nil && err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 }

--- a/testing/testutil/errors.go
+++ b/testing/testutil/errors.go
@@ -28,7 +28,7 @@ func CompareErrorType(err error, expected reflect.Type, t *testing.T) {
 		if reflect.TypeOf(err) != expected {
 			t.Fatalf("expected error of type %s, got %T", expected.Name(), err)
 		}
-	} else if expected == nil && err != nil {
+	} else if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 }

--- a/types/aliases.go
+++ b/types/aliases.go
@@ -193,6 +193,7 @@ var (
 	FixtureCheckRequest       = v2.FixtureCheckRequest
 	FixtureCheckConfig        = v2.FixtureCheckConfig
 	FixtureCheck              = v2.FixtureCheck
+	FixtureProxyCheck         = v2.FixtureProxyCheck
 	FixtureProxyRequests      = v2.FixtureProxyRequests
 	FixtureNamespace          = v2.FixtureNamespace
 	FixtureMetrics            = v2.FixtureMetrics
@@ -204,6 +205,7 @@ var (
 	FixtureUser               = v2.FixtureUser
 	FixtureHealthResponse     = v2.FixtureHealthResponse
 	FixtureEvent              = v2.FixtureEvent
+	FixtureProxyEvent         = v2.FixtureProxyEvent
 	FixtureEventFilter        = v2.FixtureEventFilter
 	FixtureDenyEventFilter    = v2.FixtureDenyEventFilter
 	FixtureExtension          = v2.FixtureExtension
@@ -217,6 +219,7 @@ var (
 	FixtureClusterRole        = v2.FixtureClusterRole
 	FixtureClusterRoleBinding = v2.FixtureClusterRoleBinding
 	FixtureEntity             = v2.FixtureEntity
+	FixtureProxyEntity        = v2.FixtureProxyEntity
 	FixtureHookConfig         = v2.FixtureHookConfig
 	FixtureHook               = v2.FixtureHook
 	FixtureHookList           = v2.FixtureHookList


### PR DESCRIPTION
## What is this change?

Proposed fix for #3178.

## Why is this change necessary?

There is a race condition between the scheduling of a check and the processing of that result, where if an entity is deleted before the result is received then that entity will be minimally recreated by the backend.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

Yes, see complications section.

## Were there any complications while making this change?

This was surprisingly complicated. I initially started drafting a fix for this after submitting #3192 because it's a similar problem and the solution appeared relatively simple.

I quickly discovered that the agent is quite overzealous in forcing its entity object on all events it sends, which made it effectively impossible for the backend to differentiate between the different types of events it is receiving (specifically: agent event, proxy check submitted via agent API, proxy check scheduled by backend).

I opted to utilise existing fields that were otherwise kind of ignored in order to differentiate these event types. I couldn't see a way to achieve this another way without adding a new field to the event definition. If the team prefers to add a new field, that should be quite easy to apply to this PR too, I just didn't want to make that call myself.

The three possible states result in an entity embedded in the submitted event as follows:
- agent event (eg keepalive or other non-proxy event): agent entity, as previously
- proxy check result submitted via agent `/events` API: if entity is nil, a blank one is added to the event with the agent namespace. If event namespace is empty it is set to agent namespace, and `Event.EntityClass` is set to `"proxy"`
- proxy check scheduled by backend: a blank entity is added to the event with the agent namespace, the proxy entity name, and `Event.EntityClass` set to `"proxy"`.

The backed is then able to use these expected field values to allow the following behaviour:
- if `Event.Entity.Name == store(entity)` event is ok as entity wasn't deleted
- if `Event.Entity.Name == "" and store(entity) == ""` then entity should be created (this only happens for events submitted via the agent `/events` API)
- if `Event.Entity.Name != store(entity)` event is malformed (ie: because the `Event.Entity.ProxyEntityName != Event.Entity.Name`, or the store returned the incorrect entity). This is logged and dropped
- if `Event.Entity.Name != "" and store(entity) == nil` then the entity was deleted after the check was scheduled. Event is logged and dropped.

My main concern with this is that it may be confusing to users who are using the agent `/events` API endpoint, however that's pretty advanced usage in general I think, so documenting the above behaviour may be sufficient to address that.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I didn't update docs, but they should be updated to include the above description if this approach ends up being used.

## How did you verify this change?

Added some tests.

Also did some adhoc testing with a modified `docker-compose.yml`.
Steps:
1. Remove all but `backend1` and `agent1` from `docker-compose.yml` to simplify testing
2. Run `docker-compose up`
3. Run `sensuctl configure`
4. Run `sensuctl create -f fixture.txt` using attached file: [fixture.txt](https://github.com/sensu/sensu-go/files/3493252/fixture.txt)
5. Wait for the first `foobar` check to be scheduled by watching logs
6. Immediately after the check is scheduled by the backend, run `sensuctl entity delete foo`
7. Observe the following error appear in the `backend` logs:
```
backend1_1  | {"component":"agentd","error":"foo was deleted after this event was scheduled, dropping event","level":"error","msg":"error handling message","payload":"\u0008\ufffd\ufffd\ufffd\ufffd\u0005\u0012\u001d\n\u0005proxy\u001a\u00022\u0000:\u0000r\u000e\n\u0003foo\u0012\u0007default\u001a4(\u0001j\u0003foo\ufffd\u0001\ufffd\ufffd\ufffd\ufffd\u0005\ufffd\u0001\tsomething\ufffd\u0001\u0002\ufffd\u0002\u0014\n\tcheck-foo\u0012\u0007default*\u0000","time":"2019-08-11T19:19:15Z","type":"event"}
```
8. Observe checks continue to be scheduled and events successfully received for entity `bar`

Something like this should probably be added to your existing integration/e2e test suite.

