### PR TITLE
Fix a panic in wizard bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 indefinitely.
 - [CLI] Dump multiple types as YAML to a file would print separator STDOUT
 instead of specified file
+- Fixed a bug where Sensu would crash with a panic due to a send on a closed channel.
 
 ## [5.14.0] - 2019-10-08
 

--- a/backend/messaging/wizard_topic.go
+++ b/backend/messaging/wizard_topic.go
@@ -36,7 +36,7 @@ func (t *wizardTopic) Send(msg interface{}) {
 // cancelling a subscription can lead to a send on a closed channel.
 func safeSend(c chan<- interface{}, message interface{}, done chan struct{}) {
 	defer func() {
-		recover()
+		_ = recover()
 	}()
 	select {
 	case c <- message:


### PR DESCRIPTION
## What is this change?

This commit guards against a panic when sending to a closed wizard topic.

## Why is this change necessary?

In some cases, Sensu can crash after an agent session is terminated.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

The change is unverified as it's very difficult to trigger the conditions that lead to this problem. However, we have verified that in production instances of Sensu, a panic occurs that can be traced back to this chunk of code.

I feel that the change is safe enough to deploy without a reproduction.