### PR TITLE
Add HTTP and directory support to sensuctl create

### DIFF
--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -31,7 +31,7 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	_ = cmd.Flags().StringSliceP("file", "f", nil, "Files, directories, or URLs to create resources from")
-	_ = cmd.Flags().BoolP("recurse", "r", false, "Follow subdirectories")
+	_ = cmd.Flags().BoolP("recursive", "r", false, "Follow subdirectories")
 
 	return cmd
 }
@@ -132,7 +132,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
-		recurse, err := cmd.Flags().GetBool("recurse")
+		recurse, err := cmd.Flags().GetBool("recursive")
 		if err != nil {
 			return err
 		}

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -93,7 +93,7 @@ func process(cli *cli.SensuCli, client *http.Client, input string, recurse bool)
 	}
 
 	if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/html") {
-		// The server returned us a direcory listing
+		// The server returned us a directory listing
 		if !recurse {
 			return errors.New("use -r to enable directory recursion")
 		}


### PR DESCRIPTION
## What is this change?

sensuctl create now works with http and https URLs, and file:// URLs. Existing file functionality is implemented with the HTTP client, buts works the same as before from a UX perspective.

The tool also now accepts multiple files or URLs, and also supports directories with the -r flag.

## Why is this change necessary?

Closes #2765 
Closes #2631 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are needed

## How did you verify this change?

```
$ sensuctl create -f resources.yaml
$ sensuctl create -f file://$(pwd)/resources.yaml
$ sensuctl create -f https://gist.githubusercontent.com/echlebek/85767b6c2f9e6e130bae8817c45c8c91/raw/50656db385073046e827365053d7a5a89a248395/gistfile1.txt
$ sensuctl create -r -f ./directory
$ sensuctl create -f resource1.yaml -f resource2.yaml
$ sensuclt create -f resources1.yaml,resource2.yaml
```