### PR TITLE
Add missing proto attribute to TLSOptions

### DIFF
--- a/api/core/v2/tls.proto
+++ b/api/core/v2/tls.proto
@@ -19,4 +19,5 @@ message TLSOptions {
   string key_file = 2;
   string trusted_ca_file = 3 [(gogoproto.customname) = "TrustedCAFile"];
   bool insecure_skip_verify = 4 [(gogoproto.jsontag) = "insecure_skip_verify"];
+  bool client_auth_type = 5;
 }


### PR DESCRIPTION
It fixes the unexpected diff caused by running `go generate github.com/sensu/sensu-go/api/core/v2`, which originated from https://github.com/sensu/sensu-go/pull/3282