### PR TITLE
Fix the --all-namespaces flag in sensuctl dump

### DIFF
--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -32,6 +32,9 @@ func (a *Asset) StorePrefix() string {
 
 // URIPath returns the path component of an asset URI.
 func (a *Asset) URIPath() string {
+	if a.Namespace == "" {
+		return path.Join(URLPrefix, AssetsResource, url.PathEscape(a.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(a.Namespace), AssetsResource, url.PathEscape(a.Name))
 }
 

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -132,6 +132,9 @@ func (c *Check) StorePrefix() string {
 
 // URIPath returns the path component of a check URI.
 func (c *Check) URIPath() string {
+	if c.Namespace == "" {
+		return path.Join(URLPrefix, ChecksResource, url.PathEscape(c.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(c.Namespace), ChecksResource, url.PathEscape(c.Name))
 }
 

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -76,6 +76,9 @@ func (c *CheckConfig) StorePrefix() string {
 
 // URIPath returns the path component of a CheckConfig URI.
 func (c *CheckConfig) URIPath() string {
+	if c.Namespace == "" {
+		return path.Join(URLPrefix, ChecksResource, url.PathEscape(c.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(c.Namespace), ChecksResource, url.PathEscape(c.Name))
 }
 

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -41,6 +41,9 @@ func (e *Entity) StorePrefix() string {
 
 // URIPath returns the path component of an entity URI.
 func (e *Entity) URIPath() string {
+	if e.Namespace == "" {
+		return path.Join(URLPrefix, EntitiesResource, url.PathEscape(e.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(e.Namespace), EntitiesResource, url.PathEscape(e.Name))
 }
 

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -34,6 +34,9 @@ func (e *Event) StorePrefix() string {
 
 // URIPath returns the path component of an event URI.
 func (e *Event) URIPath() string {
+	if e.Namespace == "" {
+		return path.Join(URLPrefix, EventsResource)
+	}
 	if !e.HasCheck() {
 		return ""
 	}

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -34,11 +34,11 @@ func (e *Event) StorePrefix() string {
 
 // URIPath returns the path component of an event URI.
 func (e *Event) URIPath() string {
-	if e.Namespace == "" {
+	if !e.HasCheck() && e.Entity == nil {
 		return path.Join(URLPrefix, EventsResource)
 	}
 	if !e.HasCheck() {
-		return ""
+		return path.Join(URLPrefix, EventsResource, url.PathEscape(e.Entity.Name))
 	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(e.Entity.Namespace), EventsResource, url.PathEscape(e.Entity.Name), url.PathEscape(e.Check.Name))
 }

--- a/api/core/v2/filter.go
+++ b/api/core/v2/filter.go
@@ -41,6 +41,9 @@ func (f *EventFilter) StorePrefix() string {
 
 // URIPath returns the path component of an event filter URI.
 func (f *EventFilter) URIPath() string {
+	if f.Namespace == "" {
+		return path.Join(URLPrefix, EventFiltersResource, url.PathEscape(f.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(f.Namespace), EventFiltersResource, url.PathEscape(f.Name))
 }
 

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -41,6 +41,9 @@ func (h *Handler) StorePrefix() string {
 
 // URIPath returns the path component of a handler URI.
 func (h *Handler) URIPath() string {
+	if h.Namespace == "" {
+		return path.Join(URLPrefix, HandlersResource, url.PathEscape(h.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(h.Namespace), HandlersResource, url.PathEscape(h.Name))
 }
 

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -50,6 +50,9 @@ func (c *HookConfig) StorePrefix() string {
 
 // URIPath returns the path component of a hook URI.
 func (c *HookConfig) URIPath() string {
+	if c.Namespace == "" {
+		return path.Join(URLPrefix, HooksResource, url.PathEscape(c.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(c.Namespace), HooksResource, url.PathEscape(c.Name))
 }
 

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -21,6 +21,9 @@ func (m *Mutator) StorePrefix() string {
 
 // URIPath returns the path component of a mutator URI.
 func (m *Mutator) URIPath() string {
+	if m.Namespace == "" {
+		return path.Join(URLPrefix, MutatorsResource, url.PathEscape(m.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(m.Namespace), MutatorsResource, url.PathEscape(m.Name))
 }
 

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -176,6 +176,9 @@ func (r *Role) StorePrefix() string {
 
 // URIPath returns the path component of a role URI.
 func (r *Role) URIPath() string {
+	if r.Namespace == "" {
+		return path.Join(URLPrefix, RolesResource, url.PathEscape(r.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(r.Namespace), RolesResource, url.PathEscape(r.Name))
 
 }
@@ -204,6 +207,9 @@ func (b *RoleBinding) StorePrefix() string {
 
 // URIPath returns the path component of a role binding URI.
 func (b *RoleBinding) URIPath() string {
+	if b.Namespace == "" {
+		return path.Join(URLPrefix, RoleBindingsResource, url.PathEscape(b.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(b.Namespace), RoleBindingsResource, url.PathEscape(b.Name))
 }
 

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -27,6 +27,9 @@ func (s *Silenced) URIPath() string {
 	if s.Name == "" {
 		s.Name, _ = SilencedName(s.Subscription, s.Check)
 	}
+	if s.Namespace == "" {
+		return path.Join(URLPrefix, SilencedResource, url.PathEscape(s.Name))
+	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(s.Namespace), SilencedResource, url.PathEscape(s.Name))
 }
 


### PR DESCRIPTION
## What is this change?

Fix a regression that was introduced by the sensuctl dump refactoring.

## Why is this change necessary?

The --all-namespaces flag works with this change. Closes #3306 

## Does your change need a Changelog entry?

No, as this regression was not shipped in a release.

## How did you verify this change?

I manually tested dumping every resource in sensu-go and sensu-enterprise-go with multiple namespaces to make sure they would all work properly.