### PR TITLE
Add prom gauges for schedulerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added the `APIKey` resource and HTTP API support for POST, GET, and DELETE.
 - Added sensuctl commands to manage the `APIKey` resource.
 - Added support for api keys to be used in api authentication.
+- Added prometheus gauges for check schedulers.
 
 ### Fixed
 - Opening an already open Bolt database should not cause sensu-agent to hang

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -146,6 +146,7 @@ func (c *CheckWatcher) handleWatchEvent(watchEvent store.WatchEventCheckConfig) 
 			if err := c.startScheduler(check); err != nil {
 				logger.WithError(err).Error("unable to start check scheduler")
 			}
+			return
 		}
 		if sched.Type() == GetSchedulerType(check) {
 			logger.Info("restarting scheduler")
@@ -155,6 +156,7 @@ func (c *CheckWatcher) handleWatchEvent(watchEvent store.WatchEventCheckConfig) 
 			if err := sched.Stop(); err != nil {
 				logger.WithError(err).Error("error stopping check scheduler")
 			}
+			delete(c.items, key)
 			if err := c.startScheduler(check); err != nil {
 				logger.WithError(err).Error("unable to start check scheduler")
 			}

--- a/backend/schedulerd/cron_scheduler.go
+++ b/backend/schedulerd/cron_scheduler.go
@@ -61,6 +61,7 @@ func (s *CronScheduler) schedule(timer *CronTimer, executor *CheckExecutor) {
 
 // Start starts the cron scheduler.
 func (s *CronScheduler) Start() {
+	cronCounter.WithLabelValues(s.check.Namespace).Inc()
 	go s.start()
 }
 
@@ -97,6 +98,7 @@ func (s *CronScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the cron scheduler.
 func (s *CronScheduler) Stop() error {
+	cronCounter.WithLabelValues(s.check.Namespace).Dec()
 	logger.Info("stopping cron scheduler")
 	s.cancel()
 

--- a/backend/schedulerd/interval_scheduler.go
+++ b/backend/schedulerd/interval_scheduler.go
@@ -61,6 +61,7 @@ func (s *IntervalScheduler) schedule(timer CheckTimer, executor *CheckExecutor) 
 
 // Start starts the IntervalScheduler.
 func (s *IntervalScheduler) Start() {
+	intervalCounter.WithLabelValues(s.check.Namespace).Inc()
 	go s.start()
 }
 
@@ -98,6 +99,7 @@ func (s *IntervalScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the IntervalScheduler
 func (s *IntervalScheduler) Stop() error {
+	intervalCounter.WithLabelValues(s.check.Namespace).Dec()
 	s.logger.Info("stopping scheduler")
 	s.cancel()
 

--- a/backend/schedulerd/roundrobin_cron.go
+++ b/backend/schedulerd/roundrobin_cron.go
@@ -54,6 +54,7 @@ func NewRoundRobinCronScheduler(ctx context.Context, store store.Store, bus mess
 
 // Start starts the scheduler.
 func (s *RoundRobinCronScheduler) Start() {
+	rrCronCounter.WithLabelValues(s.check.Namespace).Inc()
 	go s.start()
 }
 
@@ -192,6 +193,7 @@ func (s *RoundRobinCronScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the scheduler
 func (s *RoundRobinCronScheduler) Stop() error {
+	rrCronCounter.WithLabelValues(s.check.Namespace).Dec()
 	s.logger.Info("stopping scheduler")
 	s.cancel()
 	return nil

--- a/backend/schedulerd/roundrobin_interval.go
+++ b/backend/schedulerd/roundrobin_interval.go
@@ -103,6 +103,7 @@ func (s *RoundRobinIntervalScheduler) updateRings() {
 
 // Start starts the round robin interval scheduler.
 func (s *RoundRobinIntervalScheduler) Start() {
+	rrIntervalCounter.WithLabelValues(s.check.Namespace).Inc()
 	go s.start()
 }
 
@@ -213,6 +214,7 @@ func (s *RoundRobinIntervalScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the scheduler
 func (s *RoundRobinIntervalScheduler) Stop() error {
+	rrIntervalCounter.WithLabelValues(s.check.Namespace).Dec()
 	s.logger.Info("stopping scheduler")
 	s.cancel()
 	return nil

--- a/backend/schedulerd/schedulerd.go
+++ b/backend/schedulerd/schedulerd.go
@@ -4,12 +4,43 @@ import (
 	"context"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/prometheus/client_golang/prometheus"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/cache"
 	"github.com/sensu/sensu-go/types"
+)
+
+var (
+	intervalCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sensu_go_interval_schedulers",
+			Help: "Number of active interval check schedulers on this backend",
+		},
+		[]string{"namespace"})
+
+	cronCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sensu_go_cron_schedulers",
+			Help: "Number of active cron check schedulers on this backend",
+		},
+		[]string{"namespace"})
+
+	rrIntervalCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sensu_go_round_robin_interval_schedulers",
+			Help: "Number of active round robin interval check schedulers on this backend.",
+		},
+		[]string{"namespace"})
+
+	rrCronCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "sensu_go_round_robin_cron_schedulers",
+			Help: "Number of active round robin cron check schedulers on this backend.",
+		},
+		[]string{"namespace"})
 )
 
 // Schedulerd handles scheduling check requests for each check's

--- a/backend/schedulerd/schedulerd.go
+++ b/backend/schedulerd/schedulerd.go
@@ -98,6 +98,10 @@ func New(ctx context.Context, c Config, opts ...Option) (*Schedulerd, error) {
 
 // Start the Scheduler daemon.
 func (s *Schedulerd) Start() error {
+	_ = prometheus.Register(intervalCounter)
+	_ = prometheus.Register(cronCounter)
+	_ = prometheus.Register(rrIntervalCounter)
+	_ = prometheus.Register(rrCronCounter)
 	return s.checkWatcher.Start()
 }
 


### PR DESCRIPTION
## What is this change?

Adds a prometheus gauge for each type of check scheduler, with a label for namespace.

## Why is this change necessary?

We need to improve observability of the check scheduler.

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

I found and fixed a double-close bug in schedulerd as a result of testing the change.

## How did you verify this change?

I started a sensu-go instance, verified that the number of schedulers I was expecting to be in the metrics were there. Then I changed the scheduler type from interval to cron for one of the checks, and verified that the interval number dropped, and the cron number incremented.