### PR TITLE
Add node resolver for event filters

### DIFF
--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -51,7 +51,7 @@ func (r *nodeResolver) FindType(i interface{}) *graphql.Type {
 	resolver := r.register.Lookup(components)
 	if resolver == nil {
 		logger := logger.WithField("translator", fmt.Sprintf("%#v", translator))
-		logger.Warn("unable to find node resolver for type")
+		logger.Error("unable to find node resolver for type")
 		return nil
 	}
 	return &resolver.ObjectType

--- a/backend/apid/graphql/node_test.go
+++ b/backend/apid/graphql/node_test.go
@@ -129,6 +129,18 @@ func TestAssetNodeResolver(t *testing.T) {
 			},
 		},
 		{
+			name: "event filters",
+			setupNode: func() interface{} {
+				return corev2.FixtureEventFilter("name")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.EventFilterTranslator.EncodeToString(r)
+			},
+			setup: func(r interface{}) {
+				cfg.EventFilterClient.(onner).On("FetchEventFilter", mock.Anything, "name").Return(r, nil).Once()
+			},
+		},
+		{
 			name: "handlers",
 			setupNode: func() interface{} {
 				return corev2.FixtureHandler("name")


### PR DESCRIPTION
Signed-off-by: James Phillips <jamesdphillips@gmail.com>

## What is this change?

Registers the GraphQL's EventFilterType schema with the node registry and adds a resolver.

## Why is this change necessary?

Allows reverse lookup of types and the ability to query filter through the node interface.

```graphql
node(id: "event-filter-global-id") {
  id
  ... on EventFilter {
    action
    statements
  }
}
```

---

I suspect that updating `graphql-go/graphql` may have exposed this error; previous version may have been more permissive.