### PR TITLE
Add GetClientURLs method to Etcd type.

### DIFF
--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -235,3 +235,13 @@ func (e *Etcd) Healthy() bool {
 	_, err = mapi.Status(context.TODO(), e.cfg.AdvertiseClientURLs[0])
 	return err == nil
 }
+
+// GetClientURLs gets the valid client URLs for the etcd server.
+func (e *Etcd) GetClientURLs() []string {
+	listeners := e.etcd.Clients
+	results := make([]string, 0, len(listeners))
+	for _, list := range listeners {
+		results = append(results, list.Addr().String())
+	}
+	return results
+}

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -47,3 +47,13 @@ func TestEtcdHealthy(t *testing.T) {
 	health := e.Healthy()
 	assert.True(t, health)
 }
+
+func TestGetClientURLs(t *testing.T) {
+	etcd, cleanup := NewTestEtcd(t)
+	defer cleanup()
+
+	clientURLs := etcd.GetClientURLs()
+	if got, want := len(clientURLs), 1; got < want {
+		t.Fatalf("got %d client URLs, want at least %d", got, want)
+	}
+}

--- a/backend/etcd/testing.go
+++ b/backend/etcd/testing.go
@@ -9,7 +9,8 @@ import (
 )
 
 // NewTestEtcd creates a new Etcd for testing purposes.
-func NewTestEtcd(t *testing.T) (*Etcd, func()) {
+func NewTestEtcd(t testing.TB) (*Etcd, func()) {
+	t.Helper()
 	tmpDir, remove := testutil.TempDir(t)
 
 	clURL := "http://127.0.0.1:0"

--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -13,7 +13,7 @@ import (
 // returning the absolute path to the directory and a remove() function
 // that should be deferred immediately after calling TempDir(t) to recursively
 // delete the contents of the directory.
-func TempDir(t *testing.T) (tmpDir string, remove func()) {
+func TempDir(t testing.TB) (tmpDir string, remove func()) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "sensu")
 	if err != nil {
 		t.FailNow()


### PR DESCRIPTION
## What is this change?

The GetClientURLs method is useful when an etcd test instance has
been created, and a user would like to know how to dial it.

Some refactoring has also been done to use testing.TB instead of
testing.T; this allows the functions in question to be used by
*testing.B as well as *testing.T.

## Why is this change necessary?

I need this change to support integration testing of replicators in sensu-enterprise-go.

## Does your change need a Changelog entry?

No, this is merely plumbing.

## How did you verify this change?

The integration test verifies the functionality.