### PR TITLE
Bugfix/asset list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Listing assets with no results returns an empty array
+
 ## [5.15.0] - 2019-11-18
 
 ### Fixed

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -115,7 +115,6 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 			break
 		}
 	}
-
 	return nil
 }
 

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -115,6 +115,7 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 			break
 		}
 	}
+
 	return nil
 }
 

--- a/cli/commands/asset/list.go
+++ b/cli/commands/asset/list.go
@@ -56,7 +56,7 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 
 			// Print the results based on the user preferences
 			resources := []corev2.Resource{}
-			var resultsWithBuilds []interface{}
+			resultsWithBuilds := []interface{}{}
 			for i := range results {
 				// Break the builds into multiple assets if we use the tabular format
 				if len(results[i].Builds) > 0 && format == config.FormatTabular {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures an empty array is returned if no assets are found when using `sensuctl asset list`.

Related to https://github.com/sensu/sensu-enterprise-go/pull/754.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3392

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.