### PR TITLE
sensuctl dump can now list supported resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ manually wipe their local / session storage. This may help in the rare cases
 where something in said state is leading to an uncaught exception.
 - [Web] For operating systems with support for selecting a preferred light /dark
 theme, the application now respects the system preference by default.
+- sensuctl dump can now list the types of supported resources with --types.
 
 ### Changed
 - [Web] Github is not always the best place for feature requests and discussion,

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -177,6 +177,9 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			return err
 		}
 		if printTypes {
+			if len(args) > 0 {
+				return errors.New("--types is mutually exclusive with positional args")
+			}
 			return printAllTypes(cli, cmd)
 		}
 


### PR DESCRIPTION
Signed-off-by: Eric Chlebek <eric@sensu.io>

## What is this change?

Adds the --types flag to sensuctl dump. When this flag is activated, the dump command will list all of the resource types in the 'All' list.

## Why is this change necessary?

It helps users to know which types are supported, and it helps us document sensuctl dump.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

```
[eric@cube sensu-go]$ sensuctl dump --types 
core/v2.Namespace
core/v2.ClusterRole
core/v2.ClusterRoleBinding
core/v2.User
core/v2.TessenConfig
core/v2.Asset
core/v2.CheckConfig
core/v2.Entity
core/v2.Event
core/v2.EventFilter
core/v2.Handler
core/v2.Hook
core/v2.Mutator
core/v2.Role
core/v2.RoleBinding
core/v2.Silenced

[eric@cube sensu-go]$ sensuctl dump --types --format json
[
  "core/v2.Namespace",
  "core/v2.ClusterRole",
  "core/v2.ClusterRoleBinding",
  "core/v2.User",
  "core/v2.TessenConfig",
  "core/v2.Asset",
  "core/v2.CheckConfig",
  "core/v2.Entity",
  "core/v2.Event",
  "core/v2.EventFilter",
  "core/v2.Handler",
  "core/v2.Hook",
  "core/v2.Mutator",
  "core/v2.Role",
  "core/v2.RoleBinding",
  "core/v2.Silenced"
]

[eric@cube sensu-go]$ sensuctl dump --types --format yaml
- core/v2.Namespace
- core/v2.ClusterRole
- core/v2.ClusterRoleBinding
- core/v2.User
- core/v2.TessenConfig
- core/v2.Asset
- core/v2.CheckConfig
- core/v2.Entity
- core/v2.Event
- core/v2.EventFilter
- core/v2.Handler
- core/v2.Hook
- core/v2.Mutator
- core/v2.Role
- core/v2.RoleBinding
- core/v2.Silenced
```