### PR TITLE
Agent command execution segfault bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ the system will refer to the namespace in the URL.
 are joined with `&&` and exclusive filter expressions are joined with `||`.
 - The REST API now correctly only returns events for the specific entity
 queried in the `GET /events/:entity` endpoint (#3141)
-- Prevent a segmentation violation when running `sensuctl config view` without
+- Prevent a segmentation fault when running `sensuctl config view` without
 configuration.
 - Added entity name to the interactive sensuctl survey.
 - Check hooks with `stdin: true` now receive actual event data on STDIN instead
-  of an empty event.
+of an empty event.
+- Prevent a segmentation fault on the agent when a command execution returns an
+error.
 
 ### Removed
 - Removed encoded protobuf payloads from log messages (when decoded, they can reveal

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -218,6 +218,7 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 	checkExec, err := a.executor.Execute(context.Background(), ex)
 	if err != nil {
 		event.Check.Output = err.Error()
+		checkExec.Status = 3
 	} else {
 		event.Check.Output = checkExec.Output
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -177,7 +177,7 @@ func (e *ExecutionRequest) Execute(ctx context.Context, execution ExecutionReque
 	if err := cmd.Start(); err != nil {
 		// Something unexpected happended when attepting to
 		// fork/exec, return immediately.
-		return nil, err
+		return resp, err
 	}
 
 	err := cmd.Wait()


### PR DESCRIPTION
## What is this change?

This PR prevents a segmentation fault when the `exec.Start()` method returns an error (usually a sign of a major problem with bash and its environment).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3216

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

I was unable to reproduce this issue; it's still not clear to me how the `Start()` could return an error; I tried multiple things (bad permissions, invalid `PATH`, etc.) without any success.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

I mocked an error from `exec.Start()` to make sure the rest of the code would behave as expected.
