### PR TITLE
sensuctl dump redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Only validate check interval/cron when publish true
 
 ### Fixed
+- sensuctl dump no longer silently discards errors.
 - Interactive check create and update modes now have 'none' as the first
 highlighted option, instead of nagios-perfdata.
 - Fixed a bug where silences would not expire on event resolution.

--- a/cli/client/error.go
+++ b/cli/client/error.go
@@ -29,6 +29,10 @@ func UnmarshalError(res *resty.Response) error {
 		apiErr.Code = uint32(actions.PaymentRequired)
 		apiErr.Message = "This functionality requires a valid Sensu Go license. Please install a valid license file and restart or contact Sales for a trial."
 
+	case http.StatusNotFound:
+		apiErr.Code = uint32(actions.NotFound)
+		fallthrough
+
 	default:
 		if err := json.Unmarshal(res.Body(), &apiErr); err != nil {
 			if len(res.Body()) > 0 {

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -55,18 +55,35 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 		if err != nil {
 			return err
 		}
-		*header = resp.Header()
+		if header != nil {
+			*header = resp.Header()
+		}
 
 		if resp.StatusCode() >= 400 {
 			return UnmarshalError(resp)
 		}
 
 		newObjs := reflect.New(objsType.Elem())
-		if err := json.Unmarshal(resp.Body(), newObjs.Interface()); err != nil {
+		o := reflect.ValueOf(objs).Elem()
+
+		body := resp.Body()
+		if len(body) == 0 {
+			return nil
+		}
+		if len(body) > 0 && body[0] == '{' {
+			// Special case for a single resource being returned
+			elem := reflect.New(reflect.Indirect(newObjs).Type().Elem().Elem())
+			if err := json.Unmarshal(body, elem.Interface()); err != nil {
+				return err
+			}
+			o.Set(reflect.Append(o, elem))
+			return nil
+		}
+
+		if err := json.Unmarshal(body, newObjs.Interface()); err != nil {
 			return err
 		}
 
-		o := reflect.ValueOf(objs).Elem()
 		o.Set(reflect.AppendSlice(o, newObjs.Elem()))
 
 		options.ContinueToken = resp.Header().Get(corev2.PaginationContinueHeader)

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -53,6 +53,10 @@ func init() {
 	}
 }
 
+type lifter interface {
+	Lift() types.Resource
+}
+
 var resourceRE = regexp.MustCompile(`(\w+\/v\d+\.)?(\w+)`)
 
 func resolveResource(resource string) (types.Resource, error) {
@@ -126,6 +130,9 @@ func getResourceRequests(actionSpec string) ([]types.Resource, error) {
 		resource, err := resolveResource(t)
 		if err != nil {
 			return nil, fmt.Errorf("invalid resource type: %s", t)
+		}
+		if lifter, ok := resource.(lifter); ok {
+			resource = lifter.Lift()
 		}
 		actions = append(actions, resource)
 	}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -172,7 +172,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			w = f
 		}
 
-		for _, req := range requests {
+		for i, req := range requests {
 			// set the namespaces on the requests
 			ok, err := cmd.Flags().GetBool(flags.AllNamespaces)
 			if err != nil {
@@ -204,6 +204,10 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			}
 
 			val = reflect.Indirect(val)
+			if val.Len() == 0 {
+				continue
+			}
+
 			resources := make([]corev2.Resource, val.Len())
 			for i := range resources {
 				resources[i] = val.Index(i).Interface().(corev2.Resource)
@@ -215,6 +219,9 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			case config.FormatWrappedJSON:
 				err = helpers.PrintWrappedJSONList(resources, w)
 			case config.FormatYAML:
+				if i > 0 {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+				}
 				err = helpers.PrintYAML(resources, w)
 			default:
 				err = fmt.Errorf("invalid output format: %s", format)

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -3,59 +3,92 @@ package dump
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
+	"reflect"
+	"regexp"
 	"strings"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/cobra"
 )
 
-const (
-	// VerbList is the sensuctl verb to list resources.
-	VerbList = "list"
-	// VerbInfo is the sensuctl verb to get info about a resource.
-	VerbInfo = "info"
-)
-
-// Action is a resource/verb tuple for sensuctl commands.
-type Action struct {
-	Resource   string
-	Verb       string
-	Namespaced bool
-}
-
 var (
 	// All is all the core resource types and associated sensuctl verbs (non-namespaced resources are intentionally ordered first).
-	All = []Action{
-		Action{Resource: "namespace", Verb: VerbList, Namespaced: false},
-		Action{Resource: "cluster-role", Verb: VerbList, Namespaced: false},
-		Action{Resource: "cluster-role-binding", Verb: VerbList, Namespaced: false},
-		Action{Resource: "user", Verb: VerbList, Namespaced: false},
-		Action{Resource: "tessen", Verb: VerbInfo, Namespaced: false},
-		Action{Resource: "asset", Verb: VerbList, Namespaced: true},
-		Action{Resource: "check", Verb: VerbList, Namespaced: true},
-		Action{Resource: "entity", Verb: VerbList, Namespaced: true},
-		Action{Resource: "event", Verb: VerbList, Namespaced: true},
-		Action{Resource: "filter", Verb: VerbList, Namespaced: true},
-		Action{Resource: "handler", Verb: VerbList, Namespaced: true},
-		Action{Resource: "hook", Verb: VerbList, Namespaced: true},
-		Action{Resource: "mutator", Verb: VerbList, Namespaced: true},
-		Action{Resource: "role", Verb: VerbList, Namespaced: true},
-		Action{Resource: "role-binding", Verb: VerbList, Namespaced: true},
-		Action{Resource: "silenced", Verb: VerbList, Namespaced: true},
+	All = []types.Resource{
+		&corev2.Namespace{},
+		&corev2.ClusterRole{},
+		&corev2.ClusterRoleBinding{},
+		&corev2.User{},
+		&corev2.TessenConfig{},
+		&corev2.Asset{},
+		&corev2.CheckConfig{},
+		&corev2.Entity{},
+		&corev2.Event{},
+		&corev2.EventFilter{},
+		&corev2.Handler{},
+		&corev2.Hook{},
+		&corev2.Mutator{},
+		&corev2.Role{},
+		&corev2.RoleBinding{},
+		&corev2.Silenced{},
 	}
+
+	ChunkSize = 100
+
+	// synonyms provides user-friendly resource synonyms like checks, entities
+	synonyms = map[string]corev2.Resource{}
 )
+
+func init() {
+	for _, resource := range All {
+		synonyms[resource.RBACName()] = resource
+	}
+}
+
+var resourceRE = regexp.MustCompile(`(\w+\/v\d+\.)?(\w+)`)
+
+func resolveResource(resource string) (types.Resource, error) {
+	if resource, ok := synonyms[resource]; ok {
+		return resource, nil
+	}
+	matches := resourceRE.FindStringSubmatch(resource)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("bad resource qualifier: %s. hint: try something like core/v2.CheckConfig", resource)
+	}
+	apiVersion := strings.TrimSuffix(matches[1], ".")
+	typeName := matches[2]
+	if apiVersion == "" {
+		apiVersion = "core/v2"
+	}
+	return types.ResolveType(apiVersion, typeName)
+}
+
+var description = `sensuctl dump
+
+Dump resources to stdout or a file. Example:
+$ sensuctl dump checks
+
+The tool also supports naming types by their fully-qualified names:
+$ sensuctl dump core/v2.CheckConfig,core/v2.Entity
+
+You can also use the 'all' qualifier to dump all supported resources:
+$ sensuctl dump all
+`
 
 // Command dumps generic Sensu resources to a file or STDOUT.
 func Command(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "dump [RESOURCE TYPE],[RESOURCE TYPE]... [-f FILE]",
-		Short: "dump resources to a file or STDOUT",
-		RunE:  execute(cli),
+		Use:  "dump [RESOURCE TYPE],[RESOURCE TYPE]... [-f FILE]",
+		Long: description,
+		RunE: execute(cli),
 	}
 
 	helpers.AddAllNamespace(cmd.Flags())
@@ -63,6 +96,40 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
 
 	return cmd
+}
+
+func dedupTypes(arg string) []string {
+	types := strings.Split(arg, ",")
+	seen := make(map[string]struct{})
+	result := make([]string, 0, len(types))
+	for _, t := range types {
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		result = append(result, t)
+	}
+	return result
+}
+
+func getResourceRequests(actionSpec string) ([]types.Resource, error) {
+	// parse the comma separated resource types and match against the defined actions
+	if actionSpec == "all" {
+		return All, nil
+	}
+	var actions []types.Resource
+	// deduplicate requested resources
+	types := dedupTypes(actionSpec)
+
+	// build resource requests for sensuctl
+	for _, t := range types {
+		resource, err := resolveResource(t)
+		if err != nil {
+			return nil, fmt.Errorf("invalid resource type: %s", t)
+		}
+		actions = append(actions, resource)
+	}
+	return actions, nil
 }
 
 func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
@@ -84,82 +151,80 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		}
 
 		// parse the comma separated resource types and match against the defined actions
-		var actions []Action
-		if args[0] == "all" {
-			actions = All
-		} else {
-			// check for duplicates first
-			types := strings.Split(args[0], ",")
-			for i := 0; i < len(types); i++ {
-				for v := 0; v < i; v++ {
-					if types[v] == types[i] {
-						return fmt.Errorf("duplicate resource type: %s", types[v])
-					}
-				}
-			}
-			// build actions for sensuctl
-			for _, t := range types {
-				length := len(actions)
-				for _, action := range All {
-					if t == action.Resource {
-						actions = append(actions, action)
-					}
-				}
-				if length == len(actions) {
-					return fmt.Errorf("invalid resource type: %s", t)
-				}
-			}
+		requests, err := getResourceRequests(args[0])
+		if err != nil {
+			return err
 		}
 
-		// iterate the matched actions and start building a sensuctl command
-		var out string
-		for _, a := range actions {
-			ctlArgs := []string{
-				a.Resource,
-				a.Verb,
-				"--format",
-				format,
-			}
+		var w io.Writer = cmd.OutOrStdout()
 
-			// append --namespace or --all-namespaces flag if compatible with the resource type
-			if a.Namespaced {
-				if ok, err := cmd.Flags().GetBool(flags.AllNamespaces); err != nil {
-					return err
-				} else if ok {
-					ctlArgs = append(ctlArgs, "--all-namespaces")
-				} else {
-					ctlArgs = append(ctlArgs, "--namespace")
-					ctlArgs = append(ctlArgs, cli.Config.Namespace())
-				}
-			}
-
-			// execute the command and build wrapped-json or yaml lists
-			originalBytes, _ := exec.Command(os.Args[0], ctlArgs...).Output()
-			if len(originalBytes) == 0 {
-				continue
-			}
-			if format == config.FormatWrappedJSON {
-				out = fmt.Sprintf("%s%s", out, string(originalBytes))
-			} else {
-				out = fmt.Sprintf("%s---\n%s", out, string(originalBytes))
-			}
-		}
-
-		// write data to file or STDOUT
+		// if a file is requested, write data to that
 		fp, err := cmd.Flags().GetString("file")
 		if err != nil {
 			return err
 		}
-		if fp == "" {
-			_, err := fmt.Print(out)
-			return err
+		if fp != "" {
+			f, err := os.Create(fp)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			w = f
 		}
-		f, err := os.Create(fp)
-		if err != nil {
-			return err
+
+		for _, req := range requests {
+			// set the namespaces on the requests
+			ok, err := cmd.Flags().GetBool(flags.AllNamespaces)
+			if err != nil {
+				return err
+			}
+			if ok {
+				req.SetNamespace(corev2.NamespaceTypeAll)
+			} else {
+				req.SetNamespace(cli.Config.Namespace())
+			}
+
+			val := reflect.New(reflect.SliceOf(reflect.TypeOf(req)))
+			err = cli.Client.List(
+				req.URIPath(), val.Interface(), &client.ListOptions{
+					ChunkSize: ChunkSize,
+				}, nil)
+			if err != nil {
+				// We want to ignore non-nil errors that are a result of
+				// resources not existing, or features being licensed.
+				err, ok := err.(client.APIError)
+				if !ok {
+					return fmt.Errorf("API error: %s", err)
+				}
+				switch actions.ErrCode(err.Code) {
+				case actions.PaymentRequired, actions.NotFound:
+					continue
+				}
+				return fmt.Errorf("API error: %s", err)
+			}
+
+			val = reflect.Indirect(val)
+			resources := make([]corev2.Resource, val.Len())
+			for i := range resources {
+				resources[i] = val.Index(i).Interface().(corev2.Resource)
+			}
+
+			switch format {
+			case config.FormatJSON:
+				err = helpers.PrintJSON(resources, w)
+			case config.FormatWrappedJSON:
+				err = helpers.PrintWrappedJSONList(resources, w)
+			case config.FormatYAML:
+				err = helpers.PrintYAML(resources, w)
+			default:
+				err = fmt.Errorf("invalid output format: %s", format)
+			}
+
+			if err != nil {
+				return err
+			}
 		}
-		defer f.Close()
-		_, err = f.WriteString(out)
-		return err
+
+		return nil
 	}
 }

--- a/cli/commands/dump/dump_test.go
+++ b/cli/commands/dump/dump_test.go
@@ -16,7 +16,6 @@ func TestCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("dump", cmd.Use)
-	assert.Regexp("dump resources", cmd.Short)
 }
 
 func TestCommandArgs(t *testing.T) {
@@ -27,11 +26,6 @@ func TestCommandArgs(t *testing.T) {
 
 	out, err := test.RunCmd(cmd, []string{})
 	assert.NotEmpty(out)
-	assert.Error(err)
-
-	// duplicate resources
-	out, err = test.RunCmd(cmd, []string{"check,handler,check"})
-	assert.Empty(out)
 	assert.Error(err)
 
 	// invalid resources

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -36,6 +36,10 @@ var packageMap = map[string]func(string) (Resource, error){
 
 var packageMapMu = &sync.RWMutex{}
 
+type lifter interface {
+	Lift() Resource
+}
+
 // UnmarshalJSON implements json.Unmarshaler
 func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	var wrapper rawWrapper
@@ -93,6 +97,9 @@ func (w *Wrapper) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 	val.FieldByName("ObjectMeta").Set(reflect.ValueOf(innerMeta))
+	if lifter, ok := resource.(lifter); ok {
+		resource = lifter.Lift()
+	}
 	w.Value = resource
 	return nil
 }


### PR DESCRIPTION
## What is this change?

Fixes sensuctl dump again, this time with support for wrapped resources as well.

## Why is this change necessary?

The original edition was backed out.
Closes #3236

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

The original edition of this PR was merged, but backed out due to the enterprise resources not working correctly with it.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required, for dumping enterprise resources.

## How did you verify this change?

I ran `sensuctl dump all`, and:
```
[eric@localhost sensu-enterprise-go]$ sensuctl dump 'store/v1.PostgresConfig'
type: PostgresConfig
api_version: store/v1
metadata:
  name: postgres
  namespace: default
spec:
  dsn: foo=foo
  pool_size: 0
```