### PR TITLE
Add --etcd-{heartbeat-interval,election-timeout}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ theme, the application now respects the system preference by default.
 - sensuctl dump can now list the types of supported resources with --types.
 - Added the `sensu_agent_version` field to the `Entity` resource, which reflects
 the Sensu semver version of the agent entity.
+- Added the `--etcd-heartbeat-interval` and `--etcd-election-timeout` flags to
+`sensu-backend`
 
 ### Changed
 - [Web] Github is not always the best place for feature requests and discussion,

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -87,6 +87,16 @@ func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 	cfg.AdvertiseClientURLs = config.EtcdAdvertiseClientURLs
 	cfg.Name = config.EtcdName
 
+	// Heartbeat interval
+	if config.EtcdHeartbeatInterval > 0 {
+		cfg.TickMs = config.EtcdHeartbeatInterval
+	}
+
+	// Election timeout
+	if config.EtcdElectionTimeout > 0 {
+		cfg.ElectionMs = config.EtcdElectionTimeout
+	}
+
 	// Etcd TLS config
 	cfg.ClientTLSInfo = config.EtcdClientTLSInfo
 	cfg.PeerTLSInfo = config.EtcdPeerTLSInfo

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -61,6 +61,8 @@ const (
 	flagEtcdNodeName                           = "etcd-name"
 	flagNoEmbedEtcd                            = "no-embed-etcd"
 	flagEtcdAdvertiseClientURLs                = "etcd-advertise-client-urls"
+	flagEtcdHeartbeatInterval                  = "etcd-heartbeat-interval"
+	flagEtcdElectionTimeout                    = "etcd-election-timeout"
 
 	// Etcd TLS flag constants
 	flagEtcdCertFile           = "etcd-cert-file"
@@ -177,6 +179,8 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 				EtcdCipherSuites:             viper.GetStringSlice(flagEtcdCipherSuites),
 				EtcdQuotaBackendBytes:        viper.GetInt64(flagEtcdQuotaBackendBytes),
 				EtcdMaxRequestBytes:          viper.GetUint(flagEtcdMaxRequestBytes),
+				EtcdHeartbeatInterval:        viper.GetUint(flagEtcdHeartbeatInterval),
+				EtcdElectionTimeout:          viper.GetUint(flagEtcdElectionTimeout),
 				NoEmbedEtcd:                  viper.GetBool(flagNoEmbedEtcd),
 			}
 
@@ -296,6 +300,8 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetDefault(flagEtcdNodeName, defaultEtcdName)
 	viper.SetDefault(flagEtcdQuotaBackendBytes, etcd.DefaultQuotaBackendBytes)
 	viper.SetDefault(flagEtcdMaxRequestBytes, etcd.DefaultMaxRequestBytes)
+	viper.SetDefault(flagEtcdHeartbeatInterval, etcd.DefaultTickMs)
+	viper.SetDefault(flagEtcdElectionTimeout, etcd.DefaultElectionMs)
 	viper.SetDefault(flagNoEmbedEtcd, false)
 
 	// Merge in config flag set so that it appears in command usage
@@ -351,6 +357,10 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	_ = cmd.Flags().SetAnnotation(flagEtcdQuotaBackendBytes, "categories", []string{"store"})
 	cmd.Flags().Uint(flagEtcdMaxRequestBytes, viper.GetUint(flagEtcdMaxRequestBytes), "maximum etcd request size in bytes (use with caution)")
 	_ = cmd.Flags().SetAnnotation(flagEtcdMaxRequestBytes, "categories", []string{"store"})
+	cmd.Flags().Uint(flagEtcdHeartbeatInterval, viper.GetUint(flagEtcdHeartbeatInterval), "interval in ms with which the etcd leader will notify followers that it is still the leader")
+	_ = cmd.Flags().SetAnnotation(flagEtcdHeartbeatInterval, "categories", []string{"store"})
+	cmd.Flags().Uint(flagEtcdElectionTimeout, viper.GetUint(flagEtcdElectionTimeout), "time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself")
+	_ = cmd.Flags().SetAnnotation(flagEtcdElectionTimeout, "categories", []string{"store"})
 
 	// Etcd TLS flags
 	cmd.Flags().String(flagEtcdCertFile, viper.GetString(flagEtcdCertFile), "path to the client server TLS cert file")

--- a/backend/config.go
+++ b/backend/config.go
@@ -63,6 +63,8 @@ type Config struct {
 	EtcdListenPeerURLs           []string
 	EtcdName                     string
 	NoEmbedEtcd                  bool
+	EtcdHeartbeatInterval        uint
+	EtcdElectionTimeout          uint
 
 	// Etcd TLS configuration
 	EtcdClientTLSInfo     etcd.TLSInfo


### PR DESCRIPTION
# What is this change?

These new sensu-backend flags control the embedded etcd's heartbeat
interval and election timeout respectively. For details, see
https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters

## Why is this change necessary?

Allow operators to tune these etcd options and potentially have more stable clusters when the nodes are not necessarily on the same local network.

Closes #3300.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required, along with links to the relevant etcd documentation.
Tracked by https://github.com/sensu/sensu-docs/issues/1807.

## How did you verify this change?

Since this is passing configuration straight to the embedded etcd, I don't think it warrants trying to test; that would equates to testing etcd itself. I've tested the input value validation manually though, e.g.:

```
$ sensu-backend start --etcd-election-timeout 3491732913
{"component":"backend","error":"error starting etcd: --election-timeout[3491732913ms] is too long, and should be set less than 50000ms","level":"fatal","msg":"error executing sensu-backend","time":"2019-10-02T14:05:31-07:00"}

$ sensu-backend start --etcd-election-timeout -34
{"component":"backend","error":"invalid argument \"-34\" for \"--etcd-election-timeout\" flag: strconv.ParseUint: parsing \"-34\": invalid syntax","level":"fatal","msg":"error executing sensu-backend","time":"2019-10-02T14:05:37-07:00"}
```