### PR TITLE
Display JWT expires timestamp in sensuctl config view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Display the JWT expiration Unix timestamp in `sensuctl config view`.
+
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health
 

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
@@ -24,10 +25,11 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 				return errors.New("no active configuration found")
 			}
 			activeConfig := map[string]string{
-				"api-url":   cli.Config.APIUrl(),
-				"namespace": cli.Config.Namespace(),
-				"format":    cli.Config.Format(),
-				"username":  helpers.GetCurrentUsername(cli.Config),
+				"api-url":        cli.Config.APIUrl(),
+				"namespace":      cli.Config.Namespace(),
+				"format":         cli.Config.Format(),
+				"username":       helpers.GetCurrentUsername(cli.Config),
+				"jwt_expires_at": strconv.Itoa(int(cli.Config.Tokens().GetExpiresAt())),
 			}
 
 			// Determine the format to use to output the data
@@ -71,6 +73,10 @@ func printToList(v interface{}, writer io.Writer) error {
 			{
 				Label: "Username",
 				Value: r["username"],
+			},
+			{
+				Label: "JWT Expiration Timestamp",
+				Value: r["jwt_expires_at"],
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds a field for the JWT expiration timestamp in `sensuctl config view` command.

## Why is this change necessary?

To facilitate our QA around JWTs. 

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested