### PR TITLE
Only validate check interval/cron when publish true

### DIFF
--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -140,17 +140,19 @@ func (c *Check) Validate() error {
 	if err := ValidateName(c.Name); err != nil {
 		return errors.New("check name " + err.Error())
 	}
-	if c.Cron != "" {
-		if c.Interval > 0 {
-			return errors.New("must only specify either an interval or a cron schedule")
-		}
+	if c.Publish {
+		if c.Cron != "" {
+			if c.Interval > 0 {
+				return errors.New("must only specify either an interval or a cron schedule")
+			}
 
-		if _, err := cron.ParseStandard(c.Cron); err != nil {
-			return errors.New("check cron string is invalid")
-		}
-	} else {
-		if c.Interval < 1 {
-			return errors.New("check interval must be greater than or equal to 1")
+			if _, err := cron.ParseStandard(c.Cron); err != nil {
+				return errors.New("check cron string is invalid")
+			}
+		} else {
+			if c.Interval < 1 {
+				return errors.New("check interval must be greater than or equal to 1")
+			}
 		}
 	}
 

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -35,6 +35,9 @@ func TestScheduleValidation(t *testing.T) {
 
 	c.Cron = "this is an invalid cron"
 	assert.Error(t, c.Validate())
+
+	c.Publish = false
+	assert.NoError(t, c.Validate())
 }
 
 func TestFixtureCheckIsValid(t *testing.T) {


### PR DESCRIPTION
Only validate check interval and cron when publish is set to true. This reduces the required fields when posting to the Events API etc.

Part of https://github.com/sensu/sensu-go/issues/3257