### PR TITLE
Fix a bug in interactive check creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Interactive check create and update modes now have 'none' as the first
+highlighted option, instead of nagios-perfdata.
+
 ## [5.12.0] - 2019-08-22
 
 ### Added

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -230,7 +230,7 @@ func (opts *checkOpts) administerQuestionnaire(editing bool) error {
 			Name: "output-metric-format",
 			Prompt: &survey.Select{
 				Message: "Metric Format:",
-				Options: append(types.OutputMetricFormats, "none"),
+				Options: append([]string{"none"}, types.OutputMetricFormats...),
 			},
 			Validate: func(val interface{}) error {
 				if value := strings.TrimSpace(val.(string)); value != "" && value != "none" {


### PR DESCRIPTION
## What is this change?

In interactive check creation, the first highlighted metrics format
is now "none" instead of "nagios-perfdata".

## Why is this change necessary?

Closes #3229 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Manually