### PR TITLE
Fix panic when no asset build filters pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Multi-asset builds with no matching filters will no longer cause a panic.
+
 ## [5.13.0] - 2019-09-09
 
 ### Added

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -95,6 +95,30 @@ func TestFilteredManagerFilteredBuildAsset(t *testing.T) {
 	assert.True(t, mockGetter.getCalled)
 }
 
+// TestFilteredManagerUnfilteredBuildAsset tests to ensure no asset is returned
+// when all build filters do not pass.
+func TestFilteredManagerUnfilteredBuildAsset(t *testing.T) {
+	_, _, filteredManager := NewTestFilteredManager()
+
+	url := "http://asset-build-url"
+	sha512 := "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+	filters := []string{"entity.name == 'asdf'"}
+
+	fixtureAsset := types.FixtureAsset("test-asset")
+	fixtureAsset.Filters = []string{"entity.name == 'foo'"}
+	fixtureAsset.Builds = []*corev2.AssetBuild{
+		{
+			URL:     url,
+			Sha512:  sha512,
+			Filters: filters,
+		},
+	}
+
+	actualAsset, err := filteredManager.Get(context.TODO(), fixtureAsset)
+	assert.NoError(t, err)
+	assert.Nil(t, actualAsset)
+}
+
 // FilteredManager should return error passed by underlying Getter.
 func TestFilteredManagerError(t *testing.T) {
 	mockGetter, _, filteredManager := NewTestFilteredManager()


### PR DESCRIPTION
## What is this change?

If an asset contains builds and none of the filters pass, the app will crash.

## Why is this change necessary?

Panics in sensu-agent & sensu-backend are bad.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## How did you verify this change?

I wrote a new test that reproduced the panic. After making the changes below, the panic no longer occurs.