### PR TITLE
Prevent panic in CreateOrUpdate store function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Fixed
-- Listing assets with no results returns an empty array
+- Listing assets with no results returns an empty array.
+- Fixed a panic that could occur when creating resources in a namespace that
+does not exist.
 
 ## [5.15.0] - 2019-11-18
 

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -60,6 +60,7 @@ func Create(ctx context.Context, client *clientv3.Client, key, namespace string,
 		return err
 	}
 	if !resp.Succeeded {
+		fmt.Printf("%#v\n", resp.Responses)
 		// Check if the namespace was missing
 		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
 			return &store.ErrNamespaceMissing{Namespace: namespace}
@@ -119,7 +120,7 @@ func CreateOrUpdate(ctx context.Context, client *clientv3.Client, key, namespace
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
-		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
+		if namespace != "" && (len(resp.Responses) == 0 || len(resp.Responses[0].GetResponseRange().Kvs) == 0) {
 			return &store.ErrNamespaceMissing{Namespace: namespace}
 		}
 

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -60,7 +60,6 @@ func Create(ctx context.Context, client *clientv3.Client, key, namespace string,
 		return err
 	}
 	if !resp.Succeeded {
-		fmt.Printf("%#v\n", resp.Responses)
 		// Check if the namespace was missing
 		if namespace != "" && len(resp.Responses[0].GetResponseRange().Kvs) == 0 {
 			return &store.ErrNamespaceMissing{Namespace: namespace}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It prevents a panic in the store's `CreateOrUpdate` function if a namespace does not exist.

## Why is this change necessary?

It fixes a bug I found while investigating https://github.com/sensu/sensu-go/issues/3367

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added a unit test to cover that case.

## Is this change a patch?

Yep