### PR TITLE
Bugfix for sensu asset list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Splayed proxy checks are now executed every interval, instead of every
 `interval + interval * splay_coverage`.
+- Do not seperate asset builds into several assets unless the the tabular format
+is used in `sensuctl asset list`.
 
 ## [5.13.1] - 2019-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 `interval + interval * splay_coverage`.
 - Do not seperate asset builds into several assets unless the the tabular format
 is used in `sensuctl asset list`.
+
 ## [5.13.2] - 2019-09-19
 
 ### Fixed

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -11,6 +11,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
+	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/flags"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
@@ -47,11 +48,18 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
+			// Determine the user preferred format
+			var format string
+			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
+				format = cli.Config.Format()
+			}
+
 			// Print the results based on the user preferences
 			resources := []corev2.Resource{}
 			var resultsWithBuilds []interface{}
 			for i := range results {
-				if len(results[i].Builds) > 0 {
+				// Break the builds into multiple assets if we use the tabular format
+				if len(results[i].Builds) > 0 && format == config.FormatTabular {
 					for _, build := range results[i].Builds {
 						asset := corev2.Asset{
 							ObjectMeta: results[i].ObjectMeta,

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -48,7 +48,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
-			// Determine the user preferred format
+			// Determine the user's preferred format
 			var format string
 			if format = helpers.GetChangedStringValueFlag("format", cmd.Flags()); format == "" {
 				format = cli.Config.Format()

--- a/cli/commands/asset/list_test.go
+++ b/cli/commands/asset/list_test.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -159,4 +160,85 @@ func TestListCommandRunEClosureWithHeader(t *testing.T) {
 	assert.Nil(err)
 	assert.Contains(out, "E_TOO_MANY_ENTITIES")
 	assert.Contains(out, "==")
+}
+
+func TestListBuildsWithTabular(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("tabular")
+
+	asset := *corev2.FixtureAsset("builds")
+	asset.Builds = []*corev2.AssetBuild{
+		&corev2.AssetBuild{
+			URL:    "http://127.0.0.1/foo",
+			Sha512: "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
+		},
+		&corev2.AssetBuild{
+			URL:    "http://127.0.0.1/bar",
+			Sha512: "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
+		},
+	}
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Asset{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Asset)
+			*resources = []corev2.Asset{asset}
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+
+	// Make sure the asset's builds have been seperated into several assets
+	assert.Contains(out, "//127.0.0.1/.../foo")
+	assert.Contains(out, "//127.0.0.1/.../bar")
+}
+
+func TestListBuildsWithJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("json")
+
+	asset := *corev2.FixtureAsset("builds")
+	asset.Builds = []*corev2.AssetBuild{
+		&corev2.AssetBuild{
+			URL:    "http://127.0.0.1/foo",
+			Sha512: "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
+		},
+		&corev2.AssetBuild{
+			URL:    "http://127.0.0.1/bar",
+			Sha512: "25e01b962045f4f5b624c3e47e782bef65c6c82602524dc569a8431b76cc1f57639d267380a7ec49f70876339ae261704fc51ed2fc520513cf94bc45ed7f6e17",
+		},
+	}
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Asset{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Asset)
+			*resources = []corev2.Asset{asset}
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+
+	// Make sure the asset's builds have *not* been seperated into several assets
+	output := []map[string]interface{}{}
+	_ = json.Unmarshal([]byte(out), &output)
+	assert.Len(output, 1)
 }


### PR DESCRIPTION
## What is this change?

This PR fixes the asset listing feature of sensuctl, by making sure asset builds are only separated into several assets when the `tabular` format is used.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/3270

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added unit tests to cover this case.