### PR TITLE
Add an issue template for epics

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic_template.md
+++ b/.github/ISSUE_TEMPLATE/epic_template.md
@@ -1,0 +1,20 @@
+---
+name: 'Epic'
+about: 'Create an epic'
+---
+
+## Description
+<!--- Provide a summary of what the epic should accomplish -->
+
+## Proposal
+<!--- Link to the proposal doc --->
+
+## Spec
+<!--- Link to the spec doc -->
+
+## Issues
+<!--- Link(s) to sensu-go GH issues --->
+<!--- Link(s) to sensu-enterprise-go GH issues --->
+<!--- Link(s) to sensu-go-qa-crucible GH issues --->
+<!--- Link(s) to sensu-staging GH issues --->
+<!--- Link(s) to sensu-docs GH issues --->


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Add an issue template for epics.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3209.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Template will be visible at https://github.com/sensu/sensu-go/issues/new/choose once merged.

## Is this change a patch?

No, this will go to master!