### PR TITLE
Fix sensuctl create stdin regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ is used in `sensuctl asset list`.
 - Fix generic API client's `SetTypeMeta` method. The APIGroup is now correctly
 configured and by virtue unintended authorization denied errs are avoided.
 - Fixed a bug where checks would stop executing after a network error.
+- Fixed a bug where sensuctl create with stdin was not working.
 
 ## [5.13.2] - 2019-09-19
 

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -132,6 +132,9 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
+		if len(inputs) == 0 {
+			return processStdin(cli, client)
+		}
 		recurse, err := cmd.Flags().GetBool("recursive")
 		if err != nil {
 			return err
@@ -143,6 +146,17 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		}
 		return nil
 	}
+}
+
+func processStdin(cli *cli.SensuCli, client *http.Client) error {
+	resources, err := ParseResources(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("in stdin: %s", err)
+	}
+	if err := ValidateResources(resources, cli.Config.Namespace()); err != nil {
+		return err
+	}
+	return PutResources(cli.Client, resources)
 }
 
 var jsonRe = regexp.MustCompile(`^(\s)*[\{\[]`)


### PR DESCRIPTION
## What is this change?

This commit fixes a regression in sensuctl create, where stdin mode
was no longer working. A test has been added to ensure that this
regression does not appear again.

## Why is this change necessary?

Closes #3318 

## Does your change need a Changelog entry?

Yes

## Aside from unit/integration tests, please describe the e2e steps to verify this change.

`cat check.json | sensuctl create`