### PR TITLE
Expose GlobalID funcs for upstream implementations

### DIFF
--- a/backend/apid/graphql/asset.go
+++ b/backend/apid/graphql/asset.go
@@ -14,7 +14,7 @@ type assetImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*assetImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.AssetTranslator.EncodeToString(p.Source), nil
+	return globalid.AssetTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type

--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -26,7 +26,7 @@ type checkCfgImpl struct {
 
 // ID implements response to request for 'id' field.
 func (r *checkCfgImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.CheckTranslator.EncodeToString(p.Source), nil
+	return globalid.CheckTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // Handlers implements response to request for 'handlers' field.
@@ -132,7 +132,7 @@ func (r *checkImpl) NodeID(p graphql.ResolveParams) (string, error) {
 			Name:      check.Name,
 		},
 	}
-	return globalid.CheckTranslator.EncodeToString(&config), nil
+	return globalid.CheckTranslator.EncodeToString(p.Context, &config), nil
 }
 
 // Executed implements response to request for 'executed' field.

--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -29,7 +29,7 @@ type entityImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*entityImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.EntityTranslator.EncodeToString(p.Source), nil
+	return globalid.EntityTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // Metadata implements response to request for 'metadata' field.

--- a/backend/apid/graphql/event.go
+++ b/backend/apid/graphql/event.go
@@ -22,7 +22,7 @@ type eventImpl struct {
 
 // ID implements response to request for 'id' field.
 func (r *eventImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.EventTranslator.EncodeToString(p.Source), nil
+	return globalid.EventTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // Namespace implements response to request for 'namespace' field.

--- a/backend/apid/graphql/event_filter.go
+++ b/backend/apid/graphql/event_filter.go
@@ -24,7 +24,7 @@ type eventFilterImpl struct {
 
 // ID implements response to request for 'id' field
 func (*eventFilterImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.EventFilterTranslator.EncodeToString(p.Source), nil
+	return globalid.EventFilterTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type

--- a/backend/apid/graphql/globalid/assets.go
+++ b/backend/apid/graphql/globalid/assets.go
@@ -20,4 +20,4 @@ var AssetTranslator = commonTranslator{
 }
 
 // Register asset encoder/decoder
-func init() { registerTranslator(AssetTranslator) }
+func init() { RegisterTranslator(AssetTranslator) }

--- a/backend/apid/graphql/globalid/checks.go
+++ b/backend/apid/graphql/globalid/checks.go
@@ -20,4 +20,4 @@ var CheckTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(CheckTranslator) }
+func init() { RegisterTranslator(CheckTranslator) }

--- a/backend/apid/graphql/globalid/clusterrolebindings.go
+++ b/backend/apid/graphql/globalid/clusterrolebindings.go
@@ -19,4 +19,4 @@ var ClusterRoleBindingTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(ClusterRoleBindingTranslator) }
+func init() { RegisterTranslator(ClusterRoleBindingTranslator) }

--- a/backend/apid/graphql/globalid/clusterroles.go
+++ b/backend/apid/graphql/globalid/clusterroles.go
@@ -19,4 +19,4 @@ var ClusterRoleTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(ClusterRoleTranslator) }
+func init() { RegisterTranslator(ClusterRoleTranslator) }

--- a/backend/apid/graphql/globalid/components.go
+++ b/backend/apid/graphql/globalid/components.go
@@ -44,14 +44,24 @@ type Components interface {
 	// this is the resource's name.
 	UniqueComponent() string
 
-	// Extra return value for given key within extras dict
-	Extra(key string) string
-
-	// SetExtra sets value for given key within extras dict
-	SetExtra(key, val string)
+	// Extras returns interface with access to extra values
+	Extras() Values
 
 	// String return string representation of ID
 	String() string
+}
+
+type Values interface {
+	// Get gets the first value associated with the given key. If there are no
+	// values associated with the key, Get returns the empty string. To access
+	// multiple values, use the map directly.
+	Get(key string) string
+
+	// Set sets the key to value. It replaces any existing values.
+	Set(key, val string)
+
+	// Clear removes all keys
+	Clear()
 }
 
 // StandardComponents describes the standard components of a global identifier.
@@ -111,16 +121,11 @@ func (id *StandardComponents) UniqueComponent() string {
 }
 
 // Extra returns the extra value associated with the given key.
-func (id *StandardComponents) Extra(key string) string {
-	return id.extras.Get(key)
-}
-
-// SetExtra sets the extra value associated with the given key.
-func (id *StandardComponents) SetExtra(key, val string) {
+func (id *StandardComponents) Extras() Values {
 	if id.extras == nil {
 		id.extras = url.Values{}
 	}
-	id.extras.Set(key, val)
+	return &dict{id.extras}
 }
 
 // Parse takes a global ID string, decodes it and returns it's components.
@@ -187,4 +192,14 @@ func omitEmpty(in []string) (out []string) {
 	}
 
 	return
+}
+
+type dict struct {
+	url.Values
+}
+
+func (d *dict) Clear() {
+	for key := range d.Values {
+		d.Values.Del(key)
+	}
 }

--- a/backend/apid/graphql/globalid/components.go
+++ b/backend/apid/graphql/globalid/components.go
@@ -125,7 +125,7 @@ func (id *StandardComponents) Extras() Values {
 	if id.extras == nil {
 		id.extras = url.Values{}
 	}
-	return &dict{id.extras}
+	return &dict{&id.extras}
 }
 
 // Parse takes a global ID string, decodes it and returns it's components.
@@ -195,11 +195,9 @@ func omitEmpty(in []string) (out []string) {
 }
 
 type dict struct {
-	url.Values
+	*url.Values
 }
 
 func (d *dict) Clear() {
-	for key := range d.Values {
-		d.Values.Del(key)
-	}
+	*d.Values = make(url.Values, len(*d.Values))
 }

--- a/backend/apid/graphql/globalid/components_test.go
+++ b/backend/apid/graphql/globalid/components_test.go
@@ -120,3 +120,14 @@ func TestStandardComponentsString(t *testing.T) {
 		})
 	}
 }
+
+func TestStandardComponents_Extras(t *testing.T) {
+	id := &StandardComponents{}
+	assert.Empty(t, id.Extras().Get("key"))
+
+	id.Extras().Set("key", "val")
+	assert.Equal(t, id.Extras().Get("key"), "val")
+
+	id.Extras().Clear()
+	assert.Empty(t, id.Extras().Get("key"))
+}

--- a/backend/apid/graphql/globalid/components_test.go
+++ b/backend/apid/graphql/globalid/components_test.go
@@ -129,5 +129,7 @@ func TestStandardComponents_Extras(t *testing.T) {
 	assert.Equal(t, id.Extras().Get("key"), "val")
 
 	id.Extras().Clear()
+	id.Extras().Set("key", "bum")
+	id.Extras().Clear()
 	assert.Empty(t, id.Extras().Get("key"))
 }

--- a/backend/apid/graphql/globalid/encoder.go
+++ b/backend/apid/graphql/globalid/encoder.go
@@ -1,0 +1,20 @@
+package globalid
+
+import "context"
+
+type EncodeFn func(context.Context, interface{}) *StandardComponents
+
+// DefaultEncoder is the default implementation of Encode.
+func DefaultEncoder(_ context.Context, res interface{}) *StandardComponents {
+	cmp := StandardComponents{}
+	if res, ok := res.(interface{ GetName() string }); ok {
+		cmp.uniqueComponent = res.GetName()
+	}
+	if res, ok := res.(interface{ GetNamespace() string }); ok {
+		cmp.namespace = res.GetNamespace()
+	}
+	return &cmp
+}
+
+// Encode produces a globalid components for a given resource.
+var Encode EncodeFn = DefaultEncoder

--- a/backend/apid/graphql/globalid/entity.go
+++ b/backend/apid/graphql/globalid/entity.go
@@ -22,4 +22,4 @@ var EntityTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(EntityTranslator) }
+func init() { RegisterTranslator(EntityTranslator) }

--- a/backend/apid/graphql/globalid/event_filters.go
+++ b/backend/apid/graphql/globalid/event_filters.go
@@ -20,4 +20,4 @@ var EventFilterTranslator = commonTranslator{
 }
 
 // Register event filter encoder/decoder
-func init() { registerTranslator(EventFilterTranslator) }
+func init() { RegisterTranslator(EventFilterTranslator) }

--- a/backend/apid/graphql/globalid/events_test.go
+++ b/backend/apid/graphql/globalid/events_test.go
@@ -1,6 +1,7 @@
 package globalid
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
@@ -10,8 +11,9 @@ import (
 func TestEncodeEvent(t *testing.T) {
 	assert := assert.New(t)
 
+	ctx := context.Background()
 	event := types.FixtureEvent("one", "two")
-	components := encodeEvent(event)
+	components := encodeEvent(ctx, event)
 	assert.Equal("events", components.Resource())
 	assert.Equal("default", components.Namespace())
 	assert.Equal("check", components.ResourceType())
@@ -19,14 +21,14 @@ func TestEncodeEvent(t *testing.T) {
 
 	event.Check = nil
 	event.Metrics = &types.Metrics{}
-	components = encodeEvent(event)
+	components = encodeEvent(ctx, event)
 	assert.Equal("metric", components.ResourceType())
 	assert.NotEmpty(components.UniqueComponent())
 }
 
 func TestEventComponents(t *testing.T) {
 	assert := assert.New(t)
-	components := NewEventComponents(StandardComponents{
+	components := NewEventComponents(&StandardComponents{
 		resource:        "events",
 		resourceType:    "check",
 		uniqueComponent: "WyJvbmUiLCJ0d28iLCIxMjM0Il0K",

--- a/backend/apid/graphql/globalid/handlers.go
+++ b/backend/apid/graphql/globalid/handlers.go
@@ -20,4 +20,4 @@ var HandlerTranslator = commonTranslator{
 }
 
 // Register handler encoder/decoder
-func init() { registerTranslator(HandlerTranslator) }
+func init() { RegisterTranslator(HandlerTranslator) }

--- a/backend/apid/graphql/globalid/hooks.go
+++ b/backend/apid/graphql/globalid/hooks.go
@@ -20,4 +20,4 @@ var HookTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(HookTranslator) }
+func init() { RegisterTranslator(HookTranslator) }

--- a/backend/apid/graphql/globalid/main.go
+++ b/backend/apid/graphql/globalid/main.go
@@ -7,7 +7,7 @@ package globalid
 // Register & friends
 var register = NewRegister()
 var registrar = NewRegistrar(register)
-var registerTranslator = registrar.Add
+var RegisterTranslator = registrar.Add
 
 // Lookup given ID components return applicable encoder
 var Lookup = register.Lookup
@@ -22,11 +22,11 @@ func Decode(gid string) (Components, error) {
 		return standardComponents, err
 	}
 
-	decoder, err := Lookup(standardComponents)
+	decoder, err := Lookup(*standardComponents)
 	if err != nil {
 		return standardComponents, err
 	}
 
-	components := decoder.Decode(standardComponents)
+	components := decoder.Decode(*standardComponents)
 	return components, nil
 }

--- a/backend/apid/graphql/globalid/mutators.go
+++ b/backend/apid/graphql/globalid/mutators.go
@@ -20,4 +20,4 @@ var MutatorTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(MutatorTranslator) }
+func init() { RegisterTranslator(MutatorTranslator) }

--- a/backend/apid/graphql/globalid/namespace.go
+++ b/backend/apid/graphql/globalid/namespace.go
@@ -1,6 +1,10 @@
 package globalid
 
-import "github.com/sensu/sensu-go/types"
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/types"
+)
 
 //
 // Namespaces
@@ -23,19 +27,12 @@ var NamespaceTranslator = commonTranslator{
 	//   srn:namespaces:myns
 	//   srn:namespaces:myns
 	//
-	encodeFunc: func(record interface{}) Components {
-		nsp, ok := record.(*types.Namespace)
-		if !ok {
-			return nil
-		}
-
-		components := StandardComponents{
-			resource:        namespaceName,
-			uniqueComponent: nsp.Name,
-		}
-		return &components
+	encodeFunc: func(ctx context.Context, record interface{}) Components {
+		components := Encode(ctx, record)
+		components.resource = namespaceName
+		return components
 	},
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(NamespaceTranslator) }
+func init() { RegisterTranslator(NamespaceTranslator) }

--- a/backend/apid/graphql/globalid/namespace_test.go
+++ b/backend/apid/graphql/globalid/namespace_test.go
@@ -1,6 +1,7 @@
 package globalid
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
@@ -11,10 +12,12 @@ import (
 func TestNamespaceTranslator(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+
+	ctx := context.Background()
 	nsp := &types.Namespace{Name: "myns"}
 
 	// Encode
-	gid := NamespaceTranslator.EncodeToString(nsp)
+	gid := NamespaceTranslator.EncodeToString(ctx, nsp)
 	assert.Equal("srn:namespaces:myns", gid)
 
 	// Decode

--- a/backend/apid/graphql/globalid/register_test.go
+++ b/backend/apid/graphql/globalid/register_test.go
@@ -25,7 +25,7 @@ func TestRegisterLookup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.gid, func(t *testing.T) {
 			components, _ := Parse(tc.gid)
-			decoder, err := register.Lookup(components)
+			decoder, err := register.Lookup(*components)
 			assert.Equal(t, tc.want, decoder)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})

--- a/backend/apid/graphql/globalid/rolebindings.go
+++ b/backend/apid/graphql/globalid/rolebindings.go
@@ -19,4 +19,4 @@ var RoleBindingTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(RoleBindingTranslator) }
+func init() { RegisterTranslator(RoleBindingTranslator) }

--- a/backend/apid/graphql/globalid/roles.go
+++ b/backend/apid/graphql/globalid/roles.go
@@ -19,4 +19,4 @@ var RoleTranslator = commonTranslator{
 }
 
 // Register entity encoder/decoder
-func init() { registerTranslator(RoleTranslator) }
+func init() { RegisterTranslator(RoleTranslator) }

--- a/backend/apid/graphql/globalid/silences.go
+++ b/backend/apid/graphql/globalid/silences.go
@@ -20,4 +20,4 @@ var SilenceTranslator = commonTranslator{
 }
 
 // Register silence encoder/decoder
-func init() { registerTranslator(SilenceTranslator) }
+func init() { RegisterTranslator(SilenceTranslator) }

--- a/backend/apid/graphql/globalid/translator.go
+++ b/backend/apid/graphql/globalid/translator.go
@@ -1,5 +1,7 @@
 package globalid
 
+import "context"
+
 //
 // Translators
 //
@@ -7,8 +9,8 @@ package globalid
 // An Encoder can encode global IDs for a specific resource
 type Encoder interface {
 	IsResponsible(interface{}) bool
-	Encode(interface{}) Components
-	EncodeToString(interface{}) string
+	Encode(context.Context, interface{}) Components
+	EncodeToString(context.Context, interface{}) string
 }
 
 // A Decoder can decode global IDs for a specific resource

--- a/backend/apid/graphql/globalid/users.go
+++ b/backend/apid/graphql/globalid/users.go
@@ -20,4 +20,4 @@ var UserTranslator = commonTranslator{
 }
 
 // Register user encoder/decoder
-func init() { registerTranslator(UserTranslator) }
+func init() { RegisterTranslator(UserTranslator) }

--- a/backend/apid/graphql/globalid/util_test.go
+++ b/backend/apid/graphql/globalid/util_test.go
@@ -1,6 +1,7 @@
 package globalid
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sensu/sensu-go/types"
@@ -10,9 +11,10 @@ import (
 func TestStandardDecoder(t *testing.T) {
 	assert := assert.New(t)
 
+	ctx := context.Background()
 	handler := types.FixtureHandler("myHandler")
 	encoderFn := standardEncoder("handlers", "Name")
-	components := encoderFn(handler)
+	components := encoderFn(ctx, handler)
 
 	assert.Equal("handlers", components.Resource())
 	assert.Equal("default", components.Namespace())

--- a/backend/apid/graphql/handler.go
+++ b/backend/apid/graphql/handler.go
@@ -23,7 +23,7 @@ type handlerImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*handlerImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.HandlerTranslator.EncodeToString(p.Source), nil
+	return globalid.HandlerTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // Mutator implements response to request for 'mutator' field.

--- a/backend/apid/graphql/hook.go
+++ b/backend/apid/graphql/hook.go
@@ -36,7 +36,7 @@ type hookCfgImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*hookCfgImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.HookTranslator.EncodeToString(p.Source), nil
+	return globalid.HookTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -181,7 +182,7 @@ func TestMutationTypeDeleteEntityField(t *testing.T) {
 
 func TestMutationTypeDeleteEventField(t *testing.T) {
 	evt := corev2.FixtureEvent("a", "b")
-	gid := globalid.EventTranslator.EncodeToString(evt)
+	gid := globalid.EventTranslator.EncodeToString(context.Background(), evt)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
 	params := schema.MutationDeleteEventFieldResolverParams{}
@@ -212,7 +213,7 @@ func TestMutationTypeDeleteEventField(t *testing.T) {
 
 func TestMutationTypeDeleteHandlerField(t *testing.T) {
 	hd := corev2.FixtureHandler("a")
-	gid := globalid.HandlerTranslator.EncodeToString(hd)
+	gid := globalid.HandlerTranslator.EncodeToString(context.Background(), hd)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
 	params := schema.MutationDeleteHandlerFieldResolverParams{}
@@ -237,7 +238,7 @@ func TestMutationTypeDeleteHandlerField(t *testing.T) {
 
 func TestMutationTypeDeleteMutatorField(t *testing.T) {
 	mut := corev2.FixtureMutator("a")
-	gid := globalid.MutatorTranslator.EncodeToString(mut)
+	gid := globalid.MutatorTranslator.EncodeToString(context.Background(), mut)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
 	params := schema.MutationDeleteMutatorFieldResolverParams{}
@@ -262,7 +263,7 @@ func TestMutationTypeDeleteMutatorField(t *testing.T) {
 
 func TestMutationTypeDeleteEventFilterField(t *testing.T) {
 	flr := corev2.FixtureEventFilter("a")
-	gid := globalid.EventFilterTranslator.EncodeToString(flr)
+	gid := globalid.EventFilterTranslator.EncodeToString(context.Background(), flr)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
 	params := schema.MutationDeleteEventFilterFieldResolverParams{}

--- a/backend/apid/graphql/mutator.go
+++ b/backend/apid/graphql/mutator.go
@@ -20,7 +20,7 @@ type mutatorImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*mutatorImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.MutatorTranslator.EncodeToString(p.Source), nil
+	return globalid.MutatorTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -25,7 +25,7 @@ type namespaceImpl struct {
 
 // ID implements response to request for 'id' field.
 func (r *namespaceImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.NamespaceTranslator.EncodeToString(p.Source), nil
+	return globalid.NamespaceTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // Name implements response to request for 'name' field.

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -16,7 +16,7 @@ import (
 //
 
 type nodeResolver struct {
-	register relay.NodeRegister
+	register *relay.NodeRegister
 }
 
 func newNodeResolver(cfg ServiceConfig) *nodeResolver {
@@ -38,16 +38,16 @@ func newNodeResolver(cfg ServiceConfig) *nodeResolver {
 	registerNamespaceNodeResolver(register, cfg.NamespaceClient)
 	registerSilencedNodeResolver(register, cfg.SilencedClient)
 
-	return &nodeResolver{register}
+	return &nodeResolver{&register}
 }
 
-func (r *nodeResolver) FindType(i interface{}) *graphql.Type {
+func (r *nodeResolver) FindType(ctx context.Context, i interface{}) *graphql.Type {
 	translator, err := globalid.ReverseLookup(i)
 	if err != nil {
 		return nil
 	}
 
-	components := translator.Encode(i)
+	components := translator.Encode(ctx, i)
 	resolver := r.register.Lookup(components)
 	if resolver == nil {
 		logger := logger.WithField("translator", fmt.Sprintf("%#v", translator))

--- a/backend/apid/graphql/node_test.go
+++ b/backend/apid/graphql/node_test.go
@@ -29,7 +29,7 @@ func TestNodeResolverFindType(t *testing.T) {
 	resolver := newNodeResolver(cfg)
 
 	check := corev2.FixtureCheckConfig("http-check")
-	typeID := resolver.FindType(check)
+	typeID := resolver.FindType(context.Background(), check)
 	assert.NotNil(t, typeID)
 }
 
@@ -42,7 +42,7 @@ func TestNodeResolverFind(t *testing.T) {
 	info := graphql.ResolveInfo{}
 
 	check := corev2.FixtureCheckConfig("http-check")
-	gid := globalid.CheckTranslator.EncodeToString(check)
+	gid := globalid.CheckTranslator.EncodeToString(context.Background(), check)
 
 	// Success
 	client.On("FetchCheck", mock.Anything, check.Name).Return(check, nil).Once()
@@ -98,7 +98,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureAsset("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.AssetTranslator.EncodeToString(r)
+				return globalid.AssetTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.AssetClient.(onner).On("FetchAsset", mock.Anything, "name").Return(r, nil).Once()
@@ -110,7 +110,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureCheckConfig("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.CheckTranslator.EncodeToString(r)
+				return globalid.CheckTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.CheckClient.(onner).On("FetchCheck", mock.Anything, "name").Return(r, nil).Once()
@@ -122,7 +122,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureEntity("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.EntityTranslator.EncodeToString(r)
+				return globalid.EntityTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.EntityClient.(onner).On("FetchEntity", mock.Anything, "name").Return(r, nil).Once()
@@ -134,7 +134,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureEventFilter("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.EventFilterTranslator.EncodeToString(r)
+				return globalid.EventFilterTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.EventFilterClient.(onner).On("FetchEventFilter", mock.Anything, "name").Return(r, nil).Once()
@@ -146,7 +146,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureHandler("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.HandlerTranslator.EncodeToString(r)
+				return globalid.HandlerTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.HandlerClient.(onner).On("FetchHandler", mock.Anything, "name").Return(r, nil).Once()
@@ -158,7 +158,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureMutator("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.MutatorTranslator.EncodeToString(r)
+				return globalid.MutatorTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.MutatorClient.(onner).On("FetchMutator", mock.Anything, "name").Return(r, nil).Once()
@@ -170,7 +170,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureUser("name")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.UserTranslator.EncodeToString(r)
+				return globalid.UserTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.UserClient.(onner).On("FetchUser", mock.Anything, "name").Return(r, nil).Once()
@@ -182,7 +182,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureEvent("a", "b")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.EventTranslator.EncodeToString(r)
+				return globalid.EventTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.EventClient.(onner).On("FetchEvent", mock.Anything, "a", "b").Return(r, nil).Once()
@@ -194,7 +194,7 @@ func TestAssetNodeResolver(t *testing.T) {
 				return corev2.FixtureNamespace("sensu")
 			},
 			setupID: func(r interface{}) string {
-				return globalid.NamespaceTranslator.EncodeToString(r)
+				return globalid.NamespaceTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
 				cfg.NamespaceClient.(onner).On("FetchNamespace", mock.Anything, "sensu").Return(r, nil).Once()

--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -175,7 +175,7 @@ type nodeImpl struct {
 	nodeResolver *nodeResolver
 }
 
-func (impl *nodeImpl) ResolveType(i interface{}, _ graphql.ResolveTypeParams) *graphql.Type {
+func (impl *nodeImpl) ResolveType(i interface{}, p graphql.ResolveTypeParams) *graphql.Type {
 	resolver := impl.nodeResolver
-	return resolver.FindType(i)
+	return resolver.FindType(p.Context, i)
 }

--- a/backend/apid/graphql/rbac.go
+++ b/backend/apid/graphql/rbac.go
@@ -34,7 +34,7 @@ type roleImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*roleImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.RoleTranslator.EncodeToString(p.Source), nil
+	return globalid.RoleTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // IsTypeOf is used to determine if a given value is associated with the type

--- a/backend/apid/graphql/schema/resource.graphql
+++ b/backend/apid/graphql/schema/resource.graphql
@@ -1,5 +1,5 @@
 interface Resource {
-  "Metadata contains the name, namespace, labels and annotations of the resource,"
+  "Metadata contains the name, namespace, labels and annotations of the resource."
   metadata: ObjectMeta!
 
   """

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	gql "github.com/graphql-go/graphql"
+	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/graphql"
@@ -40,15 +41,20 @@ type ServiceConfig struct {
 
 // Service describes the Sensu GraphQL service capable of handling queries.
 type Service struct {
-	Target *graphql.Service
-	Config ServiceConfig
+	Target       *graphql.Service
+	Config       ServiceConfig
+	NodeRegister *relay.NodeRegister
 }
 
 // NewService instantiates new GraphQL service
 func NewService(cfg ServiceConfig) (*Service, error) {
 	svc := graphql.NewService()
-	wrapper := Service{Target: svc, Config: cfg}
 	nodeResolver := newNodeResolver(cfg)
+	wrapper := Service{
+		Target:       svc,
+		Config:       cfg,
+		NodeRegister: nodeResolver.register,
+	}
 
 	// Register types
 	schema.RegisterAsset(svc, &assetImpl{})

--- a/backend/apid/graphql/silenced.go
+++ b/backend/apid/graphql/silenced.go
@@ -47,7 +47,7 @@ func (r *silencedImpl) Expires(p graphql.ResolveParams) (*time.Time, error) {
 
 // ID implements response to request for 'id' field.
 func (r *silencedImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.SilenceTranslator.EncodeToString(p.Source), nil
+	return globalid.SilenceTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // ToJSON implements response to request for 'toJSON' field.

--- a/backend/apid/graphql/user.go
+++ b/backend/apid/graphql/user.go
@@ -19,7 +19,7 @@ type userImpl struct {
 
 // ID implements response to request for 'id' field.
 func (*userImpl) ID(p graphql.ResolveParams) (string, error) {
-	return globalid.UserTranslator.EncodeToString(p.Source), nil
+	return globalid.UserTranslator.EncodeToString(p.Context, p.Source), nil
 }
 
 // AuthorId implements response to request for 'hasPassword' field.

--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,6 @@ require (
 	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
@@ -81,7 +79,6 @@ require (
 	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/AlecAivazis/survey.v1 v1.4.0 // indirect


### PR DESCRIPTION
## What is this change?

Will allow upstream implementations to register globally unique
identifiers for their resources, as well as adding the ability to fetch
resources based on said IDs.

Brass tacks:

* Makes `RegisterTranslator` func public.
* Exposes `NodeRegister` on graphql.Service.
* Changes `globalid` package's interface to include extra contextual details.
* Adds public `Encode` func to globalid package.

## Why is this change necessary?

sensu/sensu-enterprise-go#702