### PR TITLE
Bump cron dependency for timezone support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added sensuctl commands to manage the `APIKey` resource.
 - Added support for api keys to be used in api authentication.
 - Added support for sensu-backend service environment variables.
+- Added support for timezones in check cron strings.
 
 ### Changed
 - Moved `corev2.BonsaiAsset` to `bonsai.Asset` and moved
@@ -1223,9 +1224,6 @@ and times of the week.
 ### Added
 - Logging redaction for entities
 
-### Changed
-- Removed the Visual Studio 2017 image in AppVeyor to prevent random failures
-
 ### Fixed
 - Fixed e2e test for token substitution on Windows
 - Fixed check subdue unit test for token substitution on Windows
@@ -1237,14 +1235,6 @@ current time
 ### Changed
 - Removed the Visual Studio 2017 image in AppVeyor to prevent random failures
 - Made some slight quality-of-life adjustments to build-gcs-release.sh.
-
-### Fixed
-- Fixed e2e test for token substitution on Windows
-- Fixed check subdue unit test for token substitution on Windows
-- Consider the first and last seconds of a time window when comparing the
-current time
-- Fixed Travis deploy stage by removing caching for $GOPATH
-- Parse for [traditional cron](https://en.wikipedia.org/wiki/Cron) strings, rather than [GoDoc cron](https://godoc.org/github.com/robfig/cron) strings.
 
 ## [2.0.0-alpha.12] - 2018-01-09
 ### Added

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	utilstrings "github.com/sensu/sensu-go/util/strings"
 )
 

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 )
 
 // FixtureCheckConfig returns a fixture for a CheckConfig object.

--- a/backend/ringv2/ringv2.go
+++ b/backend/ringv2/ringv2.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/util/retry"
 	"github.com/sirupsen/logrus"

--- a/backend/schedulerd/check_timer.go
+++ b/backend/schedulerd/check_timer.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 
 	time "github.com/echlebek/timeproxy"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 )
 
 // A CheckTimer handles starting and stopping timers for a given check

--- a/backend/schedulerd/check_timer_test.go
+++ b/backend/schedulerd/check_timer_test.go
@@ -22,6 +22,17 @@ func TestNextCronTime(t *testing.T) {
 	assert.True(t, nextCron >= 0)
 	assert.True(t, now.Add(nextCron).Minute() == 0)
 
+	// Valid cron string with timezone will return a time in the future, on an even hour
+	nextCron, err = NextCronTime(now, "CRON_TZ=Asia/Tokyo 0 * * * *")
+	assert.Nil(t, err)
+	assert.True(t, nextCron >= 0)
+	assert.True(t, now.Add(nextCron).Minute() == 0)
+
+	// Invalid cron string with timezone in the wrong spot
+	nextCron, err = NextCronTime(now, "0 * * * * CRON_TZ=Asia/Tokyo")
+	assert.NotNil(t, err)
+	assert.True(t, nextCron == 0)
+
 	// Invalid cron string will return an error
 	nextCron, err = NextCronTime(now, "invalid")
 	assert.NotNil(t, err)

--- a/backend/schedulerd/proxy_check.go
+++ b/backend/schedulerd/proxy_check.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	time "github.com/echlebek/timeproxy"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store/cache"

--- a/cli/commands/check/interactive.go
+++ b/cli/commands/check/interactive.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey"
-	"github.com/robfig/cron"
+	cron "github.com/robfig/cron/v3"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/pflag"

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/prometheus/client_golang v1.2.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d
-	github.com/robfig/cron v0.0.0-20171101201047-2315d5715e36
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/sensu/lasr v1.2.1
 	github.com/shirou/gopsutil v0.0.0-20180801053943-8048a2e9c577
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d h1:1VUlQbCfkoSGv7qP7Y+ro3ap1P1pPZxgdGVqiTVy5C4=
 github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
-github.com/robfig/cron v0.0.0-20171101201047-2315d5715e36 h1:7ELV9kd3xWoNnXRvGWOMrPiBz/6W47lSwikPlnvMTV8=
-github.com/robfig/cron v0.0.0-20171101201047-2315d5715e36/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Bumps our cron dependency to a version which supports timezones in traditional cron strings.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3057

## Does your change need a Changelog entry?

Yas. I updated some duplicated entries for an alpha release as well.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1933

## How did you verify this change?

Unit and e2e testing.