### PR TITLE
Add sensuctl env command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added the `sensuctl env` command.
+
 ### Fixed
 - sensuctl dump no longer silently discards errors.
 - Interactive check create and update modes now have 'none' as the first

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"os"
 
-	"github.com/sensu/sensu-go/api/core/v2"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/client/config/basic"
@@ -37,8 +37,8 @@ func New(flags *pflag.FlagSet) *SensuCli {
 
 	tlsConfig := tls.Config{}
 
-	if conf.TrustedCAFile != "" {
-		caCertPool, err := v2.LoadCACerts(conf.TrustedCAFile)
+	if conf.TrustedCAFile() != "" {
+		caCertPool, err := v2.LoadCACerts(conf.TrustedCAFile())
 		if err != nil {
 			logger.Warn(err)
 			logger.Warn("Trying to use the system's default CA certificates")
@@ -46,7 +46,7 @@ func New(flags *pflag.FlagSet) *SensuCli {
 		tlsConfig.RootCAs = caCertPool
 	}
 
-	tlsConfig.InsecureSkipVerify = conf.InsecureSkipTLSVerify
+	tlsConfig.InsecureSkipVerify = conf.InsecureSkipTLSVerify()
 
 	tlsConfig.BuildNameToCertificate()
 	tlsConfig.CipherSuites = v2.DefaultCipherSuites

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"os"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/client/config/basic"
@@ -38,7 +38,7 @@ func New(flags *pflag.FlagSet) *SensuCli {
 	tlsConfig := tls.Config{}
 
 	if conf.TrustedCAFile() != "" {
-		caCertPool, err := v2.LoadCACerts(conf.TrustedCAFile())
+		caCertPool, err := corev2.LoadCACerts(conf.TrustedCAFile())
 		if err != nil {
 			logger.Warn(err)
 			logger.Warn("Trying to use the system's default CA certificates")
@@ -49,7 +49,7 @@ func New(flags *pflag.FlagSet) *SensuCli {
 	tlsConfig.InsecureSkipVerify = conf.InsecureSkipTLSVerify()
 
 	tlsConfig.BuildNameToCertificate()
-	tlsConfig.CipherSuites = v2.DefaultCipherSuites
+	tlsConfig.CipherSuites = corev2.DefaultCipherSuites
 
 	client.SetTLSClientConfig(&tlsConfig)
 

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -18,6 +18,11 @@ func (c *Config) Format() string {
 	return c.Profile.Format
 }
 
+// InsecureSkipTLSVerify returns whether InsecureSkipTLSVerify is enabled
+func (c *Config) InsecureSkipTLSVerify() bool {
+	return c.Cluster.InsecureSkipTLSVerify
+}
+
 // Namespace returns the user's active namespace
 func (c *Config) Namespace() string {
 	if c.Profile.Namespace == "" {
@@ -29,4 +34,9 @@ func (c *Config) Namespace() string {
 // Tokens returns the active cluster JWT
 func (c *Config) Tokens() *types.Tokens {
 	return c.Cluster.Tokens
+}
+
+// TrustedCAFile returns the trusted CA file
+func (c *Config) TrustedCAFile() string {
+	return c.Cluster.TrustedCAFile
 }

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -35,8 +35,10 @@ type Config interface {
 type Read interface {
 	APIUrl() string
 	Format() string
+	InsecureSkipTLSVerify() bool
 	Namespace() string
 	Tokens() *types.Tokens
+	TrustedCAFile() string
 }
 
 // Write contains all methods related to setting and writting configuration

--- a/cli/client/config/mock.go
+++ b/cli/client/config/mock.go
@@ -26,8 +26,20 @@ func (m *MockConfig) Format() string {
 	return args.String(0)
 }
 
+// InsecureSkipTLSVerify mocks the insecure skip TLS verify config
+func (m *MockConfig) InsecureSkipTLSVerify() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 // Namespace mocks the namespace config
 func (m *MockConfig) Namespace() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// TrustedCAFile mocks the trusted CA file config
+func (m *MockConfig) TrustedCAFile() string {
 	args := m.Called()
 	return args.String(0)
 }

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -25,8 +25,20 @@ func (m *MockConfig) Format() string {
 	return args.String(0)
 }
 
+// InsecureSkipTLSVerify mocks the trusted CA file config
+func (m *MockConfig) InsecureSkipTLSVerify() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 // Namespace mocks the namespace config
 func (m *MockConfig) Namespace() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// TrustedCAFile mocks the trusted CA file config
+func (m *MockConfig) TrustedCAFile() string {
 	args := m.Called()
 	return args.String(0)
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/dump"
 	"github.com/sensu/sensu-go/cli/commands/edit"
 	"github.com/sensu/sensu-go/cli/commands/entity"
+	"github.com/sensu/sensu-go/cli/commands/env"
 	"github.com/sensu/sensu-go/cli/commands/event"
 	"github.com/sensu/sensu-go/cli/commands/filter"
 	"github.com/sensu/sensu-go/cli/commands/handler"
@@ -35,6 +36,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 	rootCmd.AddCommand(
 		configure.Command(cli),
 		completion.Command(rootCmd),
+		env.Command(cli),
 		logout.Command(cli),
 
 		// Management Commands

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -150,7 +150,7 @@ func refreshAccessToken(cli *cli.SensuCli) func(*cobra.Command, []string) {
 func shell() string {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
-		// Default to powershell for npw when running on Windows
+		// Default to powershell for now when running on Windows
 		if runtime.GOOS == "windows" {
 			return "powershell"
 		}

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"text/template"
@@ -51,7 +52,6 @@ type shellConfig struct {
 	Prefix     string
 	Delimiter  string
 	LineEnding string
-	// UsageHint  string
 
 	APIURL                string
 	Namespace             string
@@ -81,6 +81,7 @@ func (s shellConfig) UsageHint() string {
 	return fmt.Sprintf("%s Run this command to configure your shell: \n%s %s\n", comment, comment, cmd)
 }
 
+// execute contains the actual logic for displaying the environment
 func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		shellCfg := shellConfig{
@@ -133,6 +134,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	}
 }
 
+// refreshAccessToken attempts to silently refresh the access token
 func refreshAccessToken(cli *cli.SensuCli) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		tokens, err := cli.Client.RefreshAccessToken(cli.Config.Tokens().Refresh)
@@ -147,9 +149,14 @@ func refreshAccessToken(cli *cli.SensuCli) func(*cobra.Command, []string) {
 	}
 }
 
+// shell attempts to discover the shell currently used
 func shell() string {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
+		// Default to powershell for npw when running on Windows
+		if runtime.GOOS == "windows" {
+			return "powershell"
+		}
 		return ""
 	}
 

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -98,7 +98,6 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 
 		// Get the user shell
 		shellCfg.userShell = shell()
-		fmt.Printf("os.Getenv('SHELL') == %s\n", shell())
 
 		// Determine if the shell flag was passed to override the shell to use
 		shellFlag, err := cmd.Flags().GetString(shellFlag)
@@ -130,7 +129,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			return err
 		}
 
-		return tmpl.Execute(os.Stdout, shellCfg)
+		return tmpl.Execute(cmd.OutOrStdout(), shellCfg)
 	}
 }
 

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -1,0 +1,23 @@
+package env
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// Command display the commands to set up the environment used by sensuctl
+func Command(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "display the commands to set up the environment used by sensuctl",
+		RunE:  execute(cli),
+	}
+
+	return cmd
+}
+
+func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		return nil
+	}
+}

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -143,8 +143,6 @@ func refreshAccessToken(cli *cli.SensuCli) func(*cobra.Command, []string) {
 
 		// Write new tokens to disk
 		_ = cli.Config.SaveTokens(tokens)
-
-		return
 	}
 }
 

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -1,8 +1,26 @@
 package env
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
 	"github.com/sensu/sensu-go/cli"
 	"github.com/spf13/cobra"
+)
+
+const (
+	envTmpl = `{{ .Prefix }}SENSU_API_URL{{ .Delimiter }}{{ .APIURL }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_NAMESPACE{{ .Delimiter }}{{ .Namespace }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_FORMAT{{ .Delimiter }}{{ .Format }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_ACCESS_TOKEN{{ .Delimiter }}{{ .AccessToken }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_ACCESS_TOKEN_EXPIRES_AT{{ .Delimiter }}{{ .AccessTokenExpiresAt }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_REFRESH_TOKEN{{ .Delimiter }}{{ .RefreshToken }}{{ .LineEnding }}` // +
+	//`{{ .Prefix }}SENSU_TRUSTED_CA_FILE{{ .Delimiter }}{{ .TrustedCAFile }}{{ .LineEnding }}` +
+	//`{{ .Prefix }}SENSU_INSECURE_SKIP_TLS_VERIFY{{ .Delimiter }}{{ .InsecureSkipTLSVerify }}{{ .LineEnding }}`
+
+	shellFlag = "shell"
 )
 
 // Command display the commands to set up the environment used by sensuctl
@@ -13,11 +31,85 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 		RunE:  execute(cli),
 	}
 
+	_ = cmd.Flags().StringP(shellFlag, "", "",
+		fmt.Sprintf(
+			`force environment to be configured for a specified shell ("%s"|"%s"|"%s")`,
+			"bash", "cmd", "powershell",
+		))
+
 	return cmd
+}
+
+type shellConfig struct {
+	Prefix     string
+	Delimiter  string
+	LineEnding string
+
+	APIURL               string
+	Namespace            string
+	Format               string
+	AccessToken          string
+	AccessTokenExpiresAt int64
+	RefreshToken         string
+	// TrustedCAFile string
+	// InsecureSkipTLSVerify string
 }
 
 func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		return nil
+		shellCfg := shellConfig{
+			APIURL:               cli.Config.APIUrl(),
+			Namespace:            cli.Config.Namespace(),
+			Format:               cli.Config.Format(),
+			AccessToken:          cli.Config.Tokens().Access,
+			AccessTokenExpiresAt: cli.Config.Tokens().ExpiresAt,
+			RefreshToken:         cli.Config.Tokens().Refresh,
+			// TrustedCAFile  cli.Config.TrustedCAFile(),
+			// InsecureSkipTLSVerify: cli.Config.InsecureSkipTLSVerify(),
+		}
+
+		// Get the user shell
+		shell := shell()
+
+		// Determine if the shell flag was passed to override the shell to use
+		shellFlag, err := cmd.Flags().GetString(shellFlag)
+		if err != nil {
+			return err
+		}
+		if shellFlag != "" {
+			shell = shellFlag
+		}
+
+		switch shell {
+		case "cmd":
+			shellCfg.Prefix = "SET "
+			shellCfg.Delimiter = "="
+			shellCfg.LineEnding = "\n"
+		case "powershell":
+			shellCfg.Prefix = "$Env:"
+			shellCfg.Delimiter = "="
+			shellCfg.LineEnding = "\"\n"
+		default: // bash
+			shellCfg.Prefix = "export "
+			shellCfg.Delimiter = "=\""
+			shellCfg.LineEnding = "\"\n"
+		}
+
+		t := template.New("envConfig")
+		tmpl, err := t.Parse(envTmpl)
+		if err != nil {
+			return err
+		}
+
+		return tmpl.Execute(os.Stdout, shellCfg)
 	}
+}
+
+func shell() string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return ""
+	}
+
+	return filepath.Base(shell)
 }

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	"github.com/sensu/sensu-go/cli"
@@ -16,9 +17,9 @@ const (
 		`{{ .Prefix }}SENSU_FORMAT{{ .Delimiter }}{{ .Format }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_ACCESS_TOKEN{{ .Delimiter }}{{ .AccessToken }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_ACCESS_TOKEN_EXPIRES_AT{{ .Delimiter }}{{ .AccessTokenExpiresAt }}{{ .LineEnding }}` +
-		`{{ .Prefix }}SENSU_REFRESH_TOKEN{{ .Delimiter }}{{ .RefreshToken }}{{ .LineEnding }}` // +
-	//`{{ .Prefix }}SENSU_TRUSTED_CA_FILE{{ .Delimiter }}{{ .TrustedCAFile }}{{ .LineEnding }}` +
-	//`{{ .Prefix }}SENSU_INSECURE_SKIP_TLS_VERIFY{{ .Delimiter }}{{ .InsecureSkipTLSVerify }}{{ .LineEnding }}`
+		`{{ .Prefix }}SENSU_REFRESH_TOKEN{{ .Delimiter }}{{ .RefreshToken }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_TRUSTED_CA_FILE{{ .Delimiter }}{{ .TrustedCAFile }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_INSECURE_SKIP_TLS_VERIFY{{ .Delimiter }}{{ .InsecureSkipTLSVerify }}{{ .LineEnding }}`
 
 	shellFlag = "shell"
 )
@@ -46,27 +47,27 @@ type shellConfig struct {
 	Delimiter  string
 	LineEnding string
 
-	APIURL               string
-	Namespace            string
-	Format               string
-	AccessToken          string
-	AccessTokenExpiresAt int64
-	RefreshToken         string
-	// TrustedCAFile string
-	// InsecureSkipTLSVerify string
+	APIURL                string
+	Namespace             string
+	Format                string
+	AccessToken           string
+	AccessTokenExpiresAt  int64
+	RefreshToken          string
+	TrustedCAFile         string
+	InsecureSkipTLSVerify string
 }
 
 func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		shellCfg := shellConfig{
-			APIURL:               cli.Config.APIUrl(),
-			Namespace:            cli.Config.Namespace(),
-			Format:               cli.Config.Format(),
-			AccessToken:          cli.Config.Tokens().Access,
-			AccessTokenExpiresAt: cli.Config.Tokens().ExpiresAt,
-			RefreshToken:         cli.Config.Tokens().Refresh,
-			// TrustedCAFile  cli.Config.TrustedCAFile(),
-			// InsecureSkipTLSVerify: cli.Config.InsecureSkipTLSVerify(),
+			APIURL:                cli.Config.APIUrl(),
+			Namespace:             cli.Config.Namespace(),
+			Format:                cli.Config.Format(),
+			AccessToken:           cli.Config.Tokens().Access,
+			AccessTokenExpiresAt:  cli.Config.Tokens().ExpiresAt,
+			RefreshToken:          cli.Config.Tokens().Refresh,
+			TrustedCAFile:         cli.Config.TrustedCAFile(),
+			InsecureSkipTLSVerify: strconv.FormatBool(cli.Config.InsecureSkipTLSVerify()),
 		}
 
 		// Get the user shell

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -114,7 +114,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			shellCfg.LineEnding = "\n"
 		case "powershell":
 			shellCfg.Prefix = "$Env:"
-			shellCfg.Delimiter = "="
+			shellCfg.Delimiter = " = \""
 			shellCfg.LineEnding = "\"\n"
 		default: // bash
 			shellCfg.Prefix = "export "

--- a/cli/commands/env/env_test.go
+++ b/cli/commands/env/env_test.go
@@ -36,7 +36,7 @@ func TestEnvCommandCmd(t *testing.T) {
 	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
 
 	cmd := Command(cli)
-	cmd.Flags().Set("shell", "cmd")
+	_ = cmd.Flags().Set("shell", "cmd")
 	out, err := test.RunCmd(cmd, nil)
 	assert.Regexp(t, `SET SENSU_API_URL=http://127.0.0.1:8080`, out)
 	assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestEnvCommandPowershell(t *testing.T) {
 	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
 
 	cmd := Command(cli)
-	cmd.Flags().Set("shell", "powershell")
+	_ = cmd.Flags().Set("shell", "powershell")
 	out, err := test.RunCmd(cmd, nil)
 	assert.Regexp(t, `\$Env:SENSU_API_URL = "http://127.0.0.1:8080"`, out)
 	assert.NoError(t, err)

--- a/cli/commands/env/env_test.go
+++ b/cli/commands/env/env_test.go
@@ -1,0 +1,54 @@
+package env
+
+import (
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	mockclient "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func testSetupMocks(t *testing.T, config *mockclient.MockConfig) {
+	t.Helper()
+
+	config.On("APIUrl").Return("http://127.0.0.1:8080")
+	config.On("Format").Return("none")
+	config.On("Tokens").Return(
+		corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"),
+	)
+	config.On("TrustedCAFile").Return("")
+	config.On("InsecureSkipTLSVerify").Return(false)
+}
+
+func TestEnvCommandBash(t *testing.T) {
+	cli := test.NewMockCLI()
+	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
+
+	cmd := Command(cli)
+	out, err := test.RunCmd(cmd, nil)
+	assert.Regexp(t, `export SENSU_API_URL="http://127.0.0.1:8080"`, out)
+	assert.NoError(t, err)
+}
+
+func TestEnvCommandCmd(t *testing.T) {
+	cli := test.NewMockCLI()
+	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
+
+	cmd := Command(cli)
+	cmd.Flags().Set("shell", "cmd")
+	out, err := test.RunCmd(cmd, nil)
+	assert.Regexp(t, `SET SENSU_API_URL=http://127.0.0.1:8080`, out)
+	assert.NoError(t, err)
+}
+
+func TestEnvCommandPowershell(t *testing.T) {
+	cli := test.NewMockCLI()
+	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
+
+	cmd := Command(cli)
+	cmd.Flags().Set("shell", "powershell")
+	out, err := test.RunCmd(cmd, nil)
+	assert.Regexp(t, `\$Env:SENSU_API_URL = "http://127.0.0.1:8080"`, out)
+	assert.NoError(t, err)
+}

--- a/cli/commands/env/env_test.go
+++ b/cli/commands/env/env_test.go
@@ -26,6 +26,7 @@ func TestEnvCommandBash(t *testing.T) {
 	testSetupMocks(t, cli.Config.(*mockclient.MockConfig))
 
 	cmd := Command(cli)
+	_ = cmd.Flags().Set("shell", "bash")
 	out, err := test.RunCmd(cmd, nil)
 	assert.Regexp(t, `export SENSU_API_URL="http://127.0.0.1:8080"`, out)
 	assert.NoError(t, err)


### PR DESCRIPTION
## What is this change?

This PR adds the `sensuctl env` command.

bash:
```bash
$ sensuctl env
export SENSU_API_URL="http://127.0.0.1:8080"
export SENSU_NAMESPACE="default"
export SENSU_FORMAT="tabular"
export SENSU_ACCESS_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
export SENSU_ACCESS_TOKEN_EXPIRES_AT="1567716187"
export SENSU_REFRESH_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
export SENSU_TRUSTED_CA_FILE=""
export SENSU_INSECURE_SKIP_TLS_VERIFY="true"
# Run this command to configure your shell:
# eval $(sensuctl env)
```

cmd:
```cmd
$ sensuctl env --shell cmd
SET SENSU_API_URL=http://127.0.0.1:8080
SET SENSU_NAMESPACE=default
SET SENSU_FORMAT=tabular
SET SENSU_ACCESS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
SET SENSU_ACCESS_TOKEN_EXPIRES_AT=1567716676
SET SENSU_REFRESH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x
SET SENSU_TRUSTED_CA_FILE=
SET SENSU_INSECURE_SKIP_TLS_VERIFY=true
REM Run this command to configure your shell:
REM 	@FOR /f "tokens=*" %i IN ('sensuctl env --shell cmd') DO @%i
```

powershell:
```powershell
$ sensuctl env --shell powershell
$Env:SENSU_API_URL = "http://127.0.0.1:8080"
$Env:SENSU_NAMESPACE = "default"
$Env:SENSU_FORMAT = "tabular"
$Env:SENSU_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
$Env:SENSU_ACCESS_TOKEN_EXPIRES_AT = "1567716738"
$Env:SENSU_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.x.x"
$Env:SENSU_TRUSTED_CA_FILE = ""
$Env:SENSU_INSECURE_SKIP_TLS_VERIFY = "true"
# Run this command to configure your shell:
# & sensuctl env --shell powershell | Invoke-Expression
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3253

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Detecting the shell on Windows is hard...

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation will be required.

## How did you verify this change?

Added unit tests + https://github.com/sensu/sensu-go-qa-crucible/pull/75
