### PR TITLE
Allow colons to be used in asset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added support for sensu-backend service environment variables.
 
 ### Changed
-- Colons and periods are now allowed to be used in asset names.
+- Colons and periods are now allowed to be used in all resource names, with
+the exception of users.
 
 ## [5.14.2] - 2019-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added support for api keys to be used in api authentication.
 - Added support for sensu-backend service environment variables.
 
+### Changed
+- Colons and periods are now allowed to be used in asset names.
+
 ## [5.14.2] - 2019-11-04
 
 ### Changed

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	// AssetNameRegexStr used to validate name of asset
-	AssetNameRegexStr = `[a-z0-9\/\_\.\-]+`
+	AssetNameRegexStr = `[a-z0-9\/\_\.\-\:]+`
 
 	// AssetNameRegex used to validate name of asset
 	AssetNameRegex = regexp.MustCompile("^" + AssetNameRegexStr + "$")

--- a/api/core/v2/asset_test.go
+++ b/api/core/v2/asset_test.go
@@ -59,3 +59,9 @@ func TestValidator(t *testing.T) {
 	asset.Sha512 = "nope"
 	assert.Error(asset.Validate())
 }
+
+func TestValidateName_GH3344(t *testing.T) {
+	assert := assert.New(t)
+	asset := FixtureAsset("my-asset:1.0.2")
+	assert.NoError(asset.Validate())
+}

--- a/api/core/v2/validators.go
+++ b/api/core/v2/validators.go
@@ -11,7 +11,7 @@ type ConstrainedResource interface {
 }
 
 // NameRegex is used to validate the name of a resource
-var NameRegex = regexp.MustCompile(`\A[\w\.\-]+\z`)
+var NameRegex = regexp.MustCompile(`\A[\w\.\-\:]+\z`)
 
 // StrictNameRegex is used to validate names of resources using a strict subset
 // of charset.

--- a/api/core/v2/validators_test.go
+++ b/api/core/v2/validators_test.go
@@ -11,6 +11,7 @@ func TestValidateName(t *testing.T) {
 	assert.Error(t, ValidateName("foo bar"))
 	assert.Error(t, ValidateName("foo@bar"))
 	assert.NoError(t, ValidateName("foo-bar"))
+	assert.NoError(t, ValidateName("foo:bar"))
 }
 
 func TestValidateNameStrict(t *testing.T) {
@@ -19,6 +20,7 @@ func TestValidateNameStrict(t *testing.T) {
 	assert.Error(t, ValidateNameStrict("foo@bar"))
 	assert.Error(t, ValidateNameStrict("FOO-bar"))
 	assert.NoError(t, ValidateNameStrict("foo-bar_2"))
+	assert.Error(t, ValidateNameStrict("foo:bar"))
 }
 
 func TestValidateSubscriptionName(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Updates the asset name regex so that colons are allowed.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3344

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Yes, I'm actually not sure if https://github.com/sensu/sensu-go/issues/3344 is intended for _all_ resources or just assets.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Unit test and manual testing.
```$ sensuctl asset add sensu/sensu-influxdb-handler --rename sensu-influxdb-handler:3.1.2```