### PR TITLE
Prevent segfault with sensuctl config view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ backend to use JSON.
 are joined with `&&` and exclusive filter expressions are joined with `||`.
 - The REST API now correctly only returns events for the specific entity
 queried in the `GET /events/:entity` endpoint (#3141)
+- Prevent a segmentation violation when running `sensuctl config view` without
+configuration.
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -18,6 +19,10 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 		Short:        "Display active configuration",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			username := helpers.GetCurrentUsername(cli.Config)
+			if username == "" {
+				return errors.New("no active configuration found")
+			}
 			activeConfig := map[string]string{
 				"api-url":   cli.Config.APIUrl(),
 				"namespace": cli.Config.Namespace(),

--- a/cli/commands/config/view_test.go
+++ b/cli/commands/config/view_test.go
@@ -34,10 +34,27 @@ func TestViewExec(t *testing.T) {
 	config := cli.Config.(*clienttest.MockConfig)
 	config.On("APIUrl").Return("http://127.0.0.1:8080")
 	config.On("Format").Return("none")
-	config.On("Tokens").Return(corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"))
+	config.On("Tokens").Return(
+		corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"),
+	)
 
-	out, err := test.RunCmd(cmd, []string{"default"})
+	out, err := test.RunCmd(cmd, nil)
 	assert.Regexp("Active Configuration", out)
 	assert.Regexp("admin", out)
 	assert.Nil(err, "Should not produce any errors")
+}
+
+func TestViewErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := ViewCommand(cli)
+
+	config := cli.Config.(*clienttest.MockConfig)
+	config.On("APIUrl").Return("")
+	config.On("Format").Return("")
+	config.On("Tokens").Return((*corev2.Tokens)(nil))
+
+	_, err := test.RunCmd(cmd, nil)
+	assert.NotNil(err, "Should not produce any errors")
 }

--- a/cli/commands/helpers/user.go
+++ b/cli/commands/helpers/user.go
@@ -2,14 +2,19 @@ package helpers
 
 import (
 	jwt "github.com/dgrijalva/jwt-go"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli/client/config"
-	"github.com/sensu/sensu-go/types"
 )
 
 // GetCurrentUsername retrieves the username from the active JWT
 func GetCurrentUsername(cfg config.Config) string {
-	accessToken := cfg.Tokens().Access
-	token, _ := jwt.ParseWithClaims(accessToken, &types.Claims{}, nil)
-	claims := token.Claims.(*types.Claims)
+	tokens := cfg.Tokens()
+	if tokens == nil {
+		return ""
+	}
+
+	accessToken := tokens.Access
+	token, _ := jwt.ParseWithClaims(accessToken, &corev2.Claims{}, nil)
+	claims := token.Claims.(*corev2.Claims)
 	return claims.StandardClaims.Subject
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It prevents a panic error if `sensuctl config view` is run without any defined configuration.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3154

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added a unit test.