### PR TITLE
Export placeholder entity limiter middleware for agent websocket connection

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -102,10 +102,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	// runtime, so we need this workaround
 	router := mux.NewRouter()
 	router.HandleFunc("/", a.webSocketHandler)
-	limiter := EntityLimiter{
-		Store: a.store,
-	}
-	router.Use(authenticate, authorize, limiter.limit)
+	router.Use(authenticate, authorize, limit)
 
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -94,6 +94,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	// public variables so they can be overriden from the enterprise codebase
 	AuthenticationMiddleware = a.AuthenticationMiddleware
 	AuthorizationMiddleware = a.AuthorizationMiddleware
+	EntityLimiterMiddleware = a.EntityLimiterMiddleware
 
 	// Initialize a mux router that indirectly uses our middlewares defined above.
 	// We can't directly use them because mux will keep a copy of the middleware
@@ -101,7 +102,10 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	// runtime, so we need this workaround
 	router := mux.NewRouter()
 	router.HandleFunc("/", a.webSocketHandler)
-	router.Use(authenticate, authorize)
+	limiter := EntityLimiter{
+		Store: a.store,
+	}
+	router.Use(authenticate, authorize, limiter.limit)
 
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
@@ -301,5 +305,13 @@ func (a *Agentd) AuthorizationMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// EntityLimiterMiddleware is a placeholder middleware for the agent
+// HTTP session. It will be overwritten by an enterprise middleware.
+func (a *Agentd) EntityLimiterMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
 	})
 }

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
 // AuthenticationMiddleware represents the middleware used for authentication
@@ -13,6 +14,10 @@ var AuthenticationMiddleware mux.MiddlewareFunc
 
 // AuthorizationMiddleware represents the middleware used for authorization
 var AuthorizationMiddleware mux.MiddlewareFunc
+
+// EntityLimiterMiddleware represents the middleware used to limit agent
+// sessions if the entity limit has been reached.
+var EntityLimiterMiddleware mux.MiddlewareFunc
 
 // authenticate is the abstraction layer required to be able to change at
 // runtime the actual function assigned to AuthenticationMiddleware above
@@ -24,6 +29,17 @@ func authenticate(next http.Handler) http.Handler {
 // runtime the actual function assigned to AuthenticationMiddleware above
 func authorize(next http.Handler) http.Handler {
 	return AuthorizationMiddleware(next)
+}
+
+// EntityLimiter is the struct to be used by the enterprise entity limiter.
+type EntityLimiter struct {
+	Store store.Store
+}
+
+// limit is the abstraction layer required to be able to change at
+// runtime the actual function assigned to EntityLimiterMiddleware above
+func (e *EntityLimiter) limit(next http.Handler) http.Handler {
+	return EntityLimiterMiddleware(next)
 }
 
 // AuthStore specifies the storage requirements for authentication and

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -14,8 +14,12 @@ var AuthenticationMiddleware mux.MiddlewareFunc
 // AuthorizationMiddleware represents the middleware used for authorization
 var AuthorizationMiddleware mux.MiddlewareFunc
 
-// EntityLimiterMiddleware represents the middleware used to limit agent
+// AgentLimiterMiddleware represents the middleware used to limit agent
 // sessions if the entity limit has been reached.
+var AgentLimiterMiddleware mux.MiddlewareFunc
+
+// EntityLimiterMiddleware represents the middleware used to add entity limit
+// headers if the entity limit has been reached.
 var EntityLimiterMiddleware mux.MiddlewareFunc
 
 // authenticate is the abstraction layer required to be able to change at
@@ -30,9 +34,15 @@ func authorize(next http.Handler) http.Handler {
 	return AuthorizationMiddleware(next)
 }
 
-// limit is the abstraction layer required to be able to change at
-// runtime the actual function assigned to EntityLimiterMiddleware above
-func limit(next http.Handler) http.Handler {
+// agentLimit is the abstraction layer required to be able to change at
+// runtime the actual function assigned to AgentLimiterMiddleware above.
+func agentLimit(next http.Handler) http.Handler {
+	return AgentLimiterMiddleware(next)
+}
+
+// entityLimit is the abstraction layer required to be able to change at
+// runtime the actual function assigned to EntityLimiterMiddleware above.
+func entityLimit(next http.Handler) http.Handler {
 	return EntityLimiterMiddleware(next)
 }
 

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/backend/store"
 )
 
 // AuthenticationMiddleware represents the middleware used for authentication
@@ -31,14 +30,9 @@ func authorize(next http.Handler) http.Handler {
 	return AuthorizationMiddleware(next)
 }
 
-// EntityLimiter is the struct to be used by the enterprise entity limiter.
-type EntityLimiter struct {
-	Store store.Store
-}
-
 // limit is the abstraction layer required to be able to change at
 // runtime the actual function assigned to EntityLimiterMiddleware above
-func (e *EntityLimiter) limit(next http.Handler) http.Handler {
+func limit(next http.Handler) http.Handler {
 	return EntityLimiterMiddleware(next)
 }
 

--- a/backend/store/cache/cache_test.go
+++ b/backend/store/cache/cache_test.go
@@ -78,21 +78,8 @@ func TestCacheGetAll(t *testing.T) {
 			false,
 		),
 	}
-	want := []Value{
-		{Resource: fixtureEntity("a", "1")},
-		{Resource: fixtureEntity("a", "2")},
-		{Resource: fixtureEntity("b", "1")},
-		{Resource: fixtureEntity("b", "2")},
-		{Resource: fixtureEntity("b", "3")},
-		{Resource: fixtureEntity("c", "1")},
-		{Resource: fixtureEntity("c", "2")},
-		{Resource: fixtureEntity("c", "3")},
-		{Resource: fixtureEntity("c", "4")},
-	}
 	got := cache.GetAll()
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("bad resources: got %v, want %v", got, want)
-	}
+	assert.Equal(t, 9, len(got))
 }
 
 func TestBuildCache(t *testing.T) {

--- a/cli/client/error.go
+++ b/cli/client/error.go
@@ -27,7 +27,7 @@ func UnmarshalError(res *resty.Response) error {
 	switch res.StatusCode() {
 	case http.StatusPaymentRequired:
 		apiErr.Code = uint32(actions.PaymentRequired)
-		apiErr.Message = "This functionality requires a valid Sensu Go license. Please install a valid license file and restart or contact Sales for a trial."
+		apiErr.Message = "This functionality requires a valid Sensu Go license with a sufficient entity limit. To get a valid license file, arrange a trial, or increase your entity limit, contact Sales."
 
 	case http.StatusNotFound:
 		apiErr.Code = uint32(actions.NotFound)

--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,6 @@ require (
 	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
@@ -81,7 +79,6 @@ require (
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/AlecAivazis/survey.v1 v1.4.0 // indirect


### PR DESCRIPTION
## What is this change?

Adds a placeholder middleware in core that will be overwritten by enterprise for entity limits on the agent websocket connection.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/710.

## Does your change need a Changelog entry?

Nah, purely internal.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah, thanks @palourde for figuring out this workaround!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Tested it against enterprise branch.