### PR TITLE
Asset builds support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ backend to use JSON.
 - Added `event.check.name` as a supported field selector.
 - [Web] Added timeline chart to event details view.
 - Added `entity.system.arm_version` to record the value of `GOARM` at compile time.
+- Added `builds` field to the `Asset` type to allow assets to specify different
+URLs for each platform/architecture/arch_version.
 
 ### Changed
 - The project now uses Go modules instead of dep for dependency management.

--- a/api/core/v2/asset.pb.go
+++ b/api/core/v2/asset.pb.go
@@ -24,7 +24,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-// Asset defines an asset agents install as a dependency for a check.
+// Asset defines an asset and optionally a list of assets (builds) that agents install as a dependency for a check, handler, mutator, etc.
 type Asset struct {
 	// URL is the location of the asset
 	URL string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
@@ -34,6 +34,8 @@ type Asset struct {
 	// if the asset should be installed. If more than one filter is present the
 	// queries are joined by the "AND" operator.
 	Filters []string `protobuf:"bytes,5,rep,name=filters,proto3" json:"filters"`
+	// AssetBuilds are a list of one or more assets to install.
+	Builds []*AssetBuild `protobuf:"bytes,6,rep,name=builds,proto3" json:"builds"`
 	// Metadata contains the name, namespace, labels and annotations of the asset
 	ObjectMeta `protobuf:"bytes,8,opt,name=metadata,proto3,embedded=metadata" json:"metadata,omitempty"`
 	// Headers is a collection of key/value string pairs used as HTTP headers
@@ -77,38 +79,94 @@ func (m *Asset) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Asset proto.InternalMessageInfo
 
+// AssetBuild defines an individual asset that an asset can install as a dependency for a check, handler, mutator, etc.
+type AssetBuild struct {
+	// URL is the location of the asset
+	URL string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	// Sha512 is the SHA-512 checksum of the asset
+	Sha512 string `protobuf:"bytes,3,opt,name=sha512,proto3" json:"sha512,omitempty"`
+	// Filters are a collection of sensu queries, used by the system to determine
+	// if the asset should be installed. If more than one filter is present the
+	// queries are joined by the "AND" operator.
+	Filters []string `protobuf:"bytes,5,rep,name=filters,proto3" json:"filters"`
+	// Headers is a collection of key/value string pairs used as HTTP headers
+	// for asset retrieval.
+	Headers              map[string]string `protobuf:"bytes,9,rep,name=headers,proto3" json:"headers" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
+}
+
+func (m *AssetBuild) Reset()         { *m = AssetBuild{} }
+func (m *AssetBuild) String() string { return proto.CompactTextString(m) }
+func (*AssetBuild) ProtoMessage()    {}
+func (*AssetBuild) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4785e5163229d617, []int{1}
+}
+func (m *AssetBuild) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *AssetBuild) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_AssetBuild.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *AssetBuild) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AssetBuild.Merge(m, src)
+}
+func (m *AssetBuild) XXX_Size() int {
+	return m.Size()
+}
+func (m *AssetBuild) XXX_DiscardUnknown() {
+	xxx_messageInfo_AssetBuild.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AssetBuild proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*Asset)(nil), "sensu.core.v2.Asset")
 	proto.RegisterMapType((map[string]string)(nil), "sensu.core.v2.Asset.HeadersEntry")
+	proto.RegisterType((*AssetBuild)(nil), "sensu.core.v2.AssetBuild")
+	proto.RegisterMapType((map[string]string)(nil), "sensu.core.v2.AssetBuild.HeadersEntry")
 }
 
 func init() { proto.RegisterFile("asset.proto", fileDescriptor_4785e5163229d617) }
 
 var fileDescriptor_4785e5163229d617 = []byte{
-	// 359 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x5c, 0x50, 0x4d, 0x4a, 0xc3, 0x40,
-	0x18, 0xed, 0x24, 0xf4, 0x6f, 0xa2, 0x20, 0x83, 0x48, 0xda, 0xc5, 0x24, 0x0a, 0x42, 0x16, 0x32,
-	0xa5, 0x51, 0x41, 0xba, 0xd2, 0x80, 0xd0, 0x85, 0x22, 0x04, 0xba, 0x71, 0x37, 0x69, 0xa7, 0x3f,
-	0xda, 0x74, 0x4a, 0x32, 0x09, 0xf4, 0x06, 0x1e, 0xc1, 0x65, 0x97, 0x3d, 0x82, 0x47, 0xe8, 0xb2,
-	0x27, 0x08, 0x1a, 0x77, 0x3d, 0x81, 0x4b, 0xc9, 0xa4, 0x11, 0x75, 0xf7, 0xbe, 0x37, 0xef, 0x7b,
-	0x6f, 0xde, 0x07, 0x35, 0x1a, 0x86, 0x4c, 0x90, 0x79, 0xc0, 0x05, 0x47, 0xfb, 0x21, 0x9b, 0x85,
-	0x11, 0xe9, 0xf3, 0x80, 0x91, 0xd8, 0x6e, 0x5e, 0x8c, 0x26, 0x62, 0x1c, 0x79, 0xa4, 0xcf, 0xfd,
-	0xd6, 0x88, 0x8f, 0x78, 0x4b, 0xaa, 0xbc, 0x68, 0x78, 0x1d, 0xb7, 0x89, 0x4d, 0xda, 0x92, 0x94,
-	0x9c, 0x44, 0xb9, 0x49, 0x13, 0xfa, 0x4c, 0xd0, 0x1c, 0x9f, 0xac, 0x15, 0x58, 0xbe, 0xc9, 0x02,
-	0x50, 0x03, 0xaa, 0x51, 0x30, 0xd5, 0x15, 0x13, 0x58, 0x75, 0xa7, 0x9a, 0x26, 0x86, 0xda, 0x73,
-	0xef, 0xdc, 0x8c, 0x43, 0x47, 0xb0, 0x12, 0x8e, 0xe9, 0x65, 0xdb, 0xd6, 0xd5, 0xec, 0xd5, 0xdd,
-	0x4d, 0xe8, 0x14, 0x56, 0x87, 0x93, 0xa9, 0x60, 0x41, 0xa8, 0x97, 0x4d, 0xd5, 0xaa, 0x3b, 0xda,
-	0x36, 0x31, 0x0a, 0xca, 0x2d, 0x00, 0xea, 0xc1, 0x5a, 0x96, 0x38, 0xa0, 0x82, 0xea, 0x35, 0x13,
-	0x58, 0x9a, 0xdd, 0x20, 0x7f, 0x7a, 0x90, 0x07, 0xef, 0x89, 0xf5, 0xc5, 0x3d, 0x13, 0xd4, 0xc1,
-	0xeb, 0xc4, 0x28, 0x6d, 0x12, 0x03, 0x6c, 0x13, 0x03, 0x15, 0x6b, 0x67, 0xdc, 0x9f, 0x08, 0xe6,
-	0xcf, 0xc5, 0xc2, 0xfd, 0xb1, 0x42, 0x5d, 0x58, 0x1d, 0x33, 0x3a, 0xc8, 0xd2, 0xeb, 0xa6, 0x6a,
-	0x69, 0xf6, 0xf1, 0x3f, 0x57, 0xd9, 0x8b, 0x74, 0x73, 0xcd, 0xed, 0x4c, 0x04, 0x8b, 0xfc, 0x83,
-	0xbb, 0x2d, 0xb7, 0x00, 0xcd, 0x0e, 0xdc, 0xfb, 0xad, 0x42, 0x07, 0x50, 0x7d, 0x66, 0x0b, 0x1d,
-	0xc8, 0xb2, 0x19, 0x44, 0x87, 0xb0, 0x1c, 0xd3, 0x69, 0xc4, 0xf2, 0xf3, 0xb8, 0xf9, 0xd0, 0x51,
-	0xae, 0x40, 0xa7, 0xf6, 0xb2, 0x34, 0x4a, 0xab, 0xa5, 0x01, 0x1c, 0xf3, 0xeb, 0x03, 0x83, 0x55,
-	0x8a, 0xc1, 0x5b, 0x8a, 0xc1, 0x3a, 0xc5, 0x60, 0x93, 0x62, 0xf0, 0x9e, 0x62, 0xf0, 0xfa, 0x89,
-	0x4b, 0x8f, 0x4a, 0x6c, 0x7b, 0x15, 0x79, 0xf3, 0xf3, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0xd9,
-	0x23, 0xf4, 0x0a, 0xd3, 0x01, 0x00, 0x00,
+	// 410 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4e, 0x2c, 0x2e, 0x4e,
+	0x2d, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x2d, 0x4e, 0xcd, 0x2b, 0x2e, 0xd5, 0x4b,
+	0xce, 0x2f, 0x4a, 0xd5, 0x2b, 0x33, 0x92, 0x32, 0x49, 0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b,
+	0xce, 0xcf, 0xd5, 0x4f, 0xcf, 0x4f, 0xcf, 0xd7, 0x07, 0xab, 0x4a, 0x2a, 0x4d, 0x73, 0x28, 0x33,
+	0xd4, 0x33, 0xd2, 0x33, 0x04, 0x0b, 0x82, 0xc5, 0xc0, 0x2c, 0x88, 0x21, 0x52, 0x5c, 0xb9, 0xa9,
+	0x25, 0x89, 0x10, 0xb6, 0x52, 0x3b, 0x33, 0x17, 0xab, 0x23, 0xc8, 0x02, 0x21, 0x49, 0x2e, 0xe6,
+	0xd2, 0xa2, 0x1c, 0x09, 0x26, 0x05, 0x46, 0x0d, 0x4e, 0x27, 0xf6, 0x47, 0xf7, 0xe4, 0x99, 0x43,
+	0x83, 0x7c, 0x82, 0x40, 0x62, 0x42, 0x62, 0x5c, 0x6c, 0xc5, 0x19, 0x89, 0xa6, 0x86, 0x46, 0x12,
+	0xcc, 0x20, 0xd9, 0x20, 0x28, 0x4f, 0x48, 0x95, 0x8b, 0x3d, 0x2d, 0x33, 0xa7, 0x24, 0xb5, 0xa8,
+	0x58, 0x82, 0x55, 0x81, 0x59, 0x83, 0xd3, 0x89, 0xfb, 0xd5, 0x3d, 0x79, 0x98, 0x50, 0x10, 0x8c,
+	0x21, 0x64, 0xcb, 0xc5, 0x96, 0x54, 0x9a, 0x99, 0x93, 0x52, 0x2c, 0xc1, 0xa6, 0xc0, 0xac, 0xc1,
+	0x6d, 0x24, 0xa9, 0x87, 0xe2, 0x0b, 0x3d, 0xb0, 0xfd, 0x4e, 0x20, 0x15, 0x4e, 0x5c, 0xaf, 0xee,
+	0xc9, 0x43, 0x15, 0x07, 0x41, 0x69, 0xa1, 0x50, 0x2e, 0x0e, 0x90, 0x83, 0x53, 0x12, 0x4b, 0x12,
+	0x25, 0x38, 0x14, 0x18, 0xb1, 0x18, 0xe0, 0x9f, 0x94, 0x95, 0x9a, 0x5c, 0xe2, 0x9b, 0x5a, 0x92,
+	0xe8, 0x24, 0x77, 0xe2, 0x9e, 0x3c, 0xc3, 0x85, 0x7b, 0xf2, 0x8c, 0xaf, 0xee, 0xc9, 0x0b, 0xc1,
+	0xb4, 0xe9, 0xe4, 0xe7, 0x66, 0x96, 0xa4, 0xe6, 0x16, 0x94, 0x54, 0x06, 0xc1, 0x8d, 0x12, 0xf2,
+	0xe0, 0x62, 0xcf, 0x48, 0x4d, 0x4c, 0x01, 0x39, 0x9e, 0x13, 0xec, 0x2c, 0x45, 0x6c, 0xce, 0xd2,
+	0xf3, 0x80, 0xa8, 0x71, 0xcd, 0x2b, 0x29, 0xaa, 0x84, 0xf8, 0x0f, 0xaa, 0x2b, 0x08, 0xc6, 0x90,
+	0xb2, 0xe2, 0xe2, 0x41, 0x56, 0x25, 0x24, 0xc0, 0xc5, 0x9c, 0x9d, 0x5a, 0x29, 0xc1, 0x08, 0x0e,
+	0x2b, 0x10, 0x53, 0x48, 0x84, 0x8b, 0xb5, 0x2c, 0x31, 0xa7, 0x34, 0x15, 0x12, 0xba, 0x41, 0x10,
+	0x8e, 0x15, 0x93, 0x05, 0xa3, 0x15, 0x47, 0xc7, 0x02, 0x79, 0x86, 0x15, 0x0b, 0xe4, 0x19, 0x95,
+	0x7e, 0x33, 0x72, 0x71, 0x21, 0x42, 0x82, 0x86, 0xd1, 0xe1, 0x8b, 0xee, 0x71, 0x35, 0x9c, 0xf1,
+	0x41, 0x37, 0xdf, 0x3b, 0x29, 0xfc, 0x78, 0x28, 0xc7, 0xb8, 0xe2, 0x91, 0x1c, 0xe3, 0x8e, 0x47,
+	0x72, 0x8c, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0, 0x91, 0x1c, 0xe3, 0x8c,
+	0xc7, 0x72, 0x0c, 0x51, 0x4c, 0x65, 0x46, 0x49, 0x6c, 0xe0, 0x04, 0x6b, 0x0c, 0x08, 0x00, 0x00,
+	0xff, 0xff, 0xb9, 0xa0, 0x04, 0x4e, 0x10, 0x03, 0x00, 0x00,
 }
 
 func (this *Asset) Equal(that interface{}) bool {
@@ -144,8 +202,62 @@ func (this *Asset) Equal(that interface{}) bool {
 			return false
 		}
 	}
+	if len(this.Builds) != len(that1.Builds) {
+		return false
+	}
+	for i := range this.Builds {
+		if !this.Builds[i].Equal(that1.Builds[i]) {
+			return false
+		}
+	}
 	if !this.ObjectMeta.Equal(&that1.ObjectMeta) {
 		return false
+	}
+	if len(this.Headers) != len(that1.Headers) {
+		return false
+	}
+	for i := range this.Headers {
+		if this.Headers[i] != that1.Headers[i] {
+			return false
+		}
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *AssetBuild) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AssetBuild)
+	if !ok {
+		that2, ok := that.(AssetBuild)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.URL != that1.URL {
+		return false
+	}
+	if this.Sha512 != that1.Sha512 {
+		return false
+	}
+	if len(this.Filters) != len(that1.Filters) {
+		return false
+	}
+	for i := range this.Filters {
+		if this.Filters[i] != that1.Filters[i] {
+			return false
+		}
 	}
 	if len(this.Headers) != len(that1.Headers) {
 		return false
@@ -166,6 +278,7 @@ type AssetFace interface {
 	GetURL() string
 	GetSha512() string
 	GetFilters() []string
+	GetBuilds() []*AssetBuild
 	GetObjectMeta() ObjectMeta
 	GetHeaders() map[string]string
 }
@@ -190,6 +303,10 @@ func (this *Asset) GetFilters() []string {
 	return this.Filters
 }
 
+func (this *Asset) GetBuilds() []*AssetBuild {
+	return this.Builds
+}
+
 func (this *Asset) GetObjectMeta() ObjectMeta {
 	return this.ObjectMeta
 }
@@ -203,7 +320,49 @@ func NewAssetFromFace(that AssetFace) *Asset {
 	this.URL = that.GetURL()
 	this.Sha512 = that.GetSha512()
 	this.Filters = that.GetFilters()
+	this.Builds = that.GetBuilds()
 	this.ObjectMeta = that.GetObjectMeta()
+	this.Headers = that.GetHeaders()
+	return this
+}
+
+type AssetBuildFace interface {
+	Proto() github_com_golang_protobuf_proto.Message
+	GetURL() string
+	GetSha512() string
+	GetFilters() []string
+	GetHeaders() map[string]string
+}
+
+func (this *AssetBuild) Proto() github_com_golang_protobuf_proto.Message {
+	return this
+}
+
+func (this *AssetBuild) TestProto() github_com_golang_protobuf_proto.Message {
+	return NewAssetBuildFromFace(this)
+}
+
+func (this *AssetBuild) GetURL() string {
+	return this.URL
+}
+
+func (this *AssetBuild) GetSha512() string {
+	return this.Sha512
+}
+
+func (this *AssetBuild) GetFilters() []string {
+	return this.Filters
+}
+
+func (this *AssetBuild) GetHeaders() map[string]string {
+	return this.Headers
+}
+
+func NewAssetBuildFromFace(that AssetBuildFace) *AssetBuild {
+	this := &AssetBuild{}
+	this.URL = that.GetURL()
+	this.Sha512 = that.GetSha512()
+	this.Filters = that.GetFilters()
 	this.Headers = that.GetHeaders()
 	return this
 }
@@ -250,6 +409,18 @@ func (m *Asset) MarshalTo(dAtA []byte) (int, error) {
 			i += copy(dAtA[i:], s)
 		}
 	}
+	if len(m.Builds) > 0 {
+		for _, msg := range m.Builds {
+			dAtA[i] = 0x32
+			i++
+			i = encodeVarintAsset(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
 	dAtA[i] = 0x42
 	i++
 	i = encodeVarintAsset(dAtA, i, uint64(m.ObjectMeta.Size()))
@@ -258,6 +429,71 @@ func (m *Asset) MarshalTo(dAtA []byte) (int, error) {
 		return 0, err
 	}
 	i += n1
+	if len(m.Headers) > 0 {
+		for k, _ := range m.Headers {
+			dAtA[i] = 0x4a
+			i++
+			v := m.Headers[k]
+			mapSize := 1 + len(k) + sovAsset(uint64(len(k))) + 1 + len(v) + sovAsset(uint64(len(v)))
+			i = encodeVarintAsset(dAtA, i, uint64(mapSize))
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintAsset(dAtA, i, uint64(len(k)))
+			i += copy(dAtA[i:], k)
+			dAtA[i] = 0x12
+			i++
+			i = encodeVarintAsset(dAtA, i, uint64(len(v)))
+			i += copy(dAtA[i:], v)
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *AssetBuild) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AssetBuild) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.URL) > 0 {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.URL)))
+		i += copy(dAtA[i:], m.URL)
+	}
+	if len(m.Sha512) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.Sha512)))
+		i += copy(dAtA[i:], m.Sha512)
+	}
+	if len(m.Filters) > 0 {
+		for _, s := range m.Filters {
+			dAtA[i] = 0x2a
+			i++
+			l = len(s)
+			for l >= 1<<7 {
+				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
+				l >>= 7
+				i++
+			}
+			dAtA[i] = uint8(l)
+			i++
+			i += copy(dAtA[i:], s)
+		}
+	}
 	if len(m.Headers) > 0 {
 		for k, _ := range m.Headers {
 			dAtA[i] = 0x4a
@@ -299,12 +535,41 @@ func NewPopulatedAsset(r randyAsset, easy bool) *Asset {
 	for i := 0; i < v1; i++ {
 		this.Filters[i] = string(randStringAsset(r))
 	}
-	v2 := NewPopulatedObjectMeta(r, easy)
-	this.ObjectMeta = *v2
 	if r.Intn(10) != 0 {
-		v3 := r.Intn(10)
+		v2 := r.Intn(5)
+		this.Builds = make([]*AssetBuild, v2)
+		for i := 0; i < v2; i++ {
+			this.Builds[i] = NewPopulatedAssetBuild(r, easy)
+		}
+	}
+	v3 := NewPopulatedObjectMeta(r, easy)
+	this.ObjectMeta = *v3
+	if r.Intn(10) != 0 {
+		v4 := r.Intn(10)
 		this.Headers = make(map[string]string)
-		for i := 0; i < v3; i++ {
+		for i := 0; i < v4; i++ {
+			this.Headers[randStringAsset(r)] = randStringAsset(r)
+		}
+	}
+	if !easy && r.Intn(10) != 0 {
+		this.XXX_unrecognized = randUnrecognizedAsset(r, 10)
+	}
+	return this
+}
+
+func NewPopulatedAssetBuild(r randyAsset, easy bool) *AssetBuild {
+	this := &AssetBuild{}
+	this.URL = string(randStringAsset(r))
+	this.Sha512 = string(randStringAsset(r))
+	v5 := r.Intn(10)
+	this.Filters = make([]string, v5)
+	for i := 0; i < v5; i++ {
+		this.Filters[i] = string(randStringAsset(r))
+	}
+	if r.Intn(10) != 0 {
+		v6 := r.Intn(10)
+		this.Headers = make(map[string]string)
+		for i := 0; i < v6; i++ {
 			this.Headers[randStringAsset(r)] = randStringAsset(r)
 		}
 	}
@@ -333,9 +598,9 @@ func randUTF8RuneAsset(r randyAsset) rune {
 	return rune(ru + 61)
 }
 func randStringAsset(r randyAsset) string {
-	v4 := r.Intn(100)
-	tmps := make([]rune, v4)
-	for i := 0; i < v4; i++ {
+	v7 := r.Intn(100)
+	tmps := make([]rune, v7)
+	for i := 0; i < v7; i++ {
 		tmps[i] = randUTF8RuneAsset(r)
 	}
 	return string(tmps)
@@ -357,11 +622,11 @@ func randFieldAsset(dAtA []byte, r randyAsset, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateAsset(dAtA, uint64(key))
-		v5 := r.Int63()
+		v8 := r.Int63()
 		if r.Intn(2) == 0 {
-			v5 *= -1
+			v8 *= -1
 		}
-		dAtA = encodeVarintPopulateAsset(dAtA, uint64(v5))
+		dAtA = encodeVarintPopulateAsset(dAtA, uint64(v8))
 	case 1:
 		dAtA = encodeVarintPopulateAsset(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))
@@ -406,8 +671,48 @@ func (m *Asset) Size() (n int) {
 			n += 1 + l + sovAsset(uint64(l))
 		}
 	}
+	if len(m.Builds) > 0 {
+		for _, e := range m.Builds {
+			l = e.Size()
+			n += 1 + l + sovAsset(uint64(l))
+		}
+	}
 	l = m.ObjectMeta.Size()
 	n += 1 + l + sovAsset(uint64(l))
+	if len(m.Headers) > 0 {
+		for k, v := range m.Headers {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovAsset(uint64(len(k))) + 1 + len(v) + sovAsset(uint64(len(v)))
+			n += mapEntrySize + 1 + sovAsset(uint64(mapEntrySize))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *AssetBuild) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.URL)
+	if l > 0 {
+		n += 1 + l + sovAsset(uint64(l))
+	}
+	l = len(m.Sha512)
+	if l > 0 {
+		n += 1 + l + sovAsset(uint64(l))
+	}
+	if len(m.Filters) > 0 {
+		for _, s := range m.Filters {
+			l = len(s)
+			n += 1 + l + sovAsset(uint64(l))
+		}
+	}
 	if len(m.Headers) > 0 {
 		for k, v := range m.Headers {
 			_ = k
@@ -560,6 +865,40 @@ func (m *Asset) Unmarshal(dAtA []byte) error {
 			}
 			m.Filters = append(m.Filters, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Builds", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAsset
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAsset
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Builds = append(m.Builds, &AssetBuild{})
+			if err := m.Builds[len(m.Builds)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field ObjectMeta", wireType)
@@ -592,6 +931,283 @@ func (m *Asset) Unmarshal(dAtA []byte) error {
 			if err := m.ObjectMeta.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Headers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAsset
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthAsset
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Headers == nil {
+				m.Headers = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowAsset
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowAsset
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthAsset
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthAsset
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowAsset
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthAsset
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthAsset
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipAsset(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthAsset
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Headers[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipAsset(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AssetBuild) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowAsset
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AssetBuild: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AssetBuild: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field URL", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAsset
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAsset
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.URL = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sha512", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAsset
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAsset
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sha512 = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Filters", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowAsset
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthAsset
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthAsset
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Filters = append(m.Filters, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {

--- a/api/core/v2/asset.proto
+++ b/api/core/v2/asset.proto
@@ -13,7 +13,7 @@ option (gogoproto.unmarshaler_all) = true;
 option (gogoproto.sizer_all) = true;
 option (gogoproto.testgen_all) = true;
 
-// Asset defines an asset agents install as a dependency for a check.
+// Asset defines an asset and optionally a list of assets (builds) that agents install as a dependency for a check, handler, mutator, etc.
 message Asset {
   option (gogoproto.face) = true;
   option (gogoproto.goproto_getters) = false;
@@ -29,8 +29,32 @@ message Asset {
   // queries are joined by the "AND" operator.
   repeated string filters = 5 [(gogoproto.jsontag) = "filters"];
 
+  // AssetBuilds are a list of one or more assets to install.
+  repeated AssetBuild builds = 6 [(gogoproto.jsontag) = "builds"];
+
   // Metadata contains the name, namespace, labels and annotations of the asset
   ObjectMeta metadata = 8 [(gogoproto.embed) = true, (gogoproto.jsontag) = "metadata,omitempty", (gogoproto.nullable) = false];
+
+  // Headers is a collection of key/value string pairs used as HTTP headers
+  // for asset retrieval.
+  map<string, string> headers = 9 [(gogoproto.jsontag) = "headers"];
+};
+
+// AssetBuild defines an individual asset that an asset can install as a dependency for a check, handler, mutator, etc.
+message AssetBuild {
+  option (gogoproto.face) = true;
+  option (gogoproto.goproto_getters) = false;
+
+  // URL is the location of the asset
+  string url = 2 [(gogoproto.customname) = "URL"];
+
+  // Sha512 is the SHA-512 checksum of the asset
+  string sha512 = 3;
+
+  // Filters are a collection of sensu queries, used by the system to determine
+  // if the asset should be installed. If more than one filter is present the
+  // queries are joined by the "AND" operator.
+  repeated string filters = 5 [(gogoproto.jsontag) = "filters"];
 
   // Headers is a collection of key/value string pairs used as HTTP headers
   // for asset retrieval.

--- a/api/core/v2/assetpb_test.go
+++ b/api/core/v2/assetpb_test.go
@@ -76,6 +76,62 @@ func TestAssetMarshalTo(t *testing.T) {
 	}
 }
 
+func TestAssetBuildProto(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, false)
+	dAtA, err := github_com_golang_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &AssetBuild{}
+	if err := github_com_golang_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	littlefuzz := make([]byte, len(dAtA))
+	copy(littlefuzz, dAtA)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+	if len(littlefuzz) > 0 {
+		fuzzamount := 100
+		for i := 0; i < fuzzamount; i++ {
+			littlefuzz[popr.Intn(len(littlefuzz))] = byte(popr.Intn(256))
+			littlefuzz = append(littlefuzz, byte(popr.Intn(256)))
+		}
+		// shouldn't panic
+		_ = github_com_golang_protobuf_proto.Unmarshal(littlefuzz, msg)
+	}
+}
+
+func TestAssetBuildMarshalTo(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, false)
+	size := p.Size()
+	dAtA := make([]byte, size)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	_, err := p.MarshalTo(dAtA)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &AssetBuild{}
+	if err := github_com_golang_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
 func TestAssetJSON(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
@@ -86,6 +142,24 @@ func TestAssetJSON(t *testing.T) {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
 	msg := &Asset{}
+	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
+	}
+}
+func TestAssetBuildJSON(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, true)
+	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
+	jsondata, err := marshaler.MarshalToString(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &AssetBuild{}
 	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
@@ -122,9 +196,45 @@ func TestAssetProtoCompactText(t *testing.T) {
 	}
 }
 
+func TestAssetBuildProtoText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, true)
+	dAtA := github_com_golang_protobuf_proto.MarshalTextString(p)
+	msg := &AssetBuild{}
+	if err := github_com_golang_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestAssetBuildProtoCompactText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, true)
+	dAtA := github_com_golang_protobuf_proto.CompactTextString(p)
+	msg := &AssetBuild{}
+	if err := github_com_golang_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
 func TestAssetFace(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
 	p := NewPopulatedAsset(popr, true)
+	msg := p.TestProto()
+	if !p.Equal(msg) {
+		t.Fatalf("%#v !Face Equal %#v", msg, p)
+	}
+}
+func TestAssetBuildFace(t *testing.T) {
+	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
+	p := NewPopulatedAssetBuild(popr, true)
 	msg := p.TestProto()
 	if !p.Equal(msg) {
 		t.Fatalf("%#v !Face Equal %#v", msg, p)
@@ -134,6 +244,28 @@ func TestAssetSize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
 	p := NewPopulatedAsset(popr, true)
+	size2 := github_com_golang_protobuf_proto.Size(p)
+	dAtA, err := github_com_golang_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	size := p.Size()
+	if len(dAtA) != size {
+		t.Errorf("seed = %d, size %v != marshalled size %v", seed, size, len(dAtA))
+	}
+	if size2 != size {
+		t.Errorf("seed = %d, size %v != before marshal proto.Size %v", seed, size, size2)
+	}
+	size3 := github_com_golang_protobuf_proto.Size(p)
+	if size3 != size {
+		t.Errorf("seed = %d, size %v != after marshal proto.Size %v", seed, size, size3)
+	}
+}
+
+func TestAssetBuildSize(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedAssetBuild(popr, true)
 	size2 := github_com_golang_protobuf_proto.Size(p)
 	dAtA, err := github_com_golang_protobuf_proto.Marshal(p)
 	if err != nil {

--- a/api/core/v2/typemap.go
+++ b/api/core/v2/typemap.go
@@ -15,6 +15,8 @@ var typeMap = map[string]interface{}{
 	"any":                    &Any{},
 	"Asset":                  &Asset{},
 	"asset":                  &Asset{},
+	"AssetBuild":             &AssetBuild{},
+	"asset_build":            &AssetBuild{},
 	"AssetList":              &AssetList{},
 	"asset_list":             &AssetList{},
 	"AuthProviderClaims":     &AuthProviderClaims{},

--- a/asset/asset.go
+++ b/asset/asset.go
@@ -16,7 +16,7 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/sensu/sensu-go/types"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 	includeDir = "include"
 )
 
-// A Getter is responsible for fetching (based on fitler selection), verifying,
+// A Getter is responsible for fetching (based on filter selection), verifying,
 // and expanding an asset. Calls to the Get method block until the Asset has
 // fetched, verified, and expanded or it returns an error indicating why getting
 // the asset failed.
@@ -33,7 +33,7 @@ const (
 // If the context is canceled while Get is in progress, then the operation will
 // be canceled and the error from the context will be returned.
 type Getter interface {
-	Get(context.Context, *types.Asset) (*RuntimeAsset, error)
+	Get(context.Context, *corev2.Asset) (*RuntimeAsset, error)
 }
 
 // A RuntimeAsset is a locally expanded Asset.

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	bolt "go.etcd.io/bbolt"
-
-	"github.com/sensu/sensu-go/types"
 )
 
 var (
@@ -67,8 +66,8 @@ type boltDBAssetManager struct {
 //
 // If a value is not returned, the asset is not installed or not installed
 // correctly. We then proceed to attempt asset installation.
-func (b *boltDBAssetManager) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
-	key := []byte(asset.Sha512)
+func (b *boltDBAssetManager) Get(ctx context.Context, asset *corev2.Asset) (*RuntimeAsset, error) {
+	key := []byte(asset.GetSha512())
 	var localAsset *RuntimeAsset
 
 	// Concurrent calls to View are allowed, but a concurrent call that has

--- a/asset/filtered_manager.go
+++ b/asset/filtered_manager.go
@@ -3,8 +3,8 @@ package asset
 import (
 	"context"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/js"
-	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"
 	"github.com/sirupsen/logrus"
 )
@@ -12,7 +12,7 @@ import (
 // NewFilteredManager returns an asset Getter that filters assets based on the
 // given entity. Assets that aren't filtered get passed to the underlying
 // getter, allowing composition with other asset managers.
-func NewFilteredManager(getter Getter, entity *types.Entity) *filteredManager {
+func NewFilteredManager(getter Getter, entity *corev2.Entity) *filteredManager {
 	return &filteredManager{
 		getter: getter,
 		entity: entity,
@@ -22,35 +22,74 @@ func NewFilteredManager(getter Getter, entity *types.Entity) *filteredManager {
 // filteredManager evaluates asset filter(s) and calls the underlying
 // asset Getter based on filter result.
 type filteredManager struct {
-	entity *types.Entity
+	entity *corev2.Entity
 	getter Getter
 }
 
 // Get fetches, verifies, and expands an asset, but only if it is filtered.
-func (f *filteredManager) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
-	fields := logrus.Fields{
-		"entity":  f.entity.Name,
-		"asset":   asset.Name,
-		"filters": asset.Filters,
-	}
-	filtered, err := f.isFiltered(asset)
-	if err != nil {
-		logger.WithFields(fields).WithError(err).Error("error filtering entities from asset")
-		return nil, err
+func (f *filteredManager) Get(ctx context.Context, asset *corev2.Asset) (*RuntimeAsset, error) {
+	var filteredAsset *corev2.Asset
+
+	if len(asset.Builds) > 0 {
+		fields := logrus.Fields{
+			"entity": f.entity.Name,
+			"asset":  asset.Name,
+		}
+		logger.WithFields(fields).Info("asset includes builds, using builds instead of asset")
+		for _, build := range asset.Builds {
+			assetBuild := &corev2.Asset{
+				URL:     build.URL,
+				Sha512:  build.Sha512,
+				Filters: build.Filters,
+				Headers: build.Headers,
+			}
+
+			buildFields := logrus.Fields{
+				"filter": assetBuild.Filters,
+			}
+
+			filtered, err := f.isFiltered(assetBuild)
+			if err != nil {
+				logger.WithFields(fields).WithFields(buildFields).WithError(err).Error("error filtering entities from asset build")
+				return nil, err
+			}
+
+			if !filtered {
+				logger.WithFields(fields).WithFields(buildFields).Debug("entity not filtered, not installing asset build")
+				continue
+			}
+
+			logger.WithFields(fields).WithFields(buildFields).Debug("entity filtered, installing asset build")
+			filteredAsset = assetBuild
+			break
+		}
+	} else {
+		fields := logrus.Fields{
+			"entity":  f.entity.Name,
+			"asset":   asset.Name,
+			"filters": asset.Filters,
+		}
+		filtered, err := f.isFiltered(asset)
+		if err != nil {
+			logger.WithFields(fields).WithError(err).Error("error filtering entities from asset")
+			return nil, err
+		}
+
+		if !filtered {
+			logger.WithFields(fields).Debug("entity not filtered, not installing asset")
+			return nil, nil
+		}
+
+		logger.WithFields(fields).Debug("entity filtered, installing asset")
+		filteredAsset = asset
 	}
 
-	if !filtered {
-		logger.WithFields(fields).Debug("entity not filtered, not installing asset")
-		return nil, nil
-	}
-
-	logger.WithFields(fields).Debug("entity filtered, installing asset")
-	return f.getter.Get(ctx, asset)
+	return f.getter.Get(ctx, filteredAsset)
 }
 
 // isFiltered evaluates the given asset's filters and returns true if all of
 // them match the current entity.
-func (f *filteredManager) isFiltered(asset *types.Asset) (bool, error) {
+func (f *filteredManager) isFiltered(asset *corev2.Asset) (bool, error) {
 	if len(asset.Filters) == 0 {
 		return true, nil
 	}

--- a/asset/filtered_manager.go
+++ b/asset/filtered_manager.go
@@ -38,10 +38,11 @@ func (f *filteredManager) Get(ctx context.Context, asset *corev2.Asset) (*Runtim
 		logger.WithFields(fields).Info("asset includes builds, using builds instead of asset")
 		for _, build := range asset.Builds {
 			assetBuild := &corev2.Asset{
-				URL:     build.URL,
-				Sha512:  build.Sha512,
-				Filters: build.Filters,
-				Headers: build.Headers,
+				URL:        build.URL,
+				Sha512:     build.Sha512,
+				Filters:    build.Filters,
+				Headers:    build.Headers,
+				ObjectMeta: asset.ObjectMeta,
 			}
 
 			buildFields := logrus.Fields{

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +18,7 @@ type MockGetter struct {
 }
 
 // Get satisfies the asset.Getter interface
-func (m *MockGetter) Get(context.Context, *types.Asset) (*RuntimeAsset, error) {
+func (m *MockGetter) Get(context.Context, *corev2.Asset) (*RuntimeAsset, error) {
 	m.getCalled = true
 	return m.asset, m.err
 }

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -68,8 +68,8 @@ func TestFilteredManagerUnfilteredAsset(t *testing.T) {
 
 // FilteredManager should pass a build asset if the asset has builds.
 // This test ensures that filteredManager detects that an asset build
-// exists and passes the build asset to its getter instead of the asset
-// containing the asset build.
+// exists and passes the build asset to filtereManager's getter
+// instead of the asset containing the asset build.
 func TestFilteredManagerFilteredBuildAsset(t *testing.T) {
 	mockGetter, entity, filteredManager := NewTestFilteredManager()
 

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -65,6 +65,29 @@ func TestFilteredManagerUnfilteredAsset(t *testing.T) {
 	assert.False(t, mockGetter.getCalled)
 }
 
+// FilteredManager should pass a build asset if the asset has builds.
+func TestFilteredManagerFilteredBuildAsset(t *testing.T) {
+	mockGetter, entity, filteredManager := NewTestFilteredManager()
+
+	url := "http://asset-build-url"
+	sha512 := "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+	filters := []string{fmt.Sprintf("entity.name == '%s'", entity.Name)}
+
+	fixtureAsset := types.FixtureAsset("test-asset")
+	fixtureAsset.Filters = []string{"entity.name == 'foo'"}
+	fixtureAsset.Builds = []*corev2.AssetBuild{
+		{
+			URL:     url,
+			Sha512:  sha512,
+			Filters: filters,
+		},
+	}
+	actualAsset, err := filteredManager.Get(context.TODO(), fixtureAsset)
+	assert.NoError(t, err)
+	assert.Equal(t, mockGetter.asset, actualAsset)
+	assert.True(t, mockGetter.getCalled)
+}
+
 // FilteredManager should return error passed by underlying Getter.
 func TestFilteredManagerError(t *testing.T) {
 	mockGetter, _, filteredManager := NewTestFilteredManager()

--- a/asset/set_test.go
+++ b/asset/set_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,7 +34,7 @@ type mockGetter struct {
 	err error
 }
 
-func (m *mockGetter) Get(ctx context.Context, asset *types.Asset) (*RuntimeAsset, error) {
+func (m *mockGetter) Get(ctx context.Context, asset *corev2.Asset) (*RuntimeAsset, error) {
 	if m.err != nil {
 		return nil, m.err
 	}


### PR DESCRIPTION
## What is this change?

Adds a new concept of 0 or more builds within an asset.

## Why is this change necessary?

Fixes #3067.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

See https://github.com/sensu/sensu-docs/issues/1685.

## How did you verify this change?

I have verified that existing asset definitions work along with newer asset definitions, and that the correct build asset was pulled in. For example:

```yaml
---
type: Asset
api_version: core/v2
metadata:
  name: sensu-go-cpu-check
  namespace: default
  labels: {}
  annotations: {}
spec:
  builds:
    - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz
      sha512: 487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3
      filters:
        - entity.system.os == 'linux'
        - entity.system.arch == 'amd64'
    - url: https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz
      sha512: 70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b
      filters:
        - entity.system.os == 'linux'
        - entity.system.arch == 'arm'
        - entity.system.arm_version == 7
```