### PR TITLE
Check Bonsai labels before checking if one or more builds exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ sensu-backend init tool.
 - Show the correct default value for the format flag in `sensuctl dump` help
 usage.
 - Added the `--etcd-discovery` and `--etcd-discovery-srv` flags to
-  `sensu-backend`. These are used to take advantage of the embedded etcd's
-  auto-discovery features.
+`sensu-backend`. These are used to take advantage of the embedded etcd's
+auto-discovery features.
+- Installing sensuctl commands via Bonsai will now check for correct labels
+before checking if the asset has 1 or more builds.
 
 ### Fixed
 - Listing assets with no results returns an empty array

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -168,10 +168,6 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		return err
 	}
 
-	if len(asset.Builds) == 0 {
-		return errors.New("one or more asset builds are required")
-	}
-
 	if err := asset.Validate(); err != nil {
 		return err
 	}
@@ -190,6 +186,10 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		}
 	} else {
 		return errors.New("requested asset does not have a provider annotation set")
+	}
+
+	if len(asset.Builds) == 0 {
+		return errors.New("one or more asset builds are required")
 	}
 
 	return m.installCommand(alias, &asset)

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -189,51 +189,6 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 			},
 		},
 		{
-			name:            "asset without builds",
-			wantErr:         true,
-			errMatch:        "one or more asset builds are required",
-			alias:           "testalias",
-			bonsaiAssetName: bAsset.fullNameWithVersion,
-			bonsaiClientFunc: func(m *MockBonsaiClient) {
-				bonsaiAsset := &bonsai.Asset{
-					Versions: []*bonsai.AssetVersionGrouping{
-						{Version: bAsset.version},
-					},
-				}
-				m.On("FetchAsset", bAsset.namespace, bAsset.name).
-					Return(bonsaiAsset, nil)
-				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
-					Return("{}", nil)
-			},
-		},
-		{
-			name:            "invalid asset",
-			wantErr:         true,
-			errMatch:        "name cannot be empty",
-			alias:           "testalias",
-			bonsaiAssetName: bAsset.fullNameWithVersion,
-			bonsaiClientFunc: func(m *MockBonsaiClient) {
-				bonsaiAsset := &bonsai.Asset{
-					Versions: []*bonsai.AssetVersionGrouping{
-						{Version: bAsset.version},
-					},
-				}
-				asset := corev2.Asset{
-					Builds: []*corev2.AssetBuild{
-						{},
-					},
-				}
-				assetJSON, err := json.Marshal(asset)
-				if err != nil {
-					t.Fatal(err)
-				}
-				m.On("FetchAsset", bAsset.namespace, bAsset.name).
-					Return(bonsaiAsset, nil)
-				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
-					Return(string(assetJSON), nil)
-			},
-		},
-		{
 			name:            "no type annotation",
 			wantErr:         true,
 			errMatch:        "requested asset does not have a type annotation set",
@@ -251,12 +206,8 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						Name:      bAsset.name,
 						Namespace: bAsset.namespace,
 					},
-					Builds: []*corev2.AssetBuild{
-						{
-							URL:    bAsset.url,
-							Sha512: bAsset.sha512,
-						},
-					},
+					URL:    bAsset.url,
+					Sha512: bAsset.sha512,
 				}
 				assetJSON, err := json.Marshal(asset)
 				if err != nil {
@@ -289,12 +240,8 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 							"io.sensu.bonsai.type": "backend",
 						},
 					},
-					Builds: []*corev2.AssetBuild{
-						{
-							URL:    bAsset.url,
-							Sha512: bAsset.sha512,
-						},
-					},
+					URL:    bAsset.url,
+					Sha512: bAsset.sha512,
 				}
 				assetJSON, err := json.Marshal(asset)
 				if err != nil {
@@ -327,12 +274,8 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 							"io.sensu.bonsai.type": "sensuctl",
 						},
 					},
-					Builds: []*corev2.AssetBuild{
-						{
-							URL:    bAsset.url,
-							Sha512: bAsset.sha512,
-						},
-					},
+					URL:    bAsset.url,
+					Sha512: bAsset.sha512,
 				}
 				assetJSON, err := json.Marshal(asset)
 				if err != nil {
@@ -366,11 +309,68 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 							"io.sensu.bonsai.provider": "backend/handler",
 						},
 					},
-					Builds: []*corev2.AssetBuild{
-						{
-							URL:    bAsset.url,
-							Sha512: bAsset.sha512,
+					URL:    bAsset.url,
+					Sha512: bAsset.sha512,
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "asset without builds",
+			wantErr:         true,
+			errMatch:        "one or more asset builds are required",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &bonsai.Asset{
+					Versions: []*bonsai.AssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.fullName,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "sensuctl/command",
 						},
+					},
+					URL:    bAsset.url,
+					Sha512: bAsset.sha512,
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
+					Return(string(assetJSON), nil)
+			},
+		},
+		{
+			name:            "invalid asset",
+			wantErr:         true,
+			errMatch:        "name cannot be empty",
+			alias:           "testalias",
+			bonsaiAssetName: bAsset.fullNameWithVersion,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &bonsai.Asset{
+					Versions: []*bonsai.AssetVersionGrouping{
+						{Version: bAsset.version},
+					},
+				}
+				asset := corev2.Asset{
+					Builds: []*corev2.AssetBuild{
+						{},
 					},
 				}
 				assetJSON, err := json.Marshal(asset)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Checks for valid Bonsai labels before checking if a Bonsai asset has one or more builds.

## Why is this change necessary?

Addresses a UX issue discovered by https://github.com/sensu/sensu-go/issues/3421. We still need a valid sensuctl command for the Sensu Docs example.

## Does your change need a Changelog entry?

Yes.

## Is this change a patch?

It can be if we want it to. Do we want it to be?