### PR TITLE
Fix silence bug on event resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ configuration.
 - Added entity name to the interactive sensuctl survey.
 - Check hooks with `stdin: true` now receive actual event data on STDIN instead
   of an empty event.
+- Fixed a bug where silences would not expire on event resolution.
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -219,13 +219,14 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 	// Add any silenced subscriptions to the event
 	getSilenced(ctx, event, e.silencedCache)
 
-	// Handle expire on resolve silenced entries
-	if err := handleExpireOnResolveEntries(ctx, event, e.store); err != nil {
+	// Merge the new event with the stored event if a match is found
+	event, prevEvent, err := e.eventStore.UpdateEvent(ctx, event)
+	if err != nil {
 		return err
 	}
 
-	event, prevEvent, err := e.eventStore.UpdateEvent(ctx, event)
-	if err != nil {
+	// Handle expire on resolve silenced entries
+	if err := handleExpireOnResolveEntries(ctx, event, e.store); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a bug where silences would not expire on event resolution. This is because we were attempting to determine if an event - with no history - was a resolution. The event needed to be merged with the stored event first.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3139

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

https://github.com/sensu/sensu-go-qa-crucible/pull/70