### PR TITLE
Ignore PermissionDenied errors in sensuctl dump

### DIFF
--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -204,7 +204,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 					return fmt.Errorf("API error: %s", err)
 				}
 				switch actions.ErrCode(err.Code) {
-				case actions.PaymentRequired, actions.NotFound:
+				case actions.PaymentRequired, actions.NotFound, actions.PermissionDenied:
 					continue
 				}
 				return fmt.Errorf("API error: %s", err)


### PR DESCRIPTION
Fixes an issue discovered when testing with enterprise resources, but in an unlicensed context.

Signed-off-by: Eric Chlebek <eric@sensu.io>