### PR TITLE
Remove duplicated instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ This helps us to provide direction as to implementation details, which
 branch to base your changes on, and so on.
 
 1. Open an issue to describe your proposed improvement or feature
-1. Fork https://github.com/sensu/sensu-go
-1. Clone the fork to $GOPATH/src/github.com/sensu/sensu-go. (This exact path must be used. If GOPATH is undefined, use /home/go.)
+1. [Install Go and fork the Sensu Go repository](https://github.com/sensu/sensu-go#building-from-source)
 1. Create your feature branch (`git checkout -b my-new-feature`)
 1. If applicable, add a [CHANGELOG.md entry](#changelog) describing your change.
 1. Commit your changes with a [DCO Signed-off-by statement](#dco) (`git commit --signoff`)
@@ -191,11 +190,6 @@ Here are the highlights:
 ![](https://i.imgur.com/AinipVI.jpg)
 
 ## Development
-
-Sensu is written in Go, and targets the 1.10.x branch of the compiler and
-toolchain. When working on Sensu, you should use this version of Go.
-
-[Go installation instructions](https://golang.org/doc/install)
 
 ### Protobuf
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the [installation documentation](https://docs.sensu.io/sensu-go/latest/insta
 ### Building from source
 
 The various components of Sensu Go can be manually built from this repository.
-You will first need [Go 1.13.1](https://golang.org/doc/install#install)
+You will first need [Go 1.13.3](https://golang.org/doc/install#install)
 installed. Then, you should clone this repository **outside** of the GOPATH
 since Sensu Go uses [Go Modules](https://github.com/golang/go/wiki/Modules):
 ```


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes the outdated and duplicated installation instructions from CONTRIBUTING.md.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3396

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

N/A