### PR TITLE
Add default timeout to bolt.Open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Opening an already open Bolt database should not cause sensu-agent to hang
 indefinitely.
 
-## [5.14.0] - 2019-10-03
 ## [5.14.0] - 2019-10-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Opening an already open Bolt database should not cause sensu-agent to hang
+indefinitely.
+
 ## [5.14.0] - 2019-10-03
 
 ### Added

--- a/agent/queue.go
+++ b/agent/queue.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/sensu/lasr"
 	bolt "go.etcd.io/bbolt"
@@ -68,12 +69,12 @@ func newQueue(path string) (queue, error) {
 		return newMemoryQueue(1000), nil
 	}
 	if err := os.MkdirAll(path, 0744|os.ModeDir); err != nil {
-		return nil, fmt.Errorf("error creating api queue: %s", err)
+		return nil, fmt.Errorf("could not create directory for api queue (%s): %s", path, err)
 	}
 	queuePath := filepath.Join(path, "queue.db")
-	db, err := bolt.Open(queuePath, 0644, nil)
+	db, err := bolt.Open(queuePath, 0644, &bolt.Options{Timeout: 60 * time.Second})
 	if err != nil {
-		return nil, fmt.Errorf("error creating api queue: %s", err)
+		return nil, fmt.Errorf("could not open api queue (%s): %s", queuePath, err)
 	}
 	queue, err := lasr.NewQ(db, "api-buffer")
 	if err != nil {

--- a/agent/queue.go
+++ b/agent/queue.go
@@ -72,7 +72,10 @@ func newQueue(path string) (queue, error) {
 		return nil, fmt.Errorf("could not create directory for api queue (%s): %s", path, err)
 	}
 	queuePath := filepath.Join(path, "queue.db")
-	db, err := bolt.Open(queuePath, 0644, &bolt.Options{Timeout: 60 * time.Second})
+	// Create and open the database for the queue. The FileMode given here (0600)
+	// is only temporary since it will be enforced to 0600 when the queue is
+	// compacted below by the queue.Compact method
+	db, err := bolt.Open(queuePath, 0600, &bolt.Options{Timeout: 60 * time.Second})
 	if err != nil {
 		return nil, fmt.Errorf("could not open api queue (%s): %s", queuePath, err)
 	}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR adds a timeout when bolt opens a database, so sensu-agent does not indefinitely hang without any error if the database is already opened.

I didn't make it configurable since I don't feel like it's worth adding yet an another configuration attribute but I can do it if we feel it's necessary.

## Why is this change necessary?

While trying to run a second sensu-agent on my machine, it just hanged so I had to manually debug it to understand what conflicted with the first instance of sensu-agent.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

I manually tested it; I don't feel like we necessarily need tests that test that library. 
