### PR TITLE
Validate that a user is still enabled upon token renewal

### DIFF
--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -52,6 +52,9 @@ func (p *Provider) Refresh(ctx context.Context, claims *corev2.Claims) (*corev2.
 	if user == nil {
 		return nil, fmt.Errorf("user %q does not exist", claims.Provider.UserID)
 	}
+	if user.Disabled {
+		return nil, fmt.Errorf("user %q is disabled", claims.Provider.UserID)
+	}
 
 	newClaims, err := jwt.NewClaims(user)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures a user is still enabled before renewing its access token.

## Why is this change necessary?

Bug found during QA

## Does your change need a Changelog entry?

Nope, fixes un-released code.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested, will be covered as part of our QA
