### PR TITLE
Fix 'flag accessed but not defined' error in asset outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ after quorum loss.
 are now caught and a toast is presented to communicate what occurred.
 - [Web] Internal errors are now avoided when a user attempts to queue an ad-hoc
 check for a keepalive.
-- Do not seperate asset builds into several assets unless the the tabular format
+- Do not separate asset builds into several assets unless the the tabular format
 is used in `sensuctl asset list`.
+- Fix the 'flag accessed but not defined' error in `sensuctl asset outdated`
 
 ## [5.13.2] - 2019-09-19
 

--- a/cli/commands/asset/outdated.go
+++ b/cli/commands/asset/outdated.go
@@ -28,6 +28,10 @@ func OutdatedCommand(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	helpers.AddFormatFlag(cmd.Flags())
+	helpers.AddAllNamespace(cmd.Flags())
+	helpers.AddFieldSelectorFlag(cmd.Flags())
+	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
 
 	return cmd
 }

--- a/cli/commands/asset/outdated_test.go
+++ b/cli/commands/asset/outdated_test.go
@@ -1,0 +1,34 @@
+package asset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+)
+
+// Match a tabular output header
+var tabularHeaderPattern = ".*\n( |─)+\n"
+
+func TestOutdatedCommand(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	assets := []corev2.Asset{}
+	client := cli.Client.(*client.MockClient)
+	client.On("List", mock.Anything, &assets, mock.Anything, mock.Anything).Return(nil)
+
+	cmd := OutdatedCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	// Match a tabular output header with nothing else under it
+	assert.Regexp(tabularHeaderPattern+"$", out)
+	assert.Nil(err)
+}


### PR DESCRIPTION
## What is this change?

Properly declare flags for the `sensuctl asset outdated` command so that in doesn't error out with a 'flag accessed but not defined' message.

## Why is this change necessary?

Closes #3269.

## Does your change need a Changelog entry?

Yes, added.

## Were there any complications while making this change?

I initially wanted to add more unit tests for the `asset outdated` command, but that will require refactoring it so that the Bonsai client can be mocked. Leaving this as future work for now.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes needed.

## How did you verify this change?

Added minimal unit test to check that the command can be run.
