### PR TITLE
Refactor sensuctl list to use the generic function

### DIFF
--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -5,27 +5,16 @@ import (
 	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var assetsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "assets")
-
-// ListAssets fetches a list of asset resources from the backend
-func (client *RestClient) ListAssets(namespace string, options *ListOptions) ([]corev2.Asset, error) {
-	var assets []corev2.Asset
-
-	if err := client.List(assetsPath(namespace), &assets, options); err != nil {
-		return assets, err
-	}
-
-	return assets, nil
-}
+// AssetsPath is the api path for assets.
+var AssetsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "assets")
 
 // FetchAsset fetches an asset resource from the backend
-func (client *RestClient) FetchAsset(name string) (*types.Asset, error) {
-	var asset types.Asset
+func (client *RestClient) FetchAsset(name string) (*corev2.Asset, error) {
+	var asset corev2.Asset
 
-	path := assetsPath(client.config.Namespace(), name)
+	path := AssetsPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return &asset, fmt.Errorf("GET %q: %s", path, err)
@@ -40,13 +29,13 @@ func (client *RestClient) FetchAsset(name string) (*types.Asset, error) {
 }
 
 // CreateAsset creates an asset resource from the backend
-func (client *RestClient) CreateAsset(asset *types.Asset) error {
+func (client *RestClient) CreateAsset(asset *corev2.Asset) error {
 	bytes, err := json.Marshal(asset)
 	if err != nil {
 		return err
 	}
 
-	path := assetsPath(asset.Namespace)
+	path := AssetsPath(asset.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -64,13 +53,13 @@ func (client *RestClient) CreateAsset(asset *types.Asset) error {
 }
 
 // UpdateAsset updates an asset resource from the backend
-func (client *RestClient) UpdateAsset(asset *types.Asset) (err error) {
+func (client *RestClient) UpdateAsset(asset *corev2.Asset) (err error) {
 	bytes, err := json.Marshal(asset)
 	if err != nil {
 		return err
 	}
 
-	path := assetsPath(asset.Namespace, asset.Name)
+	path := AssetsPath(asset.Namespace, asset.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return fmt.Errorf("PUT %q: %s", path, err)

--- a/cli/client/check.go
+++ b/cli/client/check.go
@@ -5,19 +5,19 @@ import (
 	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var checksPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "checks")
+// ChecksPath is the api path for checks.
+var ChecksPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "checks")
 
 // CreateCheck creates new check on configured Sensu instance
-func (client *RestClient) CreateCheck(check *types.CheckConfig) (err error) {
+func (client *RestClient) CreateCheck(check *corev2.CheckConfig) (err error) {
 	bytes, err := json.Marshal(check)
 	if err != nil {
 		return err
 	}
 
-	path := checksPath(check.Namespace)
+	path := ChecksPath(check.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -31,13 +31,13 @@ func (client *RestClient) CreateCheck(check *types.CheckConfig) (err error) {
 }
 
 // UpdateCheck updates given check on configured Sensu instance
-func (client *RestClient) UpdateCheck(check *types.CheckConfig) (err error) {
+func (client *RestClient) UpdateCheck(check *corev2.CheckConfig) (err error) {
 	bytes, err := json.Marshal(check)
 	if err != nil {
 		return err
 	}
 
-	path := checksPath(check.Namespace, check.Name)
+	path := ChecksPath(check.Namespace, check.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err
@@ -52,17 +52,17 @@ func (client *RestClient) UpdateCheck(check *types.CheckConfig) (err error) {
 
 // DeleteCheck deletes check from configured Sensu instance
 func (client *RestClient) DeleteCheck(namespace, name string) error {
-	return client.Delete(checksPath(namespace, name))
+	return client.Delete(ChecksPath(namespace, name))
 }
 
 // ExecuteCheck sends an execution request with the provided adhoc request
-func (client *RestClient) ExecuteCheck(req *types.AdhocRequest) error {
+func (client *RestClient) ExecuteCheck(req *corev2.AdhocRequest) error {
 	bytes, err := json.Marshal(req)
 	if err != nil {
 		return err
 	}
 
-	path := checksPath(client.config.Namespace(), req.Name, "execute")
+	path := ChecksPath(client.config.Namespace(), req.Name, "execute")
 	res, err := client.R().SetBody(bytes).Post(path)
 
 	if err != nil {
@@ -77,10 +77,10 @@ func (client *RestClient) ExecuteCheck(req *types.AdhocRequest) error {
 }
 
 // FetchCheck fetches a specific check
-func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
-	var check *types.CheckConfig
+func (client *RestClient) FetchCheck(name string) (*corev2.CheckConfig, error) {
+	var check *corev2.CheckConfig
 
-	path := checksPath(client.config.Namespace(), name)
+	path := ChecksPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return nil, fmt.Errorf("GET %q: %s", path, err)
@@ -94,20 +94,9 @@ func (client *RestClient) FetchCheck(name string) (*types.CheckConfig, error) {
 	return check, err
 }
 
-// ListChecks fetches all checks from configured Sensu instance
-func (client *RestClient) ListChecks(namespace string, options *ListOptions) ([]corev2.CheckConfig, error) {
-	var checks []corev2.CheckConfig
-
-	if err := client.List(checksPath(namespace), &checks, options); err != nil {
-		return checks, err
-	}
-
-	return checks, nil
-}
-
 // AddCheckHook associates an existing hook with an existing check
-func (client *RestClient) AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error {
-	path := checksPath(check.Namespace, check.Name, "hooks", checkHook.Type)
+func (client *RestClient) AddCheckHook(check *corev2.CheckConfig, checkHook *corev2.HookList) error {
+	path := ChecksPath(check.Namespace, check.Name, "hooks", checkHook.Type)
 	res, err := client.R().SetBody(checkHook).Put(path)
 	if err != nil {
 		return err
@@ -121,8 +110,8 @@ func (client *RestClient) AddCheckHook(check *types.CheckConfig, checkHook *type
 }
 
 // RemoveCheckHook removes an association between an existing hook and an existing check
-func (client *RestClient) RemoveCheckHook(check *types.CheckConfig, checkHookType string, hookName string) error {
-	path := checksPath(check.Namespace, check.Name, "hooks", checkHookType, "hook", hookName)
+func (client *RestClient) RemoveCheckHook(check *corev2.CheckConfig, checkHookType string, hookName string) error {
+	path := ChecksPath(check.Namespace, check.Name, "hooks", checkHookType, "hook", hookName)
 	res, err := client.R().Delete(path)
 	if err != nil {
 		return err

--- a/cli/client/clusterrole.go
+++ b/cli/client/clusterrole.go
@@ -2,37 +2,26 @@ package client
 
 import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var clusterRolesPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "clusterroles")
+// ClusterRolesPath is the api path for cluster roles.
+var ClusterRolesPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "clusterroles")
 
 // CreateClusterRole with the given cluster role
-func (client *RestClient) CreateClusterRole(clusterRole *types.ClusterRole) error {
-	return client.Post(clusterRolesPath(), clusterRole)
+func (client *RestClient) CreateClusterRole(clusterRole *corev2.ClusterRole) error {
+	return client.Post(ClusterRolesPath(), clusterRole)
 }
 
 // DeleteClusterRole with the given name
 func (client *RestClient) DeleteClusterRole(name string) error {
-	return client.Delete(clusterRolesPath(name))
+	return client.Delete(ClusterRolesPath(name))
 }
 
 // FetchClusterRole with the given name
-func (client *RestClient) FetchClusterRole(name string) (*types.ClusterRole, error) {
-	clusterRole := &types.ClusterRole{}
-	if err := client.Get(clusterRolesPath(name), clusterRole); err != nil {
+func (client *RestClient) FetchClusterRole(name string) (*corev2.ClusterRole, error) {
+	clusterRole := &corev2.ClusterRole{}
+	if err := client.Get(ClusterRolesPath(name), clusterRole); err != nil {
 		return nil, err
 	}
 	return clusterRole, nil
-}
-
-// ListClusterRoles within the namespace
-func (client *RestClient) ListClusterRoles(options *ListOptions) ([]corev2.ClusterRole, error) {
-	clusterRoles := []corev2.ClusterRole{}
-
-	if err := client.List(clusterRolesPath(), &clusterRoles, options); err != nil {
-		return clusterRoles, err
-	}
-
-	return clusterRoles, nil
 }

--- a/cli/client/clusterrolebinding.go
+++ b/cli/client/clusterrolebinding.go
@@ -2,37 +2,26 @@ package client
 
 import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var clusterRoleBindingsPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "clusterrolebindings")
+// ClusterRoleBindingsPath is the api path for cluster role bindings.
+var ClusterRoleBindingsPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "clusterrolebindings")
 
 // CreateClusterRoleBinding with the given cluster role binding
-func (client *RestClient) CreateClusterRoleBinding(clusterRoleBinding *types.ClusterRoleBinding) error {
-	return client.Post(clusterRoleBindingsPath(), clusterRoleBinding)
+func (client *RestClient) CreateClusterRoleBinding(clusterRoleBinding *corev2.ClusterRoleBinding) error {
+	return client.Post(ClusterRoleBindingsPath(), clusterRoleBinding)
 }
 
 // DeleteClusterRoleBinding with the given name
 func (client *RestClient) DeleteClusterRoleBinding(name string) error {
-	return client.Delete(clusterRoleBindingsPath(name))
+	return client.Delete(ClusterRoleBindingsPath(name))
 }
 
 // FetchClusterRoleBinding with the given name
-func (client *RestClient) FetchClusterRoleBinding(name string) (*types.ClusterRoleBinding, error) {
-	clusterRoleBinding := &types.ClusterRoleBinding{}
-	if err := client.Get(clusterRoleBindingsPath(name), clusterRoleBinding); err != nil {
+func (client *RestClient) FetchClusterRoleBinding(name string) (*corev2.ClusterRoleBinding, error) {
+	clusterRoleBinding := &corev2.ClusterRoleBinding{}
+	if err := client.Get(ClusterRoleBindingsPath(name), clusterRoleBinding); err != nil {
 		return nil, err
 	}
 	return clusterRoleBinding, nil
-}
-
-// ListClusterRoleBinding in the cluster
-func (client *RestClient) ListClusterRoleBindings(options *ListOptions) ([]corev2.ClusterRoleBinding, error) {
-	clusterRoleBindings := []corev2.ClusterRoleBinding{}
-
-	if err := client.List(clusterRoleBindingsPath(), &clusterRoleBindings, options); err != nil {
-		return clusterRoleBindings, err
-	}
-
-	return clusterRoleBindings, nil
 }

--- a/cli/client/entity.go
+++ b/cli/client/entity.go
@@ -4,21 +4,21 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var entitiesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "entities")
+// EntitiesPath is the api path for entities.
+var EntitiesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "entities")
 
 // DeleteEntity deletes given entitiy from the configured sensu instance
 func (client *RestClient) DeleteEntity(namespace, name string) (err error) {
-	return client.Delete(entitiesPath(namespace, name))
+	return client.Delete(EntitiesPath(namespace, name))
 }
 
 // FetchEntity fetches a specific entity
-func (client *RestClient) FetchEntity(name string) (*types.Entity, error) {
-	var entity *types.Entity
+func (client *RestClient) FetchEntity(name string) (*corev2.Entity, error) {
+	var entity *corev2.Entity
 
-	path := entitiesPath(client.config.Namespace(), name)
+	path := EntitiesPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return entity, err
@@ -32,25 +32,14 @@ func (client *RestClient) FetchEntity(name string) (*types.Entity, error) {
 	return entity, err
 }
 
-// ListEntities fetches all entities from configured Sensu instance
-func (client *RestClient) ListEntities(namespace string, options *ListOptions) ([]corev2.Entity, error) {
-	var entities []corev2.Entity
-
-	if err := client.List(entitiesPath(namespace), &entities, options); err != nil {
-		return entities, err
-	}
-
-	return entities, nil
-}
-
 // UpdateEntity updates given entity on configured Sensu instance
-func (client *RestClient) UpdateEntity(entity *types.Entity) (err error) {
+func (client *RestClient) UpdateEntity(entity *corev2.Entity) (err error) {
 	bytes, err := json.Marshal(entity)
 	if err != nil {
 		return err
 	}
 
-	path := entitiesPath(entity.Namespace, entity.Name)
+	path := EntitiesPath(entity.Namespace, entity.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err
@@ -64,13 +53,13 @@ func (client *RestClient) UpdateEntity(entity *types.Entity) (err error) {
 }
 
 // CreateEntity creates a new entity
-func (client *RestClient) CreateEntity(entity *types.Entity) (err error) {
+func (client *RestClient) CreateEntity(entity *corev2.Entity) (err error) {
 	bytes, err := json.Marshal(entity)
 	if err != nil {
 		return err
 	}
 
-	path := entitiesPath(entity.Namespace)
+	path := EntitiesPath(entity.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err

--- a/cli/client/event.go
+++ b/cli/client/event.go
@@ -5,16 +5,16 @@ import (
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var eventsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "events")
+// EventsPath is the api path for events.
+var EventsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "events")
 
 // FetchEvent fetches a specific event
-func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error) {
-	var event *types.Event
+func (client *RestClient) FetchEvent(entity, check string) (*corev2.Event, error) {
+	var event *corev2.Event
 
-	path := eventsPath(client.config.Namespace(), entity, check)
+	path := EventsPath(client.config.Namespace(), entity, check)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return nil, err
@@ -28,30 +28,19 @@ func (client *RestClient) FetchEvent(entity, check string) (*types.Event, error)
 	return event, err
 }
 
-// ListEvents fetches events from Sensu API
-func (client *RestClient) ListEvents(namespace string, options *ListOptions) ([]corev2.Event, error) {
-	var events []corev2.Event
-
-	if err := client.List(eventsPath(namespace), &events, options); err != nil {
-		return events, err
-	}
-
-	return events, nil
-}
-
 // DeleteEvent deletes an event.
 func (client *RestClient) DeleteEvent(namespace, entity, check string) error {
-	return client.Delete(eventsPath(namespace, entity, check))
+	return client.Delete(EventsPath(namespace, entity, check))
 }
 
 // UpdateEvent updates an event.
-func (client *RestClient) UpdateEvent(event *types.Event) error {
+func (client *RestClient) UpdateEvent(event *corev2.Event) error {
 	bytes, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
 
-	path := eventsPath(event.Check.Namespace, event.Entity.Name, event.Check.Name)
+	path := EventsPath(event.Check.Namespace, event.Entity.Name, event.Check.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err
@@ -65,7 +54,7 @@ func (client *RestClient) UpdateEvent(event *types.Event) error {
 }
 
 // ResolveEvent resolves an event.
-func (client *RestClient) ResolveEvent(event *types.Event) error {
+func (client *RestClient) ResolveEvent(event *corev2.Event) error {
 	event.Check.Status = 0
 	event.Check.Output = "Resolved manually by sensuctl"
 	event.Timestamp = int64(time.Now().Unix())

--- a/cli/client/extension.go
+++ b/cli/client/extension.go
@@ -4,26 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
-var extPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "extensions")
-
-// ListExtensions retrieves a list of extension resources from the backend
-func (client *RestClient) ListExtensions(namespace string, options *ListOptions) ([]corev2.Extension, error) {
-	var extensions []corev2.Extension
-
-	if err := client.List(extPath(namespace), &extensions, options); err != nil {
-		return extensions, err
-	}
-
-	return extensions, nil
-}
+// ExtPath is the api path for extensions.
+var ExtPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "extensions")
 
 // DeregisterExtension deregisters an extension resource from the backend
 func (client *RestClient) DeregisterExtension(name, namespace string) error {
-	path := extPath(namespace, name)
+	path := ExtPath(namespace, name)
 	res, err := client.R().Delete(path)
 	if err != nil {
 		return fmt.Errorf("DELETE %q: %s", path, err)
@@ -43,7 +32,7 @@ func (client *RestClient) RegisterExtension(extension *types.Extension) error {
 		return err
 	}
 
-	path := extPath(extension.Namespace, extension.Name)
+	path := ExtPath(extension.Namespace, extension.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return fmt.Errorf("PUT %q: %s", path, err)

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var filtersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "filters")
+// FiltersPath is the api path for filters.
+var FiltersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "filters")
 
 // CreateFilter creates a new filter on configured Sensu instance
-func (client *RestClient) CreateFilter(filter *types.EventFilter) (err error) {
+func (client *RestClient) CreateFilter(filter *corev2.EventFilter) (err error) {
 	bytes, err := json.Marshal(filter)
 	if err != nil {
 		return err
 	}
 
-	path := filtersPath(client.config.Namespace())
+	path := FiltersPath(client.config.Namespace())
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -31,14 +31,14 @@ func (client *RestClient) CreateFilter(filter *types.EventFilter) (err error) {
 
 // DeleteFilter deletes a filter from configured Sensu instance
 func (client *RestClient) DeleteFilter(namespace, name string) error {
-	return client.Delete(filtersPath(namespace, name))
+	return client.Delete(FiltersPath(namespace, name))
 }
 
 // FetchFilter fetches a specific check
-func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
-	var filter *types.EventFilter
+func (client *RestClient) FetchFilter(name string) (*corev2.EventFilter, error) {
+	var filter *corev2.EventFilter
 
-	path := filtersPath(client.config.Namespace(), name)
+	path := FiltersPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return nil, err
@@ -52,25 +52,14 @@ func (client *RestClient) FetchFilter(name string) (*types.EventFilter, error) {
 	return filter, err
 }
 
-// ListFilters fetches all filters from configured Sensu instance
-func (client *RestClient) ListFilters(namespace string, options *ListOptions) ([]corev2.EventFilter, error) {
-	var filters []corev2.EventFilter
-
-	if err := client.List(filtersPath(namespace), &filters, options); err != nil {
-		return filters, err
-	}
-
-	return filters, nil
-}
-
 // UpdateFilter updates an existing filter with fields from a new one.
-func (client *RestClient) UpdateFilter(f *types.EventFilter) error {
+func (client *RestClient) UpdateFilter(f *corev2.EventFilter) error {
 	b, err := json.Marshal(f)
 	if err != nil {
 		return err
 	}
 
-	path := filtersPath(f.Namespace, f.Name)
+	path := FiltersPath(f.Namespace, f.Name)
 	resp, err := client.R().SetBody(b).Put(path)
 	if err != nil {
 		return err

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -3,9 +3,10 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -40,7 +41,7 @@ func (client *RestClient) Get(path string, obj interface{}) error {
 // List sends a GET request for all objects at the given path.
 // The options parameter allows for enhancing the request with field/label
 // selectors (filtering), pagination, ...
-func (client *RestClient) List(path string, objs interface{}, options *ListOptions) error {
+func (client *RestClient) List(path string, objs interface{}, options *ListOptions, header *http.Header) error {
 	objsType := reflect.TypeOf(objs)
 	if objsType.Kind() != reflect.Ptr || objsType.Elem().Kind() != reflect.Slice {
 		panic("unexpected type for objs")
@@ -54,6 +55,7 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 		if err != nil {
 			return err
 		}
+		*header = resp.Header()
 
 		if resp.StatusCode() >= 400 {
 			return UnmarshalError(resp)
@@ -67,7 +69,7 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 		o := reflect.ValueOf(objs).Elem()
 		o.Set(reflect.AppendSlice(o, newObjs.Elem()))
 
-		options.ContinueToken = resp.Header().Get(v2.PaginationContinueHeader)
+		options.ContinueToken = resp.Header().Get(corev2.PaginationContinueHeader)
 		if options.ContinueToken == "" {
 			break
 		}

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -4,30 +4,19 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var handlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
-
-// ListHandlers fetches all handlers from configured Sensu instance
-func (client *RestClient) ListHandlers(namespace string, options *ListOptions) ([]corev2.Handler, error) {
-	var handlers []corev2.Handler
-
-	if err := client.List(handlersPath(namespace), &handlers, options); err != nil {
-		return handlers, err
-	}
-
-	return handlers, nil
-}
+// HandlersPath is the api path for handlers.
+var HandlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
 
 // CreateHandler creates new handler on configured Sensu instance
-func (client *RestClient) CreateHandler(handler *types.Handler) (err error) {
+func (client *RestClient) CreateHandler(handler *corev2.Handler) (err error) {
 	bytes, err := json.Marshal(handler)
 	if err != nil {
 		return err
 	}
 
-	path := handlersPath(handler.Namespace)
+	path := HandlersPath(handler.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -42,13 +31,13 @@ func (client *RestClient) CreateHandler(handler *types.Handler) (err error) {
 
 // DeleteHandler deletes given handler from the configured Sensu instance
 func (client *RestClient) DeleteHandler(namespace, name string) (err error) {
-	return client.Delete(handlersPath(namespace, name))
+	return client.Delete(HandlersPath(namespace, name))
 }
 
 // FetchHandler fetches a specific handler
-func (client *RestClient) FetchHandler(name string) (*types.Handler, error) {
-	var handler *types.Handler
-	path := handlersPath(client.config.Namespace(), name)
+func (client *RestClient) FetchHandler(name string) (*corev2.Handler, error) {
+	var handler *corev2.Handler
+	path := HandlersPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return nil, err
@@ -63,13 +52,13 @@ func (client *RestClient) FetchHandler(name string) (*types.Handler, error) {
 }
 
 // UpdateHandler updates given handler on configured Sensu instance
-func (client *RestClient) UpdateHandler(handler *types.Handler) (err error) {
+func (client *RestClient) UpdateHandler(handler *corev2.Handler) (err error) {
 	bytes, err := json.Marshal(handler)
 	if err != nil {
 		return err
 	}
 
-	path := handlersPath(handler.Namespace, handler.Name)
+	path := HandlersPath(handler.Namespace, handler.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err

--- a/cli/client/health.go
+++ b/cli/client/health.go
@@ -4,16 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sensu/sensu-go/types"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 const healthPath = "/health"
 
-func (c *RestClient) Health() (*types.HealthResponse, error) {
+// Health returns the health of the cluster.
+func (c *RestClient) Health() (*corev2.HealthResponse, error) {
 	res, err := c.R().Get(healthPath)
 	if err != nil {
 		return nil, fmt.Errorf("GET %q: %s", healthPath, err)
 	}
-	var healthResponse *types.HealthResponse
+	var healthResponse *corev2.HealthResponse
 	return healthResponse, json.Unmarshal(res.Body(), &healthResponse)
 }

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var hooksPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "hooks")
+// HooksPath is the api path for hooks.
+var HooksPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "hooks")
 
 // CreateHook creates new hook on configured Sensu instance
-func (client *RestClient) CreateHook(hook *types.HookConfig) (err error) {
+func (client *RestClient) CreateHook(hook *corev2.HookConfig) (err error) {
 	bytes, err := json.Marshal(hook)
 	if err != nil {
 		return err
 	}
 
-	path := hooksPath(hook.Namespace)
+	path := HooksPath(hook.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -30,13 +30,13 @@ func (client *RestClient) CreateHook(hook *types.HookConfig) (err error) {
 }
 
 // UpdateHook updates given hook on configured Sensu instance
-func (client *RestClient) UpdateHook(hook *types.HookConfig) (err error) {
+func (client *RestClient) UpdateHook(hook *corev2.HookConfig) (err error) {
 	bytes, err := json.Marshal(hook)
 	if err != nil {
 		return err
 	}
 
-	path := hooksPath(hook.Namespace, hook.Name)
+	path := HooksPath(hook.Namespace, hook.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err
@@ -51,14 +51,14 @@ func (client *RestClient) UpdateHook(hook *types.HookConfig) (err error) {
 
 // DeleteHook deletes hook from configured Sensu instance
 func (client *RestClient) DeleteHook(namespace, name string) error {
-	return client.Delete(hooksPath(namespace, name))
+	return client.Delete(HooksPath(namespace, name))
 }
 
 // FetchHook fetches a specific hook
-func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
-	var hook *types.HookConfig
+func (client *RestClient) FetchHook(name string) (*corev2.HookConfig, error) {
+	var hook *corev2.HookConfig
 
-	path := hooksPath(client.config.Namespace(), name)
+	path := HooksPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return nil, err
@@ -70,15 +70,4 @@ func (client *RestClient) FetchHook(name string) (*types.HookConfig, error) {
 
 	err = json.Unmarshal(res.Body(), &hook)
 	return hook, err
-}
-
-// ListHooks fetches all hooks from configured Sensu instance
-func (client *RestClient) ListHooks(namespace string, options *ListOptions) ([]corev2.HookConfig, error) {
-	var hooks []corev2.HookConfig
-
-	if err := client.List(hooksPath(namespace), &hooks, options); err != nil {
-		return hooks, err
-	}
-
-	return hooks, nil
 }

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	"github.com/coreos/etcd/clientv3"
-	"github.com/sensu/sensu-go/types"
+	"net/http"
 
+	"github.com/coreos/etcd/clientv3"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // ListOptions represents the various options that can be used when listing
@@ -54,7 +55,7 @@ type GenericClient interface {
 	// Get retrieves the key at the given path and stores it into obj
 	Get(path string, obj interface{}) error
 	// List retrieves all keys with the given path prefix and stores them into objs
-	List(path string, objs interface{}, options *ListOptions) error
+	List(path string, objs interface{}, options *ListOptions, header *http.Header) error
 	// Post creates the given obj at the specified path
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
@@ -66,133 +67,120 @@ type GenericClient interface {
 
 // AuthenticationAPIClient client methods for authenticating
 type AuthenticationAPIClient interface {
-	CreateAccessToken(url string, userid string, secret string) (*types.Tokens, error)
+	CreateAccessToken(url string, userid string, secret string) (*corev2.Tokens, error)
 	TestCreds(userid string, secret string) error
 	Logout(token string) error
-	RefreshAccessToken(refreshToken string) (*types.Tokens, error)
+	RefreshAccessToken(refreshToken string) (*corev2.Tokens, error)
 }
 
 // AssetAPIClient client methods for assets
 type AssetAPIClient interface {
-	CreateAsset(*types.Asset) error
-	UpdateAsset(*types.Asset) error
-	FetchAsset(string) (*types.Asset, error)
-	ListAssets(string, *ListOptions) ([]types.Asset, error)
+	CreateAsset(*corev2.Asset) error
+	UpdateAsset(*corev2.Asset) error
+	FetchAsset(string) (*corev2.Asset, error)
 }
 
 // CheckAPIClient client methods for checks
 type CheckAPIClient interface {
-	CreateCheck(*types.CheckConfig) error
+	CreateCheck(*corev2.CheckConfig) error
 	DeleteCheck(string, string) error
-	ExecuteCheck(*types.AdhocRequest) error
-	FetchCheck(string) (*types.CheckConfig, error)
-	ListChecks(string, *ListOptions) ([]types.CheckConfig, error)
-	UpdateCheck(*types.CheckConfig) error
+	ExecuteCheck(*corev2.AdhocRequest) error
+	FetchCheck(string) (*corev2.CheckConfig, error)
+	UpdateCheck(*corev2.CheckConfig) error
 
-	AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error
-	RemoveCheckHook(check *types.CheckConfig, checkHookType string, hookName string) error
+	AddCheckHook(check *corev2.CheckConfig, checkHook *corev2.HookList) error
+	RemoveCheckHook(check *corev2.CheckConfig, checkHookType string, hookName string) error
 }
 
 // ClusterRoleAPIClient client methods for cluster roles
 type ClusterRoleAPIClient interface {
-	CreateClusterRole(*types.ClusterRole) error
+	CreateClusterRole(*corev2.ClusterRole) error
 	DeleteClusterRole(string) error
-	FetchClusterRole(string) (*types.ClusterRole, error)
-	ListClusterRoles(*ListOptions) ([]types.ClusterRole, error)
+	FetchClusterRole(string) (*corev2.ClusterRole, error)
 }
 
 // ClusterRoleBindingAPIClient client methods for cluster role bindings
 type ClusterRoleBindingAPIClient interface {
-	CreateClusterRoleBinding(*types.ClusterRoleBinding) error
+	CreateClusterRoleBinding(*corev2.ClusterRoleBinding) error
 	DeleteClusterRoleBinding(string) error
-	FetchClusterRoleBinding(string) (*types.ClusterRoleBinding, error)
-	ListClusterRoleBindings(*ListOptions) ([]types.ClusterRoleBinding, error)
+	FetchClusterRoleBinding(string) (*corev2.ClusterRoleBinding, error)
 }
 
 // EntityAPIClient client methods for entities
 type EntityAPIClient interface {
-	CreateEntity(entity *types.Entity) error
+	CreateEntity(entity *corev2.Entity) error
 	DeleteEntity(string, string) error
-	FetchEntity(ID string) (*types.Entity, error)
-	ListEntities(string, *ListOptions) ([]types.Entity, error)
-	UpdateEntity(entity *types.Entity) error
+	FetchEntity(ID string) (*corev2.Entity, error)
+	UpdateEntity(entity *corev2.Entity) error
 }
 
 // FilterAPIClient client methods for filters
 type FilterAPIClient interface {
-	CreateFilter(*types.EventFilter) error
+	CreateFilter(*corev2.EventFilter) error
 	DeleteFilter(string, string) error
-	FetchFilter(string) (*types.EventFilter, error)
-	ListFilters(string, *ListOptions) ([]types.EventFilter, error)
-	UpdateFilter(*types.EventFilter) error
+	FetchFilter(string) (*corev2.EventFilter, error)
+	UpdateFilter(*corev2.EventFilter) error
 }
 
 // EventAPIClient client methods for events
 type EventAPIClient interface {
-	FetchEvent(string, string) (*types.Event, error)
-	ListEvents(string, *ListOptions) ([]corev2.Event, error)
+	FetchEvent(string, string) (*corev2.Event, error)
 
 	// DeleteEvent deletes the event identified by entity, check.
 	DeleteEvent(namespace, entity, check string) error
-	UpdateEvent(*types.Event) error
-	ResolveEvent(*types.Event) error
+	UpdateEvent(*corev2.Event) error
+	ResolveEvent(*corev2.Event) error
 }
 
 // ExtensionAPIClient client methods for extensions
 type ExtensionAPIClient interface {
-	ListExtensions(namespace string, options *ListOptions) ([]types.Extension, error)
-	RegisterExtension(*types.Extension) error
+	RegisterExtension(*corev2.Extension) error
 	DeregisterExtension(name, namespace string) error
 }
 
 // HandlerAPIClient client methods for handlers
 type HandlerAPIClient interface {
-	CreateHandler(*types.Handler) error
+	CreateHandler(*corev2.Handler) error
 	DeleteHandler(string, string) error
-	ListHandlers(string, *ListOptions) ([]types.Handler, error)
-	FetchHandler(string) (*types.Handler, error)
-	UpdateHandler(*types.Handler) error
+	FetchHandler(string) (*corev2.Handler, error)
+	UpdateHandler(*corev2.Handler) error
 }
 
 // HealthAPIClient client methods for health api
 type HealthAPIClient interface {
-	Health() (*types.HealthResponse, error)
+	Health() (*corev2.HealthResponse, error)
 }
 
 // HookAPIClient client methods for hooks
 type HookAPIClient interface {
-	CreateHook(*types.HookConfig) error
-	UpdateHook(*types.HookConfig) error
+	CreateHook(*corev2.HookConfig) error
+	UpdateHook(*corev2.HookConfig) error
 	DeleteHook(string, string) error
-	FetchHook(string) (*types.HookConfig, error)
-	ListHooks(string, *ListOptions) ([]types.HookConfig, error)
+	FetchHook(string) (*corev2.HookConfig, error)
 }
 
 // MutatorAPIClient client methods for mutators
 type MutatorAPIClient interface {
-	CreateMutator(*types.Mutator) error
-	ListMutators(string, *ListOptions) ([]types.Mutator, error)
+	CreateMutator(*corev2.Mutator) error
 	DeleteMutator(string, string) error
-	FetchMutator(string) (*types.Mutator, error)
-	UpdateMutator(*types.Mutator) error
+	FetchMutator(string) (*corev2.Mutator, error)
+	UpdateMutator(*corev2.Mutator) error
 }
 
 // NamespaceAPIClient client methods for namespaces
 type NamespaceAPIClient interface {
-	CreateNamespace(*types.Namespace) error
-	UpdateNamespace(*types.Namespace) error
+	CreateNamespace(*corev2.Namespace) error
+	UpdateNamespace(*corev2.Namespace) error
 	DeleteNamespace(string) error
-	ListNamespaces(*ListOptions) ([]types.Namespace, error)
-	FetchNamespace(string) (*types.Namespace, error)
+	FetchNamespace(string) (*corev2.Namespace, error)
 }
 
 // UserAPIClient client methods for users
 type UserAPIClient interface {
 	AddGroupToUser(string, string) error
-	CreateUser(*types.User) error
+	CreateUser(*corev2.User) error
 	DisableUser(string) error
-	FetchUser(string) (*types.User, error)
-	ListUsers(*ListOptions) ([]types.User, error)
+	FetchUser(string) (*corev2.User, error)
 	ReinstateUser(string) error
 	RemoveGroupFromUser(string, string) error
 	RemoveAllGroupsFromUser(string) error
@@ -202,37 +190,35 @@ type UserAPIClient interface {
 
 // RoleAPIClient client methods for roles
 type RoleAPIClient interface {
-	CreateRole(*types.Role) error
+	CreateRole(*corev2.Role) error
 	DeleteRole(string, string) error
-	FetchRole(string) (*types.Role, error)
-	ListRoles(string, *ListOptions) ([]types.Role, error)
+	FetchRole(string) (*corev2.Role, error)
 }
 
 // RoleBindingAPIClient client methods for role bindings
 type RoleBindingAPIClient interface {
-	CreateRoleBinding(*types.RoleBinding) error
+	CreateRoleBinding(*corev2.RoleBinding) error
 	DeleteRoleBinding(string, string) error
-	FetchRoleBinding(string) (*types.RoleBinding, error)
-	ListRoleBindings(string, *ListOptions) ([]types.RoleBinding, error)
+	FetchRoleBinding(string) (*corev2.RoleBinding, error)
 }
 
 // SilencedAPIClient client methods for silenced
 type SilencedAPIClient interface {
 	// CreateSilenced creates a new silenced entry from its input.
-	CreateSilenced(*types.Silenced) error
+	CreateSilenced(*corev2.Silenced) error
 
 	// DeleteSilenced deletes an existing silenced entry given its ID.
 	DeleteSilenced(namespace string, name string) error
 
 	// ListSilenceds lists all silenced entries, optionally constraining by
 	// subscription or check.
-	ListSilenceds(namespace, subscription, check string, options *ListOptions) ([]types.Silenced, error)
+	ListSilenceds(namespace, subscription, check string, options *ListOptions, header *http.Header) ([]types.Silenced, error)
 
 	// FetchSilenced fetches the silenced entry by ID.
-	FetchSilenced(id string) (*types.Silenced, error)
+	FetchSilenced(id string) (*corev2.Silenced, error)
 
 	// UpdateSilenced updates an existing silenced entry.
-	UpdateSilenced(*types.Silenced) error
+	UpdateSilenced(*corev2.Silenced) error
 }
 
 // ClusterMemberClient specifies client methods for cluster membership management.

--- a/cli/client/mutator.go
+++ b/cli/client/mutator.go
@@ -4,30 +4,19 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var mutatorsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "mutators")
-
-// ListMutators fetches all mutators from the configured Sensu instance
-func (client *RestClient) ListMutators(namespace string, options *ListOptions) ([]corev2.Mutator, error) {
-	var mutators []corev2.Mutator
-
-	if err := client.List(mutatorsPath(namespace), &mutators, options); err != nil {
-		return mutators, err
-	}
-
-	return mutators, nil
-}
+// MutatorsPath is the api path for mutators.
+var MutatorsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "mutators")
 
 // CreateMutator creates new mutator on the configured Sensu instance
-func (client *RestClient) CreateMutator(mutator *types.Mutator) (err error) {
+func (client *RestClient) CreateMutator(mutator *corev2.Mutator) (err error) {
 	bytes, err := json.Marshal(mutator)
 	if err != nil {
 		return err
 	}
 
-	path := mutatorsPath(mutator.Namespace)
+	path := MutatorsPath(mutator.Namespace)
 	res, err := client.R().SetBody(bytes).Post(path)
 	if err != nil {
 		return err
@@ -42,14 +31,14 @@ func (client *RestClient) CreateMutator(mutator *types.Mutator) (err error) {
 
 // DeleteMutator deletes the given mutator from the configured Sensu instance
 func (client *RestClient) DeleteMutator(namespace, name string) (err error) {
-	return client.Delete(mutatorsPath(namespace, name))
+	return client.Delete(MutatorsPath(namespace, name))
 }
 
 // FetchMutator fetches a specific handler from the configured Sensu instance
-func (client *RestClient) FetchMutator(name string) (*types.Mutator, error) {
-	var mutator *types.Mutator
+func (client *RestClient) FetchMutator(name string) (*corev2.Mutator, error) {
+	var mutator *corev2.Mutator
 
-	path := mutatorsPath(client.config.Namespace(), name)
+	path := MutatorsPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return mutator, err
@@ -64,13 +53,13 @@ func (client *RestClient) FetchMutator(name string) (*types.Mutator, error) {
 }
 
 // UpdateMutator updates a given mutator on a configured Sensu instance
-func (client *RestClient) UpdateMutator(mutator *types.Mutator) (err error) {
+func (client *RestClient) UpdateMutator(mutator *corev2.Mutator) (err error) {
 	bytes, err := json.Marshal(mutator)
 	if err != nil {
 		return err
 	}
 
-	path := mutatorsPath(mutator.Namespace, mutator.Name)
+	path := MutatorsPath(mutator.Namespace, mutator.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err

--- a/cli/client/namespace.go
+++ b/cli/client/namespace.go
@@ -4,19 +4,19 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var namespacesPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "namespaces")
+// NamespacesPath is the api path for namespaces.
+var NamespacesPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "namespaces")
 
 // CreateNamespace creates new namespace on configured Sensu instance
-func (client *RestClient) CreateNamespace(namespace *types.Namespace) error {
+func (client *RestClient) CreateNamespace(namespace *corev2.Namespace) error {
 	bytes, err := json.Marshal(namespace)
 	if err != nil {
 		return err
 	}
 
-	path := namespacesPath()
+	path := NamespacesPath()
 	res, err := client.R().SetBody(bytes).Post(path)
 
 	if err != nil {
@@ -31,13 +31,13 @@ func (client *RestClient) CreateNamespace(namespace *types.Namespace) error {
 }
 
 // UpdateNamespace updates given namespace on a configured Sensu instance
-func (client *RestClient) UpdateNamespace(namespace *types.Namespace) error {
+func (client *RestClient) UpdateNamespace(namespace *corev2.Namespace) error {
 	bytes, err := json.Marshal(namespace)
 	if err != nil {
 		return err
 	}
 
-	path := namespacesPath(namespace.Name)
+	path := NamespacesPath(namespace.Name)
 	res, err := client.R().SetBody(bytes).Put(path)
 	if err != nil {
 		return err
@@ -52,25 +52,14 @@ func (client *RestClient) UpdateNamespace(namespace *types.Namespace) error {
 
 // DeleteNamespace deletes an namespace on configured Sensu instance
 func (client *RestClient) DeleteNamespace(namespace string) error {
-	return client.Delete(namespacesPath(namespace))
-}
-
-// ListNamespaces fetches all namespaces from configured Sensu instance
-func (client *RestClient) ListNamespaces(options *ListOptions) ([]corev2.Namespace, error) {
-	var namespaces []corev2.Namespace
-
-	if err := client.List(namespacesPath(), &namespaces, options); err != nil {
-		return namespaces, err
-	}
-
-	return namespaces, nil
+	return client.Delete(NamespacesPath(namespace))
 }
 
 // FetchNamespace fetches an namespace by name
-func (client *RestClient) FetchNamespace(namespaceName string) (*types.Namespace, error) {
-	var namespace *types.Namespace
+func (client *RestClient) FetchNamespace(namespaceName string) (*corev2.Namespace, error) {
+	var namespace *corev2.Namespace
 
-	path := namespacesPath(namespaceName)
+	path := NamespacesPath(namespaceName)
 	res, err := client.R().Get(path)
 	if err != nil {
 		return namespace, err

--- a/cli/client/role.go
+++ b/cli/client/role.go
@@ -2,37 +2,26 @@ package client
 
 import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var rolesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "roles")
+// RolesPath is the api path for roles.
+var RolesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "roles")
 
 // CreateRole with the given role
-func (client *RestClient) CreateRole(role *types.Role) error {
-	return client.Post(rolesPath(role.Namespace), role)
+func (client *RestClient) CreateRole(role *corev2.Role) error {
+	return client.Post(RolesPath(role.Namespace), role)
 }
 
 // DeleteRole with the given name
 func (client *RestClient) DeleteRole(namespace, name string) error {
-	return client.Delete(rolesPath(namespace, name))
+	return client.Delete(RolesPath(namespace, name))
 }
 
 // FetchRole with the given name
-func (client *RestClient) FetchRole(name string) (*types.Role, error) {
-	role := &types.Role{}
-	if err := client.Get(rolesPath(client.config.Namespace(), name), role); err != nil {
+func (client *RestClient) FetchRole(name string) (*corev2.Role, error) {
+	role := &corev2.Role{}
+	if err := client.Get(RolesPath(client.config.Namespace(), name), role); err != nil {
 		return nil, err
 	}
 	return role, nil
-}
-
-// ListRoles lists the roles within the given namespace.
-func (client *RestClient) ListRoles(namespace string, options *ListOptions) ([]corev2.Role, error) {
-	roles := []corev2.Role{}
-
-	if err := client.List(rolesPath(namespace), &roles, options); err != nil {
-		return roles, err
-	}
-
-	return roles, nil
 }

--- a/cli/client/rolebinding.go
+++ b/cli/client/rolebinding.go
@@ -2,37 +2,26 @@ package client
 
 import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var roleBindingsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "rolebindings")
+// RoleBindingsPath is the api path for role bindings.
+var RoleBindingsPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "rolebindings")
 
 // CreateRoleBinding with the given role binding
-func (client *RestClient) CreateRoleBinding(roleBinding *types.RoleBinding) error {
-	return client.Post(roleBindingsPath(roleBinding.Namespace), roleBinding)
+func (client *RestClient) CreateRoleBinding(roleBinding *corev2.RoleBinding) error {
+	return client.Post(RoleBindingsPath(roleBinding.Namespace), roleBinding)
 }
 
 // DeleteRoleBinding with the given name
 func (client *RestClient) DeleteRoleBinding(namespace, name string) error {
-	return client.Delete(roleBindingsPath(namespace, name))
+	return client.Delete(RoleBindingsPath(namespace, name))
 }
 
 // FetchRoleBinding with the given name
-func (client *RestClient) FetchRoleBinding(name string) (*types.RoleBinding, error) {
-	roleBinding := &types.RoleBinding{}
-	if err := client.Get(roleBindingsPath(client.config.Namespace(), name), roleBinding); err != nil {
+func (client *RestClient) FetchRoleBinding(name string) (*corev2.RoleBinding, error) {
+	roleBinding := &corev2.RoleBinding{}
+	if err := client.Get(RoleBindingsPath(client.config.Namespace(), name), roleBinding); err != nil {
 		return nil, err
 	}
 	return roleBinding, nil
-}
-
-// ListRoleBindings lists the role bindings within the given namespace.
-func (client *RestClient) ListRoleBindings(namespace string, options *ListOptions) ([]corev2.RoleBinding, error) {
-	roleBindings := []corev2.RoleBinding{}
-
-	if err := client.List(roleBindingsPath(namespace), &roleBindings, options); err != nil {
-		return roleBindings, err
-	}
-
-	return roleBindings, nil
 }

--- a/cli/client/silenced.go
+++ b/cli/client/silenced.go
@@ -2,15 +2,15 @@ package client
 
 import (
 	"encoding/json"
+	"net/http"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
 var silencedPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "silenced")
 
 // CreateSilenced creates a new silenced  entry.
-func (client *RestClient) CreateSilenced(silenced *types.Silenced) error {
+func (client *RestClient) CreateSilenced(silenced *corev2.Silenced) error {
 	b, err := json.Marshal(silenced)
 	if err != nil {
 		return err
@@ -35,9 +35,9 @@ func (client *RestClient) DeleteSilenced(namespace, name string) error {
 }
 
 // ListSilenceds fetches all silenced entries from configured Sensu instance
-func (client *RestClient) ListSilenceds(namespace, sub, check string, options *ListOptions) ([]corev2.Silenced, error) {
+func (client *RestClient) ListSilenceds(namespace, sub, check string, options *ListOptions, header *http.Header) ([]corev2.Silenced, error) {
 	if sub != "" && check != "" {
-		name, err := types.SilencedName(sub, check)
+		name, err := corev2.SilencedName(sub, check)
 		if err != nil {
 			return nil, err
 		}
@@ -61,17 +61,18 @@ func (client *RestClient) ListSilenceds(namespace, sub, check string, options *L
 	if err != nil {
 		return nil, err
 	}
+	*header = resp.Header()
 	if resp.StatusCode() >= 400 {
 		return nil, UnmarshalError(resp)
 	}
 
-	var result []types.Silenced
+	var result []corev2.Silenced
 	err = json.Unmarshal(resp.Body(), &result)
 	return result, err
 }
 
 // FetchSilenced fetches a silenced entry from configured Sensu instance
-func (client *RestClient) FetchSilenced(name string) (*types.Silenced, error) {
+func (client *RestClient) FetchSilenced(name string) (*corev2.Silenced, error) {
 	path := silencedPath(client.config.Namespace(), name)
 	resp, err := client.R().Get(path)
 	if err != nil {
@@ -80,12 +81,12 @@ func (client *RestClient) FetchSilenced(name string) (*types.Silenced, error) {
 	if resp.StatusCode() >= 400 {
 		return nil, UnmarshalError(resp)
 	}
-	var result types.Silenced
+	var result corev2.Silenced
 	return &result, json.Unmarshal(resp.Body(), &result)
 }
 
 // UpdateSilenced updates a silenced entry from configured Sensu instance
-func (client *RestClient) UpdateSilenced(s *types.Silenced) error {
+func (client *RestClient) UpdateSilenced(s *corev2.Silenced) error {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return err

--- a/cli/client/testing/mock_asset_client.go
+++ b/cli/client/testing/mock_asset_client.go
@@ -1,32 +1,23 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
-// ListAssets for use with mock lib
-func (c *MockClient) ListAssets(namespace string, options *client.ListOptions) ([]corev2.Asset, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Asset), args.Error(1)
-}
-
 // FetchAsset for use with mock lib
-func (c *MockClient) FetchAsset(name string) (*types.Asset, error) {
+func (c *MockClient) FetchAsset(name string) (*corev2.Asset, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.Asset), args.Error(1)
+	return args.Get(0).(*corev2.Asset), args.Error(1)
 }
 
 // CreateAsset for use with mock lib
-func (c *MockClient) CreateAsset(asset *types.Asset) error {
+func (c *MockClient) CreateAsset(asset *corev2.Asset) error {
 	args := c.Called(asset)
 	return args.Error(0)
 }
 
 // UpdateAsset for use with mock lib
-func (c *MockClient) UpdateAsset(asset *types.Asset) error {
+func (c *MockClient) UpdateAsset(asset *corev2.Asset) error {
 	args := c.Called(asset)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_check_client.go
+++ b/cli/client/testing/mock_check_client.go
@@ -1,20 +1,17 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateCheck for use with mock lib
-func (c *MockClient) CreateCheck(check *types.CheckConfig) error {
+func (c *MockClient) CreateCheck(check *corev2.CheckConfig) error {
 	args := c.Called(check)
 	return args.Error(0)
 }
 
 // UpdateCheck for use with mock lib
-func (c *MockClient) UpdateCheck(check *types.CheckConfig) error {
+func (c *MockClient) UpdateCheck(check *corev2.CheckConfig) error {
 	args := c.Called(check)
 	return args.Error(0)
 }
@@ -26,31 +23,25 @@ func (c *MockClient) DeleteCheck(namespace, name string) error {
 }
 
 // ExecuteCheck for use with mock lib
-func (c *MockClient) ExecuteCheck(req *types.AdhocRequest) error {
+func (c *MockClient) ExecuteCheck(req *corev2.AdhocRequest) error {
 	args := c.Called(req)
 	return args.Error(0)
 }
 
 // FetchCheck for use with mock lib
-func (c *MockClient) FetchCheck(name string) (*types.CheckConfig, error) {
+func (c *MockClient) FetchCheck(name string) (*corev2.CheckConfig, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.CheckConfig), args.Error(1)
-}
-
-// ListChecks for use with mock lib
-func (c *MockClient) ListChecks(namespace string, options *client.ListOptions) ([]corev2.CheckConfig, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.CheckConfig), args.Error(1)
+	return args.Get(0).(*corev2.CheckConfig), args.Error(1)
 }
 
 // AddCheckHook for use with mock lib
-func (c *MockClient) AddCheckHook(check *types.CheckConfig, checkHook *types.HookList) error {
+func (c *MockClient) AddCheckHook(check *corev2.CheckConfig, checkHook *corev2.HookList) error {
 	args := c.Called(check, checkHook)
 	return args.Error(0)
 }
 
 // RemoveCheckHook for use with mock lib
-func (c *MockClient) RemoveCheckHook(check *types.CheckConfig, hookType string, hookName string) error {
+func (c *MockClient) RemoveCheckHook(check *corev2.CheckConfig, hookType string, hookName string) error {
 	args := c.Called(check, hookType, hookName)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_clusterrole_client.go
+++ b/cli/client/testing/mock_clusterrole_client.go
@@ -1,32 +1,23 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateClusterRole ...
-func (c *MockClient) CreateClusterRole(obj *types.ClusterRole) error {
+func (c *MockClient) CreateClusterRole(obj *corev2.ClusterRole) error {
 	args := c.Called(obj)
 	return args.Error(0)
 }
 
 // FetchClusterRole ...
-func (c *MockClient) FetchClusterRole(name string) (*types.ClusterRole, error) {
+func (c *MockClient) FetchClusterRole(name string) (*corev2.ClusterRole, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.ClusterRole), args.Error(1)
+	return args.Get(0).(*corev2.ClusterRole), args.Error(1)
 }
 
 // DeleteClusterRole ...
 func (c *MockClient) DeleteClusterRole(name string) error {
 	args := c.Called(name)
 	return args.Error(0)
-}
-
-// ListClusterRoles ...
-func (c *MockClient) ListClusterRoles(options *client.ListOptions) ([]corev2.ClusterRole, error) {
-	args := c.Called(options)
-	return args.Get(0).([]corev2.ClusterRole), args.Error(1)
 }

--- a/cli/client/testing/mock_clusterrolebinding_client.go
+++ b/cli/client/testing/mock_clusterrolebinding_client.go
@@ -1,32 +1,23 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateClusterRoleBinding ...
-func (c *MockClient) CreateClusterRoleBinding(obj *types.ClusterRoleBinding) error {
+func (c *MockClient) CreateClusterRoleBinding(obj *corev2.ClusterRoleBinding) error {
 	args := c.Called(obj)
 	return args.Error(0)
 }
 
 // FetchClusterRoleBinding ...
-func (c *MockClient) FetchClusterRoleBinding(name string) (*types.ClusterRoleBinding, error) {
+func (c *MockClient) FetchClusterRoleBinding(name string) (*corev2.ClusterRoleBinding, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.ClusterRoleBinding), args.Error(1)
+	return args.Get(0).(*corev2.ClusterRoleBinding), args.Error(1)
 }
 
 // DeleteClusterRoleBinding ...
 func (c *MockClient) DeleteClusterRoleBinding(name string) error {
 	args := c.Called(name)
 	return args.Error(0)
-}
-
-// ListClusterRoleBindings ...
-func (c *MockClient) ListClusterRoleBindings(options *client.ListOptions) ([]corev2.ClusterRoleBinding, error) {
-	args := c.Called(options)
-	return args.Get(0).([]corev2.ClusterRoleBinding), args.Error(1)
 }

--- a/cli/client/testing/mock_entity_client.go
+++ b/cli/client/testing/mock_entity_client.go
@@ -1,22 +1,13 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
-// ListEntities for use with mock lib
-func (c *MockClient) ListEntities(namespace string, options *client.ListOptions) ([]corev2.Entity, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Entity), args.Error(1)
-}
-
 // FetchEntity for use with mock lib
-func (c *MockClient) FetchEntity(ID string) (*types.Entity, error) {
+func (c *MockClient) FetchEntity(ID string) (*corev2.Entity, error) {
 	args := c.Called(ID)
-	return args.Get(0).(*types.Entity), args.Error(1)
+	return args.Get(0).(*corev2.Entity), args.Error(1)
 }
 
 // DeleteEntity for use with mock lib
@@ -26,13 +17,13 @@ func (c *MockClient) DeleteEntity(namespace, name string) error {
 }
 
 // UpdateEntity for use with mock lib
-func (c *MockClient) UpdateEntity(entity *types.Entity) error {
+func (c *MockClient) UpdateEntity(entity *corev2.Entity) error {
 	args := c.Called(entity)
 	return args.Error(0)
 }
 
 // CreateEntity for use with mock lib
-func (c *MockClient) CreateEntity(entity *types.Entity) error {
+func (c *MockClient) CreateEntity(entity *corev2.Entity) error {
 	args := c.Called(entity)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_event_client.go
+++ b/cli/client/testing/mock_event_client.go
@@ -1,22 +1,13 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // FetchEvent for use with mock lib
-func (c *MockClient) FetchEvent(entity, check string) (*types.Event, error) {
+func (c *MockClient) FetchEvent(entity, check string) (*corev2.Event, error) {
 	args := c.Called(entity, check)
-	return args.Get(0).(*types.Event), args.Error(1)
-}
-
-// ListEvents for use with mock lib
-func (c *MockClient) ListEvents(namespace string, options *client.ListOptions) ([]corev2.Event, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Event), args.Error(1)
+	return args.Get(0).(*corev2.Event), args.Error(1)
 }
 
 // DeleteEvent for use with mock lib
@@ -26,13 +17,13 @@ func (c *MockClient) DeleteEvent(namespace, entity, check string) error {
 }
 
 // UpdateEvent for use with mock lib
-func (c *MockClient) UpdateEvent(event *types.Event) error {
+func (c *MockClient) UpdateEvent(event *corev2.Event) error {
 	args := c.Called(event)
 	return args.Error(0)
 }
 
 // ResolveEvent for use with mock lib
-func (c *MockClient) ResolveEvent(event *types.Event) error {
+func (c *MockClient) ResolveEvent(event *corev2.Event) error {
 	args := c.Called(event)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_extension_client.go
+++ b/cli/client/testing/mock_extension_client.go
@@ -1,20 +1,11 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
-// ListExtensions ...
-func (c *MockClient) ListExtensions(namespace string, options *client.ListOptions) ([]corev2.Extension, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Extension), args.Error(1)
-}
-
 // RegisterExtension ...
-func (c *MockClient) RegisterExtension(e *types.Extension) error {
+func (c *MockClient) RegisterExtension(e *corev2.Extension) error {
 	args := c.Called(e)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_filter_client.go
+++ b/cli/client/testing/mock_filter_client.go
@@ -1,14 +1,11 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateFilter for use with mock lib
-func (c *MockClient) CreateFilter(filter *types.EventFilter) error {
+func (c *MockClient) CreateFilter(filter *corev2.EventFilter) error {
 	args := c.Called(filter)
 	return args.Error(0)
 }
@@ -20,19 +17,13 @@ func (c *MockClient) DeleteFilter(namespace, name string) error {
 }
 
 // FetchFilter for use with mock lib
-func (c *MockClient) FetchFilter(name string) (*types.EventFilter, error) {
+func (c *MockClient) FetchFilter(name string) (*corev2.EventFilter, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.EventFilter), args.Error(1)
-}
-
-// ListFilters for use with mock lib
-func (c *MockClient) ListFilters(namespace string, options *client.ListOptions) ([]corev2.EventFilter, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.EventFilter), args.Error(1)
+	return args.Get(0).(*corev2.EventFilter), args.Error(1)
 }
 
 // UpdateFilter for use with mock lib
-func (c *MockClient) UpdateFilter(filter *types.EventFilter) error {
+func (c *MockClient) UpdateFilter(filter *corev2.EventFilter) error {
 	args := c.Called(filter)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"net/http"
+
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
 )
@@ -18,8 +20,8 @@ func (c *MockClient) Get(path string, obj interface{}) error {
 }
 
 // List ...
-func (c *MockClient) List(path string, objs interface{}, options *client.ListOptions) error {
-	args := c.Called(path, objs, options)
+func (c *MockClient) List(path string, objs interface{}, options *client.ListOptions, header *http.Header) error {
+	args := c.Called(path, objs, options, header)
 	return args.Error(0)
 }
 

--- a/cli/client/testing/mock_handler_client.go
+++ b/cli/client/testing/mock_handler_client.go
@@ -1,20 +1,11 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
-// ListHandlers for use with mock package
-func (c *MockClient) ListHandlers(namespace string, options *client.ListOptions) ([]corev2.Handler, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Handler), args.Error(1)
-}
-
 // CreateHandler for use with mock package
-func (c *MockClient) CreateHandler(h *types.Handler) error {
+func (c *MockClient) CreateHandler(h *corev2.Handler) error {
 	args := c.Called(h)
 	return args.Error(0)
 }
@@ -26,13 +17,13 @@ func (c *MockClient) DeleteHandler(namespace, name string) error {
 }
 
 // FetchHandler for use with mock lib
-func (c *MockClient) FetchHandler(name string) (*types.Handler, error) {
+func (c *MockClient) FetchHandler(name string) (*corev2.Handler, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.Handler), args.Error(1)
+	return args.Get(0).(*corev2.Handler), args.Error(1)
 }
 
 // UpdateHandler for use with mock lib
-func (c *MockClient) UpdateHandler(h *types.Handler) error {
+func (c *MockClient) UpdateHandler(h *corev2.Handler) error {
 	args := c.Called(h)
 	return args.Error(0)
 }

--- a/cli/client/testing/mock_hook_client.go
+++ b/cli/client/testing/mock_hook_client.go
@@ -1,20 +1,17 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateHook for use with mock lib
-func (c *MockClient) CreateHook(hook *types.HookConfig) error {
+func (c *MockClient) CreateHook(hook *corev2.HookConfig) error {
 	args := c.Called(hook)
 	return args.Error(0)
 }
 
 // UpdateHook for use with mock lib
-func (c *MockClient) UpdateHook(hook *types.HookConfig) error {
+func (c *MockClient) UpdateHook(hook *corev2.HookConfig) error {
 	args := c.Called(hook)
 	return args.Error(0)
 }
@@ -26,13 +23,7 @@ func (c *MockClient) DeleteHook(namespace, name string) error {
 }
 
 // FetchHook for use with mock lib
-func (c *MockClient) FetchHook(name string) (*types.HookConfig, error) {
+func (c *MockClient) FetchHook(name string) (*corev2.HookConfig, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.HookConfig), args.Error(1)
-}
-
-// ListHooks for use with mock lib
-func (c *MockClient) ListHooks(namespace string, options *client.ListOptions) ([]corev2.HookConfig, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.HookConfig), args.Error(1)
+	return args.Get(0).(*corev2.HookConfig), args.Error(1)
 }

--- a/cli/client/testing/mock_mutator_client.go
+++ b/cli/client/testing/mock_mutator_client.go
@@ -1,14 +1,11 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateMutator for use with mock package
-func (c *MockClient) CreateMutator(m *types.Mutator) error {
+func (c *MockClient) CreateMutator(m *corev2.Mutator) error {
 	args := c.Called(m)
 	return args.Error(0)
 }
@@ -20,19 +17,13 @@ func (c *MockClient) DeleteMutator(namespace, name string) error {
 }
 
 // FetchMutator for use with mock package
-func (c *MockClient) FetchMutator(name string) (*types.Mutator, error) {
+func (c *MockClient) FetchMutator(name string) (*corev2.Mutator, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.Mutator), args.Error(1)
+	return args.Get(0).(*corev2.Mutator), args.Error(1)
 }
 
 // UpdateMutator for use with mock package
-func (c *MockClient) UpdateMutator(m *types.Mutator) error {
+func (c *MockClient) UpdateMutator(m *corev2.Mutator) error {
 	args := c.Called(m)
 	return args.Error(0)
-}
-
-// ListMutators for use with mock lib
-func (c *MockClient) ListMutators(namespace string, options *client.ListOptions) ([]corev2.Mutator, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Mutator), args.Error(1)
 }

--- a/cli/client/testing/mock_namespace_client.go
+++ b/cli/client/testing/mock_namespace_client.go
@@ -1,20 +1,17 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateNamespace for use with mock lib
-func (c *MockClient) CreateNamespace(namespace *types.Namespace) error {
+func (c *MockClient) CreateNamespace(namespace *corev2.Namespace) error {
 	args := c.Called(namespace)
 	return args.Error(0)
 }
 
 // UpdateNamespace for use with mock lib
-func (c *MockClient) UpdateNamespace(namespace *types.Namespace) error {
+func (c *MockClient) UpdateNamespace(namespace *corev2.Namespace) error {
 	args := c.Called(namespace)
 	return args.Error(0)
 }
@@ -25,14 +22,8 @@ func (c *MockClient) DeleteNamespace(namespace string) error {
 	return args.Error(0)
 }
 
-// ListNamespaces for use with mock lib
-func (c *MockClient) ListNamespaces(options *client.ListOptions) ([]corev2.Namespace, error) {
-	args := c.Called(options)
-	return args.Get(0).([]corev2.Namespace), args.Error(1)
-}
-
 // FetchNamespace for use with mock lib
-func (c *MockClient) FetchNamespace(namespace string) (*types.Namespace, error) {
+func (c *MockClient) FetchNamespace(namespace string) (*corev2.Namespace, error) {
 	args := c.Called(namespace)
-	return args.Get(0).(*types.Namespace), args.Error(1)
+	return args.Get(0).(*corev2.Namespace), args.Error(1)
 }

--- a/cli/client/testing/mock_role_client.go
+++ b/cli/client/testing/mock_role_client.go
@@ -1,32 +1,23 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateRole ...
-func (c *MockClient) CreateRole(check *types.Role) error {
+func (c *MockClient) CreateRole(check *corev2.Role) error {
 	args := c.Called(check)
 	return args.Error(0)
 }
 
 // FetchRole ...
-func (c *MockClient) FetchRole(name string) (*types.Role, error) {
+func (c *MockClient) FetchRole(name string) (*corev2.Role, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.Role), args.Error(1)
+	return args.Get(0).(*corev2.Role), args.Error(1)
 }
 
 // DeleteRole ...
 func (c *MockClient) DeleteRole(namespace, name string) error {
 	args := c.Called(namespace, name)
 	return args.Error(0)
-}
-
-// ListRoles ...
-func (c *MockClient) ListRoles(namespace string, options *client.ListOptions) ([]corev2.Role, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.Role), args.Error(1)
 }

--- a/cli/client/testing/mock_rolebinding_client.go
+++ b/cli/client/testing/mock_rolebinding_client.go
@@ -1,32 +1,23 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // CreateRoleBinding ...
-func (c *MockClient) CreateRoleBinding(obj *types.RoleBinding) error {
+func (c *MockClient) CreateRoleBinding(obj *corev2.RoleBinding) error {
 	args := c.Called(obj)
 	return args.Error(0)
 }
 
 // FetchRoleBinding ...
-func (c *MockClient) FetchRoleBinding(name string) (*types.RoleBinding, error) {
+func (c *MockClient) FetchRoleBinding(name string) (*corev2.RoleBinding, error) {
 	args := c.Called(name)
-	return args.Get(0).(*types.RoleBinding), args.Error(1)
+	return args.Get(0).(*corev2.RoleBinding), args.Error(1)
 }
 
 // DeleteRoleBinding ...
 func (c *MockClient) DeleteRoleBinding(namespace, name string) error {
 	args := c.Called(namespace, name)
 	return args.Error(0)
-}
-
-// ListRoleBindings ...
-func (c *MockClient) ListRoleBindings(namespace string, options *client.ListOptions) ([]corev2.RoleBinding, error) {
-	args := c.Called(namespace, options)
-	return args.Get(0).([]corev2.RoleBinding), args.Error(1)
 }

--- a/cli/client/testing/mock_silenced_client.go
+++ b/cli/client/testing/mock_silenced_client.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"net/http"
+
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
 
@@ -32,7 +34,7 @@ func (c *MockClient) FetchSilenced(id string) (*types.Silenced, error) {
 }
 
 // ListSilenceds for use with mock lib
-func (c *MockClient) ListSilenceds(namespace, sub, check string, options *client.ListOptions) ([]corev2.Silenced, error) {
-	args := c.Called(namespace, sub, check, options)
+func (c *MockClient) ListSilenceds(namespace, sub, check string, options *client.ListOptions, header *http.Header) ([]corev2.Silenced, error) {
+	args := c.Called(namespace, sub, check, options, header)
 	return args.Get(0).([]corev2.Silenced), args.Error(1)
 }

--- a/cli/client/testing/mock_user_client.go
+++ b/cli/client/testing/mock_user_client.go
@@ -1,9 +1,6 @@
 package testing
 
 import (
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/types"
-
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
@@ -14,7 +11,7 @@ func (c *MockClient) AddGroupToUser(username, group string) error {
 }
 
 // CreateUser for use with mock lib
-func (c *MockClient) CreateUser(user *types.User) error {
+func (c *MockClient) CreateUser(user *corev2.User) error {
 	args := c.Called(user)
 	return args.Error(0)
 }
@@ -26,15 +23,9 @@ func (c *MockClient) DisableUser(username string) error {
 }
 
 // FetchUser for use with mock lib
-func (c *MockClient) FetchUser(username string) (*types.User, error) {
+func (c *MockClient) FetchUser(username string) (*corev2.User, error) {
 	args := c.Called(username)
-	return args.Get(0).(*types.User), args.Error(1)
-}
-
-// ListUsers for use with mock lib
-func (c *MockClient) ListUsers(options *client.ListOptions) ([]corev2.User, error) {
-	args := c.Called(options)
-	return args.Get(0).([]corev2.User), args.Error(1)
+	return args.Get(0).(*corev2.User), args.Error(1)
 }
 
 // ReinstateUser for use with mock lib

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -4,14 +4,14 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
-var usersPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "users")
+// UsersPath is the api path for users.
+var UsersPath = CreateBasePath(coreAPIGroup, coreAPIVersion, "users")
 
 // AddGroupToUser makes "username" a member of "group".
 func (client *RestClient) AddGroupToUser(username, group string) error {
-	path := usersPath(username, "groups", group)
+	path := UsersPath(username, "groups", group)
 	res, err := client.R().Put(path)
 	if err != nil {
 		return err
@@ -25,8 +25,8 @@ func (client *RestClient) AddGroupToUser(username, group string) error {
 }
 
 // CreateUser creates new check on configured Sensu instance
-func (client *RestClient) CreateUser(user *types.User) error {
-	path := usersPath("")
+func (client *RestClient) CreateUser(user *corev2.User) error {
+	path := UsersPath("")
 	res, err := client.R().SetBody(user).Post(path)
 	if err != nil {
 		return err
@@ -41,7 +41,7 @@ func (client *RestClient) CreateUser(user *types.User) error {
 
 // DisableUser disables a user on configured Sensu instance
 func (client *RestClient) DisableUser(username string) error {
-	path := usersPath(username)
+	path := UsersPath(username)
 	res, err := client.R().Delete(path)
 
 	if err != nil {
@@ -56,9 +56,9 @@ func (client *RestClient) DisableUser(username string) error {
 }
 
 // FetchUser retrieve the given user
-func (client *RestClient) FetchUser(username string) (*types.User, error) {
-	user := &types.User{}
-	path := usersPath(username)
+func (client *RestClient) FetchUser(username string) (*corev2.User, error) {
+	user := &corev2.User{}
+	path := UsersPath(username)
 	res, err := client.R().Get(path)
 
 	if err != nil {
@@ -73,20 +73,9 @@ func (client *RestClient) FetchUser(username string) (*types.User, error) {
 	return user, err
 }
 
-// ListUsers fetches all users from configured Sensu instance
-func (client *RestClient) ListUsers(options *ListOptions) ([]corev2.User, error) {
-	var users []corev2.User
-
-	if err := client.List(usersPath(), &users, options); err != nil {
-		return users, err
-	}
-
-	return users, nil
-}
-
 // ReinstateUser reinstates a disabled user on configured Sensu instance
 func (client *RestClient) ReinstateUser(username string) error {
-	path := usersPath(username, "reinstate")
+	path := UsersPath(username, "reinstate")
 	res, err := client.R().Put(path)
 
 	if err != nil {
@@ -102,7 +91,7 @@ func (client *RestClient) ReinstateUser(username string) error {
 
 // RemoveGroupFromUser removes "username" from the given "group".
 func (client *RestClient) RemoveGroupFromUser(username, group string) error {
-	path := usersPath(username, "groups", group)
+	path := UsersPath(username, "groups", group)
 	res, err := client.R().Delete(path)
 	if err != nil {
 		return err
@@ -115,9 +104,9 @@ func (client *RestClient) RemoveGroupFromUser(username, group string) error {
 	return nil
 }
 
-// RemoveGroupsFromUser removes all the groups for "username".
+// RemoveAllGroupsFromUser removes all the groups for "username".
 func (client *RestClient) RemoveAllGroupsFromUser(username string) error {
-	path := usersPath(username, "groups")
+	path := UsersPath(username, "groups")
 	res, err := client.R().Delete(path)
 	if err != nil {
 		return err
@@ -157,7 +146,7 @@ func (client *RestClient) UpdatePassword(username, pwd string) error {
 		return err
 	}
 
-	path := usersPath(username, "password")
+	path := UsersPath(username, "password")
 	res, err := client.R().
 		SetBody(bytes).
 		Put(path)

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -4,14 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"path"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -38,17 +40,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch assets from API
-			results, err := cli.Client.ListAssets(namespace, &opts)
+			var header http.Header
+			results := []corev2.Asset{}
+			err = cli.Client.List(client.AssetsPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -67,7 +71,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				asset, ok := data.(types.Asset)
+				asset, ok := data.(corev2.Asset)
 				if !ok {
 					return cli.TypeError
 				}
@@ -77,7 +81,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "URL",
 			CellTransformer: func(data interface{}) string {
-				asset, ok := data.(types.Asset)
+				asset, ok := data.(corev2.Asset)
 				if !ok {
 					return cli.TypeError
 				}
@@ -97,7 +101,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Hash",
 			CellTransformer: func(data interface{}) string {
-				asset, ok := data.(types.Asset)
+				asset, ok := data.(corev2.Asset)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/check/list.go
+++ b/cli/commands/check/list.go
@@ -3,15 +3,17 @@ package check
 import (
 	"errors"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/globals"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -38,17 +40,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch checks from the API
-			results, err := cli.Client.ListChecks(namespace, &opts)
+			var header http.Header
+			results := []corev2.CheckConfig{}
+			err = cli.Client.List(client.ChecksPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -67,7 +71,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -77,7 +81,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Command",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -87,7 +91,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Interval",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -98,7 +102,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Cron",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -108,7 +112,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Timeout",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -119,7 +123,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "TTL",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -130,7 +134,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Subscriptions",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -140,7 +144,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Handlers",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -150,7 +154,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Assets",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -160,7 +164,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Hooks",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -170,7 +174,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Publish?",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -180,7 +184,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Stdin?",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -190,7 +194,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Metric Format",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}
@@ -200,7 +204,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Metric Handlers",
 			CellTransformer: func(data interface{}) string {
-				check, ok := data.(types.CheckConfig)
+				check, ok := data.(corev2.CheckConfig)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -2,12 +2,14 @@ package check
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,10 +32,16 @@ func TestListCommandRunEClosure(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{
-		*types.FixtureCheckConfig("name-one"),
-		*types.FixtureCheckConfig("name-two"),
-	}, nil)
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.CheckConfig)
+			*resources = []corev2.CheckConfig{
+				*corev2.FixtureCheckConfig("name-one"),
+				*corev2.FixtureCheckConfig("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -43,6 +51,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	assert.Contains(out, "name-one")
 	assert.Contains(out, "name-two")
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 
 func TestListCommandRunEClosureWithAll(t *testing.T) {
@@ -50,9 +59,15 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", "", mock.Anything).Return([]types.CheckConfig{
-		*types.FixtureCheckConfig("name-one"),
-	}, nil)
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.CheckConfig)
+			*resources = []corev2.CheckConfig{
+				*corev2.FixtureCheckConfig("name-one"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -66,11 +81,19 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 
-	check := types.FixtureCheckConfig("name-one")
+	check := corev2.FixtureCheckConfig("name-one")
 	check.RuntimeAssets = []string{"asset-one"}
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{*check}, nil)
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.CheckConfig)
+			*resources = []corev2.CheckConfig{
+				*check,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -94,7 +117,8 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListChecks", mock.Anything, mock.Anything).Return([]types.CheckConfig{}, errors.New("my-err"))
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -109,11 +133,17 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	checkConfig := types.FixtureCheckConfig("name-one")
+	checkConfig := corev2.FixtureCheckConfig("name-one")
 	checkConfig.Command = "echo foo && exit 1"
-	client.On("ListChecks", "", mock.Anything).Return([]types.CheckConfig{
-		*checkConfig,
-	}, nil)
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.CheckConfig)
+			*resources = []corev2.CheckConfig{
+				*checkConfig,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -135,4 +165,33 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.CheckConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.CheckConfig)
+			*resources = []corev2.CheckConfig{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/clusterrole/list.go
+++ b/cli/commands/clusterrole/list.go
@@ -2,12 +2,14 @@ package clusterrole
 
 import (
 	"io"
+	"net/http"
 	"strconv"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -25,17 +27,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListClusterRoles(&opts)
+			var header http.Header
+			results := []corev2.ClusterRole{}
+			err = cli.Client.List(client.ClusterRolesPath(), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -52,7 +56,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.ClusterRole)
+				role, ok := data.(corev2.ClusterRole)
 				if !ok {
 					return cli.TypeError
 				}
@@ -62,7 +66,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Rules",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.ClusterRole)
+				role, ok := data.(corev2.ClusterRole)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/clusterrole/list_test.go
+++ b/cli/commands/clusterrole/list_test.go
@@ -2,11 +2,13 @@ package clusterrole
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -24,14 +26,21 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{
-		*types.FixtureClusterRole("one"),
-		*types.FixtureClusterRole("two"),
-	}, nil)
+	resources := []corev2.ClusterRole{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.ClusterRole)
+			*resources = []corev2.ClusterRole{
+				*corev2.FixtureClusterRole("one"),
+				*corev2.FixtureClusterRole("two"),
+			}
+		},
+	)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -39,10 +48,16 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("")
 	client := cli.Client.(*client.MockClient)
-	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{
-		*types.FixtureClusterRole("one"),
-		*types.FixtureClusterRole("two"),
-	}, nil)
+	resources := []corev2.ClusterRole{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.ClusterRole)
+			*resources = []corev2.ClusterRole{
+				*corev2.FixtureClusterRole("one"),
+				*corev2.FixtureClusterRole("two"),
+			}
+		},
+	)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -55,10 +70,40 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListClusterRoles", mock.Anything).Return([]types.ClusterRole{}, errors.New("fire"))
+	resources := []corev2.ClusterRole{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("fire"))
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.ClusterRole{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.ClusterRole)
+			*resources = []corev2.ClusterRole{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/clusterrolebinding/list.go
+++ b/cli/commands/clusterrolebinding/list.go
@@ -2,12 +2,14 @@ package clusterrolebinding
 
 import (
 	"io"
+	"net/http"
 	"strconv"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -25,17 +27,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListClusterRoleBindings(&opts)
+			var header http.Header
+			results := []corev2.ClusterRoleBinding{}
+			err = cli.Client.List(client.ClusterRoleBindingsPath(), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -52,7 +56,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
+				clusterRoleBinding, ok := data.(corev2.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -62,7 +66,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Cluster Role",
 			CellTransformer: func(data interface{}) string {
-				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
+				clusterRoleBinding, ok := data.(corev2.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -72,7 +76,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Subjects",
 			CellTransformer: func(data interface{}) string {
-				clusterRoleBinding, ok := data.(types.ClusterRoleBinding)
+				clusterRoleBinding, ok := data.(corev2.ClusterRoleBinding)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/clusterrolebinding/list_test.go
+++ b/cli/commands/clusterrolebinding/list_test.go
@@ -1,10 +1,15 @@
 package clusterrolebinding
 
 import (
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestListCommand(t *testing.T) {
@@ -15,4 +20,33 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("list", cmd.Use)
 	assert.Regexp("role bindings", cmd.Short)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.ClusterRoleBinding{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.ClusterRoleBinding)
+			*resources = []corev2.ClusterRoleBinding{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -2,12 +2,14 @@ package entity
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,10 +32,16 @@ func TestListCommandRunEClosure(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListEntities", mock.Anything, mock.Anything).Return([]types.Entity{
-		*types.FixtureEntity("name-one"),
-		*types.FixtureEntity("name-two"),
-	}, nil)
+	resources := []corev2.Entity{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Entity)
+			*resources = []corev2.Entity{
+				*corev2.FixtureEntity("name-one"),
+				*corev2.FixtureEntity("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -42,6 +50,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	assert.Contains(out, "name-one")
 	assert.Contains(out, "name-two")
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 
 func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
@@ -49,9 +58,15 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListEntities", "", mock.Anything).Return([]types.Entity{
-		*types.FixtureEntity("name-two"),
-	}, nil)
+	resources := []corev2.Entity{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Entity)
+			*resources = []corev2.Entity{
+				*corev2.FixtureEntity("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.AllNamespaces, "t"))
@@ -66,10 +81,16 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListEntities", mock.Anything, mock.Anything).Return([]types.Entity{
-		*types.FixtureEntity("name-one"),
-		*types.FixtureEntity("name-two"),
-	}, nil)
+	resources := []corev2.Entity{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Entity)
+			*resources = []corev2.Entity{
+				*corev2.FixtureEntity("name-one"),
+				*corev2.FixtureEntity("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "none"))
@@ -89,7 +110,8 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListEntities", mock.Anything, mock.Anything).Return([]types.Entity{}, errors.New("my-err"))
+	resources := []corev2.Entity{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -110,4 +132,33 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Entity{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Entity)
+			*resources = []corev2.Entity{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -3,15 +3,17 @@ package event
 import (
 	"errors"
 	"io"
+	"net/http"
 	"strconv"
 	"time"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/globals"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -38,17 +40,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch events from API
-			results, err := cli.Client.ListEvents(namespace, &opts)
+			var header http.Header
+			results := []corev2.Event{}
+			err = cli.Client.List(client.EventsPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -67,7 +71,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Entity",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}
@@ -77,7 +81,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Check",
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}
@@ -87,7 +91,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Output",
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}
@@ -97,7 +101,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Status",
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}
@@ -107,7 +111,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Silenced",
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}
@@ -117,7 +121,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Timestamp",
 			CellTransformer: func(data interface{}) string {
-				event, ok := data.(types.Event)
+				event, ok := data.(corev2.Event)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/extension/list.go
+++ b/cli/commands/extension/list.go
@@ -4,15 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"path"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -41,7 +42,7 @@ func runList(config string, c client.APIClient, namespace, format string) func(*
 			return errors.New("invalid arguments received")
 		}
 		if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-			namespace = types.NamespaceTypeAll
+			namespace = corev2.NamespaceTypeAll
 		}
 
 		opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -49,17 +50,20 @@ func runList(config string, c client.APIClient, namespace, format string) func(*
 			return err
 		}
 
-		extensions, err := c.ListExtensions(namespace, &opts)
+		// Fetch filters from the API
+		var header http.Header
+		results := []corev2.Extension{}
+		err = c.List(client.ExtPath(namespace), &results, &opts, &header)
 		if err != nil {
 			return err
 		}
 
 		// Print the results based on the user preferences
-		resources := []types.Resource{}
-		for i := range extensions {
-			resources = append(resources, &extensions[i])
+		resources := []corev2.Resource{}
+		for i := range results {
+			resources = append(resources, &results[i])
 		}
-		return helpers.Print(cmd, config, printToTable, resources, extensions)
+		return helpers.PrintList(cmd, config, printToTable, resources, results, header)
 	}
 }
 
@@ -69,7 +73,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				extension, ok := data.(types.Extension)
+				extension, ok := data.(corev2.Extension)
 				if !ok {
 					return cli.TypeError
 				}
@@ -79,7 +83,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "URL",
 			CellTransformer: func(data interface{}) string {
-				extension, ok := data.(types.Extension)
+				extension, ok := data.(corev2.Extension)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/filter/list.go
+++ b/cli/commands/filter/list.go
@@ -4,13 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -28,7 +30,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -37,17 +39,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch filters from the API
-			results, err := cli.Client.ListFilters(namespace, &opts)
+			var header http.Header
+			results := []corev2.EventFilter{}
+			err = cli.Client.List(client.FiltersPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -66,7 +70,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				filter, ok := data.(types.EventFilter)
+				filter, ok := data.(corev2.EventFilter)
 				if !ok {
 					return cli.TypeError
 				}
@@ -76,7 +80,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Action",
 			CellTransformer: func(data interface{}) string {
-				filter, ok := data.(types.EventFilter)
+				filter, ok := data.(corev2.EventFilter)
 				if !ok {
 					return cli.TypeError
 				}
@@ -86,16 +90,16 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Expressions",
 			CellTransformer: func(data interface{}) string {
-				filter, ok := data.(types.EventFilter)
+				filter, ok := data.(corev2.EventFilter)
 				if !ok {
 					return cli.TypeError
 				}
 				var expressions []string
 				var sep string
 				switch action := filter.Action; action {
-				case types.EventFilterActionAllow:
+				case corev2.EventFilterActionAllow:
 					sep = " && "
-				case types.EventFilterActionDeny:
+				case corev2.EventFilterActionDeny:
 					sep = " || "
 				default:
 					sep = ", "

--- a/cli/commands/handler/list.go
+++ b/cli/commands/handler/list.go
@@ -4,14 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -29,7 +31,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -38,17 +40,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch handlers from API
-			results, err := cli.Client.ListHandlers(namespace, &opts)
+			var header http.Header
+			results := []corev2.Handler{}
+			err = cli.Client.List(client.HandlersPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -67,7 +71,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -77,7 +81,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Type",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -87,7 +91,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Timeout",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -97,7 +101,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Filters",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -107,7 +111,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Mutator",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -117,14 +121,14 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Execute",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
 				switch handler.Type {
-				case types.HandlerTCPType:
+				case corev2.HandlerTCPType:
 					fallthrough
-				case types.HandlerUDPType:
+				case corev2.HandlerUDPType:
 					return fmt.Sprintf(
 						"%s %s://%s:%d",
 						table.TitleStyle("PUSH:"),
@@ -132,13 +136,13 @@ func printToTable(results interface{}, writer io.Writer) {
 						handler.Socket.Host,
 						handler.Socket.Port,
 					)
-				case types.HandlerPipeType:
+				case corev2.HandlerPipeType:
 					return fmt.Sprintf(
 						"%s  %s",
 						table.TitleStyle("RUN:"),
 						handler.Command,
 					)
-				case types.HandlerSetType:
+				case corev2.HandlerSetType:
 					return fmt.Sprintf(
 						"%s %s",
 						table.TitleStyle("CALL:"),
@@ -153,7 +157,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Environment Variables",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}
@@ -163,7 +167,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Assets",
 			CellTransformer: func(data interface{}) string {
-				handler, ok := data.(types.Handler)
+				handler, ok := data.(corev2.Handler)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
@@ -12,6 +13,19 @@ import (
 )
 
 type printTableFunc func(interface{}, io.Writer)
+
+// HeaderWarning is the header key for entity limit warnings
+const HeaderWarning = "Sensu-Entity-Warning"
+
+// PrintList prints a list of resources to stdout with a title, if relevant.
+func PrintList(cmd *cobra.Command, format string, printTable printTableFunc, objects []types.Resource, v interface{}, header http.Header) error {
+	if warning := header.Get(HeaderWarning); warning != "" {
+		if err := PrintTitle(GetChangedStringValueFlag(flags.Format, cmd.Flags()), format, warning, cmd.OutOrStdout()); err != nil {
+			return err
+		}
+	}
+	return Print(cmd, format, printTable, objects, v)
+}
 
 // Print displays
 func Print(cmd *cobra.Command, format string, printTable printTableFunc, objects []types.Resource, v interface{}) error {

--- a/cli/commands/hook/list_test.go
+++ b/cli/commands/hook/list_test.go
@@ -2,12 +2,14 @@ package hook
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,10 +32,16 @@ func TestListCommandRunEClosure(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{
-		*types.FixtureHookConfig("name-one"),
-		*types.FixtureHookConfig("name-two"),
-	}, nil)
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.HookConfig)
+			*resources = []corev2.HookConfig{
+				*corev2.FixtureHookConfig("name-one"),
+				*corev2.FixtureHookConfig("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -43,6 +51,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	assert.Contains(out, "name-one")
 	assert.Contains(out, "name-two")
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 
 func TestListCommandRunEClosureWithAll(t *testing.T) {
@@ -50,9 +59,15 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", "", mock.Anything).Return([]types.HookConfig{
-		*types.FixtureHookConfig("name-one"),
-	}, nil)
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.HookConfig)
+			*resources = []corev2.HookConfig{
+				*corev2.FixtureHookConfig("name-one"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -66,10 +81,18 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 
-	hook := types.FixtureHookConfig("name-one")
+	hook := corev2.FixtureHookConfig("name-one")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{*hook}, nil)
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.HookConfig)
+			*resources = []corev2.HookConfig{
+				*hook,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -89,7 +112,8 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListHooks", mock.Anything, mock.Anything).Return([]types.HookConfig{}, errors.New("my-err"))
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -104,11 +128,17 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	hookConfig := types.FixtureHookConfig("name-one")
+	hookConfig := corev2.FixtureHookConfig("name-one")
 	hookConfig.Command = "echo foo && exit 1"
-	client.On("ListHooks", "", mock.Anything).Return([]types.HookConfig{
-		*hookConfig,
-	}, nil)
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.HookConfig)
+			*resources = []corev2.HookConfig{
+				*hookConfig,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -130,4 +160,33 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.HookConfig{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.HookConfig)
+			*resources = []corev2.HookConfig{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/mutator/list_test.go
+++ b/cli/commands/mutator/list_test.go
@@ -2,12 +2,14 @@ package mutator
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -30,10 +32,16 @@ func TestListCommandRunEClosure(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{
-		*types.FixtureMutator("name-one"),
-		*types.FixtureMutator("name-two"),
-	}, nil)
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Mutator)
+			*resources = []corev2.Mutator{
+				*corev2.FixtureMutator("name-one"),
+				*corev2.FixtureMutator("name-two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "json"))
@@ -43,6 +51,7 @@ func TestListCommandRunEClosure(t *testing.T) {
 	assert.Contains(out, "name-one")
 	assert.Contains(out, "name-two")
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 
 func TestListCommandRunEClosureWithAll(t *testing.T) {
@@ -50,9 +59,15 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", "", mock.Anything).Return([]types.Mutator{
-		*types.FixtureMutator("name-one"),
-	}, nil)
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Mutator)
+			*resources = []corev2.Mutator{
+				*corev2.FixtureMutator("name-one"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -66,10 +81,18 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 
-	mutator := types.FixtureMutator("name-one")
+	mutator := corev2.FixtureMutator("name-one")
 
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{*mutator}, nil)
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Mutator)
+			*resources = []corev2.Mutator{
+				*mutator,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "none"))
@@ -88,7 +111,8 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListMutators", mock.Anything, mock.Anything).Return([]types.Mutator{}, errors.New("my-err"))
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("my-err"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -103,9 +127,17 @@ func TestListCommandRunEClosureWithAlphaNumericChars(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	mutator := types.FixtureMutator("name-one")
+	mutator := corev2.FixtureMutator("name-one")
 	mutator.Command = "echo foo && exit 1"
-	client.On("ListMutators", "", mock.Anything).Return([]types.Mutator{*mutator}, nil)
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Mutator)
+			*resources = []corev2.Mutator{
+				*mutator,
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
@@ -127,4 +159,33 @@ func TestListFlags(t *testing.T) {
 
 	flag = cmd.Flag("format")
 	assert.NotNil(flag)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Mutator{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Mutator)
+			*resources = []corev2.Mutator{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/namespace/list.go
+++ b/cli/commands/namespace/list.go
@@ -3,11 +3,13 @@ package namespace
 import (
 	"errors"
 	"io"
+	"net/http"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -30,17 +32,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch namespaces from API
-			results, err := cli.Client.ListNamespaces(&opts)
+			var header http.Header
+			results := []corev2.Namespace{}
+			err = cli.Client.List(client.NamespacesPath(), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -58,7 +62,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				namespace, ok := data.(types.Namespace)
+				namespace, ok := data.(corev2.Namespace)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/namespace/list_test.go
+++ b/cli/commands/namespace/list_test.go
@@ -2,11 +2,13 @@ package namespace
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -28,16 +30,23 @@ func TestListCommandRunEClosure(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{
-		*types.FixtureNamespace("one"),
-		*types.FixtureNamespace("two"),
-	}, nil)
+	resources := []corev2.Namespace{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Namespace)
+			*resources = []corev2.Namespace{
+				*corev2.FixtureNamespace("one"),
+				*corev2.FixtureNamespace("two"),
+			}
+		},
+	)
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 
 func TestListCommandRunEClosureWithErr(t *testing.T) {
@@ -45,7 +54,8 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListNamespaces", mock.Anything).Return([]types.Namespace{}, errors.New("fire"))
+	resources := []corev2.Namespace{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("fire"))
 
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
@@ -53,4 +63,33 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Namespace{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Namespace)
+			*resources = []corev2.Namespace{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/role/list.go
+++ b/cli/commands/role/list.go
@@ -2,13 +2,15 @@ package role
 
 import (
 	"io"
+	"net/http"
 	"strconv"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -22,7 +24,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -31,17 +33,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch roles from API
-			results, err := cli.Client.ListRoles(namespace, &opts)
+			var header http.Header
+			results := []corev2.Role{}
+			err = cli.Client.List(client.RolesPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -59,7 +63,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				role, ok := data.(corev2.Role)
 				if !ok {
 					return cli.TypeError
 				}
@@ -69,7 +73,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Namespace",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				role, ok := data.(corev2.Role)
 				if !ok {
 					return cli.TypeError
 				}
@@ -79,7 +83,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Rules",
 			CellTransformer: func(data interface{}) string {
-				role, ok := data.(types.Role)
+				role, ok := data.(corev2.Role)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/role/list_test.go
+++ b/cli/commands/role/list_test.go
@@ -2,11 +2,13 @@ package role
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -24,14 +26,21 @@ func TestListCommandRunEClosureJSONFormat(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{
-		*types.FixtureRole("one", "default"),
-		*types.FixtureRole("two", "default"),
-	}, nil)
+	resources := []corev2.Role{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Role)
+			*resources = []corev2.Role{
+				*corev2.FixtureRole("one", "default"),
+				*corev2.FixtureRole("two", "default"),
+			}
+		},
+	)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
 	assert.Nil(err)
+	assert.NotContains(out, "==")
 }
 func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	assert := assert.New(t)
@@ -39,10 +48,16 @@ func TestListCommandRunEClosureTabularFormat(t *testing.T) {
 	config := cli.Config.(*client.MockConfig)
 	config.On("Format").Return("")
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{
-		*types.FixtureRole("one", "default"),
-		*types.FixtureRole("two", "default"),
-	}, nil)
+	resources := []corev2.Role{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Role)
+			*resources = []corev2.Role{
+				*corev2.FixtureRole("one", "default"),
+				*corev2.FixtureRole("two", "default"),
+			}
+		},
+	)
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
@@ -55,10 +70,40 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewCLI()
 	client := cli.Client.(*client.MockClient)
-	client.On("ListRoles", "default", mock.Anything).Return([]types.Role{}, errors.New("fire"))
+	resources := []corev2.Role{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("fire"))
 	cmd := ListCommand(cli)
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Empty(out)
 	assert.NotNil(err)
 	assert.Equal("fire", err.Error())
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Role{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Role)
+			*resources = []corev2.Role{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/rolebinding/list.go
+++ b/cli/commands/rolebinding/list.go
@@ -2,13 +2,15 @@ package rolebinding
 
 import (
 	"io"
+	"net/http"
 	"strconv"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -22,7 +24,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace := cli.Config.Namespace()
 			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 
 			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
@@ -31,17 +33,19 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// Fetch role bindings from API
-			results, err := cli.Client.ListRoleBindings(namespace, &opts)
+			var header http.Header
+			results := []corev2.RoleBinding{}
+			err = cli.Client.List(client.RoleBindingsPath(namespace), &results, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -60,7 +64,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				roleBinding, ok := data.(types.RoleBinding)
+				roleBinding, ok := data.(corev2.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -70,7 +74,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Namespace",
 			CellTransformer: func(data interface{}) string {
-				roleBinding, ok := data.(types.RoleBinding)
+				roleBinding, ok := data.(corev2.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -80,7 +84,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Cluster Role",
 			CellTransformer: func(data interface{}) string {
-				roleBinding, ok := data.(types.RoleBinding)
+				roleBinding, ok := data.(corev2.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -93,7 +97,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Role",
 			CellTransformer: func(data interface{}) string {
-				roleBinding, ok := data.(types.RoleBinding)
+				roleBinding, ok := data.(corev2.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}
@@ -106,7 +110,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Subjects",
 			CellTransformer: func(data interface{}) string {
-				roleBinding, ok := data.(types.RoleBinding)
+				roleBinding, ok := data.(corev2.RoleBinding)
 				if !ok {
 					return cli.TypeError
 				}

--- a/cli/commands/rolebinding/list_test.go
+++ b/cli/commands/rolebinding/list_test.go
@@ -1,10 +1,15 @@
 package rolebinding
 
 import (
+	"net/http"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestListCommand(t *testing.T) {
@@ -15,4 +20,33 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("list", cmd.Use)
 	assert.Regexp("role bindings", cmd.Short)
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.RoleBinding{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.RoleBinding)
+			*resources = []corev2.RoleBinding{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
 }

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -4,14 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/globals"
 	"github.com/sensu/sensu-go/cli/elements/table"
-	"github.com/sensu/sensu-go/types"
 
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			if ok, err := flg.GetBool(flags.AllNamespaces); err != nil {
 				return err
 			} else if ok {
-				namespace = types.NamespaceTypeAll
+				namespace = corev2.NamespaceTypeAll
 			}
 			// Fetch silenceds from the API
 			sub, err := flg.GetString("subscription")
@@ -41,7 +42,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 
 			// We do not support both subscription and all-namespaces flags together
-			if sub != "" && namespace == types.NamespaceTypeAll {
+			if sub != "" && namespace == corev2.NamespaceTypeAll {
 				return fmt.Errorf("the subscription and %s flags are mutually exclusive", flags.AllNamespaces)
 			}
 
@@ -56,17 +57,18 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
-			results, err := cli.Client.ListSilenceds(namespace, sub, check, &opts)
+			var header http.Header
+			results, err := cli.Client.ListSilenceds(namespace, sub, check, &opts, &header)
 			if err != nil {
 				return err
 			}
 
 			// Print the results based on the user preferences
-			resources := []types.Resource{}
+			resources := []corev2.Resource{}
 			for i := range results {
 				resources = append(resources, &results[i])
 			}
-			return helpers.Print(cmd, cli.Config.Format(), printToTable, resources, results)
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
 		},
 	}
 
@@ -89,7 +91,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Name",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -99,7 +101,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Subscription",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -109,7 +111,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Check",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -119,7 +121,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Begin",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -129,7 +131,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Expire",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -139,7 +141,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "ExpireOnResolve",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -149,7 +151,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Creator",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -159,7 +161,7 @@ func printToTable(results interface{}, writer io.Writer) {
 		{
 			Title: "Reason",
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
@@ -170,7 +172,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			Title:       "Namespace",
 			ColumnStyle: table.PrimaryTextStyle,
 			CellTransformer: func(data interface{}) string {
-				silenced, ok := data.(types.Silenced)
+				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}


### PR DESCRIPTION
## What is this change?

Removes resource specific list commands from the client (with the exception of ❄️ silenceds). Refactors sensuctl list commands so that they use the generic client.

## Why is this change necessary?

Removes technical debt, required for work in sensu-enterprise-go. Is a major improvement from the initial attempt https://github.com/sensu/sensu-go/pull/2903 where 30 more files were refactored.

## Does your change need a Changelog entry?

No. This is mostly an internal refactor that has no real OSS user impact.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Unit tests and `sensuctl [resource] list` on all impacted resources.