### PR TITLE
Use the embedded client when etcd is embedded

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -284,7 +284,7 @@ func Initialize(config *Config) (*Backend, error) {
 		EventStore:          eventStoreProxy,
 		QueueGetter:         queueGetter,
 		TLS:                 config.TLS,
-		Cluster:             clientv3.NewCluster(b.Client),
+		Cluster:             b.Client.Cluster,
 		EtcdClientTLSConfig: etcdClientTLSConfig,
 		Authenticator:       authenticator,
 		ClusterVersion:      clusterVersion,

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,7 +16,7 @@ func TestNewEtcd(t *testing.T) {
 
 	client, err := e.NewClient()
 	assert.NoError(t, err)
-	kv := clientv3.NewKV(client)
+	kv := client.KV
 	assert.NotNil(t, kv)
 
 	putsResp, err := kv.Put(context.Background(), "key", "value")

--- a/backend/store/etcd/health_store_test.go
+++ b/backend/store/etcd/health_store_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGetClusterHealth(t *testing.T) {
 	testWithEtcdClient(t, func(store store.Store, client *clientv3.Client) {
-		healthResult := store.GetClusterHealth(context.Background(), clientv3.NewCluster(client), (*tls.Config)(nil))
+		healthResult := store.GetClusterHealth(context.Background(), client.Cluster, (*tls.Config)(nil))
 		assert.Empty(t, healthResult.ClusterHealth[0].Err)
 	})
 }

--- a/backend/store/etcd/testutil/store.go
+++ b/backend/store/etcd/testutil/store.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -53,9 +52,9 @@ func NewStoreInstance() (*IntegrationTestStore, error) {
 	cfg.DataDir = tmpDir
 	cfg.InitialClusterState = etcd.ClusterStateNew
 
-	cfg.ListenClientURLs = []string{fmt.Sprintf("http://127.0.0.1:%d", p[0])}
-	cfg.ListenPeerURLs = []string{fmt.Sprintf("http://127.0.0.1:%d", p[1])}
-	cfg.InitialCluster = fmt.Sprintf("default=http://127.0.0.1:%d", p[1])
+	cfg.ListenClientURLs = []string{"http://127.0.0.1:0"}
+	cfg.ListenPeerURLs = []string{"http://127.0.0.1:0"}
+	cfg.InitialCluster = "default=http://127.0.0.1:0"
 	cfg.AdvertiseClientURLs = cfg.ListenClientURLs
 	cfg.InitialAdvertisePeerURLs = cfg.ListenPeerURLs
 	e, err := etcd.NewEtcd(cfg)

--- a/backend/store/etcd/watcher_test.go
+++ b/backend/store/etcd/watcher_test.go
@@ -99,7 +99,7 @@ func TestWatchErrConnClosed(t *testing.T) {
 		watchChanStopped := make(chan struct{})
 		w.watch(ctx, opts, watchChanStopped)
 
-		if err := client.ActiveConnection().Close(); err != nil {
+		if err := client.Close(); err != nil && err != context.Canceled {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
## What is this change?

This commit makes Sensu use an embedded client for etcd requests,
instead of connecing localhost. This has several useful effects:
  * Avoids the network stack for etcd requests, for embedded etcd
  * Avoids gRPC serialization, for embedded etcd
  * Simplifies integration testing

The biggest win here is that we can have the integration test etcd
servers listen on ':0', which assigns an arbitrary port instead of
one that we have to pick. This should let the OS pick a port
instead of us, which solves a long-standing CI bug where our tests
could sometimes pick the same port to listen on in parallel,
causing failure.

There should also be some performance wins from avoiding the
network stack, but this is yet to be verified.

## Why is this change necessary?

Closes #697 
Closes #3263 

## Does your change need a Changelog entry?

No, this is not a user-visible change.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes necessary.

## How did you verify this change?

Integration testing, which I believe is sufficient here.