### PR TITLE
Add implicit access to namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Upgraded etcd to 3.3.17
+- Listing namespaces is now done implicitly based on access to resources within
+a namespace. Users will no longer be able to list all namespaces by default, in
+new installations. Existing installations will function as before. Operators can
+change to the new behaviour, by modifying the system:user role.
 
 ### Fixed
 - As a result of upgrading etcd, TLS etcd clients that lose their connection will

--- a/backend/api/namespace_test.go
+++ b/backend/api/namespace_test.go
@@ -1,0 +1,317 @@
+package api
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/authorization/rbac"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+func TestNamespaceList(t *testing.T) {
+	namespaces := []*corev2.Namespace{
+		corev2.FixtureNamespace("a"),
+		corev2.FixtureNamespace("b"),
+		corev2.FixtureNamespace("c"),
+		corev2.FixtureNamespace("d"),
+		corev2.FixtureNamespace("e"),
+		corev2.FixtureNamespace("f"),
+	}
+	tests := []struct {
+		Name                string
+		Attrs               *authorization.Attributes
+		ClusterRoles        []*corev2.ClusterRole
+		ClusterRoleBindings []*corev2.ClusterRoleBinding
+		Roles               []*corev2.Role
+		RoleBindings        []*corev2.RoleBinding
+		AllNamespaces       []*corev2.Namespace
+		ExpNamespaces       []*corev2.Namespace
+		ExpError            bool
+	}{
+		{
+			Name: "all access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "admin",
+					Groups:   []string{"cluster-admins"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			RoleBindings:  []*corev2.RoleBinding{},
+			AllNamespaces: namespaces,
+			ExpNamespaces: namespaces,
+		},
+		{
+			Name: "no access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "default",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			RoleBindings:  []*corev2.RoleBinding{},
+			AllNamespaces: namespaces,
+			ExpNamespaces: nil,
+		},
+		{
+			Name: "partial access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "default",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			Roles: []*corev2.Role{
+				{
+					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
+					Rules: []corev2.Rule{
+						{
+							Verbs:         []string{"get"},
+							Resources:     []string{corev2.NamespacesResource},
+							ResourceNames: []string{"a", "c", "e"},
+						},
+					},
+				},
+			},
+			RoleBindings: []*corev2.RoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "plebs",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "Role",
+						Name: "pleb",
+					},
+					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
+				},
+			},
+			AllNamespaces: namespaces,
+			ExpNamespaces: []*corev2.Namespace{
+				namespaces[0],
+				namespaces[2],
+				namespaces[4],
+			},
+		},
+		{
+			Name: "implicit access via resources in namespace",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "a",
+				Resource:     corev2.ChecksResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			Roles: []*corev2.Role{
+				{
+					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{"delete"},
+							Resources: []string{corev2.ChecksResource},
+						},
+						{
+							Verbs:     []string{"get"},
+							Resources: []string{corev2.ChecksResource},
+						},
+					},
+				},
+			},
+			RoleBindings: []*corev2.RoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "plebs",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "Role",
+						Name: "pleb",
+					},
+					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
+				},
+			},
+			AllNamespaces: namespaces,
+			ExpNamespaces: []*corev2.Namespace{
+				namespaces[0],
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			store := new(mockstore.MockStore)
+			store.On("ListClusterRoles", mock.Anything, mock.Anything).Return(test.ClusterRoles, nil)
+			store.On("ListClusterRoleBindings", mock.Anything, mock.Anything).Return(test.ClusterRoleBindings, nil)
+			store.On("ListRoles", mock.Anything, mock.Anything).Return(test.Roles, nil)
+			store.On("ListRoleBindings", mock.Anything, mock.Anything).Return(test.RoleBindings, nil)
+			store.On("ListResources", mock.Anything, corev2.NamespacesResource, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				resources := args[2].(*[]*corev2.Namespace)
+				*resources = append(*resources, test.AllNamespaces...)
+			}).Return(nil)
+			setupGetClusterRoleAndGetRole(store, test.ClusterRoles, test.Roles)
+
+			ctx := contextWithUser(defaultContext(), test.Attrs.User.Username, test.Attrs.User.Groups)
+
+			auth := &rbac.Authorizer{Store: store}
+			client := NewNamespaceClient(store, auth)
+
+			got, err := client.ListNamespaces(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sort.Slice(got, sortFunc(got))
+
+			if got, want := got, test.ExpNamespaces; !reflect.DeepEqual(got, want) {
+				t.Fatalf("bad namespaces: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func setupGetClusterRoleAndGetRole(store *mockstore.MockStore, clusterRoles []*corev2.ClusterRole, roles []*corev2.Role) {
+	for _, role := range clusterRoles {
+		store.On("GetClusterRole", mock.Anything, role.Name).Return(role, nil)
+	}
+
+	for _, role := range roles {
+		store.On("GetRole", mock.Anything, role.Name).Return(role, nil)
+	}
+}
+
+func sortFunc(namespaces []*corev2.Namespace) func(i, j int) bool {
+	return func(i, j int) bool {
+		return namespaces[i].Name < namespaces[j].Name
+	}
+}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -171,7 +171,7 @@ func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		routers.NewHandlersRouter(cfg.Store),
 		routers.NewHooksRouter(cfg.Store),
 		routers.NewMutatorsRouter(cfg.Store),
-		routers.NewNamespacesRouter(cfg.Store),
+		routers.NewNamespacesRouter(cfg.Store, &rbac.Authorizer{Store: cfg.Store}),
 		routers.NewRolesRouter(cfg.Store),
 		routers.NewRoleBindingsRouter(cfg.Store),
 		routers.NewSilencedRouter(cfg.Store),

--- a/backend/apid/middlewares/authorization.go
+++ b/backend/apid/middlewares/authorization.go
@@ -3,6 +3,7 @@ package middlewares
 import (
 	"net/http"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/authorization"
 )
@@ -24,6 +25,12 @@ func (a Authorization) Then(next http.Handler) http.Handler {
 				actions.InternalErr,
 				"could not retrieve the request info",
 			))
+			return
+		}
+
+		if attrs.APIGroup == "core" && attrs.APIVersion == "v2" && attrs.Resource == (&corev2.Namespace{}).RBACName() && attrs.Verb == "get" {
+			// Special case for getting namespaces - it is up to the router to handle authz
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 

--- a/backend/apid/middlewares/authorization.go
+++ b/backend/apid/middlewares/authorization.go
@@ -13,6 +13,14 @@ type Authorization struct {
 	Authorizer authorization.Authorizer
 }
 
+func namespaceGetAttrs(attrs *authorization.Attributes) bool {
+	return (attrs.APIGroup == "core" &&
+		attrs.APIVersion == "v2" &&
+		attrs.Resource == (&corev2.Namespace{}).RBACName() &&
+		(attrs.Verb == "get" || attrs.Verb == "list"))
+
+}
+
 // Then middleware
 func (a Authorization) Then(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +36,7 @@ func (a Authorization) Then(next http.Handler) http.Handler {
 			return
 		}
 
-		if attrs.APIGroup == "core" && attrs.APIVersion == "v2" && attrs.Resource == (&corev2.Namespace{}).RBACName() && attrs.Verb == "get" {
+		if namespaceGetAttrs(attrs) {
 			// Special case for getting namespaces - it is up to the router to handle authz
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return

--- a/backend/apid/middlewares/authorization_test.go
+++ b/backend/apid/middlewares/authorization_test.go
@@ -439,12 +439,12 @@ func TestAuthorization(t *testing.T) {
 			expectedCode:        403,
 		},
 		{
-			description:         "system:agents can't list namespaces",
+			description:         "system:agents can list namespaces",
 			method:              "GET",
 			url:                 "/api/core/v2/namespaces",
 			group:               "system:agents",
 			attibutesMiddleware: AuthorizationAttributes{},
-			expectedCode:        403,
+			expectedCode:        200,
 		},
 		{
 			description:         "system:agents can create events",

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -30,6 +30,7 @@ type routerTestCase struct {
 }
 
 func run(t *testing.T, tt routerTestCase, router *mux.Router, store *mockstore.MockStore) bool {
+	t.Helper()
 	return t.Run(tt.name, func(t *testing.T) {
 		// Only start the HTTP server here to prevent data races in tests
 		server := httptest.NewServer(router)

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -33,6 +33,7 @@ func run(t *testing.T, tt routerTestCase, router *mux.Router, store *mockstore.M
 	t.Helper()
 	return t.Run(tt.name, func(t *testing.T) {
 		// Only start the HTTP server here to prevent data races in tests
+		t.Helper()
 		server := httptest.NewServer(router)
 		defer server.Close()
 

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -1,20 +1,38 @@
 package routers
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/store"
 )
+
+type ListStore interface {
+	ListResources(ctx context.Context, kind string, resources interface{}, pred *store.SelectionPredicate) error
+}
+
+type RuleVisitor interface {
+	VisitRulesFor(ctx context.Context, attrs *authorization.Attributes, fn rbac.RuleVisitFunc)
+}
 
 // NamespacesRouter handles requests for /namespaces
 type NamespacesRouter struct {
 	handlers handlers.Handlers
+	store    ListStore
+	auth     RuleVisitor
 }
 
 // NewNamespacesRouter instantiates new router for controlling check resources
-func NewNamespacesRouter(store store.ResourceStore) *NamespacesRouter {
+func NewNamespacesRouter(store store.ResourceStore, auth RuleVisitor) *NamespacesRouter {
 	return &NamespacesRouter{
+		store: store,
+		auth:  auth,
 		handlers: handlers.Handlers{
 			Resource: &corev2.Namespace{},
 			Store:    store,
@@ -30,8 +48,66 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Del(r.handlers.DeleteResource)
-	routes.Get(r.handlers.GetResource)
+	routes.Get(r.get)
 	routes.List(r.handlers.ListResources, corev2.NamespaceFields)
 	routes.Post(r.handlers.CreateResource)
 	routes.Put(r.handlers.CreateOrUpdateResource)
+}
+
+func (r *NamespacesRouter) get(req *http.Request) (interface{}, error) {
+	attrs := authorization.GetAttributes(req.Context())
+	if attrs == nil {
+		return nil, actions.NewErrorf(actions.InvalidArgument)
+	}
+
+	resources := []*corev2.Namespace{}
+	err := r.store.ListResources(req.Context(), corev2.NamespacesResource, &resources, &store.SelectionPredicate{})
+	if err != nil {
+		return nil, actions.NewError(actions.InternalErr, err)
+	}
+
+	namespaceMap := make(map[string]*corev2.Namespace, len(resources))
+	for _, namespace := range resources {
+		namespaceMap[namespace.Name] = namespace
+	}
+
+	namespaces := make([]*corev2.Namespace, 0, len(resources))
+
+	var funcErr error
+
+	// Iterate over the rbac rules to discover namespaces that this
+	// user has read access to.
+	r.auth.VisitRulesFor(req.Context(), attrs, func(binding rbac.RoleBinding, rule corev2.Rule, err error) (terminate bool) {
+		if err != nil {
+			funcErr = err
+			return true
+		}
+		if len(namespaceMap) == 0 {
+			return true
+		}
+		if !rule.VerbMatches("get") {
+			return false
+		}
+		if !rule.ResourceMatches(corev2.NamespacesResource) {
+			return false
+		}
+		if len(rule.ResourceNames) == 0 {
+			// All resources of type "namespace" are allowed
+			namespaces = resources
+			return true
+		}
+		for name, namespace := range namespaceMap {
+			if rule.ResourceNameMatches(name) {
+				namespaces = append(namespaces, namespace)
+				delete(namespaceMap, name)
+			}
+		}
+		return false
+	})
+
+	if funcErr != nil {
+		return nil, actions.NewErrorf(actions.InternalErr, funcErr)
+	}
+
+	return namespaces, nil
 }

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -89,6 +89,12 @@ func (r *NamespacesRouter) get(req *http.Request) (interface{}, error) {
 			return false
 		}
 		if !rule.ResourceMatches(corev2.NamespacesResource) {
+			// Find namespaces with implicit access
+			ns := binding.GetObjectMeta().Namespace
+			if namespace, ok := namespaceMap[ns]; ok {
+				namespaces = append(namespaces, namespace)
+				delete(namespaceMap, ns)
+			}
 			return false
 		}
 		if len(rule.ResourceNames) == 0 {

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -1,7 +1,7 @@
 package routers
 
 import (
-	"net/http"
+	"context"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -38,13 +38,21 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 	}
 
 	routes.Del(r.handlers.DeleteResource)
-	routes.Get(r.get)
-	routes.List(r.handlers.ListResources, corev2.NamespaceFields)
+	routes.Get(r.handlers.GetResource)
+	routes.List(r.list, corev2.NamespaceFields)
 	routes.Post(r.handlers.CreateResource)
 	routes.Put(r.handlers.CreateOrUpdateResource)
 }
 
-func (r *NamespacesRouter) get(req *http.Request) (interface{}, error) {
+func (r *NamespacesRouter) list(ctx context.Context, _ *store.SelectionPredicate) ([]corev2.Resource, error) {
 	client := api.NewNamespaceClient(r.store, r.auth)
-	return client.ListNamespaces(req.Context())
+	namespaces, err := client.ListNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]corev2.Resource, len(namespaces))
+	for i := range namespaces {
+		result[i] = namespaces[i]
+	}
+	return result, nil
 }

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -214,6 +214,76 @@ func TestNamespaceRouterGet(t *testing.T) {
 				namespaces[4],
 			},
 		},
+		{
+			Name: "implicit access via resources in namespace",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "a",
+				Resource:     corev2.ChecksResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			Roles: []*corev2.Role{
+				{
+					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{"get"},
+							Resources: []string{corev2.ChecksResource},
+						},
+					},
+				},
+			},
+			RoleBindings: []*corev2.RoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "plebs",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "Role",
+						Name: "pleb",
+					},
+					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
+				},
+			},
+			AllNamespaces: namespaces,
+			ExpNamespaces: []*corev2.Namespace{
+				namespaces[0],
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -1,17 +1,24 @@
 package routers
 
 import (
+	"context"
+	"net/http"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestNamespacesRouter(t *testing.T) {
 	// Setup the router
 	s := &mockstore.MockStore{}
-	router := NewNamespacesRouter(s)
+	router := NewNamespacesRouter(s, nil)
 	parentRouter := mux.NewRouter().PathPrefix(corev2.URLPrefix).Subrouter()
 	router.Mount(parentRouter)
 
@@ -19,12 +26,246 @@ func TestNamespacesRouter(t *testing.T) {
 	fixture := corev2.FixtureNamespace("foo")
 
 	tests := []routerTestCase{}
-	tests = append(tests, getTestCases(fixture)...)
 	tests = append(tests, listTestCases(empty)...)
 	tests = append(tests, createTestCases(empty)...)
 	tests = append(tests, updateTestCases(fixture)...)
 	tests = append(tests, deleteTestCases(fixture)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
+	}
+}
+
+func TestNamespaceRouterGet(t *testing.T) {
+	namespaces := []*corev2.Namespace{
+		corev2.FixtureNamespace("a"),
+		corev2.FixtureNamespace("b"),
+		corev2.FixtureNamespace("c"),
+		corev2.FixtureNamespace("d"),
+		corev2.FixtureNamespace("e"),
+		corev2.FixtureNamespace("f"),
+	}
+	tests := []struct {
+		Name                string
+		Attrs               *authorization.Attributes
+		ClusterRoles        []*corev2.ClusterRole
+		ClusterRoleBindings []*corev2.ClusterRoleBinding
+		Roles               []*corev2.Role
+		RoleBindings        []*corev2.RoleBinding
+		AllNamespaces       []*corev2.Namespace
+		ExpNamespaces       []*corev2.Namespace
+		ExpError            bool
+	}{
+		{
+			Name: "all access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "admin",
+					Groups:   []string{"cluster-admins"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			RoleBindings:  []*corev2.RoleBinding{},
+			AllNamespaces: namespaces,
+			ExpNamespaces: namespaces,
+		},
+		{
+			Name: "no access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "default",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			RoleBindings:  []*corev2.RoleBinding{},
+			AllNamespaces: namespaces,
+			ExpNamespaces: []*corev2.Namespace{},
+		},
+		{
+			Name: "partial access",
+			Attrs: &authorization.Attributes{
+				APIGroup:     "core",
+				APIVersion:   "v2",
+				Namespace:    "default",
+				Resource:     corev2.NamespacesResource,
+				ResourceName: "",
+				User: corev2.User{
+					Username: "regular-user",
+					Groups:   []string{"plebs"},
+				},
+			},
+			ClusterRoles: []*corev2.ClusterRole{
+				{
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "cluster-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "ClusterRole",
+						Name: "cluster-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+				},
+			},
+			Roles: []*corev2.Role{
+				{
+					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
+					Rules: []corev2.Rule{
+						{
+							Verbs:         []string{"get"},
+							Resources:     []string{corev2.NamespacesResource},
+							ResourceNames: []string{"a", "c", "e"},
+						},
+					},
+				},
+			},
+			RoleBindings: []*corev2.RoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "plebs",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "Role",
+						Name: "pleb",
+					},
+					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
+				},
+			},
+			AllNamespaces: namespaces,
+			ExpNamespaces: []*corev2.Namespace{
+				namespaces[0],
+				namespaces[2],
+				namespaces[4],
+			},
+		},
+	}
+
+	for _, test := range tests {
+		store := new(mockstore.MockStore)
+		store.On("ListClusterRoles", mock.Anything, mock.Anything).Return(test.ClusterRoles, nil)
+		store.On("ListClusterRoleBindings", mock.Anything, mock.Anything).Return(test.ClusterRoleBindings, nil)
+		store.On("ListRoles", mock.Anything, mock.Anything).Return(test.Roles, nil)
+		store.On("ListRoleBindings", mock.Anything, mock.Anything).Return(test.RoleBindings, nil)
+		store.On("ListResources", mock.Anything, corev2.NamespacesResource, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			resources := args[2].(*[]*corev2.Namespace)
+			*resources = append(*resources, test.AllNamespaces...)
+		}).Return(nil)
+		setupGetClusterRoleAndGetRole(store, test.ClusterRoles, test.Roles)
+
+		ctx := authorization.SetAttributes(context.Background(), test.Attrs)
+
+		// The path doesn't matter as we really only are extracting the context from
+		// the request here.
+		req, err := http.NewRequest("GET", "/asdf", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req = req.WithContext(ctx)
+
+		auth := &rbac.Authorizer{Store: store}
+		router := NewNamespacesRouter(store, auth)
+
+		got, err := router.get(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sort.Slice(got, sortFunc(got.([]*corev2.Namespace)))
+
+		if got, want := got, test.ExpNamespaces; !reflect.DeepEqual(got, want) {
+			t.Fatalf("bad namespaces: got %+v, want %+v", got, want)
+		}
+	}
+}
+
+func sortFunc(namespaces []*corev2.Namespace) func(i, j int) bool {
+	return func(i, j int) bool {
+		return namespaces[i].Name < namespaces[j].Name
+	}
+}
+
+func setupGetClusterRoleAndGetRole(store *mockstore.MockStore, clusterRoles []*corev2.ClusterRole, roles []*corev2.Role) {
+	for _, role := range clusterRoles {
+		store.On("GetClusterRole", mock.Anything, role.Name).Return(role, nil)
+	}
+
+	for _, role := range roles {
+		store.On("GetRole", mock.Anything, role.Name).Return(role, nil)
 	}
 }

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -72,7 +72,7 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 		}
 	}
 
-	if len(attrs.Namespace) == 0 {
+	if attrs.Namespace == "" && attrs.Resource != (&corev2.Namespace{}).RBACName() {
 		return
 	}
 

--- a/backend/authorization/rbac/rbac_test.go
+++ b/backend/authorization/rbac/rbac_test.go
@@ -80,7 +80,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetClusterRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+				s.On("GetClusterRole", mock.Anything, "admin").
 					Return(nil, errors.New("error"))
 			},
 			wantErr: true,
@@ -106,7 +106,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetClusterRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+				s.On("GetClusterRole", mock.Anything, "admin").
 					Return(&types.ClusterRole{Rules: []types.Rule{
 						types.Rule{
 							Verbs:         []string{"create"},
@@ -240,7 +240,7 @@ func TestAuthorize(t *testing.T) {
 							types.Subject{Type: types.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetClusterRole", mock.AnythingOfType("*context.emptyCtx"), "cluster-admin", mock.Anything).
+				s.On("GetClusterRole", mock.Anything, "cluster-admin").
 					Return(&types.ClusterRole{Rules: []types.Rule{
 						types.Rule{
 							Verbs:     []string{"*"},
@@ -424,7 +424,7 @@ func TestVisitRulesFor(t *testing.T) {
 				ResourceNames: []string{"check-cpu"},
 			},
 		}}, nil)
-	stor.On("GetClusterRole", mock.AnythingOfType("*context.emptyCtx"), "admin", mock.Anything).
+	stor.On("GetClusterRole", mock.Anything, "admin").
 		Return(&types.ClusterRole{Rules: []types.Rule{
 			types.Rule{
 				Verbs:         []string{"delete"},

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -223,7 +223,7 @@ func setupClusterRoles(store store.Store) error {
 	}
 
 	// The systemAgent ClusterRole is used by Sensu agents and should not be
-	// modified by the users. Modification to his ClusterRole can result in
+	// modified by the users. Modification to this ClusterRole can result in
 	// non-functional Sensu agents.
 	systemAgent := &types.ClusterRole{
 		ObjectMeta: corev2.NewObjectMeta("system:agent", ""),
@@ -248,12 +248,6 @@ func setupClusterRoles(store store.Store) error {
 			types.Rule{
 				Verbs:     []string{"get", "update"},
 				Resources: []string{types.LocalSelfUserResource},
-			},
-			types.Rule{
-				Verbs: []string{"get", "list"},
-				Resources: []string{
-					"namespaces",
-				},
 			},
 		},
 	}


### PR DESCRIPTION
## What is this change?

Users can now list namespaces that they can access other resources in, even if they don't have explicit permission via rbac to list all namespaces, or explicit permission to get the namespace in question.

## Why is this change necessary?

This simplifies several aspects of access control, and also simplifies display of namespaces in the web ui.

Closes https://github.com/sensu/sensu-enterprise-go/issues/649

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

To accomplish this task, I have pulled code from the enterprise repository into the open source repository. We will need to update the enterprise repository accordingly.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes may be required.

## How did you verify this change?

Unit tests only so far.