### PR TITLE
Fix a CLI flag that was accidentally removed

### DIFF
--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -70,7 +70,6 @@ func InitCommand() *cobra.Command {
 
 			cfg := &backend.Config{
 				EtcdClientURLs:      fallbackStringSlice(flagEtcdClientURLs, flagEtcdAdvertiseClientURLs),
-				EtcdName:            viper.GetString(flagEtcdNodeName),
 				EtcdCipherSuites:    viper.GetStringSlice(flagEtcdCipherSuites),
 				EtcdMaxRequestBytes: viper.GetUint(flagEtcdMaxRequestBytes),
 				NoEmbedEtcd:         true,
@@ -163,7 +162,7 @@ func InitCommand() *cobra.Command {
 }
 
 func seedCluster(client *clientv3.Client, config seedConfig) error {
-	store := etcdstore.NewStore(client, config.EtcdName)
+	store := etcdstore.NewStore(client, "")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	if err := seeds.SeedCluster(ctx, store, config.SeedConfig); err != nil {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -391,6 +391,8 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 		_ = cmd.Flags().SetAnnotation(flagEtcdPeerClientCertAuth, "categories", []string{"store"})
 		cmd.Flags().String(flagEtcdPeerTrustedCAFile, viper.GetString(flagEtcdPeerTrustedCAFile), "path to the peer server TLS trusted CA file")
 		_ = cmd.Flags().SetAnnotation(flagEtcdPeerTrustedCAFile, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdNodeName, viper.GetString(flagEtcdNodeName), "name for this etcd node")
+		_ = cmd.Flags().SetAnnotation(flagEtcdNodeName, "categories", []string{"store"})
 	}
 
 	// Etcd client/server flags


### PR DESCRIPTION
## What is this change?

Fixes a bug that was introduced by https://github.com/sensu/sensu-go/pull/3414

## Why is this change necessary?

The flag `--etcd-name` was accidentally removed.

## Does your change need a Changelog entry?

No

## How did you verify this change?

Manual testing. Started a backend, used the init tool, etc.