### PR TITLE
Add distribution field to tessen's cluster data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added a new flag, --etcd-client-urls, which should be used with sensu-backend
 when it is not operating as an etcd member. The flag is also used by the new
 sensu-backend init tool.
+- Added the cluster's distribution to Tessen data.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -8,6 +8,12 @@ const (
 	licenseStorePath = "/sensu.io/api/enterprise/licensing/v2/license"
 )
 
+var (
+	// Distribution indicates that Sensu Go was distributed from OSS but can be
+	// overridden
+	Distribution = "oss"
+)
+
 // Data is the payload sent to tessen
 type Data struct {
 	// General information about the Sensu installation.
@@ -21,6 +27,9 @@ type Data struct {
 type Cluster struct {
 	// ID is the ID of the sensu-enterprise-go cluster.
 	ID string `json:"id"`
+
+	// Distribution indicates how Sensu Go was distributed
+	Distribution string `json:"distribution"`
 
 	// Version is the Sensu release version (e.g. "1.4.1").
 	Version string `json:"version"`

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -513,9 +513,10 @@ func (t *Tessend) getDataPayload() *Data {
 	// populate data payload
 	data := &Data{
 		Cluster: Cluster{
-			ID:      clusterID,
-			Version: version.Semver(),
-			License: wrapper.Value.License,
+			ID:           clusterID,
+			Distribution: Distribution,
+			Version:      version.Semver(),
+			License:      wrapper.Value.License,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds a `distribution` field to Tessen's cluster data, with the default value `oss` for sensu-go.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3431

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

Nope