### PR TITLE
Pass context with timeout to etcd health requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Add a timeout to etcd requests when retrieving the nodes health
+
 ## [5.15.0] - 2019-11-18
 
 ### Fixed

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -66,7 +66,10 @@ func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, 
 			_ = cli.Close()
 		}()
 
-		_, getErr := cli.Get(context.Background(), "health")
+		// Specify the client request timeout to get the health
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, getErr := cli.Get(ctx, "health")
+		cancel()
 
 		if getErr == nil || getErr == rpctypes.ErrPermissionDenied {
 			health.Err = ""


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It passes `context.WithTimeout` to `cli.Get` when retrieving the health of each cluster member.

Before this patch, when a node was down:
```
$ /usr/bin/time sensuctl cluster health
Error: GET "/health": Get http://127.0.0.1:8080/health: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
       15.07 real         0.01 user         0.01 sys
```

Now:
```
$ /usr/bin/time sensuctl cluster health
=== Cluster ID: 80c05ee29d12458
         ID            Name               Error             Healthy
 ────────────────── ────────── ─────────────────────────── ─────────
  8927110dc66458af   backend0                               true
  a23843c228b27241   backend2   context deadline exceeded   false
  bb75bf8de77581cc   backend1                               true
        5.09 real         0.00 user         0.01 sys
```



## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3398

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested, I don't believe we need any additional testing.
