### PR TITLE
Pass populated event object to ExecuteHooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ queried in the `GET /events/:entity` endpoint (#3141)
 - Prevent a segmentation violation when running `sensuctl config view` without
 configuration.
 - Added entity name to the interactive sensuctl survey.
+- Check hooks with `stdin: true` now receive actual event data on STDIN instead
+  of an empty event.
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -228,10 +228,6 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 	event.Entity = a.getAgentEntity()
 	event.Timestamp = time.Now().Unix()
 
-	if len(checkHooks) != 0 {
-		event.Check.Hooks = a.ExecuteHooks(ctx, request, checkExec.Status, hookAssets)
-	}
-
 	// Instantiate metrics in the event if the check is attempting to extract metrics
 	if check.OutputMetricFormat != "" || len(check.OutputMetricHandlers) != 0 {
 		event.Metrics = &corev2.Metrics{}
@@ -243,6 +239,11 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 
 	if len(check.OutputMetricHandlers) != 0 {
 		event.Metrics.Handlers = check.OutputMetricHandlers
+	}
+
+	// Execute hooks after we have a completely populated event object
+	if len(checkHooks) != 0 {
+		event.Check.Hooks = a.ExecuteHooks(ctx, request, event, hookAssets)
 	}
 
 	// The check requested that we discard its output before writing back

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -32,14 +32,22 @@ func TestExecuteHook(t *testing.T) {
 	execution := command.FixtureExecutionResponse(0, "")
 	ex.Return(execution, nil)
 
-	hook := agent.executeHook(ctx, hookConfig, "check", nil)
+	evt := &types.Event{
+		Check: &types.Check{
+			ObjectMeta: types.ObjectMeta{
+				Name: "check",
+			},
+		},
+	}
+
+	hook := agent.executeHook(ctx, hookConfig, evt, nil)
 
 	assert.NotZero(hook.Executed)
 	assert.Equal(int32(0), hook.Status)
 	assert.Equal("", hook.Output)
 
 	execution.Output = "hello"
-	hook = agent.executeHook(ctx, hookConfig, "check", nil)
+	hook = agent.executeHook(ctx, hookConfig, evt, nil)
 
 	assert.NotZero(hook.Executed)
 	assert.Equal(int32(0), hook.Status)


### PR DESCRIPTION
## What is this change?

Previously, hooks that expected data on stdin received an empty event.  Now they are passed the event object constructed as part of check execution.

## Why is this change necessary?

Fixes #3173, which also has more details on the motivation.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This fixes the behavior to match the documentation, so I don't think any changes are needed.

## How did you verify this change?

I haven't verified this in a real environment yet and the existing tests don't fully cover the functionality, so it is only partially tested.
