### PR TITLE
Re-use leases instead of creating new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ successfully reconnect when using --no-embed-etcd.
 - Check TTL switches are now correctly buried when associated events and entities
 are deleted.
 - Keepalive switches are now correctly buried when the keepalive event is deleted.
+- Sensu now uses far fewer leases for keepalives and check TTLs, resulting in a
+stability improvement for most deployments.
 
 ## [5.14.1] - 2019-10-16
 


### PR DESCRIPTION
## What is this change?

Recent testing has revealed that we are creating leases at a ferocious rate, and they are not getting cleaned up quickly enough. For instance, in a 6000 entity cluster, the number leases from keepalives alone was over 40,000.

This change tracks leases that are in-use, and attempts to keep them alive if they are still valid. If they are not, a new lease is granted instead.

## Why is this change necessary?

Etcd <3.4 has a performance problem when many leases are present or expiring, and I believe it is causing stability problems.

Closes #3355

## Does your change need a Changelog entry?

Maybe, more testing needed.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs changes needed.

## How did you verify this change?

The existing test suite should suffice. I'm going to do some manual testing to see if we get a more reasonable number of leases.