### PR TITLE
Add support for sensu-backend service environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added the `APIKey` resource and HTTP API support for POST, GET, and DELETE.
 - Added sensuctl commands to manage the `APIKey` resource.
 - Added support for api keys to be used in api authentication.
+- Added support for sensu-backend service environment variables
 
 ### Fixed
 - Opening an already open Bolt database should not cause sensu-agent to hang

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -411,6 +412,10 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.RegisterAlias(deprecatedFlagEtcdInitialClusterToken, flagEtcdInitialClusterToken)
 	viper.RegisterAlias(deprecatedFlagEtcdNodeName, flagEtcdNodeName)
 	viper.RegisterAlias(deprecatedFlagEtcdPeerURLs, flagEtcdPeerURLs)
+
+	viper.SetEnvPrefix("sensu_backend")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
 
 	// Use our custom template for the start command
 	cobra.AddTemplateFunc("categoryFlags", categoryFlags)


### PR DESCRIPTION
Fixes #2680

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

Support `SENSU_BACKEND` prefixed environment variables to configure `sensu-backend` service.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
Matches behavior that already exists for sensu-agent. Resolves #2680. The service startup scripts for sensu-backend already try and import environment variables from config files but those environment variables currently don't have any impact on the daemon.

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/pull/1724

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

```
[root@sensu-backend ~]# cat /etc/sensu/backend.yml 
---
state-dir: "/var/lib/sensu/sensu-backend"
api-url: http://sensu-backend.example.com:8080

[root@sensu-backend ~]# cat /etc/sysconfig/sensu-backend 
SENSU_BACKEND_AGENT_PORT="9081"

[root@sensu-backend ~]# netstat --listen -n -p | grep sensu-backend
tcp        0      0 127.0.0.1:2379          0.0.0.0:*               LISTEN      3950/sensu-backend  
tcp        0      0 127.0.0.1:2380          0.0.0.0:*               LISTEN      3950/sensu-backend  
tcp6       0      0 :::8080                 :::*                    LISTEN      3950/sensu-backend  
tcp6       0      0 :::3000                 :::*                    LISTEN      3950/sensu-backend  
tcp6       0      0 :::9081                 :::*                    LISTEN      3950/sensu-backend  
```

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->
