### PR TITLE
Add experimental solaris support for sensu-agent

### DIFF
--- a/agent/statsd.go
+++ b/agent/statsd.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// StatsdUnsupported is returned when statsd can't be supported on the platform.
+var StatsdUnsupported = errors.New("statsd not supported on this platform")
+
+// StatsdServer is the interface the agent requires to run a statsd server.
+type StatsdServer interface {
+	Run(context.Context) error
+}

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -1,3 +1,5 @@
+// +build !solaris
+
 // Package agent is the running Sensu agent. Agents connect to a Sensu backend,
 // register their presence, subscribe to check channels, download relevant
 // check packages, execute checks, and send results to the Sensu backend via
@@ -18,6 +20,15 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"
 )
+
+// GetMetricsAddr gets the metrics address of the statsd server.
+func GetMetricsAddr(s StatsdServer) string {
+	server, ok := s.(*statsd.Server)
+	if !ok {
+		return ""
+	}
+	return server.MetricsAddr
+}
 
 // NewStatsdServer provides a new statsd server for the sensu-agent.
 func NewStatsdServer(a *Agent) *statsd.Server {

--- a/agent/statsd_server_solaris.go
+++ b/agent/statsd_server_solaris.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"context"
+)
+
+// GetMetricsAddr always returns ""
+func GetMetricsAddr(s StatsdServer) string {
+	return ""
+}
+
+// statsdServer is a no-op statsd server for solaris support.
+// the gostatsd package requires a library that can't be built on solaris.
+type statsdServer struct {
+}
+
+func (s statsdServer) Run(context.Context) error {
+	return StatsdUnsupported
+}
+
+func NewStatsdServer(*Agent) statsdServer {
+	return statsdServer{}
+}

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build integration,!solaris
 
 package agent
 

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -23,7 +23,7 @@ func TestNewStatsdServer(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, BackendName, s.Backends[0].Name())
 	assert.Equal(t, DefaultStatsdFlushInterval*time.Second, s.FlushInterval)
-	assert.Equal(t, "127.0.0.1:8125", s.MetricsAddr)
+	assert.Equal(t, "127.0.0.1:8125", GetMetricsAddr(s))
 
 	c.StatsdServer.FlushInterval = 20
 	c.StatsdServer.Port = 8126
@@ -33,7 +33,7 @@ func TestNewStatsdServer(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, BackendName, s.Backends[0].Name())
 	assert.Equal(t, 20*time.Second, s.FlushInterval)
-	assert.Equal(t, "foo:8126", s.MetricsAddr)
+	assert.Equal(t, "foo:8126", GetMetricsAddr(s))
 }
 
 func TestComposeMetricTags(t *testing.T) {
@@ -164,7 +164,7 @@ func TestReceiveMetrics(t *testing.T) {
 	// Give the server a second to start up
 	time.Sleep(time.Second * 1)
 
-	udpClient, err := net.Dial("udp", ta.statsdServer.MetricsAddr)
+	udpClient, err := net.Dial("udp", GetMetricsAddr(ta.statsdServer))
 	if err != nil {
 		assert.FailNow("failed to create UDP connection")
 	}


### PR DESCRIPTION
This commit adds experimental support for the sensu-agent under the
Solaris 11 OS. This is accomplished by removing support for the
agent's statsd server, which is incompatible with Solaris.

No testing other than compilation has been done.

Signed-off-by: Eric Chlebek <eric@sensu.io>