### PR TITLE
Output yaml separator to file output stream instead of default cmd output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Opening an already open Bolt database should not cause sensu-agent to hang
 indefinitely.
+- [CLI] Dump multiple types as YAML to a file would print separator STDOUT
+instead of specified file
 
 ## [5.14.0] - 2019-10-08
 

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -264,7 +264,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 				err = helpers.PrintWrappedJSONList(resources, w)
 			case config.FormatYAML:
 				if i > 0 {
-					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "---")
+					_, _ = fmt.Fprintln(w, "---")
 				}
 				err = helpers.PrintYAML(resources, w)
 			default:


### PR DESCRIPTION
## What is this change?

If you dump multiple types via the CLI dump command the separator for types would be printed to STDOUT instead of the file specified as a flag.

Example:
```
# sensuctl dump Namespace,ClusterRole,ClusterRoleBinding,TessenConfig,Asset,CheckConfig,Entity,EventFilter,Handler,Hook,Mutator,Role,RoleBinding,Silenced -f /tmp/sensu.dump --all-namespaces
---
---
---
---
---
---
---
---
---
```


## Why is this change necessary?

The command should not return any output like when exporting as JSON.

## Does your change need a Changelog entry?

Changelog was updated.
