### PR TITLE
Remove the enterprise commands section in sensuctl help usage

### DIFF
--- a/cli/commands/root/templates.go
+++ b/cli/commands/root/templates.go
@@ -42,15 +42,6 @@ Management Commands:
 {{- end}}
 {{- end}}
 
-{{- if hasEnterpriseSubCommands . }}
-
-Enterprise Commands:
-
-{{- range enterpriseSubCommands . }}
-  {{rpad .Name .NamePadding }} {{.Short}}
-{{- end}}
-{{- end}}
-
 {{- if .HasSubCommands }}
 
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
@@ -59,22 +50,12 @@ Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 `
 
 func init() {
-	cobra.AddTemplateFunc("enterpriseSubCommands", enterpriseSubCommands)
-	cobra.AddTemplateFunc("hasEnterpriseSubCommands", hasEnterpriseSubCommands)
 	cobra.AddTemplateFunc("hasOperationalSubCommands", hasOperationalSubCommands)
 	cobra.AddTemplateFunc("hasManagementSubCommands", hasManagementSubCommands)
 	cobra.AddTemplateFunc("operationalSubCommands", operationalSubCommands)
 	cobra.AddTemplateFunc("managementSubCommands", managementSubCommands)
 	cobra.AddTemplateFunc("wrappedInheritedFlagUsages", wrappedInheritedFlagUsages)
 	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
-}
-
-func enterpriseSubCommands(cmd *cobra.Command) []*cobra.Command {
-	return []*cobra.Command{}
-}
-
-func hasEnterpriseSubCommands(cmd *cobra.Command) bool {
-	return false
 }
 
 func hasOperationalSubCommands(cmd *cobra.Command) bool {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It remove the enterprise commands section in sensuctl help usage 

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/725

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Tested via sensu-enterprise-go