### PR TITLE
Show correct default format value for sensuctl dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Fixed
-- Add a timeout to etcd requests when retrieving the nodes health
+- Add a timeout to etcd requests when retrieving the nodes health.
+- Show the correct default value for the format flag in `sensuctl dump` help
+usage.
 
 ## [5.15.0] - 2019-11-18
 

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -99,7 +99,11 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	helpers.AddAllNamespace(cmd.Flags())
-	_ = cmd.Flags().StringP("format", "", cli.Config.Format(), fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
+	format := cli.Config.Format()
+	if format != config.FormatWrappedJSON && format != config.FormatYAML {
+		format = config.FormatYAML
+	}
+	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
 	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
 	_ = cmd.Flags().BoolP("types", "t", false, "list supported resource types")
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes the default format value in the help usage of `sensuctl dump`:
```
 $ sensuctl dump --help
sensuctl dump

[...]
Flags:
      --all-namespaces   Include records from all namespaces
  -f, --file string      file to dump resources to
      --format string    format of data returned ("wrapped-json"|"yaml") (default "yaml")
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3369

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested
