### PR TITLE
sensuctl commands support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   - go version
   - go env
   - mkdir %GOPATH%\bin
-  - go mod verify
+  - go mod download
 
 platform:
   - x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,7 @@ install:
   - go version
   - go env
   - mkdir %GOPATH%\bin
+  - go mod verify
 
 platform:
   - x64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ cache:
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.13.1
+  GOVERSION: 1.13.3
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ sensu_go_build_env: &sensu_go_build_env
   ####   /go/src/bitbucket.org/circleci/go-tool
   working_directory: /go/src/github.com/sensu/sensu-go
   docker:
-    - image: circleci/golang:1.13.1
+    - image: circleci/golang:1.13.3
 
 jobs:
   test:

--- a/bonsai/client.go
+++ b/bonsai/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,6 +17,11 @@ const DefaultEndpointURL = "https://bonsai.sensu.io/api/v1/assets"
 // Config is the configuration for bonsai.
 type Config struct {
 	EndpointURL string
+}
+
+type Client interface {
+	FetchAsset(string, string) (*corev2.BonsaiAsset, error)
+	FetchAssetVersion(string, string, string) (string, error)
 }
 
 // RestClient wraps resty.Client

--- a/bonsai/client.go
+++ b/bonsai/client.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/go-resty/resty"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,7 +19,7 @@ type Config struct {
 }
 
 type Client interface {
-	FetchAsset(string, string) (*corev2.BonsaiAsset, error)
+	FetchAsset(string, string) (*Asset, error)
 	FetchAssetVersion(string, string, string) (string, error)
 }
 

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -1,0 +1,268 @@
+package cmdmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/sensu/sensu-go/asset"
+	"github.com/sensu/sensu-go/bonsai"
+	"github.com/sensu/sensu-go/command"
+	"github.com/sensu/sensu-go/system"
+	"github.com/sensu/sensu-go/util/environment"
+	"github.com/sensu/sensu-go/util/path"
+
+	goversion "github.com/hashicorp/go-version"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	dbName = "commands.db"
+)
+
+var (
+	commandBucketName = []byte("commands")
+)
+
+type CommandManager struct {
+	assetManager *asset.Manager
+	assetGetter  asset.Getter
+	db           *bolt.DB
+}
+
+type CommandPlugin struct {
+	Alias string       `json:"alias"`
+	Asset corev2.Asset `json:"asset"`
+}
+
+func NewCommandManager() (*CommandManager, error) {
+	m := CommandManager{}
+
+	// create an entity for using with command asset filtering
+	systemInfo, err := system.Info()
+	if err != nil {
+		return nil, err
+	}
+	meta := corev2.NewObjectMeta("sensuctl", "")
+	entity := &corev2.Entity{
+		EntityClass: "sensuctl",
+		ObjectMeta:  meta,
+		System:      systemInfo,
+	}
+
+	cacheDir := path.UserCacheDir("sensuctl")
+	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{})
+
+	// start the asset manager
+	ctx := context.TODO()
+	wg := sync.WaitGroup{}
+	m.assetManager = asset.NewManager(cacheDir, entity, &wg)
+	m.assetGetter, err = m.assetManager.StartAssetManager(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string) error {
+	bAsset, err := corev2.NewBonsaiBaseAsset(bonsaiAssetName)
+	if err != nil {
+		return err
+	}
+
+	var version *goversion.Version
+	if bAsset.Version != "" {
+		version, err = goversion.NewVersion(bAsset.Version)
+		if err != nil {
+			return err
+		}
+	}
+
+	bonsaiClient := bonsai.New(bonsai.BonsaiConfig{})
+	bonsaiAsset, err := bonsaiClient.FetchAsset(bAsset.Namespace, bAsset.Name)
+	if err != nil {
+		return err
+	}
+
+	if version == nil {
+		fmt.Println("no version specified, using latest:", bonsaiAsset.LatestVersion())
+		version = bonsaiAsset.LatestVersion()
+	} else if !bonsaiAsset.HasVersion(version) {
+		availableVersions := bonsaiAsset.ValidVersions()
+		sort.Sort(goversion.Collection(availableVersions))
+		availableVersionStrs := []string{}
+		for _, v := range availableVersions {
+			availableVersionStrs = append(availableVersionStrs, v.String())
+		}
+		return fmt.Errorf("version \"%s\" of asset \"%s/%s\" does not exist\navailable versions: %s",
+			version, bAsset.Namespace, bAsset.Name, strings.Join(availableVersionStrs, ", "))
+	}
+
+	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version)
+
+	assetJSON, err := bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.String())
+	if err != nil {
+		return err
+	}
+
+	var asset corev2.Asset
+	if err := json.Unmarshal([]byte(assetJSON), &asset); err != nil {
+		return err
+	}
+
+	return m.installCommand(alias, &asset)
+}
+
+func (m *CommandManager) InstallCommandFromURL(alias, url, sha512 string) error {
+	commandAsset := &corev2.Asset{
+		ObjectMeta: corev2.ObjectMeta{
+			Name:      alias,
+			Namespace: "",
+		},
+		Builds: []*corev2.AssetBuild{
+			{
+				URL:     url,
+				Sha512:  sha512,
+				Filters: []string{},
+			},
+		},
+	}
+	return m.installCommand(alias, commandAsset)
+}
+
+func (m *CommandManager) installCommand(alias string, commandAsset *corev2.Asset) error {
+	err := m.registerCommandPlugin(alias, commandAsset)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("command was installed successfully")
+
+	return nil
+}
+
+func (m *CommandManager) ExecCommand(alias string, args []string) error {
+	commandPlugin, err := m.fetchCommandPlugin(alias)
+	if err != nil {
+		return err
+	}
+
+	if commandPlugin == nil {
+		return errors.New("the alias specified does not exist")
+	}
+
+	ctx := context.TODO()
+	runtimeAsset, err := m.assetGetter.Get(ctx, &commandPlugin.Asset)
+	if err != nil {
+		return err
+	}
+
+	if runtimeAsset == nil {
+		return errors.New("no asset filters were matched")
+	}
+
+	env := environment.MergeEnvironments(os.Environ(), runtimeAsset.Env())
+
+	executor := command.NewExecutor()
+
+	ex := command.ExecutionRequest{
+		Env:     env,
+		Command: "entrypoint",
+		Timeout: 30,
+		Name:    commandPlugin.Alias,
+	}
+
+	checkExec, err := executor.Execute(context.Background(), ex)
+	if err != nil {
+		return err
+	} else {
+		fmt.Printf(checkExec.Output)
+	}
+
+	return nil
+}
+
+func (m *CommandManager) registerCommandPlugin(alias string, commandAsset *corev2.Asset) error {
+	commandPlugin, err := m.fetchCommandPlugin(alias)
+	if err != nil {
+		return err
+	}
+
+	if commandPlugin != nil {
+		return errors.New("the alias specified already exists")
+	}
+
+	key := []byte(alias)
+
+	localCommandPlugin := CommandPlugin{
+		Alias: alias,
+		Asset: *commandAsset,
+	}
+
+	if err := m.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(commandBucketName)
+		if err != nil {
+			return err
+		}
+
+		// Though we've already attempted to do this, it's possible that a previous
+		// call completed installation of the asset while this transaction
+		// was blocked on serialization. Re-attempt to get the key in case that is
+		// what happened.
+		value := bucket.Get(key)
+		if value != nil {
+			// deserialize command plugin
+			if err := json.Unmarshal(value, &localCommandPlugin); err == nil {
+				return nil
+			}
+		}
+
+		// serialize the command plugin and add the command plugin to boltdb
+		commandJSON, err := json.Marshal(localCommandPlugin)
+		if err != nil {
+			panic(err)
+		}
+
+		return bucket.Put(key, commandJSON)
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *CommandManager) fetchCommandPlugin(alias string) (*CommandPlugin, error) {
+	key := []byte(alias)
+	var localCommandPlugin *CommandPlugin
+
+	// check boltdb for command alias
+	if err := m.db.View(func(tx *bolt.Tx) error {
+		// If the key exists, the bucket should already exist.
+		bucket := tx.Bucket(commandBucketName)
+		if bucket == nil {
+			return nil
+		}
+
+		value := bucket.Get(key)
+		if value != nil {
+			// deserialize command mapping
+			if err := json.Unmarshal(value, &localCommandPlugin); err == nil {
+				return nil
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return localCommandPlugin, nil
+}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -77,7 +77,7 @@ func (p *CommandPlugin) SetObjectMeta(meta corev2.ObjectMeta) {
 func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 	m := CommandManager{
 		cli:          cli,
-		bonsaiClient: bonsai.New(bonsai.BonsaiConfig{}),
+		bonsaiClient: bonsai.New(bonsai.Config{}),
 	}
 
 	// create an entity for using with command asset filtering
@@ -114,7 +114,7 @@ func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 }
 
 func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string) error {
-	bAsset, err := corev2.NewBonsaiBaseAsset(bonsaiAssetName)
+	bAsset, err := bonsai.NewBaseAsset(bonsaiAssetName)
 	if err != nil {
 		return err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/bonsai"
@@ -99,7 +100,9 @@ func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 	}
 
 	cacheDir := path.UserCacheDir("sensuctl")
-	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{})
+	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{
+		Timeout: 60 * time.Second,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -87,6 +87,9 @@ func NewCommandManager() (*CommandManager, error) {
 
 	cacheDir := path.UserCacheDir("sensuctl")
 	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{})
+	if err != nil {
+		return nil, err
+	}
 
 	// start the asset manager
 	ctx := context.TODO()
@@ -319,7 +322,7 @@ func (m *CommandManager) FetchCommandPlugins() ([]*CommandPlugin, error) {
 			return nil
 		}
 
-		b.ForEach(func(k, v []byte) error {
+		if err := b.ForEach(func(k, v []byte) error {
 			var localCommandPlugin *CommandPlugin
 
 			// deserialize command plugin
@@ -329,7 +332,9 @@ func (m *CommandManager) FetchCommandPlugins() ([]*CommandPlugin, error) {
 			localCommandPlugins = append(localCommandPlugins, localCommandPlugin)
 
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
 
 		return nil
 	}); err != nil {

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -100,18 +100,19 @@ func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 	}
 
 	cacheDir := path.UserCacheDir("sensuctl")
-	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{
-		Timeout: 60 * time.Second,
-	})
-	if err != nil {
-		return nil, err
-	}
 
 	// start the asset manager
 	ctx := context.TODO()
 	wg := sync.WaitGroup{}
 	m.assetManager = asset.NewManager(cacheDir, entity, &wg)
 	m.assetGetter, err = m.assetManager.StartAssetManager(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{
+		Timeout: 60 * time.Second,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -244,7 +244,7 @@ func (m *CommandManager) installCommand(alias string, commandAsset *corev2.Asset
 	return nil
 }
 
-func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []string) error {
+func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []string, commandEnv []string) error {
 	commandPlugin, err := m.fetchCommandPlugin(alias)
 	if err != nil {
 		return err
@@ -263,7 +263,8 @@ func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []s
 		return errors.New("no asset filters were matched")
 	}
 
-	env := environment.MergeEnvironments(os.Environ(), runtimeAsset.Env())
+	env := environment.MergeEnvironments(os.Environ(), commandEnv)
+	env = environment.MergeEnvironments(env, runtimeAsset.Env())
 
 	executor := command.NewExecutor()
 

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -323,3 +323,16 @@ func (m *CommandManager) FetchCommandPlugins() ([]*CommandPlugin, error) {
 
 	return localCommandPlugins, nil
 }
+
+func (m *CommandManager) DeleteCommandPlugin(alias string) error {
+	key := []byte(alias)
+
+	return m.db.Batch(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(commandBucketName)
+		if bucket == nil {
+			return nil
+		}
+
+		return bucket.Delete(key)
+	})
+}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -146,6 +146,22 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		return err
 	}
 
+	if val, ok := asset.Annotations["io.sensu.bonsai.type"]; ok {
+		if val != "sensuctl" {
+			return errors.New("requested asset is not a sensuctl asset")
+		}
+	} else {
+		return errors.New("requested asset does not have a type annotation set")
+	}
+
+	if val, ok := asset.Annotations["io.sensu.bonsai.provider"]; ok {
+		if val != "sensuctl/command" {
+			return errors.New("requested asset is not a sensuctl/command asset")
+		}
+	} else {
+		return errors.New("requested asset does not have a provider annotation set")
+	}
+
 	return m.installCommand(alias, &asset)
 }
 

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -367,6 +367,11 @@ func (m *CommandManager) DeleteCommandPlugin(alias string) error {
 			return nil
 		}
 
+		value := bucket.Get(key)
+		if value == nil {
+			return errors.New("a command by that name does not exist")
+		}
+
 		return bucket.Delete(key)
 	})
 }

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	dbName = "commands.db"
+	dbName      = "commands.db"
+	commandName = "entrypoint"
 )
 
 var (
@@ -249,9 +250,11 @@ func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []s
 	env := environment.MergeEnvironments(os.Environ(), commandEnv)
 	env = environment.MergeEnvironments(env, runtimeAsset.Env())
 
+	commandWithArgs := append([]string{commandName}, args...)
+
 	ex := command.ExecutionRequest{
 		Env:     env,
-		Command: "entrypoint",
+		Command: strings.Join(commandWithArgs, " "),
 		Timeout: 30,
 		Name:    commandPlugin.Alias,
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -177,7 +177,7 @@ func (m *CommandManager) installCommand(alias string, commandAsset *corev2.Asset
 	return nil
 }
 
-func (m *CommandManager) ExecCommand(alias string, args []string) error {
+func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []string) error {
 	commandPlugin, err := m.fetchCommandPlugin(alias)
 	if err != nil {
 		return err
@@ -187,7 +187,6 @@ func (m *CommandManager) ExecCommand(alias string, args []string) error {
 		return errors.New("the alias specified does not exist")
 	}
 
-	ctx := context.TODO()
 	runtimeAsset, err := m.assetGetter.Get(ctx, &commandPlugin.Asset)
 	if err != nil {
 		return err

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -728,7 +728,7 @@ func TestCommandManager_ExecCommand(t *testing.T) {
 			},
 		},
 		{
-			name:  "executor success",
+			name:  "executor success without args",
 			alias: alias,
 			commandEnv: []string{
 				"EXAMPLE_SENSU_ENV_VAR=1234",
@@ -762,6 +762,26 @@ func TestCommandManager_ExecCommand(t *testing.T) {
 				assert.Equal(t, "entrypoint", execution.Command)
 				assert.Equal(t, 30, execution.Timeout)
 				assert.Equal(t, env, execution.Env)
+			},
+		},
+		{
+			name:  "executor success with args",
+			alias: alias,
+			args:  []string{"arg1", "arg2"},
+			assetGetterFunc: func(m *mockassetgetter.MockAssetGetter) {
+				runtimeAsset := asset.RuntimeAsset{
+					Path:   assetPath,
+					SHA512: checksum,
+				}
+				m.On("Get", ctx, &testAsset).
+					Return(&runtimeAsset, nil)
+			},
+			executorFunc: func(m *mockexecutor.MockExecutor) {
+				executionResponse := command.FixtureExecutionResponse(0, "success\n")
+				m.Return(executionResponse, nil)
+			},
+			executionRequestFunc: func(c context.Context, execution command.ExecutionRequest) {
+				assert.Equal(t, "entrypoint arg1 arg2", execution.Command)
 			},
 		},
 	}

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -635,7 +635,7 @@ func TestCommandManager_ExecCommand(t *testing.T) {
 
 	callbackFn := func(m *CommandManager, cacheDir string) {
 		m.assetManager = asset.NewManager(cacheDir, entity, &wg)
-		m.assetGetter = mockassetgetter.MockAssetGetter{}
+		m.assetGetter = &mockassetgetter.MockAssetGetter{}
 	}
 
 	m, err := setupCommandManager(callbackFn)

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -1,0 +1,693 @@
+package cmdmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func nextPatchVersion(version string) (string, error) {
+	versions := strings.Split(version, ".")
+	i, err := strconv.Atoi(versions[2])
+	if err != nil {
+		return "", err
+	}
+	versions[2] = strconv.Itoa(i + 1)
+	return strings.Join(versions, "."), nil
+}
+
+type MockBonsaiClient struct {
+	mock.Mock
+}
+
+func (m *MockBonsaiClient) FetchAsset(namespace, name string) (*corev2.BonsaiAsset, error) {
+	args := m.Called(namespace, name)
+	return args.Get(0).(*corev2.BonsaiAsset), args.Error(1)
+}
+
+func (m *MockBonsaiClient) FetchAssetVersion(namespace, name, version string) (string, error) {
+	args := m.Called(namespace, name, version)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
+	type bonsaiClientFunc func(*MockBonsaiClient)
+
+	var nilBonsaiAsset *corev2.BonsaiAsset
+
+	bAsset := struct {
+		name                string
+		namespace           string
+		version             string
+		url                 string
+		sha512              string
+		fullName            string
+		fullNameWithVersion string
+	}{
+		name:      "bonsaiasset",
+		namespace: "sensu",
+		version:   "1.0.0",
+		url:       "https://fakeurl",
+		sha512:    "2842ea31d1b9b68f25a76a3a323f9b480a6e8a499729cbd7d9ff42dd15a233951bfd7b1b14667edad979324476c9f9127ec74662795f37210291d5803d7647db",
+	}
+	bAsset.fullName = fmt.Sprintf("%s/%s", bAsset.namespace, bAsset.name)
+	bAsset.fullNameWithVersion = fmt.Sprintf("%s:%s", bAsset.fullName, bAsset.version)
+
+	m := CommandManager{}
+
+	cacheDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.db, err = bolt.Open(filepath.Join(cacheDir, dbName), 0600, &bolt.Options{
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.db.Close()
+
+	tests := []struct {
+		name             string
+		m                *CommandManager
+		wantErr          bool
+		errMatch         string
+		alias            string
+		bonsaiAssetName  string
+		bonsaiClientFunc bonsaiClientFunc
+	}{
+		{
+			name:            "bonsai base asset failure",
+			wantErr:         true,
+			errMatch:        "asset name must be specified in the format",
+			alias:           "testalias",
+			bonsaiAssetName: "",
+		},
+		{
+			name:            "bonsai version failure",
+			wantErr:         true,
+			errMatch:        "Malformed version",
+			alias:           "testalias",
+			bonsaiAssetName: "sensu/bonsaiasset:badversion",
+		},
+		{
+			name:            "fetch asset failure",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "fetch asset failure",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				m.On("FetchAsset", mock.Anything, mock.Anything).
+					Return(nilBonsaiAsset, errors.New("fetch asset failure"))
+			},
+		},
+		{
+			name:            "non-existent version",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        fmt.Sprintf("version \"%s\" of asset \"%s\" does not exist", bAsset.version, bAsset.fullName),
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: "0.1.0"},
+					},
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+			},
+		},
+		{
+			name:            "fetch asset version failure",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "fetch asset version failure",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return("", errors.New("fetch asset version failure"))
+			},
+		},
+		{
+			name:            "invalid asset json",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "unexpected end of JSON input",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return("", nil)
+			},
+		},
+		{
+			name:            "asset without builds",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "one or more asset builds are required",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return("{}", nil)
+			},
+		},
+		{
+			name:            "invalid asset",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "name cannot be empty",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					Builds: []*corev2.AssetBuild{
+						{},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "no type annotation",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "requested asset does not have a type annotation set",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "invalid type annotation",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "requested asset is not a sensuctl asset",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type": "backend",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "no provider annotation",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "requested asset does not have a provider annotation set",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type": "sensuctl",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "invalid provider annotation",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "requested asset is not a sensuctl/command asset",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "backend/handler",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "valid asset with no version specified",
+			m:               &m,
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullName,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				newerVersion, err := nextPatchVersion(bAsset.version)
+				if err != nil {
+					t.Fatal(err)
+				}
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+						{Version: newerVersion},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "sensuctl/command",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, newerVersion).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "valid asset with version specified",
+			m:               &m,
+			alias:           "testalias2",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "sensuctl/command",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "alias already exists",
+			m:               &m,
+			wantErr:         true,
+			errMatch:        "the alias specified already exists",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &corev2.BonsaiAsset{
+					Name: bAsset.fullName,
+					Versions: []*corev2.BonsaiAssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "sensuctl/command",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.m != nil {
+				mockBonsaiClient := &MockBonsaiClient{}
+				tt.m.bonsaiClient = mockBonsaiClient
+				tt.bonsaiClientFunc(mockBonsaiClient)
+			}
+
+			err := tt.m.InstallCommandFromBonsai(tt.alias, tt.bonsaiAssetName)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.InstallCommandFromBonsai() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.errMatch != "" {
+				if err != nil {
+					assert.Contains(t, err.Error(), tt.errMatch)
+				} else {
+					assert.Contains(t, "", tt.errMatch)
+				}
+			}
+
+			// if tt.errMatch != "" {
+			// 	if err == nil || !strings.Contains(fmt.Sprintf("%v", err), tt.errMatch) {
+			// 		t.Errorf("CommandManager.InstallCommandFromBonsai() error = %v, want errMatch %v", err, tt.errMatch)
+			// 	}
+			// }
+		})
+	}
+}
+
+func TestCommandManager_InstallCommandFromURL(t *testing.T) {
+	type args struct {
+		alias      string
+		archiveURL string
+		checksum   string
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.m.InstallCommandFromURL(tt.args.alias, tt.args.archiveURL, tt.args.checksum)
+			if err != nil {
+				t.Logf("error: %v", err)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.InstallCommandFromURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandManager_installCommand(t *testing.T) {
+	type args struct {
+		alias        string
+		commandAsset *corev2.Asset
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.m.installCommand(tt.args.alias, tt.args.commandAsset); (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.installCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandManager_ExecCommand(t *testing.T) {
+	type args struct {
+		ctx        context.Context
+		alias      string
+		args       []string
+		commandEnv []string
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.m.ExecCommand(tt.args.ctx, tt.args.alias, tt.args.args, tt.args.commandEnv); (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.ExecCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandManager_registerCommandPlugin(t *testing.T) {
+	type args struct {
+		alias        string
+		commandAsset *corev2.Asset
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.m.registerCommandPlugin(tt.args.alias, tt.args.commandAsset); (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.registerCommandPlugin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCommandManager_fetchCommandPlugin(t *testing.T) {
+	type args struct {
+		alias string
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		want    *CommandPlugin
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.m.fetchCommandPlugin(tt.args.alias)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.fetchCommandPlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CommandManager.fetchCommandPlugin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandManager_FetchCommandPlugins(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		want    []*CommandPlugin
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.m.FetchCommandPlugins()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.FetchCommandPlugins() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CommandManager.FetchCommandPlugins() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandManager_DeleteCommandPlugin(t *testing.T) {
+	type args struct {
+		alias string
+	}
+	tests := []struct {
+		name    string
+		m       *CommandManager
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.m.DeleteCommandPlugin(tt.args.alias); (err != nil) != tt.wantErr {
+				t.Errorf("CommandManager.DeleteCommandPlugin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cli/commands/command/command.go
+++ b/cli/commands/command/command.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new "command" command
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "command",
+		Short: "Manage sensuctl commands",
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(ExecCommand(cli))
+	cmd.AddCommand(InstallCommand(cli))
+
+	return cmd
+}

--- a/cli/commands/command/command.go
+++ b/cli/commands/command/command.go
@@ -15,6 +15,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	// Add sub-commands
 	cmd.AddCommand(ExecCommand(cli))
 	cmd.AddCommand(InstallCommand(cli))
+	cmd.AddCommand(ListCommand(cli))
 
 	return cmd
 }

--- a/cli/commands/command/command.go
+++ b/cli/commands/command/command.go
@@ -16,6 +16,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd.AddCommand(ExecCommand(cli))
 	cmd.AddCommand(InstallCommand(cli))
 	cmd.AddCommand(ListCommand(cli))
+	cmd.AddCommand(DeleteCommand(cli))
 
 	return cmd
 }

--- a/cli/commands/command/delete.go
+++ b/cli/commands/command/delete.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/cmdmanager"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCommand adds command that allows a user to delete a command plugin.
+func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete [ALIAS]",
+		Short:        "delete sensuctl commands",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// If no name is present print out usage
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			name := args[0]
+			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
+				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
+					return nil
+				}
+			}
+
+			manager, err := cmdmanager.NewCommandManager()
+			if err != nil {
+				return err
+			}
+
+			if err := manager.DeleteCommandPlugin(name); err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Deleted")
+			return err
+		},
+	}
+
+	cmd.Flags().Bool("skip-confirm", false, "skip interactive confirmation prompt")
+
+	return cmd
+}

--- a/cli/commands/command/delete.go
+++ b/cli/commands/command/delete.go
@@ -31,7 +31,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 				}
 			}
 
-			manager, err := cmdmanager.NewCommandManager()
+			manager, err := cmdmanager.NewCommandManager(cli)
 			if err != nil {
 				return err
 			}

--- a/cli/commands/command/exec.go
+++ b/cli/commands/command/exec.go
@@ -1,0 +1,41 @@
+package command
+
+import (
+	"errors"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/cmdmanager"
+	"github.com/spf13/cobra"
+)
+
+// ExecCommand provides a method to execute command plugins.
+func ExecCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exec [ALIAS] [args]",
+		Short: "executes a sensuctl command plugin",
+		RunE:  execCommandExecute(cli),
+	}
+
+	return cmd
+}
+
+func execCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// If no name is present print out usage
+		if len(args) < 1 {
+			_ = cmd.Help()
+			return errors.New("invalid argument(s) received")
+		}
+
+		manager, err := cmdmanager.NewCommandManager()
+		if err != nil {
+			return err
+		}
+
+		if err = manager.ExecCommand(args[0], args[1:]); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/cli/commands/command/exec.go
+++ b/cli/commands/command/exec.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"errors"
 
 	"github.com/sensu/sensu-go/cli"
@@ -32,7 +33,8 @@ func execCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []strin
 			return err
 		}
 
-		if err = manager.ExecCommand(args[0], args[1:]); err != nil {
+		ctx := context.TODO()
+		if err = manager.ExecCommand(ctx, args[0], args[1:]); err != nil {
 			return err
 		}
 

--- a/cli/commands/command/exec.go
+++ b/cli/commands/command/exec.go
@@ -36,7 +36,7 @@ func execCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []strin
 		}
 
 		// refresh the access token
-		tokens, err := cli.Client.RefreshAccessToken(cli.Config.Tokens().Refresh)
+		tokens, err := cli.Client.RefreshAccessToken(cli.Config.Tokens())
 		if err != nil {
 			return err
 		}

--- a/cli/commands/command/exec.go
+++ b/cli/commands/command/exec.go
@@ -28,7 +28,7 @@ func execCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []strin
 			return errors.New("invalid argument(s) received")
 		}
 
-		manager, err := cmdmanager.NewCommandManager()
+		manager, err := cmdmanager.NewCommandManager(cli)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/command/install.go
+++ b/cli/commands/command/install.go
@@ -1,0 +1,65 @@
+package command
+
+import (
+	"errors"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/cmdmanager"
+	"github.com/spf13/cobra"
+)
+
+var assetURL string
+var assetChecksum string
+
+// InstallCommand adds command that allows a user to install a command plugin
+// via Bonsai or a URL.
+func InstallCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install [ALIAS] [NAME][:VERSION]",
+		Short: "installs a sensuctl command from Bonsai or a URL",
+		RunE:  installCommandExecute(cli),
+	}
+
+	cmd.Flags().StringVarP(&assetURL, "url", "", "", "specifies a URL to fetch a sensuctl command asset from")
+	cmd.Flags().StringVarP(&assetChecksum, "checksum", "", "", "specifies the checksum (SHA512) of a URL asset")
+
+	return cmd
+}
+
+func installCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// If no name is present print out usage
+		if len(args) < 1 || len(args) > 2 {
+			_ = cmd.Help()
+			return errors.New("invalid argument(s) received")
+		}
+
+		if len(args) == 1 {
+			if assetURL == "" {
+				return errors.New("must specify a Bonsai asset name or use --url flag")
+			}
+			if assetChecksum == "" {
+				return errors.New("must specify checksum (SHA512) with --checksum when using --url")
+			}
+		}
+
+		alias := args[0]
+
+		manager, err := cmdmanager.NewCommandManager()
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 2 {
+			if err = manager.InstallCommandFromBonsai(alias, args[1]); err != nil {
+				return err
+			}
+		} else {
+			if err = manager.InstallCommandFromURL(alias, assetURL, assetChecksum); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/cli/commands/command/install.go
+++ b/cli/commands/command/install.go
@@ -15,13 +15,13 @@ var assetChecksum string
 // via Bonsai or a URL.
 func InstallCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install [ALIAS] [NAME][:VERSION]",
+		Use:   "install [ALIAS] ([NAME]:[VERSION] | --url [ARCHIVE_URL] --checksum [ARCHIVE_CHECKSUM])",
 		Short: "installs a sensuctl command from Bonsai or a URL",
 		RunE:  installCommandExecute(cli),
 	}
 
-	cmd.Flags().StringVarP(&assetURL, "url", "", "", "specifies a URL to fetch a sensuctl command asset from")
-	cmd.Flags().StringVarP(&assetChecksum, "checksum", "", "", "specifies the checksum (SHA512) of a URL asset")
+	cmd.Flags().StringVarP(&assetURL, "url", "", "", "specifies a URL to fetch a sensuctl command archive from")
+	cmd.Flags().StringVarP(&assetChecksum, "checksum", "", "", "specifies the checksum (SHA512) of the command archive from the --url flag")
 
 	return cmd
 }
@@ -32,6 +32,11 @@ func installCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []st
 		if len(args) < 1 || len(args) > 2 {
 			_ = cmd.Help()
 			return errors.New("invalid argument(s) received")
+		}
+
+		if len(args) > 1 && (assetURL != "" || assetChecksum != "") {
+			_ = cmd.Help()
+			return errors.New("the url and checksum flags can only be used when NAME is not specified")
 		}
 
 		if len(args) == 1 {

--- a/cli/commands/command/install.go
+++ b/cli/commands/command/install.go
@@ -45,7 +45,7 @@ func installCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []st
 
 		alias := args[0]
 
-		manager, err := cmdmanager.NewCommandManager()
+		manager, err := cmdmanager.NewCommandManager(cli)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/command/list.go
+++ b/cli/commands/command/list.go
@@ -1,0 +1,129 @@
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/cmdmanager"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/table"
+	"github.com/spf13/cobra"
+)
+
+// ListCommand adds command that allows a user to list installed command
+// plugins.
+func ListCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "lists installed sensuctl commands",
+		RunE:  listCommandExecute(cli),
+	}
+
+	return cmd
+}
+
+func listCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// If args are provided print out usage
+		if len(args) > 0 {
+			_ = cmd.Help()
+			return errors.New("invalid argument(s) received")
+		}
+
+		manager, err := cmdmanager.NewCommandManager()
+		if err != nil {
+			return err
+		}
+
+		commandPlugins, err := manager.FetchCommandPlugins()
+		if err != nil {
+			return err
+		}
+
+		var header http.Header
+
+		// Print the results based on the user preferences
+		resources := []corev2.Resource{}
+		var resultsWithBuilds []interface{}
+		for i := range commandPlugins {
+			if len(commandPlugins[i].Asset.Builds) > 0 {
+				for _, build := range commandPlugins[i].Asset.Builds {
+					asset := corev2.Asset{
+						ObjectMeta: commandPlugins[i].Asset.ObjectMeta,
+						URL:        build.URL,
+						Sha512:     build.Sha512,
+						Filters:    build.Filters,
+						Headers:    build.Headers,
+					}
+					commandPlugin := &cmdmanager.CommandPlugin{
+						Alias: commandPlugins[i].Alias,
+						Asset: asset,
+					}
+					resultsWithBuilds = append(resultsWithBuilds, commandPlugin)
+				}
+			} else {
+				resultsWithBuilds = append(resultsWithBuilds, commandPlugins[i])
+			}
+			resources = append(resources, commandPlugins[i])
+		}
+
+		return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, resultsWithBuilds, header)
+	}
+}
+
+func printToTable(results interface{}, writer io.Writer) {
+	table := table.New([]*table.Column{
+		{
+			Title:       "Alias",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				commandPlugin, ok := data.(*cmdmanager.CommandPlugin)
+				if !ok {
+					return cli.TypeError
+				}
+				return commandPlugin.Alias
+			},
+		},
+		{
+			Title: "URL",
+			CellTransformer: func(data interface{}) string {
+				commandPlugin, ok := data.(*cmdmanager.CommandPlugin)
+				if !ok {
+					return cli.TypeError
+				}
+				u, err := url.Parse(commandPlugin.Asset.URL)
+				if err != nil {
+					return ""
+				}
+
+				_, file := path.Split(u.EscapedPath())
+				return fmt.Sprintf(
+					"//%s/.../%s",
+					u.Hostname(),
+					file,
+				)
+			},
+		},
+		{
+			Title: "Hash",
+			CellTransformer: func(data interface{}) string {
+				commandPlugin, ok := data.(*cmdmanager.CommandPlugin)
+				if !ok {
+					return cli.TypeError
+				}
+				if len(commandPlugin.Asset.Sha512) >= 128 {
+					return string(commandPlugin.Asset.Sha512[0:7])
+				}
+				return "invalid"
+			},
+		},
+	})
+
+	table.Render(writer, results)
+}

--- a/cli/commands/command/list.go
+++ b/cli/commands/command/list.go
@@ -36,7 +36,7 @@ func listCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []strin
 			return errors.New("invalid argument(s) received")
 		}
 
-		manager, err := cmdmanager.NewCommandManager()
+		manager, err := cmdmanager.NewCommandManager(cli)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/cluster"
 	"github.com/sensu/sensu-go/cli/commands/clusterrole"
 	"github.com/sensu/sensu-go/cli/commands/clusterrolebinding"
+	"github.com/sensu/sensu-go/cli/commands/command"
 	"github.com/sensu/sensu-go/cli/commands/completion"
 	"github.com/sensu/sensu-go/cli/commands/config"
 	"github.com/sensu/sensu-go/cli/commands/configure"
@@ -65,6 +66,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		edit.Command(cli),
 		tessen.HelpCommand(cli),
 		dump.Command(cli),
+		command.HelpCommand(cli),
 	)
 
 	for _, cmd := range rootCmd.Commands() {

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	go.uber.org/multierr v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582
-	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
+	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go
 
-go 1.12
+go 1.13
 
 require (
 	github.com/AlecAivazis/survey v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 h1:dHtDnRWQtSx0Hjq9kvKFpBh9uPPKfQN70NZZmvssGwk=
+golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -344,6 +346,7 @@ golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/testing/mockassetgetter/mockassetgetter.go
+++ b/testing/mockassetgetter/mockassetgetter.go
@@ -1,0 +1,20 @@
+package mockassetgetter
+
+import (
+	"context"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/asset"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockAssetGetter ...
+type MockAssetGetter struct {
+	mock.Mock
+}
+
+// Get ...
+func (m MockAssetGetter) Get(ctx context.Context, a *corev2.Asset) (*asset.RuntimeAsset, error) {
+	args := m.Called(ctx, a)
+	return args.Get(0).(*asset.RuntimeAsset), args.Error(1)
+}

--- a/testing/mockassetgetter/mockassetgetter.go
+++ b/testing/mockassetgetter/mockassetgetter.go
@@ -14,7 +14,7 @@ type MockAssetGetter struct {
 }
 
 // Get ...
-func (m MockAssetGetter) Get(ctx context.Context, a *corev2.Asset) (*asset.RuntimeAsset, error) {
+func (m *MockAssetGetter) Get(ctx context.Context, a *corev2.Asset) (*asset.RuntimeAsset, error) {
 	args := m.Called(ctx, a)
 	return args.Get(0).(*asset.RuntimeAsset), args.Error(1)
 }

--- a/testing/mockexecutor/executor.go
+++ b/testing/mockexecutor/executor.go
@@ -7,14 +7,17 @@ import (
 	"github.com/sensu/sensu-go/command"
 )
 
+type RequestFunc func(context.Context, command.ExecutionRequest)
+
 // MockExecutor ...
 type MockExecutor struct {
 	// Note: this used to use the testify mock.Mock type, but I removed that,
 	// because it was causing race conditions to occur in tests, since the mock
 	// library wanted to inspect fields that were being guarded by mutexes.
-	response *command.ExecutionResponse
-	err      error
-	mu       sync.Mutex
+	requestFunc RequestFunc
+	response    *command.ExecutionResponse
+	err         error
+	mu          sync.Mutex
 }
 
 func (e *MockExecutor) Return(r *command.ExecutionResponse, err error) {
@@ -24,9 +27,18 @@ func (e *MockExecutor) Return(r *command.ExecutionResponse, err error) {
 	e.err = err
 }
 
+func (e *MockExecutor) SetRequestFunc(fn RequestFunc) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.requestFunc = fn
+}
+
 // Execute ...
 func (e *MockExecutor) Execute(ctx context.Context, execution command.ExecutionRequest) (*command.ExecutionResponse, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	if e.requestFunc != nil {
+		e.requestFunc(ctx, execution)
+	}
 	return e.response, e.err
 }


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds support for sensuctl commands which can be installed to extend the functionality of sensuctl.

This is currently a WIP.

A few things still need to be completed:

- [x] Refactor code duplicated between `cli/cmdmanager/manager.go` & `cli/commands/asset/add.go`
- [x] Support for listing & removing command plugins
- [x] A way to filter out non-command Bonsai assets (e.g. handlers, checks, etc.)
- [x] Other code quality changes

## Does your change need a Changelog entry?

Yes.