### PR TITLE
Use serializable reads for events

### DIFF
--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -182,7 +182,7 @@ func (s *Store) GetEventByEntityCheck(ctx context.Context, entityName, checkName
 		return nil, err
 	}
 
-	resp, err := s.client.Get(ctx, path, clientv3.WithPrefix())
+	resp, err := s.client.Get(ctx, path, clientv3.WithPrefix(), clientv3.WithSerializable())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What is this change?

Uses `clientv3.WithSerializable` for event reads. This trades the possibility of stale event reads for performance.

I believe that for our use case, this will not have a correctness impact.

## Why is this change necessary?

Closes #3349 

## Does your change need a Changelog entry?

One should be added once the change is verified.

## How did you verify this change?

In progress.