### PR TITLE
Banish the remaining testutil.RandomPorts bits

### DIFF
--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -59,16 +59,11 @@ func TestBackendHTTPListener(t *testing.T) {
 			cachePath, cleanup := testutil.TempDir(t)
 			defer cleanup()
 
-			ports := make([]int, 5)
-			err := testutil.RandomPorts(ports)
-			if err != nil {
-				t.Fatal(err)
-			}
-			clURL := fmt.Sprintf("%s://127.0.0.1:%d", tc.httpScheme, ports[0])
-			apURL := fmt.Sprintf("%s://127.0.0.1:%d", tc.httpScheme, ports[1])
-			agentPort := ports[2]
-			apiPort := ports[3]
-			dashboardPort := ports[4]
+			clURL := fmt.Sprintf("%s://127.0.0.1:0", tc.httpScheme)
+			apURL := fmt.Sprintf("%s://127.0.0.1:0", tc.httpScheme)
+			agentPort := 8081
+			apiPort := 8080
+			dashboardPort := 3000
 			initCluster := fmt.Sprintf("default=%s", apURL)
 
 			var tlsInfo etcd.TLSInfo
@@ -82,14 +77,14 @@ func TestBackendHTTPListener(t *testing.T) {
 			}
 
 			b, err := Initialize(&Config{
-				AgentHost:                    "127.0.0.1",
-				AgentPort:                    agentPort,
-				APIListenAddress:             fmt.Sprintf("127.0.0.1:%d", apiPort),
-				DashboardHost:                "127.0.0.1",
-				DashboardPort:                dashboardPort,
-				StateDir:                     dataPath,
-				CacheDir:                     cachePath,
-				TLS:                          tc.tls,
+				AgentHost:        "127.0.0.1",
+				AgentPort:        agentPort,
+				APIListenAddress: fmt.Sprintf("127.0.0.1:%d", apiPort),
+				DashboardHost:    "127.0.0.1",
+				DashboardPort:    dashboardPort,
+				StateDir:         dataPath,
+				CacheDir:         cachePath,
+				TLS:              tc.tls,
 				EtcdAdvertiseClientURLs:      []string{clURL},
 				EtcdListenClientURLs:         []string{clURL},
 				EtcdListenPeerURLs:           []string{apURL},

--- a/backend/etcd/testing.go
+++ b/backend/etcd/testing.go
@@ -2,7 +2,6 @@ package etcd
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/sensu/sensu-go/testing/testutil"
@@ -13,14 +12,8 @@ import (
 func NewTestEtcd(t *testing.T) (*Etcd, func()) {
 	tmpDir, remove := testutil.TempDir(t)
 
-	ports := make([]int, 2)
-	err := testutil.RandomPorts(ports)
-	if err != nil {
-		remove()
-		log.Panic(err)
-	}
-	clURL := fmt.Sprintf("http://127.0.0.1:%d", ports[0])
-	apURL := fmt.Sprintf("http://127.0.0.1:%d", ports[1])
+	clURL := "http://127.0.0.1:0"
+	apURL := "http://127.0.0.1:0"
 	initCluster := fmt.Sprintf("default=%s", apURL)
 
 	cfg := NewConfig()

--- a/backend/store/etcd/testutil/store.go
+++ b/backend/store/etcd/testutil/store.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
-	"github.com/sensu/sensu-go/testing/testutil"
 )
 
 // IntegrationTestStore wrapper for etcd & store
@@ -39,13 +38,6 @@ func NewStoreInstance() (*IntegrationTestStore, error) {
 		return nil, err
 	}
 	removeTmp := func() { _ = os.RemoveAll(tmpDir) }
-
-	p := make([]int, 2)
-	perr := testutil.RandomPorts(p)
-	if perr != nil {
-		removeTmp()
-		return nil, perr
-	}
 
 	cfg := etcd.NewConfig()
 	cfg.Name = "default"

--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"runtime"
 	"strings"
@@ -21,29 +20,6 @@ func TempDir(t *testing.T) (tmpDir string, remove func()) {
 	}
 
 	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }
-}
-
-// RandomPorts generates len(p) random ports and assigns them to elements of p.
-func RandomPorts(p []int) (err error) {
-	for i := range p {
-		l, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			return err
-		}
-		defer func() {
-			e := l.Close()
-			if err == nil {
-				err = e
-			}
-		}()
-
-		addr, err := net.ResolveTCPAddr("tcp", l.Addr().String())
-		if err != nil {
-			return err
-		}
-		p[i] = addr.Port
-	}
-	return nil
 }
 
 // CleanOutput takes a string and strips extra characters that are not


### PR DESCRIPTION
## What is this change?

Get rid of the remaining uses of testutil.RandomPorts.

## Why is this change necessary?

Using testutil.RandomPorts resulted in incorrectly failing tests a significant portion of the time.

## Does your change need a Changelog entry?

No, this is not a user-facing change.