### PR TITLE
[GraphQL] Ensure generation of schema is idempotent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,6 @@ require (
 	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
@@ -81,7 +79,6 @@ require (
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/AlecAivazis/survey.v1 v1.4.0 // indirect

--- a/graphql/integration/service_test.go
+++ b/graphql/integration/service_test.go
@@ -34,6 +34,10 @@ func TestExerciseService(t *testing.T) {
 	err := svc.Regenerate()
 	require.NoError(t, err)
 
+	// regenerate should be idempotent
+	err = svc.Regenerate()
+	require.NoError(t, err)
+
 	ctx := context.Background()
 	res := svc.Do(ctx, `
 		query {

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -51,6 +51,7 @@ func (service *Service) RegisterEnum(t EnumDesc) {
 func (service *Service) RegisterInput(t InputDesc) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
+		cfg = t.Config()
 		fields := cfg.Fields.(graphql.InputObjectConfigFieldMap)
 		cfg.Fields = inputFieldsThunk(m, fields)
 		return graphql.NewInputObject(cfg)
@@ -62,6 +63,7 @@ func (service *Service) RegisterInput(t InputDesc) {
 func (service *Service) RegisterInterface(t InterfaceDesc, impl InterfaceTypeResolver) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
+		cfg = t.Config()
 		cfg.ResolveType = nil
 		if impl != nil {
 			cfg.ResolveType = newResolveTypeFn(m, impl)
@@ -76,6 +78,7 @@ func (service *Service) RegisterInterface(t InterfaceDesc, impl InterfaceTypeRes
 func (service *Service) RegisterObject(t ObjectDesc, impl interface{}) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
+		cfg = t.Config()
 		fields := cfg.Fields.(graphql.Fields)
 		for fieldName, handler := range t.FieldHandlers {
 			fields[fieldName].Resolve = handler(impl)
@@ -112,6 +115,7 @@ func (service *Service) RegisterObjectExtension(t ObjectDesc, impl interface{}) 
 func (service *Service) RegisterUnion(t UnionDesc, impl UnionTypeResolver) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
+		cfg = t.Config()
 		newTypes := make([]*graphql.Object, len(cfg.Types))
 		for i, t := range cfg.Types {
 			objType := m[t.PrivateName].(*graphql.Object)


### PR DESCRIPTION
## What is this change?

Fixes bug in GraphQL service definition that could lead to a panic when trying to regenerate the schema.

## Why is this change necessary?

Allows any upstream implementations or extensions to add types without fear of a panic.

## Does your change need a Changelog entry?

Given scope, it is probably unnecessary.

## How did you verify this change?

Added an assertion to integration test.
