### PR TITLE
Correctly apply silences to events from proxy entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ are deleted.
 - Sensu now uses far fewer leases for keepalives and check TTLs, resulting in a
 stability improvement for most deployments.
 - Fixed a minor UX issue in interactive filter commands in sensuctl.
+- Silences now successfully apply to proxy entities where the check doesn't contain
+  the same subscriptions as the entity (#3356)
 
 ## [5.14.1] - 2019-10-16
 

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -123,7 +123,7 @@ func GetEntitySubscription(entityName string) string {
 func FixtureEntity(name string) *Entity {
 	return &Entity{
 		EntityClass:   "host",
-		Subscriptions: []string{"linux"},
+		Subscriptions: []string{"linux", GetEntitySubscription(name)},
 		ObjectMeta: ObjectMeta{
 			Namespace: "default",
 			Name:      name,

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	stringsutil "github.com/sensu/sensu-go/util/strings"
 )
 
 const (
@@ -82,6 +84,27 @@ func (s *Silenced) Prepare(ctx context.Context) {
 			s.Creator = claims.Subject
 		}
 	}
+}
+
+// Matches returns true if the given check name and subscription match the silence.
+//
+// The two properties compared, Subscription and Check, are only compared if they are
+// not empty. An empty value for either of those fields is considered a wildcard,
+// ie: s.Check = "foo" && s.Subscription = "" will return true for s.Matches("foo", <anything>).
+func (s *Silenced) Matches(check, subscription string) bool {
+	if s == nil {
+		return false
+	}
+
+	if !stringsutil.InArray(s.Subscription, []string{"", "*", subscription}) {
+		return false
+	}
+
+	if !stringsutil.InArray(s.Check, []string{"", "*", check}) {
+		return false
+	}
+
+	return true
 }
 
 // NewSilenced creates a new Silenced entry.

--- a/api/core/v2/silenced_test.go
+++ b/api/core/v2/silenced_test.go
@@ -80,3 +80,69 @@ func TestSortSilencedByBegin(t *testing.T) {
 	sort.Sort(SortSilencedByBegin(in))
 	assert.EqualValues(t, []*Silenced{a, b, c}, in)
 }
+
+func TestSilencedMatches(t *testing.T) {
+	testCases := []struct {
+		name         string
+		silenced     *Silenced
+		check        string
+		subscription string
+		expected     bool
+	}{
+		{
+			name:         "nil silence",
+			silenced:     nil,
+			check:        "",
+			subscription: "",
+			expected:     false,
+		},
+		{
+			name:         "No subscription or check",
+			silenced:     FixtureSilenced("*:*"),
+			subscription: "matches",
+			check:        "anything",
+			expected:     true,
+		},
+		{
+			name:         "Subscription matches, no check",
+			silenced:     FixtureSilenced("foo:*"),
+			subscription: "foo",
+			check:        "wildcard",
+			expected:     true,
+		},
+		{
+			name:         "Subscription matches, check doesn't",
+			silenced:     FixtureSilenced("foo:bar"),
+			subscription: "foo",
+			check:        "nomatch",
+			expected:     false,
+		},
+		{
+			name:         "Check matches, no subscription",
+			silenced:     FixtureSilenced("*:foo"),
+			subscription: "anything",
+			check:        "foo",
+			expected:     true,
+		},
+		{
+			name:         "Check matches, subscription doesn't",
+			silenced:     FixtureSilenced("foo:bar"),
+			subscription: "nomatch",
+			check:        "bar",
+			expected:     false,
+		},
+		{
+			name:         "Both check and subscription match",
+			silenced:     FixtureSilenced("foo:bar"),
+			subscription: "foo",
+			check:        "bar",
+			expected:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.silenced.Matches(tc.check, tc.subscription))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3356 by removing dependence on silence name for applying silences.

## What is this change?

There is a longer description in this comment: https://github.com/sensu/sensu-go/issues/3356#issuecomment-545471799

The tl;dr is that silences currently depend heavily on the name of the silence to determine whether a silence applies. The name contains the subscription, check, and may or may not have wildcards denoted with `*`.

This PR removes that dependency, instead checking the `subscription` and `check` properties of the silence directly.

Additionally, it adds better support for proxy entities, where subscriptions are used differently to non-proxy entities. Subscriptions on proxy entities may be used to target checks (via the `proxy_entity_attributes` field in check config), while the subscriptions actually attached the check are used to target the agent the check should run on. This prevented silences for them applying correctly.

I have documented all these cases extensively in the code via comments and some additional tests for these missing cases.

## Why is this change necessary?

See above. I chose to remove the dependency on the `name` property specifically because that felt like a prerequisite for being able to address #3374.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope, existing tests caught a few issues with the first pass of my implementation that I hadn't considered which was :ok_hand: 

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation explaining the difference between how silences are applied proxy and non-proxy entities is probably required. The comments in the code should be sufficiently detailed to inform that for whoever writes it.

## How did you verify this change?

- Existing tests pass
- Added new tests for proxy cases
- Ran adhoc test to confirm silence for non-proxy entity still applied as expected
```
 sensuctl create -f check.json

 sensuctl silenced create --interactive
? Namespace: default
? Subscription: switches
? Check: *
? Begin time: now
? Expiry in Seconds: -1
? Expire on Resolve: No
? Reason: testing PR
Created

 sensuctl silenced list
     Name      Subscription   Check          Begin          Expire   ExpireOnResolve   Creator     Reason     Namespace
 ──────────── ────────────── ─────── ───────────────────── ──────── ───────────────── ───────── ──────────── ───────────
  switches:*   switches       *       04 Nov 19 10:37 EST   -1s      false             admin     testing PR   default

 sensuctl event list
  Entity     Check                                  Output                                Status   Silenced             Timestamp
 ──────── ─────────── ────────────────────────────────────────────────────────────────── ──────── ────────── ───────────────────────────────
  agent1   foo                                                                                 1   true       2019-11-04 10:37:36 -0500 EST
  agent1   keepalive   Keepalive last sent from agent1 at 2019-11-04 15:37:35 +0000 UTC        0   false      2019-11-04 10:37:35 -0500 EST
```
where `check.json` is:
```
{
  "type": "CheckConfig",
  "api_version": "core/v2",
  "metadata": {
    "name": "foo",
    "namespace": "default"
  },
  "spec": {
    "command": "sh -c 'exit 1'",
    "interval": 5,
    "publish": true,
    "subscriptions": [
      "switches",
      "entity:agent1"
    ]
  }
}
```