### PR TITLE
Fix authorization of event & silence updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ steps.
 - Updated Go version from 1.12.3 to 1.13.1.
 
 ### Fixed
+- [Web] Fixed issue where a user with an appropriate role may have been unable
+to resolve events, queue checks, and create silenced entries.
 - Splayed proxy checks are now executed every interval, instead of every
 `interval + interval * splay_coverage`.
 - [GraphQL] Ensures that proxy entity label & annotations are redacted.

--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -37,7 +37,7 @@ func (e *EventClient) UpdateEvent(ctx context.Context, event *corev2.Event) erro
 	if err := event.Validate(); err != nil {
 		return fmt.Errorf("couldn't create event: %s", err)
 	}
-	attrs := eventCreateAttributes(ctx)
+	attrs := eventUpdateAttributes(ctx)
 	if err := authorize(ctx, e.auth, attrs); err != nil {
 		return err
 	}
@@ -80,13 +80,13 @@ func (e *EventClient) ListEvents(ctx context.Context, pred *store.SelectionPredi
 	return events, nil
 }
 
-func eventCreateAttributes(ctx context.Context) *authorization.Attributes {
+func eventUpdateAttributes(ctx context.Context) *authorization.Attributes {
 	return &authorization.Attributes{
 		APIGroup:   "core",
 		APIVersion: "v2",
 		Namespace:  corev2.ContextNamespace(ctx),
 		Resource:   "events",
-		Verb:       "create,update",
+		Verb:       "update",
 	}
 }
 

--- a/backend/api/event_test.go
+++ b/backend/api/event_test.go
@@ -336,7 +336,7 @@ func TestUpdateEvent(t *testing.T) {
 							Resource:     "events",
 							ResourceName: "default:default",
 							UserName:     "legit",
-							Verb:         "create,update",
+							Verb:         "update",
 						}: true,
 					},
 				}
@@ -400,7 +400,7 @@ func TestUpdateEvent(t *testing.T) {
 							Namespace:  "default",
 							Resource:   "events",
 							UserName:   "legit",
-							Verb:       "create,update",
+							Verb:       "update",
 						}: true,
 					},
 				}

--- a/backend/api/event_test.go
+++ b/backend/api/event_test.go
@@ -347,7 +347,7 @@ func TestUpdateEvent(t *testing.T) {
 		{
 			Name: "right user, wrong perms",
 			Ctx: func() context.Context {
-				return contextWithUser(defaultContext(), "haxor", nil)
+				return contextWithUser(defaultContext(), "legit", nil)
 			},
 			EventStore: func() store.EventStore {
 				store := new(mockstore.MockStore)

--- a/backend/api/silenced.go
+++ b/backend/api/silenced.go
@@ -112,7 +112,7 @@ func silencedUpdateAttrs(ctx context.Context, name string) *authorization.Attrib
 		APIVersion:   "v2",
 		Namespace:    corev2.ContextNamespace(ctx),
 		Resource:     "silenced",
-		Verb:         "create,update",
+		Verb:         "update",
 		ResourceName: name,
 	}
 }

--- a/backend/api/silenced_test.go
+++ b/backend/api/silenced_test.go
@@ -348,7 +348,7 @@ func TestUpdateSilenced(t *testing.T) {
 							Resource:     "silenced",
 							ResourceName: "default:default",
 							UserName:     "legit",
-							Verb:         "create,update",
+							Verb:         "update",
 						}: true,
 					},
 				}


### PR DESCRIPTION
## What is this change?

Allow users to update events and silences through GraphQL service.

## Why is this change necessary?

Fixes an issue reported on [Discourse (#1353)](https://discourse.sensu.io/t/are-these-bugs-in-5-12/1353).

### Replication Steps

1. Set up with limited access.
```
sensuctl user create jeb --password meow1234 --groups linux
sensuctl role create local-admin --verb get,list,create,update,delete --resource assets,checks,entities,events,filters,hooks,silenced --namespace linux
sensuctl role-binding create local-admin --role=local-admin --group linux --namespace linux
```
2. Attempt to resolve an event or create a silence from the web app.

## Does your change need a Changelog entry?

Yup.

## Do you need clarification on anything?

It's unclear what the original intent was. Chesterton's fence, et al.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Unit & manual
