### PR TITLE
[GraphQL] Fixup entity object meta regression

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -35,7 +35,8 @@ func (*entityImpl) ID(p graphql.ResolveParams) (string, error) {
 // Metadata implements response to request for 'metadata' field.
 func (*entityImpl) Metadata(p graphql.ResolveParams) (interface{}, error) {
 	entity := p.Source.(*corev2.Entity)
-	return entity.GetRedactedEntity(), nil
+	entity = entity.GetRedactedEntity()
+	return entity.GetObjectMeta(), nil
 }
 
 // LastSeen implements response to request for 'executed' field.

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -6,12 +6,23 @@ import (
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEntityTypeMetadataField(t *testing.T) {
+	src := corev2.FixtureEntity("bug")
+	impl := entityImpl{}
+
+	res, err := impl.Metadata(graphql.ResolveParams{Source: src})
+	require.NoError(t, err)
+	assert.NotEmpty(t, res)
+	assert.IsType(t, v2.ObjectMeta{}, res)
+}
 
 func TestEntityTypeRelatedField(t *testing.T) {
 	source := corev2.FixtureEntity("c")

--- a/backend/apid/graphql/scalars.go
+++ b/backend/apid/graphql/scalars.go
@@ -38,14 +38,6 @@ func (jsonImpl) Serialize(val interface{}) interface{} {
 	return val
 }
 
-type jsonWrapper struct {
-	data []byte
-}
-
-func (w jsonWrapper) MarshalJSON() ([]byte, error) {
-	return w.data, nil
-}
-
 // Implement ScalarResolver for JSON type
 
 type unsignedIntegerImpl struct{}


### PR DESCRIPTION
## What is this change?

Fixes regression introduced in #3275.

Closes sensu/web#201

## Does your change need a Changelog entry?

This regression was introduced prior to the last release.

## How did you verify this change?

Added an additional unit test.
