### PR TITLE
Distinguish issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,13 +1,16 @@
+---
+name: 'Bug report'
+about: 'Create bug report'
+---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior
-<!--- If you're looking for help, please see https://sensuapp.org/support for resources --->
-<!--- If you're describing a bug, tell us what should happen -->
-<!--- If you're suggesting a change/improvement, tell us how it should work -->
+<!--- If you're looking for help, please see https://sensu.io/support/ for resources --->
+<!--- Tell us what should happen -->
 
 ## Current Behavior
-<!--- If describing a bug, tell us what happens instead of the expected behavior -->
-<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+<!--- Tell us what happens instead of the expected behavior -->
 
 ## Possible Solution
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,17 @@
+---
+name: 'Feature request'
+about: 'Suggest new features and changes'
+---
+
+<!--- Provide a general summary of the feature request in the Title above -->
+
+## Feature Suggestion
+<!--- If you're looking for help, please see https://sensu.io/support/ for resources --->
+<!--- Tell us how we could improve your experience -->
+
+## Possible Implementation
+<!--- Not obligatory, but ideas as to the implementation of the addition or change -->
+
+## Context
+<!--- What are you trying to accomplish? -->
+<!--- Providing context (e.g. links to configuration settings, stack strace or log data) helps us come up with a solution that is most useful in the real world -->


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It introduces new templates for bugs and features.


## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3020

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope


## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

N/A