### PR TITLE
Match empty string correctly

### DIFF
--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -96,11 +96,11 @@ func (s *Silenced) Matches(check, subscription string) bool {
 		return false
 	}
 
-	if !stringsutil.InArray(s.Subscription, []string{"", "*", subscription}) {
+	if !stringsutil.InArray(s.Subscription, []string{"*", subscription}) && s.Subscription != "" {
 		return false
 	}
 
-	if !stringsutil.InArray(s.Check, []string{"", "*", check}) {
+	if !stringsutil.InArray(s.Check, []string{"*", check}) && s.Check != "" {
 		return false
 	}
 

--- a/api/core/v2/silenced_test.go
+++ b/api/core/v2/silenced_test.go
@@ -138,6 +138,20 @@ func TestSilencedMatches(t *testing.T) {
 			check:        "bar",
 			expected:     true,
 		},
+		{
+			name:         "empty subscription is the same as wildcard",
+			silenced:     &Silenced{Subscription: "", Check: "foo"},
+			subscription: "",
+			check:        "foo",
+			expected:     true,
+		},
+		{
+			name:         "empty check is the same as wildcard",
+			silenced:     &Silenced{Subscription: "foo", Check: ""},
+			subscription: "foo",
+			check:        "",
+			expected:     true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What is this change?

Correctly handle an empty check/subscription in a silence as a wildcard.

## Why is this change necessary?

I found a bug in my (now merged but not released) changes to how silences are applied to events.

Details here: https://github.com/sensu/sensu-go/pull/3376/files#r343748169

## Does your change need a Changelog entry?

Not if it's merged before the above PR is released.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Not a complication, just context. I decided to do it this way instead of changing `stringsutil.InArray` because it's used in a bunch of places and I don't have any context on why empty strings were chosen to be omitted or what changing that assumption may break.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Tests continue passing, the adhoc test I was doing for https://github.com/sensu/sensu-go/pull/3382 which uncovered this bug started working after I ran a binary with this fix.