### PR TITLE
[GraphQL] Expose service for upstream implementations

### DIFF
--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/apid/graphql"
 	"github.com/sensu/sensu-go/backend/apid/middlewares"
 	"github.com/sensu/sensu-go/backend/apid/routers"
 	"github.com/sensu/sensu-go/backend/authentication"
@@ -60,6 +61,7 @@ type Config struct {
 	EtcdClientTLSConfig *tls.Config
 	Authenticator       *authentication.Authenticator
 	ClusterVersion      string
+	GraphQLService      *graphql.Service
 }
 
 // New creates a new APId.
@@ -200,9 +202,7 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 
 	mountRouters(
 		subrouter,
-		routers.NewGraphQLRouter(
-			cfg.Store, cfg.EventStore, &rbac.Authorizer{Store: cfg.Store}, cfg.QueueGetter, cfg.Bus,
-		),
+		&routers.GraphQLRouter{Service: cfg.GraphQLService},
 	)
 
 	return subrouter

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -40,14 +40,14 @@ type ServiceConfig struct {
 
 // Service describes the Sensu GraphQL service capable of handling queries.
 type Service struct {
-	target *graphql.Service
-	cfg    ServiceConfig
+	Target *graphql.Service
+	Config ServiceConfig
 }
 
 // NewService instantiates new GraphQL service
 func NewService(cfg ServiceConfig) (*Service, error) {
 	svc := graphql.NewService()
-	wrapper := Service{target: svc, cfg: cfg}
+	wrapper := Service{Target: svc, Config: cfg}
 	nodeResolver := newNodeResolver(cfg)
 
 	// Register types
@@ -176,8 +176,8 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 // Do executes given query string and variables
 func (svc *Service) Do(ctx context.Context, q string, vars map[string]interface{}) *gql.Result {
 	// Instantiate loaders and lift them into the context
-	qryCtx := contextWithLoaders(ctx, svc.cfg)
+	qryCtx := contextWithLoaders(ctx, svc.Config)
 
 	// Execute query inside context
-	return svc.target.Do(qryCtx, q, vars)
+	return svc.Target.Do(qryCtx, q, vars)
 }

--- a/backend/apid/routers/graphql_test.go
+++ b/backend/apid/routers/graphql_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/graphql-go/graphql/testutil"
-	"github.com/sensu/sensu-go/testing/mockqueue"
+	"github.com/sensu/sensu-go/backend/apid/graphql"
 )
 
 func setupRequest(method string, path string, payload interface{}) (*http.Request, error) {
@@ -23,10 +23,12 @@ func setupRequest(method string, path string, payload interface{}) (*http.Reques
 }
 
 func TestHttpGraphQLRequest(t *testing.T) {
-	queue := &mockqueue.MockQueue{}
-	getter := &mockqueue.Getter{}
-	getter.On("GetQueue", "adhocRequest").Return(queue)
-	router := NewGraphQLRouter(nil, nil, nil, getter, nil)
+	service, err := graphql.NewService(graphql.ServiceConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := &GraphQLRouter{Service: service}
 	body := map[string]interface{}{
 		"operationName": "intrsopection",
 		"query":         testutil.IntrospectionQuery,
@@ -43,10 +45,12 @@ func TestHttpGraphQLRequest(t *testing.T) {
 }
 
 func TestHttpGraphQLBatchRequest(t *testing.T) {
-	queue := &mockqueue.MockQueue{}
-	getter := &mockqueue.Getter{}
-	getter.On("GetQueue", "adhocRequest").Return(queue)
-	router := NewGraphQLRouter(nil, nil, nil, getter, nil)
+	service, err := graphql.NewService(graphql.ServiceConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := &GraphQLRouter{Service: service}
 	body := []map[string]interface{}{
 		map[string]interface{}{
 			"operationName": "intrsopection",

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
@@ -79,6 +81,7 @@ require (
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/AlecAivazis/survey.v1 v1.4.0 // indirect


### PR DESCRIPTION
## What is this change?

Moves initialization of GraphQL service into the backend daemon and exposes it so that upstream implementations may extent and reconfigure it.

## Why is this change necessary?

sensu-enterprise-go#702

## How did you verify this change?

Ensured existing tests worked and fixed those that didn't.