### PR TITLE
[GraphQL] Lift namespace into context using innermeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ is front and center. Hopefully this should reduce any confusion around next
 steps.
 - Support agent TLS authentication, usable with a licensed sensu-backend.
 - Updated Go version from 1.12.3 to 1.13.1.
+- [GraphQL] `putWrapped` mutation now accepts wrapped JSON with empty
+outer objectmeta.
 
 ### Fixed
 - Splayed proxy checks are now executed every interval, instead of every

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -54,7 +54,7 @@ func (r *mutationsImpl) PutWrapped(p schema.MutationPutWrappedFieldResolverParam
 		return nil, err
 	}
 
-	ctx := store.NamespaceContext(p.Context, ret.ObjectMeta.Namespace)
+	ctx := store.NamespaceContext(p.Context, ret.Value.GetObjectMeta().Namespace)
 
 	if upsert {
 		err = client.Update(ctx, ret.Value)


### PR DESCRIPTION
## What is this change?

When creating resources, lifts namespace into context using resource's inner objectmeta.

## Why is this change necessary?

The `putWrapped` mutation takes wrapped json and creates/updates the given resource. Previous to this change the mutation relied on the outer objectmeta to set the namespace for the operation. The downside to this is that _if_ the outer object was not set, the namespace would never be lifted into the context and authorization would fail.

I've updated the mutation to use the inner objectmeta because it should be more reliable. This is because the wrapper's `UnmarshallJSON` method will copy the contents of the outer json into the inner if it is present. See [types/wrapper#L72](https://github.com/sensu/sensu-go/blob/master/types/wrapper.go#L72-L89).

Closes sensu/web#202.

## Does your change need a Changelog entry?

Sure.