### PR TITLE
Add a missing colon to interactive filter commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ are deleted.
 - Keepalive switches are now correctly buried when the keepalive event is deleted.
 - Sensu now uses far fewer leases for keepalives and check TTLs, resulting in a
 stability improvement for most deployments.
+- Fixed a minor UX issue in interactive filter commands in sensuctl.
 
 ## [5.14.1] - 2019-10-16
 

--- a/cli/commands/filter/interactive.go
+++ b/cli/commands/filter/interactive.go
@@ -66,7 +66,7 @@ func (opts *filterOpts) administerQuestionnaire(editing bool) error {
 		{
 			Name: "runtimeAssets",
 			Prompt: &survey.Input{
-				Message: "Runtime Assets",
+				Message: "Runtime Assets:",
 				Default: "",
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a missing colon to interactive filter commands in sensuctl.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3228.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

`sensuctl filter update`