### PR TITLE
The corev2.AuthProvider interface should embed the Resource int…

### DIFF
--- a/api/core/v2/provider.go
+++ b/api/core/v2/provider.go
@@ -6,23 +6,15 @@ import (
 
 // AuthProvider represents an abstracted authentication provider
 type AuthProvider interface {
+	Resource
+
 	// Authenticate attempts to authenticate a user with its username and password
 	Authenticate(ctx context.Context, username, password string) (*Claims, error)
 	// Refresh renews the user claims with the provider claims
 	Refresh(ctx context.Context, claims *Claims) (*Claims, error)
 
-	// GetObjectMeta returns the object metadata for the provider
-	GetObjectMeta() ObjectMeta
 	// Name returns the provider name (e.g. default)
 	Name() string
-	// StorePrefix gives the path prefix to this resource in the store
-	StorePrefix() string
 	// Type returns the provider type (e.g. ldap)
 	Type() string
-	// URIPath gives the path to the provider
-	URIPath() string
-	// Validate checks if the fields in the provider are valid
-	Validate() error
-	// SetNamespace sets the namespace of the resource.
-	SetNamespace(string)
 }

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -107,3 +107,13 @@ func (p *Provider) claims(username string) corev2.AuthProviderClaims {
 func (p *Provider) SetNamespace(namespace string) {
 	p.Namespace = namespace
 }
+
+// RBACName is not implemented
+func (p *Provider) RBACName() string {
+	return ""
+}
+
+// SetObjectMeta sets the meta of the resource.
+func (p *Provider) SetObjectMeta(meta corev2.ObjectMeta) {
+	p.ObjectMeta = meta
+}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This is a required PR for an enterprise bugfix. It essentially updates the AuthProvider interface to embed the Resource interface and make the basic auth provider compliant with a Resource.

## Why is this change necessary?



## Does your change need a Changelog entry?

Nope, doesn't change the user experience.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope!

## How did you verify this change?

No tests required