### PR TITLE
[GraphQL] Allow services to be configured w/ custom executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
@@ -79,6 +81,7 @@ require (
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/AlecAivazis/survey.v1 v1.4.0 // indirect

--- a/graphql/middleware.go
+++ b/graphql/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
 )
 
 // Middleware is an interface for extending a service with operations that
@@ -33,4 +34,86 @@ type Middleware interface {
 
 	// GetResult returns the data that the extension wants to add to the result
 	GetResult(context.Context) interface{}
+}
+
+type (
+	// parseFinishFuncHandler handles the call of all the ParseFinishFuncs from the extenisons
+	parseFinishFuncHandler func(error)
+
+	// validationFinishFuncHandler responsible for the call of all the ValidationFinishFuncs
+	validationFinishFuncHandler func([]gqlerrors.FormattedError)
+
+	// executionFinishFuncHandler calls all the ExecutionFinishFuncs from each extension
+	executionFinishFuncHandler func(*graphql.Result)
+
+	// resolveFieldFinishFuncHandler calls the resolveFieldFinishFns for all the extensions
+	resolveFieldFinishFuncHandler func(interface{}, error)
+)
+
+// MiddlewareHandleInits handles all the init functions for the given service.
+func MiddlewareHandleInits(s *Service, p *graphql.Params) {
+	for _, m := range s.mware {
+		// update context
+		p.Context = m.Init(p.Context, p)
+	}
+}
+
+// MiddlewareHandleParseDidStart runs the ParseDidStart functions for each extension
+func MiddlewareHandleParseDidStart(s *Service, p *graphql.Params) parseFinishFuncHandler {
+	fs := map[string]graphql.ParseFinishFunc{}
+	for _, m := range s.mware {
+		ctx, finishFn := m.ParseDidStart(p.Context)
+		p.Context = ctx
+		fs[m.Name()] = finishFn
+	}
+	return func(err error) {
+		for _, fn := range fs {
+			fn(err)
+		}
+	}
+}
+
+// MiddlewareHandleValidationDidStart notifies the extensions about the start of the validation process
+func MiddlewareHandleValidationDidStart(s *Service, p *graphql.Params) validationFinishFuncHandler {
+	fs := map[string]graphql.ValidationFinishFunc{}
+	for _, m := range s.mware {
+		ctx, finishFn := m.ValidationDidStart(p.Context)
+		p.Context = ctx
+		fs[m.Name()] = finishFn
+	}
+	return func(errs []gqlerrors.FormattedError) {
+		for _, finishFn := range fs {
+			finishFn(errs)
+		}
+	}
+}
+
+// MiddlewareHandleExecutionDidStart handles the ExecutionDidStart func
+func MiddlewareHandleExecutionDidStart(s *Service, p *graphql.ExecuteParams) executionFinishFuncHandler {
+	fs := map[string]graphql.ExecutionFinishFunc{}
+	for _, m := range s.mware {
+		ctx, finishFn := m.ExecutionDidStart(p.Context)
+		p.Context = ctx
+		fs[m.Name()] = finishFn
+	}
+	return func(result *graphql.Result) {
+		for _, finishFn := range fs {
+			finishFn(result)
+		}
+	}
+}
+
+// MiddlewareHandleResolveFieldDidStart handles the notification of the extensions about the start of a resolve function
+func MiddlewareHandleResolveFieldDidStart(ctx context.Context, mware []Middleware, i *ResolveInfo) (context.Context, resolveFieldFinishFuncHandler) {
+	fs := map[string]graphql.ResolveFieldFinishFunc{}
+	for _, m := range mware {
+		var finishFn graphql.ResolveFieldFinishFunc
+		ctx, finishFn = m.ResolveFieldDidStart(ctx, i)
+		fs[m.Name()] = finishFn
+	}
+	return ctx, func(val interface{}, err error) {
+		for _, finishFn := range fs {
+			finishFn(val, err)
+		}
+	}
 }

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -5,10 +5,15 @@ import (
 	"fmt"
 
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/source"
 )
 
 // Service ...TODO...
 type Service struct {
+	Executor func(p graphql.ExecuteParams) *graphql.Result
+
 	schema graphql.Schema
 	types  *typeRegister
 	mware  []Middleware
@@ -17,7 +22,8 @@ type Service struct {
 // NewService returns new instance of Service
 func NewService() *Service {
 	return &Service{
-		types: newTypeRegister(),
+		Executor: graphql.Execute,
+		types:    newTypeRegister(),
 	}
 }
 
@@ -140,18 +146,45 @@ func (service *Service) Regenerate() error {
 }
 
 // Do executes request given query string
-func (service *Service) Do(
-	ctx context.Context,
-	q string,
-	vars map[string]interface{},
-) *graphql.Result {
+func (service *Service) Do(ctx context.Context, q string, vars map[string]interface{}) *graphql.Result {
+	schema := service.schema
 	params := graphql.Params{
-		Schema:         service.schema,
+		Schema:         schema,
 		VariableValues: vars,
 		Context:        ctx,
 		RequestString:  q,
 	}
-	return graphql.Do(params)
+
+	// run init middleware
+	MiddlewareHandleInits(service, &params)
+
+	// parse the source
+	parseFinishFn := MiddlewareHandleParseDidStart(service, &params)
+	source := source.NewSource(&source.Source{
+		Body: []byte(q),
+		Name: "GraphQL request",
+	})
+	AST, err := parser.Parse(parser.ParseParams{Source: source})
+	parseFinishFn(err)
+	if err != nil {
+		return &graphql.Result{Errors: gqlerrors.FormatErrors(err)}
+	}
+
+	// validate document
+	validationFinishFn := MiddlewareHandleValidationDidStart(service, &params)
+	validationResult := graphql.ValidateDocument(&schema, AST, nil)
+	validationFinishFn(validationResult.Errors)
+	if !validationResult.IsValid {
+		return &graphql.Result{Errors: validationResult.Errors}
+	}
+
+	// execute query
+	return service.Executor(graphql.ExecuteParams{
+		Schema:  schema,
+		AST:     AST,
+		Args:    vars,
+		Context: ctx,
+	})
 }
 
 type typeRegister struct {

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -10,8 +10,10 @@ import (
 	"github.com/graphql-go/graphql/language/source"
 )
 
-// Service ...TODO...
+// Service describes the whole of a GraphQL schema, validation, and execution.
 type Service struct {
+	// Executor evaluates a given request and returns a result. If none
+	// the default executor is used.
 	Executor func(p graphql.ExecuteParams) *graphql.Result
 
 	schema graphql.Schema


### PR DESCRIPTION
## What is this change?

Allow GraphQL service to be configured w/ custom executor. This will allow upstream implementations to be tailored to their specific needs.

## Why is this change necessary?

sensu-enterprise-go#702

## How did you verify this change?

Ensured that `graphql/integration` covered execution of queries.