### PR TITLE
Fix predicate that selects mTLS or password

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -149,7 +149,7 @@ func (a *Agent) buildTransportHeaderMap() http.Header {
 	header := http.Header{}
 	header.Set(transport.HeaderKeyNamespace, a.config.Namespace)
 	header.Set(transport.HeaderKeyAgentName, a.config.AgentName)
-	if tls := a.config.TLS; tls != nil && len(tls.CertFile) == 0 && len(tls.KeyFile) == 0 {
+	if tls := a.config.TLS; tls == nil || len(tls.CertFile) == 0 && len(tls.KeyFile) == 0 {
 		logger.Info("using password auth")
 		header.Set(transport.HeaderKeyUser, a.config.User)
 		userCredentials := fmt.Sprintf("%s:%s", a.config.User, a.config.Password)


### PR DESCRIPTION
The agent was trying to use mTLS authentication when its config.TLS
option was nil; it should obviously use password authentication in that
case!