### PR TITLE
Bury switches when they are no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - As a result of upgrading etcd, TLS etcd clients that lose their connection will
 successfully reconnect when using --no-embed-etcd.
+- Check TTL switches are now correctly buried when associated events and entities
+are deleted.
+- Keepalive switches are now correctly buried when the keepalive event is deleted.
 
 ## [5.14.1] - 2019-10-16
 

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -9,6 +9,8 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
+const deletedEventSentinel = -1
+
 // EventController expose actions in which a viewer can perform.
 type EventController struct {
 	store store.EventStore
@@ -84,7 +86,7 @@ func (a EventController) Delete(ctx context.Context, entity, check string) error
 
 	if result.HasCheck() && result.Check.Ttl > 0 {
 		// Disable check TTL for this event, and inform eventd
-		result.Check.Ttl = -1
+		result.Check.Ttl = deletedEventSentinel
 		if err := a.bus.Publish(messaging.TopicEventRaw, result); err != nil {
 			return NewError(InternalErr, err)
 		}
@@ -92,7 +94,7 @@ func (a EventController) Delete(ctx context.Context, entity, check string) error
 
 	if result.HasCheck() && result.Check.Name == "keepalive" {
 		// Notify keepalived that the keepalive was deleted
-		result.Timestamp = -1
+		result.Timestamp = deletedEventSentinel
 		if err := a.bus.Publish(messaging.TopicKeepalive, result); err != nil {
 			return NewError(InternalErr, err)
 		}

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -49,6 +49,8 @@ var (
 	)
 )
 
+const deletedEventSentinel = -1
+
 // Eventd handles incoming sensu events and stores them in etcd.
 type Eventd struct {
 	ctx             context.Context
@@ -236,7 +238,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 		if err := switches.Alive(context.TODO(), switchKey, timeout); err != nil {
 			return err
 		}
-	} else if (prevEvent != nil && prevEvent.Check.Ttl > 0) || event.Check.Ttl == -1 {
+	} else if (prevEvent != nil && prevEvent.Check.Ttl > 0) || event.Check.Ttl == deletedEventSentinel {
 		// The check TTL has been disabled, there is no longer a need to track it
 		if err := switches.Bury(context.TODO(), switchKey); err != nil {
 			// It's better to publish the event even if this fails, so

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -236,7 +236,7 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 		if err := switches.Alive(context.TODO(), switchKey, timeout); err != nil {
 			return err
 		}
-	} else if prevEvent != nil && prevEvent.Check.Ttl > 0 {
+	} else if (prevEvent != nil && prevEvent.Check.Ttl > 0) || event.Check.Ttl == -1 {
 		// The check TTL has been disabled, there is no longer a need to track it
 		if err := switches.Bury(context.TODO(), switchKey); err != nil {
 			// It's better to publish the event even if this fails, so
@@ -292,8 +292,8 @@ func (e *Eventd) dead(key string, prev liveness.State, leader bool) (bury bool) 
 	// NOTE: To support check TTL for round robin scheduling, load all events
 	// here, filter by check, and update all events involved in the round robin
 	if entity == "" {
-		lager.Error("round robin check TTL not supported")
-		return false
+		lager.Error("round robin check ttl not supported")
+		return true
 	}
 
 	ctx := store.NamespaceContext(context.Background(), namespace)
@@ -302,18 +302,20 @@ func (e *Eventd) dead(key string, prev liveness.State, leader bool) (bury bool) 
 	// TTL for it anymore.
 	if ent, err := e.store.GetEntityByName(ctx, entity); err == nil && ent == nil {
 		return true
+	} else if err != nil {
+		lager.WithError(err).Error("check ttl: error retrieving entity")
+		return false
 	}
 
 	event, err := e.eventStore.GetEventByEntityCheck(ctx, entity, check)
 	if err != nil {
-		lager.WithError(err).Error("can't handle check TTL failure")
+		lager.WithError(err).Error("check ttl: error retrieving event")
 		return false
 	}
 
 	if event == nil {
 		// The user deleted the check event but not the entity
-		lager.Error("event is nil")
-		return false
+		return true
 	}
 
 	if leader {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -36,6 +36,8 @@ const (
 	RegistrationHandlerName = "registration"
 )
 
+const deletedEventSentinel = -1
+
 // Keepalived is responsible for monitoring keepalive events and recording
 // keepalives for entities.
 type Keepalived struct {
@@ -224,7 +226,7 @@ func (k *Keepalived) processKeepalives(ctx context.Context) {
 			continue
 		}
 
-		if event.Timestamp == -1 {
+		if event.Timestamp == deletedEventSentinel {
 			// The keepalive event was deleted, so we should bury its associated switch
 			id := path.Join(entity.Namespace, entity.Name)
 			if err := switches.Bury(ctx, id); err != nil {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -158,8 +158,13 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 			return err
 		}
 
+		id := path.Join(keepalive.Namespace, keepalive.Name)
+
 		// if there's no event, the entity was deregistered/deleted.
 		if event == nil {
+			if err := switches.Bury(ctx, id); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -174,7 +179,6 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 		}
 
 		ttl := int64(event.Check.Timeout)
-		id := path.Join(keepalive.Namespace, keepalive.Name)
 		if err := switches.Dead(ctx, id, ttl); err != nil {
 			return fmt.Errorf("error initializing keepalive %q: %s", id, err)
 		}
@@ -211,12 +215,21 @@ func (k *Keepalived) processKeepalives(ctx context.Context) {
 
 		entity := event.Entity
 		if entity == nil {
-			logger.Error("received keepalive with nil entity")
+			logger.Error("keepalive channel received keepalive with nil event")
 			continue
 		}
 
 		if err := entity.Validate(); err != nil {
 			logger.WithError(err).Error("invalid keepalive event")
+			continue
+		}
+
+		if event.Timestamp == -1 {
+			// The keepalive event was deleted, so we should bury its associated switch
+			id := path.Join(entity.Namespace, entity.Name)
+			if err := switches.Bury(ctx, id); err != nil {
+				logger.WithError(err).Error("error deleting keepalive")
+			}
 			continue
 		}
 
@@ -398,8 +411,8 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 		return false
 	}
 	if currentEvent == nil {
-		lager.Error("keepalive event not found")
-		return false
+		// The keepalive was deleted, so bury the switch
+		return true
 	}
 
 	// this is a real keepalive event, emit it.

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -274,7 +274,6 @@ func TestCreateKeepaliveEvent(t *testing.T) {
 }
 
 func TestDeadCallbackNoEntity(t *testing.T) {
-	// Make sure the dead callback doesn't crash when entity is missing
 	messageBus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	if err != nil {
 		t.Fatal(err)
@@ -295,12 +294,12 @@ func TestDeadCallbackNoEntity(t *testing.T) {
 	}
 	store.On("GetEntityByName", mock.Anything, mock.Anything).Return((*corev2.Entity)(nil), nil)
 
-	// Smoke test - just want to make sure there is no panic
-	keepalived.dead("default/testSubscriber", liveness.Alive, true)
+	if got, want := keepalived.dead("default/testSubscriber", liveness.Alive, true), true; got != want {
+		t.Fatalf("got bury: %v, want bury: %v", got, want)
+	}
 }
 
 func TestDeadCallbackNoEvent(t *testing.T) {
-	// Make sure the dead callback doesn't crash when entity is missing
 	messageBus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	if err != nil {
 		t.Fatal(err)
@@ -322,6 +321,8 @@ func TestDeadCallbackNoEvent(t *testing.T) {
 	store.On("GetEntityByName", mock.Anything, mock.Anything).Return(corev2.FixtureEntity("foo"), nil)
 	store.On("GetEventByEntityCheck", mock.Anything, mock.Anything, mock.Anything).Return((*corev2.Event)(nil), nil)
 
-	// Smoke test - just want to make sure there is no panic
-	keepalived.dead("default/testSubscriber", liveness.Alive, true)
+	// The switch should be buried since the event is nil
+	if got, want := keepalived.dead("default/testSubscriber", liveness.Alive, true), true; got != want {
+		t.Fatalf("got bury: %v, want bury: %v", got, want)
+	}
 }


### PR DESCRIPTION
## What is this change?

Switches are now buried when:

- The entity is nil
- The event is nil
- Round-robin is configured with check TTL


## Why is this change necessary?

Closes #3340 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation change required.

## How did you verify this change?

I added and modified some tests, and I also verified manually that the switches were being deleted properly.