### PR TITLE
Add support for etcd and DNS SRV discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add a timeout to etcd requests when retrieving the nodes health.
 - Show the correct default value for the format flag in `sensuctl dump` help
 usage.
+- Added the `--etcd-discovery` and `--etcd-discovery-srv` flags to
+  `sensu-backend`. These are used to take advantage of the embedded etcd's
+  auto-discovery features.
+
 ### Fixed
 - Listing assets with no results returns an empty array
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -91,6 +91,8 @@ func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 	cfg.InitialClusterState = config.EtcdInitialClusterState
 	cfg.InitialAdvertisePeerURLs = config.EtcdInitialAdvertisePeerURLs
 	cfg.AdvertiseClientURLs = config.EtcdAdvertiseClientURLs
+	cfg.Discovery = config.EtcdDiscovery
+	cfg.DiscoverySrv = config.EtcdDiscoverySrv
 	cfg.Name = config.EtcdName
 
 	// Heartbeat interval

--- a/backend/config.go
+++ b/backend/config.go
@@ -77,6 +77,8 @@ type Config struct {
 	NoEmbedEtcd                  bool
 	EtcdHeartbeatInterval        uint
 	EtcdElectionTimeout          uint
+	EtcdDiscovery                string
+	EtcdDiscoverySrv             string
 
 	// Etcd TLS configuration
 	EtcdClientTLSInfo     etcd.TLSInfo

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -77,6 +77,8 @@ type Config struct {
 	InitialClusterState      string
 	InitialClusterToken      string
 	InitialAdvertisePeerURLs []string
+	Discovery                string
+	DiscoverySrv             string
 
 	ClientTLSInfo TLSInfo
 	PeerTLSInfo   TLSInfo
@@ -201,6 +203,8 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	cfg.InitialClusterToken = config.InitialClusterToken
 	cfg.InitialCluster = config.InitialCluster
 	cfg.ClusterState = config.InitialClusterState
+	cfg.Durl = config.Discovery
+	cfg.DNSCluster = config.DiscoverySrv
 
 	// Every 5 minutes, we will prune all values in etcd to only their latest
 	// revision.


### PR DESCRIPTION
Two new flags, `--etcd-discovery` and `--etcd-discovery-srv` make it
possible to use two dynamic cluster configuration methods, etcd
discovery and DNS SRV discovery, instead of the static `--initial-cluster
method`.

See:
- https://etcd.io/docs/v3.3.12/op-guide/clustering/#overview
- https://etcd.io/docs/v3.3.12/op-guide/clustering/#discovery

## Why is this change necessary?

Close #3327.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

I initially wanted to also support the `--discovery-srv-name` option, but it's not available in the etcd version we're currently using.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required, this is tracked in https://github.com/sensu/sensu-docs/issues/1956.

## How did you verify this change?

Manual invocation of `sensu-backend start` with various the various clustering options to verify that:

1. no option specified leads to the current behaviour: a default static cluster with 1 member
2. `--etcd-discovery` tries to use etcd discovery to get the cluster configuration
3. `--etcd-discovery-srv` tries to use a DNS SRV record to get the cluster configuration
4. all of these options are mutually exclusive and a clear error message is displayed if more than 1 of them is used

```
$ sensu-backend start --etcd-discovery google.com --etcd-discovery-srv test.org
{"component":"backend","error":"error starting etcd: multiple discovery or bootstrap flags are set. Choose one of \"initial-cluster\", \"discovery\" or \"discovery-srv\"","level":"fatal","msg":"error executing sensu-backend","time":"2019-11-21T17:57:15-08:00"}
```