### PR TITLE
Restart backend daemons on store failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic_template.md
+++ b/.github/ISSUE_TEMPLATE/epic_template.md
@@ -1,0 +1,20 @@
+---
+name: 'Epic'
+about: 'Create an epic'
+---
+
+## Description
+<!--- Provide a summary of what the epic should accomplish -->
+
+## Proposal
+<!--- Link to the proposal doc --->
+
+## Spec
+<!--- Link to the spec doc -->
+
+## Issues
+<!--- Link(s) to sensu-go GH issues --->
+<!--- Link(s) to sensu-enterprise-go GH issues --->
+<!--- Link(s) to sensu-go-qa-crucible GH issues --->
+<!--- Link(s) to sensu-staging GH issues --->
+<!--- Link(s) to sensu-docs GH issues --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,3 +46,11 @@ Aside from unit/integration tests, please describe the e2e steps to verify this 
 Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
 The corresponding sensu-go-qa-crucible PR or issue should be linked here.
 -->
+
+## Is this change a patch?
+
+<!--
+If so, you should be submitting this against the current release branch. Remember to merge the release branch back into master after merging this patch!
+
+If not, this feature work can go directly into the master branch.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Listing assets with no results returns an empty array.
 - Fixed a panic that could occur when creating resources in a namespace that
 does not exist.
+- Add a timeout to etcd requests when retrieving the nodes health
 
 ## [5.15.0] - 2019-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Display the JWT expiration Unix timestamp in `sensuctl config view`.
+- Added the 'sensu-backend init' subcommand.
+- Added a new flag, --etcd-client-urls, which should be used with sensu-backend
+when it is not operating as an etcd member. The flag is also used by the new
+sensu-backend init tool.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.
@@ -21,6 +25,12 @@ does not exist.
 - Add a timeout to etcd requests when retrieving the nodes health.
 - Show the correct default value for the format flag in `sensuctl dump` help
 usage.
+
+### Changed
+- The backend will no longer automatically be seeded with a default admin
+username and password. Users will need to run 'sensu-backend init' on every
+new installation.
+- Several deprecated flags were removed from sensu-backend.
 
 ## [5.15.0] - 2019-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Display the JWT expiration Unix timestamp in `sensuctl config view`.
+
 ### Fixed
 - Listing assets with no results returns an empty array.
 - Fixed a panic that could occur when creating resources in a namespace that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Display the JWT expiration Unix timestamp in `sensuctl config view`.
 
 ### Fixed
+- Add a timeout to etcd requests when retrieving the nodes health.
+- Show the correct default value for the format flag in `sensuctl dump` help
+usage.
 - Listing assets with no results returns an empty array.
 - Fixed a panic that could occur when creating resources in a namespace that
 does not exist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a panic that could occur when creating resources in a namespace that
 does not exist.
 - Add a timeout to etcd requests when retrieving the nodes health
+- Add a timeout to etcd requests when retrieving the nodes health.
+- Show the correct default value for the format flag in `sensuctl dump` help
+usage.
 
 ## [5.15.0] - 2019-11-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ This helps us to provide direction as to implementation details, which
 branch to base your changes on, and so on.
 
 1. Open an issue to describe your proposed improvement or feature
-1. Fork https://github.com/sensu/sensu-go
-1. Clone the fork to $GOPATH/src/github.com/sensu/sensu-go. (This exact path must be used. If GOPATH is undefined, use /home/go.)
+1. [Install Go and fork the Sensu Go repository](https://github.com/sensu/sensu-go#building-from-source)
 1. Create your feature branch (`git checkout -b my-new-feature`)
 1. If applicable, add a [CHANGELOG.md entry](#changelog) describing your change.
 1. Commit your changes with a [DCO Signed-off-by statement](#dco) (`git commit --signoff`)
@@ -191,11 +190,6 @@ Here are the highlights:
 ![](https://i.imgur.com/AinipVI.jpg)
 
 ## Development
-
-Sensu is written in Go, and targets the 1.10.x branch of the compiler and
-toolchain. When working on Sensu, you should use this version of Go.
-
-[Go installation instructions](https://golang.org/doc/install)
 
 ### Protobuf
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the [installation documentation](https://docs.sensu.io/sensu-go/latest/insta
 ### Building from source
 
 The various components of Sensu Go can be manually built from this repository.
-You will first need [Go 1.13.1](https://golang.org/doc/install#install)
+You will first need [Go 1.13.3](https://golang.org/doc/install#install)
 installed. Then, you should clone this repository **outside** of the GOPATH
 since Sensu Go uses [Go Modules](https://github.com/golang/go/wiki/Modules):
 ```

--- a/agent/statsd.go
+++ b/agent/statsd.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// StatsdUnsupported is returned when statsd can't be supported on the platform.
+var StatsdUnsupported = errors.New("statsd not supported on this platform")
+
+// StatsdServer is the interface the agent requires to run a statsd server.
+type StatsdServer interface {
+	Run(context.Context) error
+}

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -1,3 +1,5 @@
+// +build !solaris
+
 // Package agent is the running Sensu agent. Agents connect to a Sensu backend,
 // register their presence, subscribe to check channels, download relevant
 // check packages, execute checks, and send results to the Sensu backend via
@@ -18,6 +20,15 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/time/rate"
 )
+
+// GetMetricsAddr gets the metrics address of the statsd server.
+func GetMetricsAddr(s StatsdServer) string {
+	server, ok := s.(*statsd.Server)
+	if !ok {
+		return ""
+	}
+	return server.MetricsAddr
+}
 
 // NewStatsdServer provides a new statsd server for the sensu-agent.
 func NewStatsdServer(a *Agent) *statsd.Server {

--- a/agent/statsd_server_solaris.go
+++ b/agent/statsd_server_solaris.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"context"
+)
+
+// GetMetricsAddr always returns ""
+func GetMetricsAddr(s StatsdServer) string {
+	return ""
+}
+
+// statsdServer is a no-op statsd server for solaris support.
+// the gostatsd package requires a library that can't be built on solaris.
+type statsdServer struct {
+}
+
+func (s statsdServer) Run(context.Context) error {
+	return StatsdUnsupported
+}
+
+func NewStatsdServer(*Agent) statsdServer {
+	return statsdServer{}
+}

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,4 +1,4 @@
-// +build integration
+// +build integration,!solaris
 
 package agent
 
@@ -23,7 +23,7 @@ func TestNewStatsdServer(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, BackendName, s.Backends[0].Name())
 	assert.Equal(t, DefaultStatsdFlushInterval*time.Second, s.FlushInterval)
-	assert.Equal(t, "127.0.0.1:8125", s.MetricsAddr)
+	assert.Equal(t, "127.0.0.1:8125", GetMetricsAddr(s))
 
 	c.StatsdServer.FlushInterval = 20
 	c.StatsdServer.Port = 8126
@@ -33,7 +33,7 @@ func TestNewStatsdServer(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, BackendName, s.Backends[0].Name())
 	assert.Equal(t, 20*time.Second, s.FlushInterval)
-	assert.Equal(t, "foo:8126", s.MetricsAddr)
+	assert.Equal(t, "foo:8126", GetMetricsAddr(s))
 }
 
 func TestComposeMetricTags(t *testing.T) {
@@ -164,7 +164,7 @@ func TestReceiveMetrics(t *testing.T) {
 	// Give the server a second to start up
 	time.Sleep(time.Second * 1)
 
-	udpClient, err := net.Dial("udp", ta.statsdServer.MetricsAddr)
+	udpClient, err := net.Dial("udp", GetMetricsAddr(ta.statsdServer))
 	if err != nil {
 		assert.FailNow("failed to create UDP connection")
 	}

--- a/backend/agentd/entity.go
+++ b/backend/agentd/entity.go
@@ -2,7 +2,6 @@ package agentd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -26,7 +25,7 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 		// Query the store for an entity using the given proxy entity name
 		entity, err := s.GetEntityByName(ctx, event.Check.ProxyEntityName)
 		if err != nil {
-			return fmt.Errorf("could not query the store for a proxy entity: %s", err)
+			return err
 		}
 
 		// Check if an entity was found for this proxy entity. If not, we need to create it
@@ -41,7 +40,7 @@ func getProxyEntity(event *types.Event, s SessionStore) error {
 			}
 
 			if err := s.UpdateEntity(ctx, entity); err != nil {
-				return fmt.Errorf("could not create a proxy entity: %s", err)
+				return err
 			}
 		}
 

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -168,6 +168,10 @@ func (s *Session) receiver() {
 			logger.WithError(err).WithFields(logrus.Fields{
 				"type":    msg.Type,
 				"payload": string(msg.Payload)}).Error("error handling message")
+			if _, ok := err.(*store.ErrInternal); ok {
+				// Fatal error - boot the agent out of the session
+				go s.Stop()
+			}
 		}
 	}
 }

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -104,9 +104,7 @@ type SessionConfig struct {
 func NewSession(ctx context.Context, cfg SessionConfig, conn transport.Transport, bus messaging.MessageBus, store store.Store, unmarshal UnmarshalFunc, marshal MarshalFunc) (*Session, error) {
 	// Validate the agent namespace
 	if _, err := store.GetNamespace(ctx, cfg.Namespace); err != nil {
-		return nil, fmt.Errorf(
-			"could not retrieve the namespace '%s': %s", cfg.Namespace, err.Error(),
-		)
+		return nil, err
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -191,8 +191,8 @@ func Initialize(config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store: stor,
-		Bus:   bus,
+		Store:                   stor,
+		Bus:                     bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
 		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
@@ -262,13 +262,13 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:             bus,
-		Store:           stor,
-		EventStore:      stor,
-		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
-		RingPool:        ringPool,
-		BufferSize:      viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:     viper.GetInt(FlagKeepalivedWorkers),
+		Bus:                   bus,
+		Store:                 stor,
+		EventStore:            stor,
+		LivenessFactory:       liveness.EtcdFactory(b.ctx, b.Client),
+		RingPool:              ringPool,
+		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)
@@ -387,8 +387,24 @@ func Initialize(config *Config) (*Backend, error) {
 	return b, nil
 }
 
-// Run starts all of the Backend server's daemons
-func (b *Backend) Run() error {
+func (b *Backend) runOnce() error {
+	var derr error
+
+	if b.Etcd != nil {
+		logger.Info("shutting down etcd")
+		defer func() {
+			if err := recover(); err != nil {
+				trace := string(debug.Stack())
+				logger.WithField("panic", trace).WithError(err.(error)).
+					Error("recovering from panic due to error, shutting down etcd")
+			}
+			err := b.Etcd.Shutdown()
+			if derr == nil {
+				derr = err
+			}
+		}()
+	}
+
 	eg := errGroup{
 		out: make(chan error),
 	}
@@ -425,39 +441,33 @@ func (b *Backend) Run() error {
 
 	select {
 	case err := <-eg.Err():
-		logger.WithError(err).Error("error in error group")
+		logger.WithError(err).Error("backend stopped working and is restarting")
 	case <-b.ctx.Done():
 		logger.Info("backend shutting down")
 	}
-
-	var derr error
-
 	if err := sg.Stop(); err != nil {
 		if derr == nil {
 			derr = err
 		}
 	}
 
-	if b.Etcd != nil {
-		logger.Info("shutting down etcd")
-		defer func() {
-			if err := recover(); err != nil {
-				trace := string(debug.Stack())
-				logger.WithField("panic", trace).WithError(err.(error)).
-					Error("recovering from panic due to error, shutting down etcd")
-			}
-			err := b.Etcd.Shutdown()
-			if derr == nil {
-				derr = err
-			}
-		}()
-	}
+	return derr
+}
 
+// Run starts all of the Backend server's daemons
+func (b *Backend) Run() error {
 	// we allow inErrChan to leak to avoid panics from other
 	// goroutines writing errors to either after shutdown has been initiated.
-	close(b.done)
+	defer close(b.done)
 
-	return derr
+	for {
+		if err := b.ctx.Err(); err != nil {
+			return nil
+		}
+		if err := b.runOnce(); err != nil {
+			logger.Error(err)
+		}
+	}
 }
 
 type stopper interface {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -33,7 +33,6 @@ import (
 	"github.com/sensu/sensu-go/backend/queue"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/schedulerd"
-	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sensu/sensu-go/backend/store"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/sensu/sensu-go/backend/tessend"
@@ -72,10 +71,15 @@ func newClient(config *Config, backend *Backend) (*clientv3.Client, error) {
 			return nil, err
 		}
 
+		clientURLs := config.EtcdClientURLs
+		if len(clientURLs) == 0 {
+			clientURLs = config.EtcdAdvertiseClientURLs
+		}
+
 		// Don't start up an embedded etcd, return a client that connects to an
 		// external etcd instead.
 		return clientv3.New(clientv3.Config{
-			Endpoints:   config.EtcdAdvertiseClientURLs,
+			Endpoints:   clientURLs,
 			DialTimeout: 5 * time.Second,
 			TLS:         tlsConfig,
 		})
@@ -144,17 +148,11 @@ func Initialize(config *Config) (*Backend, error) {
 		return nil, err
 	}
 
-	// Initialize the store, which lives on top of etcd
-	logger.Debug("Initializing store...")
+	// Create the store, which lives on top of etcd
 	stor := etcdstore.NewStore(b.Client, config.EtcdName)
-	if err = seeds.SeedInitialData(stor); err != nil {
-		return nil, fmt.Errorf("error initializing the store: %s", err)
-	}
-	logger.Debug("Done initializing store")
 	b.Store = stor
 
-	_, err = stor.GetClusterID(b.ctx)
-	if err != nil {
+	if _, err := stor.GetClusterID(b.ctx); err != nil {
 		switch err := err.(type) {
 		case *store.ErrNotFound:
 			if storeErr := stor.CreateClusterID(b.ctx, uuid.New().String()); storeErr != nil {
@@ -193,8 +191,8 @@ func Initialize(config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store:                   stor,
-		Bus:                     bus,
+		Store: stor,
+		Bus:   bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
 		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
@@ -264,13 +262,13 @@ func Initialize(config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:                   bus,
-		Store:                 stor,
-		EventStore:            stor,
-		LivenessFactory:       liveness.EtcdFactory(b.ctx, b.Client),
-		RingPool:              ringPool,
-		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
+		Bus:             bus,
+		Store:           stor,
+		EventStore:      stor,
+		LivenessFactory: liveness.EtcdFactory(b.ctx, b.Client),
+		RingPool:        ringPool,
+		BufferSize:      viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:     viper.GetInt(FlagKeepalivedWorkers),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/AlecAivazis/survey"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend"
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sensu/sensu-go/backend/seeds"
+	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	flagInitAdminUsername = "cluster-admin-username"
+	flagInitAdminPassword = "cluster-admin-password"
+	flagInteractive       = "interactive"
+)
+
+type seedConfig struct {
+	backend.Config
+	SeedConfig seeds.Config
+}
+
+type initOpts struct {
+	AdminUsername string `survey:"cluster-admin-username"`
+	AdminPassword string `survey:"cluster-admin-password"`
+}
+
+func (i *initOpts) administerQuestionnaire() error {
+	qs := []*survey.Question{
+		{
+			Name: "cluster-admin-username",
+			Prompt: &survey.Input{
+				Message: "Cluster Admin Username:",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "cluster-admin-password",
+			Prompt: &survey.Password{
+				Message: "Cluster Admin Password:",
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	return survey.Ask(qs, i)
+}
+
+// InitCommand is the 'sensu-backend init' subcommand.
+func InitCommand() *cobra.Command {
+	var setupErr error
+	cmd := &cobra.Command{
+		Use:           "init",
+		Short:         "initialize a new sensu installation",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = viper.BindPFlags(cmd.Flags())
+			if setupErr != nil {
+				return setupErr
+			}
+
+			cfg := &backend.Config{
+				EtcdClientURLs:      fallbackStringSlice(flagEtcdClientURLs, flagEtcdAdvertiseClientURLs),
+				EtcdName:            viper.GetString(flagEtcdNodeName),
+				EtcdCipherSuites:    viper.GetStringSlice(flagEtcdCipherSuites),
+				EtcdMaxRequestBytes: viper.GetUint(flagEtcdMaxRequestBytes),
+				NoEmbedEtcd:         true,
+			}
+
+			// Sensu APIs TLS config
+			certFile := viper.GetString(flagCertFile)
+			keyFile := viper.GetString(flagKeyFile)
+			insecureSkipTLSVerify := viper.GetBool(flagInsecureSkipTLSVerify)
+			trustedCAFile := viper.GetString(flagTrustedCAFile)
+
+			if certFile != "" && keyFile != "" {
+				cfg.TLS = &corev2.TLSOptions{
+					CertFile:           certFile,
+					KeyFile:            keyFile,
+					TrustedCAFile:      trustedCAFile,
+					InsecureSkipVerify: insecureSkipTLSVerify,
+				}
+			} else if certFile != "" || keyFile != "" {
+				return fmt.Errorf(
+					"tls configuration error, both flags --%s & --%s are required",
+					flagCertFile, flagKeyFile)
+			}
+
+			// Etcd TLS config
+			cfg.EtcdClientTLSInfo = etcd.TLSInfo{
+				CertFile:       viper.GetString(flagEtcdCertFile),
+				KeyFile:        viper.GetString(flagEtcdKeyFile),
+				TrustedCAFile:  viper.GetString(flagEtcdTrustedCAFile),
+				ClientCertAuth: viper.GetBool(flagEtcdClientCertAuth),
+			}
+
+			// Convert the TLS config into etcd's transport.TLSInfo
+			tlsInfo := (transport.TLSInfo)(cfg.EtcdClientTLSInfo)
+			tlsConfig, err := tlsInfo.ClientConfig()
+			if err != nil {
+				return err
+			}
+
+			clientURLs := viper.GetStringSlice(flagEtcdClientURLs)
+			if len(clientURLs) == 0 {
+				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
+			}
+
+			client, err := clientv3.New(clientv3.Config{
+				Endpoints:   clientURLs,
+				DialTimeout: 5 * time.Second,
+				TLS:         tlsConfig,
+			})
+
+			if err != nil {
+				return fmt.Errorf("error connecting to cluster: %s", err)
+			}
+
+			uname := viper.GetString(flagInitAdminUsername)
+			pword := viper.GetString(flagInitAdminPassword)
+
+			if viper.GetBool(flagInteractive) {
+				var opts initOpts
+				if err := opts.administerQuestionnaire(); err != nil {
+					return err
+				}
+				uname = opts.AdminUsername
+				pword = opts.AdminPassword
+			}
+
+			if uname == "" || pword == "" {
+				return fmt.Errorf("both %s and %s are required to be set", flagInitAdminUsername, flagInitAdminPassword)
+			}
+
+			seedConfig := seedConfig{
+				Config: *cfg,
+				SeedConfig: seeds.Config{
+					AdminUsername: uname,
+					AdminPassword: pword,
+				},
+			}
+
+			return seedCluster(client, seedConfig)
+		},
+	}
+
+	cmd.Flags().String(flagInitAdminUsername, "", "cluster admin username")
+	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
+	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
+
+	setupErr = handleConfig(cmd, false)
+
+	return cmd
+}
+
+func seedCluster(client *clientv3.Client, config seedConfig) error {
+	store := etcdstore.NewStore(client, config.EtcdName)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	if err := seeds.SeedCluster(ctx, store, config.SeedConfig); err != nil {
+		return fmt.Errorf("error initializing cluster: %s", err)
+	}
+	return nil
+}

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -27,8 +27,6 @@ const (
 	flagConfigFile            = "config-file"
 	flagAgentHost             = "agent-host"
 	flagAgentPort             = "agent-port"
-	deprecatedFlagAPIHost     = "api-host"
-	deprecatedFlagAPIPort     = "api-port"
 	flagAPIListenAddress      = "api-listen-address"
 	flagAPIURL                = "api-url"
 	flagDashboardHost         = "dashboard-host"
@@ -46,24 +44,18 @@ const (
 	flagLogLevel              = "log-level"
 
 	// Etcd flag constants
-	deprecatedFlagEtcdClientURLs               = "listen-client-urls"
-	flagEtcdClientURLs                         = "etcd-listen-client-urls"
-	deprecatedFlagEtcdPeerURLs                 = "listen-peer-urls"
-	flagEtcdPeerURLs                           = "etcd-listen-peer-urls"
-	deprecatedFlagEtcdInitialCluster           = "initial-cluster"
-	flagEtcdInitialCluster                     = "etcd-initial-cluster"
-	deprecatedFlagEtcdInitialAdvertisePeerURLs = "initial-advertise-peer-urls"
-	flagEtcdInitialAdvertisePeerURLs           = "etcd-initial-advertise-peer-urls"
-	deprecatedFlagEtcdInitialClusterState      = "initial-cluster-state"
-	flagEtcdInitialClusterState                = "etcd-initial-cluster-state"
-	deprecatedFlagEtcdInitialClusterToken      = "initial-cluster-token"
-	flagEtcdInitialClusterToken                = "etcd-initial-cluster-token"
-	deprecatedFlagEtcdNodeName                 = "name"
-	flagEtcdNodeName                           = "etcd-name"
-	flagNoEmbedEtcd                            = "no-embed-etcd"
-	flagEtcdAdvertiseClientURLs                = "etcd-advertise-client-urls"
-	flagEtcdHeartbeatInterval                  = "etcd-heartbeat-interval"
-	flagEtcdElectionTimeout                    = "etcd-election-timeout"
+	flagEtcdClientURLs               = "etcd-client-urls"
+	flagEtcdListenClientURLs         = "etcd-listen-client-urls"
+	flagEtcdPeerURLs                 = "etcd-listen-peer-urls"
+	flagEtcdInitialCluster           = "etcd-initial-cluster"
+	flagEtcdInitialAdvertisePeerURLs = "etcd-initial-advertise-peer-urls"
+	flagEtcdInitialClusterState      = "etcd-initial-cluster-state"
+	flagEtcdInitialClusterToken      = "etcd-initial-cluster-token"
+	flagEtcdNodeName                 = "etcd-name"
+	flagNoEmbedEtcd                  = "no-embed-etcd"
+	flagEtcdAdvertiseClientURLs      = "etcd-advertise-client-urls"
+	flagEtcdHeartbeatInterval        = "etcd-heartbeat-interval"
+	flagEtcdElectionTimeout          = "etcd-election-timeout"
 
 	// Etcd TLS flag constants
 	flagEtcdCertFile           = "etcd-cert-file"
@@ -127,6 +119,14 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 // to initialize the backend
 type initializeFunc func(*backend.Config) (*backend.Backend, error)
 
+func fallbackStringSlice(newFlag, oldFlag string) []string {
+	slice := viper.GetStringSlice(newFlag)
+	if len(slice) == 0 {
+		slice = viper.GetStringSlice(oldFlag)
+	}
+	return slice
+}
+
 // StartCommand ...
 func StartCommand(initialize initializeFunc) *cobra.Command {
 	var setupErr error
@@ -140,14 +140,6 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 			_ = viper.BindPFlags(cmd.Flags())
 			if setupErr != nil {
 				return setupErr
-			}
-
-			// Make sure the deprecated API flags are no longer used
-			if host := viper.GetString(deprecatedFlagAPIHost); host != "[::]" {
-				logger.Fatalf("Flag --%s has been deprecated, please use --%s instead", deprecatedFlagAPIHost, flagAPIListenAddress)
-			}
-			if port := viper.GetInt(deprecatedFlagAPIPort); port != 8080 {
-				logger.Fatalf("Flag --%s has been deprecated, please use --%s instead", deprecatedFlagAPIPort, flagAPIListenAddress)
 			}
 
 			level, err := logrus.ParseLevel(viper.GetString(flagLogLevel))
@@ -171,7 +163,8 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 				StateDir:              viper.GetString(flagStateDir),
 
 				EtcdAdvertiseClientURLs:      viper.GetStringSlice(flagEtcdAdvertiseClientURLs),
-				EtcdListenClientURLs:         viper.GetStringSlice(flagEtcdClientURLs),
+				EtcdListenClientURLs:         viper.GetStringSlice(flagEtcdListenClientURLs),
+				EtcdClientURLs:               fallbackStringSlice(flagEtcdClientURLs, flagEtcdAdvertiseClientURLs),
 				EtcdListenPeerURLs:           viper.GetStringSlice(flagEtcdPeerURLs),
 				EtcdInitialCluster:           viper.GetString(flagEtcdInitialCluster),
 				EtcdInitialClusterState:      viper.GetString(flagEtcdInitialClusterState),
@@ -245,6 +238,12 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 		},
 	}
 
+	setupErr = handleConfig(cmd, true)
+
+	return cmd
+}
+
+func handleConfig(cmd *cobra.Command, server bool) error {
 	// Set up distinct flagset for handling config file
 	configFlagSet := pflag.NewFlagSet("sensu", pflag.ContinueOnError)
 	configFlagSet.StringP(flagConfigFile, "c", "", "path to sensu-backend config file")
@@ -264,36 +263,36 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(configFilePath)
 
-	// Flag defaults
-	viper.SetDefault(flagAgentHost, "[::]")
-	viper.SetDefault(flagAgentPort, 8081)
-	viper.SetDefault(deprecatedFlagAPIHost, "[::]")
-	viper.SetDefault(deprecatedFlagAPIPort, 8080)
-	viper.SetDefault(flagAPIListenAddress, "[::]:8080")
-	viper.SetDefault(flagAPIURL, "http://localhost:8080")
-	viper.SetDefault(flagDashboardHost, "[::]")
-	viper.SetDefault(flagDashboardPort, 3000)
-	viper.SetDefault(flagDashboardCertFile, "")
-	viper.SetDefault(flagDashboardKeyFile, "")
-	viper.SetDefault(flagDeregistrationHandler, "")
-	viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-backend"))
-	viper.SetDefault(flagStateDir, path.SystemDataDir("sensu-backend"))
-	viper.SetDefault(flagCertFile, "")
-	viper.SetDefault(flagKeyFile, "")
-	viper.SetDefault(flagTrustedCAFile, "")
-	viper.SetDefault(flagInsecureSkipTLSVerify, false)
-	viper.SetDefault(flagLogLevel, "warn")
-	viper.SetDefault(backend.FlagEventdWorkers, 100)
-	viper.SetDefault(backend.FlagEventdBufferSize, 100)
-	viper.SetDefault(backend.FlagKeepalivedWorkers, 100)
-	viper.SetDefault(backend.FlagKeepalivedBufferSize, 100)
-	viper.SetDefault(backend.FlagPipelinedWorkers, 100)
-	viper.SetDefault(backend.FlagPipelinedBufferSize, 100)
-	viper.SetDefault(backend.FlagAgentWriteTimeout, 15)
+	if server {
+		// Flag defaults
+		viper.SetDefault(flagAgentHost, "[::]")
+		viper.SetDefault(flagAgentPort, 8081)
+		viper.SetDefault(flagAPIListenAddress, "[::]:8080")
+		viper.SetDefault(flagAPIURL, "http://localhost:8080")
+		viper.SetDefault(flagDashboardHost, "[::]")
+		viper.SetDefault(flagDashboardPort, 3000)
+		viper.SetDefault(flagDashboardCertFile, "")
+		viper.SetDefault(flagDashboardKeyFile, "")
+		viper.SetDefault(flagDeregistrationHandler, "")
+		viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-backend"))
+		viper.SetDefault(flagStateDir, path.SystemDataDir("sensu-backend"))
+		viper.SetDefault(flagCertFile, "")
+		viper.SetDefault(flagKeyFile, "")
+		viper.SetDefault(flagTrustedCAFile, "")
+		viper.SetDefault(flagInsecureSkipTLSVerify, false)
+		viper.SetDefault(flagLogLevel, "warn")
+		viper.SetDefault(backend.FlagEventdWorkers, 100)
+		viper.SetDefault(backend.FlagEventdBufferSize, 100)
+		viper.SetDefault(backend.FlagKeepalivedWorkers, 100)
+		viper.SetDefault(backend.FlagKeepalivedBufferSize, 100)
+		viper.SetDefault(backend.FlagPipelinedWorkers, 100)
+		viper.SetDefault(backend.FlagPipelinedBufferSize, 100)
+		viper.SetDefault(backend.FlagAgentWriteTimeout, 15)
+	}
 
 	// Etcd defaults
 	viper.SetDefault(flagEtcdAdvertiseClientURLs, defaultEtcdAdvertiseClientURL)
-	viper.SetDefault(flagEtcdClientURLs, defaultEtcdClientURL)
+	viper.SetDefault(flagEtcdListenClientURLs, defaultEtcdClientURL)
 	viper.SetDefault(flagEtcdPeerURLs, defaultEtcdPeerURL)
 	viper.SetDefault(flagEtcdInitialCluster,
 		fmt.Sprintf("%s=%s", defaultEtcdName, defaultEtcdPeerURL))
@@ -305,70 +304,89 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	viper.SetDefault(flagEtcdMaxRequestBytes, etcd.DefaultMaxRequestBytes)
 	viper.SetDefault(flagEtcdHeartbeatInterval, etcd.DefaultTickMs)
 	viper.SetDefault(flagEtcdElectionTimeout, etcd.DefaultElectionMs)
-	viper.SetDefault(flagNoEmbedEtcd, false)
+
+	if server {
+		viper.SetDefault(flagNoEmbedEtcd, false)
+	}
 
 	// Merge in config flag set so that it appears in command usage
 	cmd.Flags().AddFlagSet(configFlagSet)
 
-	// Main Flags
-	cmd.Flags().String(flagAgentHost, viper.GetString(flagAgentHost), "agent listener host")
-	cmd.Flags().Int(flagAgentPort, viper.GetInt(flagAgentPort), "agent listener port")
-	cmd.Flags().String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")
-	cmd.Flags().String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
-	cmd.Flags().String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")
-	cmd.Flags().Int(flagDashboardPort, viper.GetInt(flagDashboardPort), "dashboard listener port")
-	cmd.Flags().String(flagDashboardCertFile, viper.GetString(flagDashboardCertFile), "dashboard TLS certificate in PEM format")
-	cmd.Flags().String(flagDashboardKeyFile, viper.GetString(flagDashboardKeyFile), "dashboard TLS certificate key in PEM format")
-	cmd.Flags().String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "default deregistration handler")
-	cmd.Flags().String(flagCacheDir, viper.GetString(flagCacheDir), "path to store cached data")
-	cmd.Flags().StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")
-	cmd.Flags().String(flagCertFile, viper.GetString(flagCertFile), "TLS certificate in PEM format")
-	cmd.Flags().String(flagKeyFile, viper.GetString(flagKeyFile), "TLS certificate key in PEM format")
-	cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format")
-	cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
-	cmd.Flags().Bool(flagDebug, false, "enable debugging and profiling features")
-	cmd.Flags().String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug]")
-	cmd.Flags().Int(backend.FlagEventdWorkers, viper.GetInt(backend.FlagEventdWorkers), "number of workers spawned for processing incoming events")
-	cmd.Flags().Int(backend.FlagEventdBufferSize, viper.GetInt(backend.FlagEventdBufferSize), "number of incoming events that can be buffered")
-	cmd.Flags().Int(backend.FlagKeepalivedWorkers, viper.GetInt(backend.FlagKeepalivedWorkers), "number of workers spawned for processing incoming keepalives")
-	cmd.Flags().Int(backend.FlagKeepalivedBufferSize, viper.GetInt(backend.FlagKeepalivedBufferSize), "number of incoming keepalives that can be buffered")
-	cmd.Flags().Int(backend.FlagPipelinedWorkers, viper.GetInt(backend.FlagPipelinedWorkers), "number of workers spawned for handling events through the event pipeline")
-	cmd.Flags().Int(backend.FlagPipelinedBufferSize, viper.GetInt(backend.FlagPipelinedBufferSize), "number of events to handle that can be buffered")
-	cmd.Flags().Int(backend.FlagAgentWriteTimeout, viper.GetInt(backend.FlagAgentWriteTimeout), "timeout in seconds for agent writes")
-	cmd.Flags().String(backend.FlagJWTPrivateKeyFile, viper.GetString(backend.FlagJWTPrivateKeyFile), "path to the PEM-encoded private key to use to sign JWTs")
-	cmd.Flags().String(backend.FlagJWTPublicKeyFile, viper.GetString(backend.FlagJWTPublicKeyFile), "path to the PEM-encoded public key to use to verify JWT signatures")
+	if server {
+		// Main Flags
+		cmd.Flags().String(flagAgentHost, viper.GetString(flagAgentHost), "agent listener host")
+		cmd.Flags().Int(flagAgentPort, viper.GetInt(flagAgentPort), "agent listener port")
+		cmd.Flags().String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")
+		cmd.Flags().String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
+		cmd.Flags().String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")
+		cmd.Flags().Int(flagDashboardPort, viper.GetInt(flagDashboardPort), "dashboard listener port")
+		cmd.Flags().String(flagDashboardCertFile, viper.GetString(flagDashboardCertFile), "dashboard TLS certificate in PEM format")
+		cmd.Flags().String(flagDashboardKeyFile, viper.GetString(flagDashboardKeyFile), "dashboard TLS certificate key in PEM format")
+		cmd.Flags().String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "default deregistration handler")
+		cmd.Flags().String(flagCacheDir, viper.GetString(flagCacheDir), "path to store cached data")
+		cmd.Flags().StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")
+		cmd.Flags().String(flagCertFile, viper.GetString(flagCertFile), "TLS certificate in PEM format")
+		cmd.Flags().String(flagKeyFile, viper.GetString(flagKeyFile), "TLS certificate key in PEM format")
+		cmd.Flags().String(flagTrustedCAFile, viper.GetString(flagTrustedCAFile), "TLS CA certificate bundle in PEM format")
+		cmd.Flags().Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
+		cmd.Flags().Bool(flagDebug, false, "enable debugging and profiling features")
+		cmd.Flags().String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug]")
+		cmd.Flags().Int(backend.FlagEventdWorkers, viper.GetInt(backend.FlagEventdWorkers), "number of workers spawned for processing incoming events")
+		cmd.Flags().Int(backend.FlagEventdBufferSize, viper.GetInt(backend.FlagEventdBufferSize), "number of incoming events that can be buffered")
+		cmd.Flags().Int(backend.FlagKeepalivedWorkers, viper.GetInt(backend.FlagKeepalivedWorkers), "number of workers spawned for processing incoming keepalives")
+		cmd.Flags().Int(backend.FlagKeepalivedBufferSize, viper.GetInt(backend.FlagKeepalivedBufferSize), "number of incoming keepalives that can be buffered")
+		cmd.Flags().Int(backend.FlagPipelinedWorkers, viper.GetInt(backend.FlagPipelinedWorkers), "number of workers spawned for handling events through the event pipeline")
+		cmd.Flags().Int(backend.FlagPipelinedBufferSize, viper.GetInt(backend.FlagPipelinedBufferSize), "number of events to handle that can be buffered")
+		cmd.Flags().Int(backend.FlagAgentWriteTimeout, viper.GetInt(backend.FlagAgentWriteTimeout), "timeout in seconds for agent writes")
+		cmd.Flags().String(backend.FlagJWTPrivateKeyFile, viper.GetString(backend.FlagJWTPrivateKeyFile), "path to the PEM-encoded private key to use to sign JWTs")
+		cmd.Flags().String(backend.FlagJWTPublicKeyFile, viper.GetString(backend.FlagJWTPublicKeyFile), "path to the PEM-encoded public key to use to verify JWT signatures")
 
-	// Etcd flags
-	cmd.Flags().StringSlice(flagEtcdAdvertiseClientURLs, viper.GetStringSlice(flagEtcdAdvertiseClientURLs), "list of this member's client URLs to advertise to the rest of the cluster.")
-	_ = cmd.Flags().SetAnnotation(flagEtcdAdvertiseClientURLs, "categories", []string{"store"})
-	cmd.Flags().StringSlice(flagEtcdClientURLs, viper.GetStringSlice(flagEtcdClientURLs), "list of URLs to listen on for client traffic")
-	_ = cmd.Flags().SetAnnotation(flagEtcdClientURLs, "categories", []string{"store"})
-	cmd.Flags().StringSlice(flagEtcdPeerURLs, viper.GetStringSlice(flagEtcdPeerURLs), "list of URLs to listen on for peer traffic")
-	_ = cmd.Flags().SetAnnotation(flagEtcdPeerURLs, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdInitialCluster, viper.GetString(flagEtcdInitialCluster), "initial cluster configuration for bootstrapping")
-	_ = cmd.Flags().SetAnnotation(flagEtcdInitialCluster, "categories", []string{"store"})
-	cmd.Flags().StringSlice(flagEtcdInitialAdvertisePeerURLs, viper.GetStringSlice(flagEtcdInitialAdvertisePeerURLs), "list of this member's peer URLs to advertise to the rest of the cluster")
-	_ = cmd.Flags().SetAnnotation(flagEtcdInitialAdvertisePeerURLs, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdInitialClusterState, viper.GetString(flagEtcdInitialClusterState), "initial cluster state (\"new\" or \"existing\")")
-	_ = cmd.Flags().SetAnnotation(flagEtcdInitialClusterState, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdInitialClusterToken, viper.GetString(flagEtcdInitialClusterToken), "initial cluster token for the etcd cluster during bootstrap")
-	_ = cmd.Flags().SetAnnotation(flagEtcdInitialClusterToken, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdNodeName, viper.GetString(flagEtcdNodeName), "human-readable name for this member")
-	_ = cmd.Flags().SetAnnotation(flagEtcdNodeName, "categories", []string{"store"})
-	cmd.Flags().Bool(flagNoEmbedEtcd, viper.GetBool(flagNoEmbedEtcd), "don't embed etcd, use external etcd instead")
-	_ = cmd.Flags().SetAnnotation(flagNoEmbedEtcd, "categories", []string{"store"})
+		// Etcd server flags
+		cmd.Flags().StringSlice(flagEtcdPeerURLs, viper.GetStringSlice(flagEtcdPeerURLs), "list of URLs to listen on for peer traffic")
+		_ = cmd.Flags().SetAnnotation(flagEtcdPeerURLs, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdInitialCluster, viper.GetString(flagEtcdInitialCluster), "initial cluster configuration for bootstrapping")
+		_ = cmd.Flags().SetAnnotation(flagEtcdInitialCluster, "categories", []string{"store"})
+		cmd.Flags().StringSlice(flagEtcdInitialAdvertisePeerURLs, viper.GetStringSlice(flagEtcdInitialAdvertisePeerURLs), "list of this member's peer URLs to advertise to the rest of the cluster")
+		_ = cmd.Flags().SetAnnotation(flagEtcdInitialAdvertisePeerURLs, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdInitialClusterState, viper.GetString(flagEtcdInitialClusterState), "initial cluster state (\"new\" or \"existing\")")
+		_ = cmd.Flags().SetAnnotation(flagEtcdInitialClusterState, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdInitialClusterToken, viper.GetString(flagEtcdInitialClusterToken), "initial cluster token for the etcd cluster during bootstrap")
+		_ = cmd.Flags().SetAnnotation(flagEtcdInitialClusterToken, "categories", []string{"store"})
+		cmd.Flags().StringSlice(flagEtcdListenClientURLs, viper.GetStringSlice(flagEtcdListenClientURLs), "list of etcd client URLs to listen on")
+		_ = cmd.Flags().SetAnnotation(flagEtcdListenClientURLs, "categories", []string{"store"})
+		cmd.Flags().Bool(flagNoEmbedEtcd, viper.GetBool(flagNoEmbedEtcd), "don't embed etcd, use external etcd instead")
+		_ = cmd.Flags().SetAnnotation(flagNoEmbedEtcd, "categories", []string{"store"})
+		cmd.Flags().Int64(flagEtcdQuotaBackendBytes, viper.GetInt64(flagEtcdQuotaBackendBytes), "maximum etcd database size in bytes (use with caution)")
+		_ = cmd.Flags().SetAnnotation(flagEtcdQuotaBackendBytes, "categories", []string{"store"})
+		cmd.Flags().Uint(flagEtcdHeartbeatInterval, viper.GetUint(flagEtcdHeartbeatInterval), "interval in ms with which the etcd leader will notify followers that it is still the leader")
+		_ = cmd.Flags().SetAnnotation(flagEtcdHeartbeatInterval, "categories", []string{"store"})
+		cmd.Flags().Uint(flagEtcdElectionTimeout, viper.GetUint(flagEtcdElectionTimeout), "time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself")
+		_ = cmd.Flags().SetAnnotation(flagEtcdElectionTimeout, "categories", []string{"store"})
+
+		// Etcd server TLS flags
+		cmd.Flags().String(flagEtcdPeerCertFile, viper.GetString(flagEtcdPeerCertFile), "path to the peer server TLS cert file")
+		_ = cmd.Flags().SetAnnotation(flagEtcdPeerCertFile, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdPeerKeyFile, viper.GetString(flagEtcdPeerKeyFile), "path to the peer server TLS key file")
+		_ = cmd.Flags().SetAnnotation(flagEtcdPeerKeyFile, "categories", []string{"store"})
+		cmd.Flags().Bool(flagEtcdPeerClientCertAuth, viper.GetBool(flagEtcdPeerClientCertAuth), "enable peer client cert authentication")
+		_ = cmd.Flags().SetAnnotation(flagEtcdPeerClientCertAuth, "categories", []string{"store"})
+		cmd.Flags().String(flagEtcdPeerTrustedCAFile, viper.GetString(flagEtcdPeerTrustedCAFile), "path to the peer server TLS trusted CA file")
+		_ = cmd.Flags().SetAnnotation(flagEtcdPeerTrustedCAFile, "categories", []string{"store"})
+	}
+
+	// Etcd client/server flags
 	cmd.Flags().StringSlice(flagEtcdCipherSuites, nil, "list of ciphers to use for etcd TLS configuration")
 	_ = cmd.Flags().SetAnnotation(flagEtcdCipherSuites, "categories", []string{"store"})
-	cmd.Flags().Int64(flagEtcdQuotaBackendBytes, viper.GetInt64(flagEtcdQuotaBackendBytes), "maximum etcd database size in bytes (use with caution)")
-	_ = cmd.Flags().SetAnnotation(flagEtcdQuotaBackendBytes, "categories", []string{"store"})
+
+	// This one is really only a server flag, but because we lacked
+	// --etcd-client-urls until recently, it's used as a fallback.
+	cmd.Flags().StringSlice(flagEtcdAdvertiseClientURLs, viper.GetStringSlice(flagEtcdAdvertiseClientURLs), "list of this member's client URLs to advertise to clients")
+	_ = cmd.Flags().SetAnnotation(flagEtcdAdvertiseClientURLs, "categories", []string{"store"})
+
 	cmd.Flags().Uint(flagEtcdMaxRequestBytes, viper.GetUint(flagEtcdMaxRequestBytes), "maximum etcd request size in bytes (use with caution)")
 	_ = cmd.Flags().SetAnnotation(flagEtcdMaxRequestBytes, "categories", []string{"store"})
-	cmd.Flags().Uint(flagEtcdHeartbeatInterval, viper.GetUint(flagEtcdHeartbeatInterval), "interval in ms with which the etcd leader will notify followers that it is still the leader")
-	_ = cmd.Flags().SetAnnotation(flagEtcdHeartbeatInterval, "categories", []string{"store"})
-	cmd.Flags().Uint(flagEtcdElectionTimeout, viper.GetUint(flagEtcdElectionTimeout), "time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself")
-	_ = cmd.Flags().SetAnnotation(flagEtcdElectionTimeout, "categories", []string{"store"})
 
-	// Etcd TLS flags
+	// Etcd client/server TLS flags
 	cmd.Flags().String(flagEtcdCertFile, viper.GetString(flagEtcdCertFile), "path to the client server TLS cert file")
 	_ = cmd.Flags().SetAnnotation(flagEtcdCertFile, "categories", []string{"store"})
 	cmd.Flags().String(flagEtcdKeyFile, viper.GetString(flagEtcdKeyFile), "path to the client server TLS key file")
@@ -377,43 +395,13 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	_ = cmd.Flags().SetAnnotation(flagEtcdClientCertAuth, "categories", []string{"store"})
 	cmd.Flags().String(flagEtcdTrustedCAFile, viper.GetString(flagEtcdTrustedCAFile), "path to the client server TLS trusted CA cert file")
 	_ = cmd.Flags().SetAnnotation(flagEtcdTrustedCAFile, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdPeerCertFile, viper.GetString(flagEtcdPeerCertFile), "path to the peer server TLS cert file")
-	_ = cmd.Flags().SetAnnotation(flagEtcdPeerCertFile, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdPeerKeyFile, viper.GetString(flagEtcdPeerKeyFile), "path to the peer server TLS key file")
-	_ = cmd.Flags().SetAnnotation(flagEtcdPeerKeyFile, "categories", []string{"store"})
-	cmd.Flags().Bool(flagEtcdPeerClientCertAuth, viper.GetBool(flagEtcdPeerClientCertAuth), "enable peer client cert authentication")
-	_ = cmd.Flags().SetAnnotation(flagEtcdPeerClientCertAuth, "categories", []string{"store"})
-	cmd.Flags().String(flagEtcdPeerTrustedCAFile, viper.GetString(flagEtcdPeerTrustedCAFile), "path to the peer server TLS trusted CA file")
-	_ = cmd.Flags().SetAnnotation(flagEtcdPeerTrustedCAFile, "categories", []string{"store"})
-
-	// Make sure some deprecated flags are no longer used
-	cmd.Flags().String(deprecatedFlagAPIHost, viper.GetString(deprecatedFlagAPIHost), "http api listener host")
-	cmd.Flags().Int(deprecatedFlagAPIPort, viper.GetInt(deprecatedFlagAPIPort), "http api port")
-	_ = cmd.Flags().MarkHidden(deprecatedFlagAPIHost)
-	_ = cmd.Flags().MarkHidden(deprecatedFlagAPIPort)
-
-	_ = cmd.Flags().MarkDeprecated(deprecatedFlagAPIHost, fmt.Sprintf("please use --%s instead", flagAPIListenAddress))
-	_ = cmd.Flags().MarkDeprecated(deprecatedFlagAPIPort, fmt.Sprintf("please use --%s instead", flagAPIListenAddress))
-
-	// Mark the old etcd flags as deprecated and maintain backward compability
-	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc)
+	cmd.Flags().String(flagEtcdClientURLs, viper.GetString(flagEtcdClientURLs), "client URLs to use when operating as an etcd client")
+	_ = cmd.Flags().SetAnnotation(flagEtcdClientURLs, "categories", []string{"store"})
 
 	// Load the configuration file but only error out if flagConfigFile is used
 	if err := viper.ReadInConfig(); err != nil && configFile != "" {
-		setupErr = err
+		return err
 	}
-
-	// Mark the old etcd keys as deprecated in the config file and then register
-	// aliases for older etcd attributes in config file to maintain backward
-	// compatiblity
-	deprecatedConfigAttributes()
-	viper.RegisterAlias(deprecatedFlagEtcdClientURLs, flagEtcdClientURLs)
-	viper.RegisterAlias(deprecatedFlagEtcdInitialAdvertisePeerURLs, flagEtcdInitialAdvertisePeerURLs)
-	viper.RegisterAlias(deprecatedFlagEtcdInitialCluster, flagEtcdInitialCluster)
-	viper.RegisterAlias(deprecatedFlagEtcdInitialClusterState, flagEtcdInitialClusterState)
-	viper.RegisterAlias(deprecatedFlagEtcdInitialClusterToken, flagEtcdInitialClusterToken)
-	viper.RegisterAlias(deprecatedFlagEtcdNodeName, flagEtcdNodeName)
-	viper.RegisterAlias(deprecatedFlagEtcdPeerURLs, flagEtcdPeerURLs)
 
 	viper.SetEnvPrefix("sensu_backend")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
@@ -423,7 +411,7 @@ func StartCommand(initialize initializeFunc) *cobra.Command {
 	cobra.AddTemplateFunc("categoryFlags", categoryFlags)
 	cmd.SetUsageTemplate(startUsageTemplate)
 
-	return cmd
+	return nil
 }
 
 func categoryFlags(category string, flags *pflag.FlagSet) *pflag.FlagSet {
@@ -441,64 +429,4 @@ func categoryFlags(category string, flags *pflag.FlagSet) *pflag.FlagSet {
 	})
 
 	return flagSet
-}
-
-func aliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
-	// Wait until the command-line flags have been parsed
-	if !f.Parsed() {
-		return pflag.NormalizedName(name)
-	}
-
-	switch name {
-	case deprecatedFlagEtcdClientURLs:
-		deprecatedFlagMessage(name, flagEtcdClientURLs)
-		name = flagEtcdClientURLs
-	case deprecatedFlagEtcdInitialAdvertisePeerURLs:
-		deprecatedFlagMessage(name, flagEtcdInitialAdvertisePeerURLs)
-		name = flagEtcdInitialAdvertisePeerURLs
-	case deprecatedFlagEtcdInitialCluster:
-		deprecatedFlagMessage(name, flagEtcdInitialCluster)
-		name = flagEtcdInitialCluster
-	case deprecatedFlagEtcdInitialClusterState:
-		deprecatedFlagMessage(name, flagEtcdInitialCluster)
-		name = flagEtcdInitialClusterState
-	case deprecatedFlagEtcdInitialClusterToken:
-		deprecatedFlagMessage(name, flagEtcdInitialClusterToken)
-		name = flagEtcdInitialClusterToken
-	case deprecatedFlagEtcdNodeName:
-		deprecatedFlagMessage(name, flagEtcdNodeName)
-		name = flagEtcdNodeName
-	case deprecatedFlagEtcdPeerURLs:
-		deprecatedFlagMessage(name, flagEtcdPeerURLs)
-		name = flagEtcdPeerURLs
-	}
-	return pflag.NormalizedName(name)
-}
-
-// Look up the deprecated attributes in our config file and print a warning
-// message if set
-func deprecatedConfigAttributes() {
-	attributes := map[string]string{
-		deprecatedFlagEtcdClientURLs:               flagEtcdClientURLs,
-		deprecatedFlagEtcdInitialAdvertisePeerURLs: flagEtcdInitialAdvertisePeerURLs,
-		deprecatedFlagEtcdInitialCluster:           flagEtcdInitialCluster,
-		deprecatedFlagEtcdInitialClusterState:      flagEtcdInitialClusterState,
-		deprecatedFlagEtcdInitialClusterToken:      flagEtcdInitialClusterToken,
-		deprecatedFlagEtcdNodeName:                 flagEtcdNodeName,
-		deprecatedFlagEtcdPeerURLs:                 flagEtcdPeerURLs,
-	}
-
-	for old, new := range attributes {
-		if viper.IsSet(old) {
-			logger.Warningf(
-				"config attribute %s has been deprecated, please use %s instead",
-				old, new,
-			)
-		}
-	}
-}
-
-func deprecatedFlagMessage(oldFlag, newFlag string) {
-	logger.Warningf("flag --%s has been deprecated, please use --%s instead",
-		oldFlag, newFlag)
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	EtcdInitialClusterToken      string
 	EtcdInitialClusterState      string
 	EtcdInitialCluster           string
+	EtcdClientURLs               []string
 	EtcdListenClientURLs         []string
 	EtcdListenPeerURLs           []string
 	EtcdName                     string

--- a/backend/pipeline/filter.go
+++ b/backend/pipeline/filter.go
@@ -1,29 +1,18 @@
-// Package pipelined provides the traditional Sensu event pipeline.
-package pipelined
+package pipeline
 
 import (
 	"context"
 	"time"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/js"
-	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"
 	utillogging "github.com/sensu/sensu-go/util/logging"
 )
 
-func evaluateJSFilter(event interface{}, expr string, assets asset.RuntimeAssetSet) bool {
-	parameters := map[string]interface{}{"event": event}
-	result, err := js.Evaluate(expr, parameters, assets)
-	if err != nil {
-		logger.WithError(err).Error("error executing JS")
-	}
-	return result
-}
-
 // Returns true if the event should be filtered/denied.
-func evaluateEventFilter(event *types.Event, filter *types.EventFilter, assets asset.RuntimeAssetSet) bool {
+func evaluateEventFilter(event *corev2.Event, filter *corev2.EventFilter, assets asset.RuntimeAssetSet) bool {
 	// Redact the entity to avoid leaking sensitive information
 	event.Entity = event.Entity.GetRedactedEntity()
 
@@ -39,12 +28,12 @@ func evaluateEventFilter(event *types.Event, filter *types.EventFilter, assets a
 			return false
 		}
 
-		if filter.Action == types.EventFilterActionAllow && !inWindows {
+		if filter.Action == corev2.EventFilterActionAllow && !inWindows {
 			logger.WithFields(fields).Debug("denying event outside of filtering window")
 			return true
 		}
 
-		if filter.Action == types.EventFilterActionDeny && !inWindows {
+		if filter.Action == corev2.EventFilterActionDeny && !inWindows {
 			logger.WithFields(fields).Debug("allowing event outside of filtering window")
 			return false
 		}
@@ -56,26 +45,26 @@ func evaluateEventFilter(event *types.Event, filter *types.EventFilter, assets a
 		match := evaluateJSFilter(synth, expression, assets)
 
 		// Allow - One of the expressions did not match, filter the event
-		if filter.Action == types.EventFilterActionAllow && !match {
+		if filter.Action == corev2.EventFilterActionAllow && !match {
 			logger.WithFields(fields).Debug("denying event that does not match filter")
 			return true
 		}
 
 		// Deny - One of the expressions did not match, do not filter the event
-		if filter.Action == types.EventFilterActionDeny && !match {
+		if filter.Action == corev2.EventFilterActionDeny && !match {
 			logger.WithFields(fields).Debug("allowing event that does not match filter")
 			return false
 		}
 	}
 
 	// Allow - All of the expressions matched, do not filter the event
-	if filter.Action == types.EventFilterActionAllow {
+	if filter.Action == corev2.EventFilterActionAllow {
 		logger.WithFields(fields).Debug("allowing event that matches filter")
 		return false
 	}
 
 	// Deny - All of the expressions matched, filter the event
-	if filter.Action == types.EventFilterActionDeny {
+	if filter.Action == corev2.EventFilterActionDeny {
 		logger.WithFields(fields).Debug("denying event that matches filter")
 		return true
 	}
@@ -89,7 +78,7 @@ func evaluateEventFilter(event *types.Event, filter *types.EventFilter, assets a
 
 // filterEvent filters a Sensu event, determining if it will continue
 // through the Sensu pipeline. Returns true if the event should be filtered/denied.
-func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool {
+func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bool, error) {
 	// Prepare the logging
 	fields := utillogging.EventFields(event, false)
 	fields["handler"] = handler.Name
@@ -104,51 +93,48 @@ func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool
 			// Deny an event if it is neither an incident nor resolution.
 			if !event.IsIncident() && !event.IsResolution() {
 				logger.WithFields(fields).Debug("denying event that is not an incident/resolution")
-				return true
+				return true, nil
 			}
 		case "has_metrics":
 			// Deny an event if it does not have metrics
 			if !event.HasMetrics() {
 				logger.WithFields(fields).Debug("denying event without metrics")
-				return true
+				return true, nil
 			}
 		case "not_silenced":
 			// Deny event that is silenced.
 			if event.IsSilenced() {
 				logger.WithFields(fields).Debug("denying event that is silenced")
-				return true
+				return true, nil
 			}
 		default:
 			// Retrieve the filter from the store with its name
-			ctx := types.SetContextFromResource(context.Background(), event.Entity)
+			ctx := corev2.SetContextFromResource(context.Background(), event.Entity)
 			filter, err := p.store.GetEventFilterByName(ctx, filterName)
 			if err != nil {
 				logger.WithFields(fields).WithError(err).
 					Warning("could not retrieve filter")
-				if _, ok := err.(*store.ErrInternal); ok {
-					// Fatal error
-					select {
-					case p.errChan <- err:
-					case <-p.stopping:
-					}
-				}
-				return false
+				return false, err
 			}
 
 			if filter != nil {
 				// Execute the filter, evaluating each of its
 				// expressions against the event. The event is rejected
 				// if the product of all expressions is true.
-				ctx := types.SetContextFromResource(context.Background(), filter)
+				ctx := corev2.SetContextFromResource(context.Background(), filter)
 				matchedAssets := asset.GetAssets(ctx, p.store, filter.RuntimeAssets)
 				assets, err := asset.GetAll(context.TODO(), p.assetGetter, matchedAssets)
 				if err != nil {
 					logger.WithFields(fields).WithError(err).Error("failed to retrieve assets for filter")
+					if _, ok := err.(*store.ErrInternal); ok {
+						// Fatal error
+						return false, err
+					}
 				}
 				filtered := evaluateEventFilter(event, filter, assets)
 				if filtered {
 					logger.WithFields(fields).Debug("denying event with custom filter")
-					return true
+					return true, nil
 				}
 				continue
 			}
@@ -160,11 +146,7 @@ func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool
 					Warning("could not retrieve filter")
 				if _, ok := err.(*store.ErrInternal); ok {
 					// Fatal error
-					select {
-					case p.errChan <- err:
-					case <-p.stopping:
-					}
-					return false
+					return false, err
 				}
 				continue
 			}
@@ -188,11 +170,11 @@ func (p *Pipelined) filterEvent(handler *types.Handler, event *types.Event) bool
 			}
 			if filtered {
 				logger.WithFields(fields).Debug("denying event with custom filter extension")
-				return true
+				return true, nil
 			}
 		}
 	}
 
 	logger.WithFields(fields).Debug("allowing event")
-	return false
+	return false, nil
 }

--- a/backend/pipeline/filter_test.go
+++ b/backend/pipeline/filter_test.go
@@ -1,5 +1,4 @@
-// Package pipelined provides the traditional Sensu event pipeline.
-package pipelined
+package pipeline
 
 import (
 	"testing"
@@ -12,8 +11,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestPipelinedFilter(t *testing.T) {
-	p := &Pipelined{}
+func TestPipelineFilter(t *testing.T) {
+	p := &Pipeline{}
 	store := &mockstore.MockStore{}
 	p.store = store
 
@@ -210,14 +209,14 @@ func TestPipelinedFilter(t *testing.T) {
 				Metrics: tc.metrics,
 			}
 
-			filtered := p.filterEvent(handler, event)
+			filtered, _ := p.filterEvent(handler, event)
 			assert.Equal(t, tc.expected, filtered)
 		})
 	}
 }
 
-func TestPipelinedWhenFilter(t *testing.T) {
-	p := &Pipelined{}
+func TestPipelineWhenFilter(t *testing.T) {
+	p := &Pipeline{}
 	store := &mockstore.MockStore{}
 	p.store = store
 
@@ -304,7 +303,7 @@ func TestPipelinedWhenFilter(t *testing.T) {
 				Filters: []string{tc.filterName},
 			}
 
-			filtered := p.filterEvent(handler, event)
+			filtered, _ := p.filterEvent(handler, event)
 			assert.Equal(t, tc.expected, filtered)
 		})
 	}

--- a/backend/pipeline/handle_test.go
+++ b/backend/pipeline/handle_test.go
@@ -1,5 +1,4 @@
-// Package pipelined provides the traditional Sensu event pipeline.
-package pipelined
+package pipeline
 
 import (
 	"context"
@@ -62,9 +61,9 @@ func TestHelperHandlerProcess(t *testing.T) {
 	os.Exit(0)
 }
 
-func TestPipelinedHandleEvent(t *testing.T) {
+func TestPipelineHandleEvent(t *testing.T) {
 	t.SkipNow()
-	p := &Pipelined{}
+	p := &Pipeline{}
 
 	store := &mockstore.MockStore{}
 	p.store = store
@@ -88,7 +87,7 @@ func TestPipelinedHandleEvent(t *testing.T) {
 	// Currently fire and forget. You may choose to return a map
 	// of handler execution information in the future, don't know
 	// how useful this would be.
-	assert.NoError(t, p.handleEvent(event))
+	assert.NoError(t, p.HandleEvent(event))
 
 	event.Check.Handlers = []string{"handler1", "handler2"}
 
@@ -104,11 +103,11 @@ func TestPipelinedHandleEvent(t *testing.T) {
 		return m, nil
 	}
 
-	assert.NoError(t, p.handleEvent(event))
+	assert.NoError(t, p.HandleEvent(event))
 	m.AssertCalled(t, "HandleEvent", event, mock.Anything)
 }
 
-func TestPipelinedExpandHandlers(t *testing.T) {
+func TestPipelineExpandHandlers(t *testing.T) {
 	type storeFunc func(*mockstore.MockStore)
 
 	var nilHandler *corev2.Handler
@@ -193,17 +192,17 @@ func TestPipelinedExpandHandlers(t *testing.T) {
 				tt.storeFunc(store)
 			}
 
-			p := &Pipelined{store: store}
+			p := &Pipeline{store: store}
 			got, _ := p.expandHandlers(context.Background(), tt.handlers, 1)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Pipelined.expandHandlers() = %#v, want %#v", got, tt.want)
+				t.Errorf("Pipeline.expandHandlers() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestPipelinedPipeHandler(t *testing.T) {
-	p := &Pipelined{}
+func TestPipelinePipeHandler(t *testing.T) {
+	p := &Pipeline{}
 	p.executor = &command.ExecutionRequest{}
 
 	handler := types.FakeHandlerCommand("cat")
@@ -219,11 +218,11 @@ func TestPipelinedPipeHandler(t *testing.T) {
 	assert.Equal(t, 0, handlerExec.Status)
 }
 
-func TestPipelinedTcpHandler(t *testing.T) {
+func TestPipelineTcpHandler(t *testing.T) {
 	ready := make(chan struct{})
 	done := make(chan struct{})
 
-	p := &Pipelined{}
+	p := &Pipeline{}
 
 	handlerSocket := &types.HandlerSocket{
 		Host: "127.0.0.1",
@@ -275,11 +274,11 @@ func TestPipelinedTcpHandler(t *testing.T) {
 	<-done
 }
 
-func TestPipelinedUdpHandler(t *testing.T) {
+func TestPipelineUdpHandler(t *testing.T) {
 	ready := make(chan struct{})
 	done := make(chan struct{})
 
-	p := &Pipelined{}
+	p := &Pipeline{}
 
 	handlerSocket := &types.HandlerSocket{
 		Host: "127.0.0.1",
@@ -323,7 +322,7 @@ func TestPipelinedUdpHandler(t *testing.T) {
 	<-done
 }
 
-func TestPipelinedGRPCHandler(t *testing.T) {
+func TestPipelineGRPCHandler(t *testing.T) {
 	extension := &types.Extension{}
 	event := types.FixtureEvent("foo", "bar")
 	execFn := func(ext *types.Extension) (rpc.ExtensionExecutor, error) {
@@ -334,7 +333,7 @@ func TestPipelinedGRPCHandler(t *testing.T) {
 		}, nil)
 		return mock, nil
 	}
-	p := &Pipelined{
+	p := &Pipeline{
 		extensionExecutor: execFn,
 	}
 	result, err := p.grpcHandler(extension, event, nil)

--- a/backend/pipeline/logger.go
+++ b/backend/pipeline/logger.go
@@ -1,0 +1,7 @@
+package pipeline
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "pipelined",
+})

--- a/backend/pipeline/mutate_test.go
+++ b/backend/pipeline/mutate_test.go
@@ -1,5 +1,4 @@
-// Package pipelined provides the traditional Sensu event pipeline.
-package pipelined
+package pipeline
 
 import (
 	"encoding/json"
@@ -32,9 +31,8 @@ func TestHelperMutatorProcess(t *testing.T) {
 	os.Exit(0)
 }
 
-func TestPipelinedMutate(t *testing.T) {
-	p, err := New(Config{Store: nil, Bus: nil})
-	require.NoError(t, err)
+func TestPipelineMutate(t *testing.T) {
+	p := New(Config{})
 
 	handler := types.FakeHandlerCommand("cat")
 	handler.Type = "pipe"
@@ -49,9 +47,8 @@ func TestPipelinedMutate(t *testing.T) {
 	assert.Equal(t, expected, eventData)
 }
 
-func TestPipelinedJsonMutator(t *testing.T) {
-	p, err := New(Config{Store: nil, Bus: nil})
-	require.NoError(t, err)
+func TestPipelineJsonMutator(t *testing.T) {
+	p := New(Config{})
 
 	event := &types.Event{}
 
@@ -63,9 +60,8 @@ func TestPipelinedJsonMutator(t *testing.T) {
 	assert.Equal(t, expected, output)
 }
 
-func TestPipelinedOnlyCheckOutputMutator(t *testing.T) {
-	p, err := New(Config{Store: nil, Bus: nil})
-	require.NoError(t, err)
+func TestPipelineOnlyCheckOutputMutator(t *testing.T) {
+	p := New(Config{})
 
 	event := &types.Event{}
 	event.Check = &types.Check{}
@@ -77,9 +73,8 @@ func TestPipelinedOnlyCheckOutputMutator(t *testing.T) {
 	assert.Equal(t, expected, output)
 }
 
-func TestPipelinedOnlyCheckOutputMutate(t *testing.T) {
-	p, err := New(Config{Store: nil, Bus: nil})
-	require.NoError(t, err)
+func TestPipelineOnlyCheckOutputMutate(t *testing.T) {
+	p := New(Config{})
 
 	handler := types.FakeHandlerCommand("cat")
 	handler.Type = "pipe"
@@ -97,7 +92,7 @@ func TestPipelinedOnlyCheckOutputMutate(t *testing.T) {
 	assert.Equal(t, expected, eventData)
 }
 
-func TestPipelinedExtensionMutator(t *testing.T) {
+func TestPipelineExtensionMutator(t *testing.T) {
 	m := &mockExec{}
 	ext := &types.Extension{URL: "http://127.0.0.1"}
 	store := &mockstore.MockStore{}
@@ -111,8 +106,7 @@ func TestPipelinedExtensionMutator(t *testing.T) {
 		return m, nil
 	}
 
-	p, err := New(Config{ExtensionExecutorGetter: getter, Store: store})
-	require.NoError(t, err)
+	p := New(Config{ExtensionExecutorGetter: getter, Store: store})
 
 	handler := &types.Handler{}
 	handler.Mutator = "extension"
@@ -122,9 +116,8 @@ func TestPipelinedExtensionMutator(t *testing.T) {
 	require.Equal(t, []byte("remote"), eventData)
 }
 
-func TestPipelinedPipeMutator(t *testing.T) {
-	p, err := New(Config{Store: nil, Bus: nil})
-	require.NoError(t, err)
+func TestPipelinePipeMutator(t *testing.T) {
+	p := New(Config{})
 
 	mutator := types.FakeMutatorCommand("cat")
 

--- a/backend/pipeline/mutator.go
+++ b/backend/pipeline/mutator.go
@@ -1,5 +1,4 @@
-// Package pipelined provides the traditional Sensu event pipeline.
-package pipelined
+package pipeline
 
 import (
 	"context"
@@ -18,7 +17,7 @@ import (
 
 // mutateEvent mutates (transforms) a Sensu event into a serialized
 // format (byte slice) to be provided to a Sensu event handler.
-func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]byte, error) {
+func (p *Pipeline) mutateEvent(handler *types.Handler, event *types.Event) ([]byte, error) {
 	// Prepare log entry
 	fields := utillogging.EventFields(event, false)
 	fields["handler"] = handler.Name
@@ -89,7 +88,7 @@ func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]b
 
 // jsonMutator produces the JSON encoding of the Sensu event. This
 // mutator is used when a Sensu handler does not specify one.
-func (p *Pipelined) jsonMutator(event *types.Event) ([]byte, error) {
+func (p *Pipeline) jsonMutator(event *types.Event) ([]byte, error) {
 	eventData, err := json.Marshal(event)
 
 	if err != nil {
@@ -104,7 +103,7 @@ func (p *Pipelined) jsonMutator(event *types.Event) ([]byte, error) {
 // is most commonly used by tcp/udp handlers (e.g. influxdb). This
 // mutator can probably be removed/replaced when 2.0 has extension
 // support.
-func (p *Pipelined) onlyCheckOutputMutator(event *types.Event) []byte {
+func (p *Pipeline) onlyCheckOutputMutator(event *types.Event) []byte {
 	if event.HasCheck() {
 		return []byte(event.Check.Output)
 	}
@@ -115,7 +114,7 @@ func (p *Pipelined) onlyCheckOutputMutator(event *types.Event) []byte {
 // command, writes the JSON encoding of the Sensu event to it via
 // STDIN, and captures the command output (STDOUT/ERR) to be used as
 // the mutated event data for a Sensu event handler.
-func (p *Pipelined) pipeMutator(mutator *types.Mutator, event *types.Event) ([]byte, error) {
+func (p *Pipeline) pipeMutator(mutator *types.Mutator, event *types.Event) ([]byte, error) {
 	// Prepare environment variables
 	env := environment.MergeEnvironments(os.Environ(), mutator.EnvVars)
 

--- a/backend/pipeline/pipeline.go
+++ b/backend/pipeline/pipeline.go
@@ -1,0 +1,62 @@
+package pipeline
+
+import (
+	"github.com/sensu/sensu-go/asset"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/command"
+	"github.com/sensu/sensu-go/js"
+	"github.com/sensu/sensu-go/rpc"
+	"github.com/sensu/sensu-go/types"
+)
+
+// Pipeline takes events as inputs, and treats them in various ways according
+// to the event's check configuration.
+type Pipeline struct {
+	store             store.Store
+	assetGetter       asset.Getter
+	extensionExecutor ExtensionExecutorGetterFunc
+	executor          command.Executor
+}
+
+// Config holds the configuration for a Pipeline.
+type Config struct {
+	Store                   store.Store
+	ExtensionExecutorGetter ExtensionExecutorGetterFunc
+	AssetGetter             asset.Getter
+}
+
+// Option is a functional option used to configure Pipelines.
+type Option func(*Pipeline)
+
+// New creates a new Pipeline from the provided configuration.
+func New(c Config, options ...Option) *Pipeline {
+	pipeline := &Pipeline{
+		store:             c.Store,
+		assetGetter:       c.AssetGetter,
+		extensionExecutor: c.ExtensionExecutorGetter,
+		executor:          command.NewExecutor(),
+	}
+	for _, o := range options {
+		o(pipeline)
+	}
+	return pipeline
+}
+
+const (
+	// DefaultSocketTimeout specifies the default socket dial
+	// timeout in seconds for TCP and UDP handlers.
+	DefaultSocketTimeout uint32 = 60
+)
+
+// ExtensionExecutorGetterFunc gets an ExtensionExecutor. Used to decouple
+// pipelines from gRPC.
+type ExtensionExecutorGetterFunc func(*types.Extension) (rpc.ExtensionExecutor, error)
+
+func evaluateJSFilter(event interface{}, expr string, assets asset.RuntimeAssetSet) bool {
+	parameters := map[string]interface{}{"event": event}
+	result, err := js.Evaluate(expr, parameters, assets)
+	if err != nil {
+		logger.WithError(err).Error("error executing JS")
+	}
+	return result
+}

--- a/backend/pipelined/mutate.go
+++ b/backend/pipelined/mutate.go
@@ -46,6 +46,7 @@ func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]b
 
 	mutator, err := p.store.GetMutatorByName(ctx, handler.Mutator)
 	if err != nil {
+		// Warning: do not wrap this error
 		logger.WithFields(fields).WithError(err).Error("failed to retrieve mutator")
 		return nil, err
 	}
@@ -57,6 +58,7 @@ func (p *Pipelined) mutateEvent(handler *types.Handler, event *types.Event) ([]b
 			if err == store.ErrNoExtension {
 				return nil, nil
 			}
+			// Warning: do not wrap this error
 			return nil, err
 		}
 		executor, err := p.extensionExecutor(extension)

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -139,6 +139,13 @@ func (p *Pipelined) createPipelines(count int, channel chan interface{}) {
 					}
 
 					if err := p.handleEvent(event); err != nil {
+						if _, ok := err.(*store.ErrInternal); ok {
+							select {
+							case p.errChan <- err:
+							case <-p.stopping:
+							}
+							return
+						}
 						logger.Error(err)
 					}
 				}

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
@@ -31,29 +30,23 @@ func GetEntitiesPath(ctx context.Context, name string) string {
 // DeleteEntity deletes an Entity.
 func (s *Store) DeleteEntity(ctx context.Context, e *corev2.Entity) error {
 	if err := e.Validate(); err != nil {
-		return err
+		return &store.ErrNotValid{Err: err}
 	}
-	_, err := s.client.Delete(ctx, getEntityPath(e))
-	return err
+	if _, err := s.client.Delete(ctx, getEntityPath(e)); err != nil {
+		return &store.ErrInternal{Message: err.Error()}
+	}
+	return nil
 }
 
 // DeleteEntityByName deletes an Entity by its name.
 func (s *Store) DeleteEntityByName(ctx context.Context, name string) error {
 	if name == "" {
-		return errors.New("must specify name")
+		return &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
 
 	key := GetEntitiesPath(ctx, name)
-	resp, err := s.client.Delete(ctx, key)
-	if err != nil {
-		return err
-	}
-	if resp.Deleted == 0 {
-		return &store.ErrNotFound{Key: key}
-	} else if resp.Deleted > 1 {
-		return &store.ErrInternal{
-			Message: fmt.Sprintf("expected to delete exactly 1 key, deleted %d", resp.Deleted),
-		}
+	if _, err := s.client.Delete(ctx, key); err != nil {
+		return &store.ErrInternal{Message: err.Error()}
 	}
 
 	return nil
@@ -62,19 +55,19 @@ func (s *Store) DeleteEntityByName(ctx context.Context, name string) error {
 // GetEntityByName gets an Entity by its name.
 func (s *Store) GetEntityByName(ctx context.Context, name string) (*corev2.Entity, error) {
 	if name == "" {
-		return nil, errors.New("must specify name")
+		return nil, &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
 
 	resp, err := s.client.Get(ctx, GetEntitiesPath(ctx, name), clientv3.WithLimit(1))
 	if err != nil {
-		return nil, err
+		return nil, &store.ErrInternal{Message: err.Error()}
 	}
 	if len(resp.Kvs) != 1 {
 		return nil, nil
 	}
 	entity := &corev2.Entity{}
 	if err := unmarshal(resp.Kvs[0].Value, entity); err != nil {
-		return nil, err
+		return nil, &store.ErrDecode{Err: err}
 	}
 
 	if entity.Labels == nil {
@@ -96,26 +89,22 @@ func (s *Store) GetEntities(ctx context.Context, pred *store.SelectionPredicate)
 // UpdateEntity updates an Entity.
 func (s *Store) UpdateEntity(ctx context.Context, e *corev2.Entity) error {
 	if err := e.Validate(); err != nil {
-		return err
+		return &store.ErrNotValid{Err: err}
 	}
 
 	eStr, err := proto.Marshal(e)
 	if err != nil {
-		return err
+		return &store.ErrEncode{Err: err}
 	}
 
 	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(e.Namespace)), ">", 0)
 	req := clientv3.OpPut(getEntityPath(e), string(eStr))
 	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
 	if err != nil {
-		return err
+		return &store.ErrInternal{Message: err.Error()}
 	}
 	if !res.Succeeded {
-		return fmt.Errorf(
-			"could not create the entity %s in namespace %s",
-			e.Name,
-			e.Namespace,
-		)
+		return &store.ErrNamespaceMissing{Namespace: e.Namespace}
 	}
 
 	return nil

--- a/backend/store/etcd/extension_registry.go
+++ b/backend/store/etcd/extension_registry.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
@@ -28,25 +27,22 @@ func getExtensionPath(ctx context.Context, name string) string {
 // RegisterExtension registers an extension.
 func (s *Store) RegisterExtension(ctx context.Context, ext *types.Extension) error {
 	if err := ext.Validate(); err != nil {
-		return err
+		return &store.ErrNotValid{Err: err}
 	}
 
 	b, err := proto.Marshal(ext)
 	if err != nil {
-		return err
+		return &store.ErrEncode{Err: err}
 	}
 
 	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(ext.Namespace)), ">", 0)
 	req := clientv3.OpPut(getExtensionPath(ctx, ext.Name), string(b))
 	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
 	if err != nil {
-		return err
+		return &store.ErrInternal{Message: err.Error()}
 	}
 	if !res.Succeeded {
-		return fmt.Errorf(
-			"could not create the extension %q in namespace %q",
-			ext.Name, ext.Namespace,
-		)
+		return &store.ErrNamespaceMissing{Namespace: ext.Namespace}
 	}
 
 	return nil
@@ -55,29 +51,34 @@ func (s *Store) RegisterExtension(ctx context.Context, ext *types.Extension) err
 // DeregisterExtension deregisters an extension
 func (s *Store) DeregisterExtension(ctx context.Context, name string) error {
 	if name == "" {
-		return errors.New("no extension name specified")
+		return &store.ErrNotValid{errors.New("no extension name specified")}
 	}
 
-	_, err := s.client.Delete(ctx, getExtensionPath(ctx, name))
-	return err
+	if _, err := s.client.Delete(ctx, getExtensionPath(ctx, name)); err != nil {
+		return &store.ErrInternal{Message: err.Error()}
+	}
+	return nil
 }
 
 // GetExtension gets an extension
 func (s *Store) GetExtension(ctx context.Context, name string) (*types.Extension, error) {
 	if name == "" {
-		return nil, errors.New("no extension name specified")
+		return nil, &store.ErrNotValid{Err: errors.New("no extension name specified")}
 	}
 
 	resp, err := s.client.Get(ctx, getExtensionPath(ctx, name))
 	if err != nil {
-		return nil, err
+		return nil, &store.ErrInternal{Message: err.Error()}
 	}
 	if len(resp.Kvs) == 0 {
 		return nil, store.ErrNoExtension
 	}
 
 	var ext types.Extension
-	return &ext, unmarshal(resp.Kvs[0].Value, &ext)
+	if err := unmarshal(resp.Kvs[0].Value, &ext); err != nil {
+		return nil, &store.ErrDecode{Err: err}
+	}
+	return &ext, nil
 }
 
 // GetExtensions gets an extension

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -66,7 +66,10 @@ func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, 
 			_ = cli.Close()
 		}()
 
-		_, getErr := cli.Get(context.Background(), "health")
+		// Specify the client request timeout to get the health
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, getErr := cli.Get(ctx, "health")
+		cancel()
 
 		if getErr == nil || getErr == rpctypes.ErrPermissionDenied {
 			health.Err = ""

--- a/backend/store/etcd/mutator_store.go
+++ b/backend/store/etcd/mutator_store.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
@@ -28,11 +27,13 @@ func GetMutatorsPath(ctx context.Context, name string) string {
 // DeleteMutatorByName deletes a Mutator by name.
 func (s *Store) DeleteMutatorByName(ctx context.Context, name string) error {
 	if name == "" {
-		return errors.New("must specify name of mutator")
+		return &store.ErrNotValid{Err: errors.New("must specify name of mutator")}
 	}
 
-	_, err := s.client.Delete(ctx, GetMutatorsPath(ctx, name))
-	return err
+	if _, err := s.client.Delete(ctx, GetMutatorsPath(ctx, name)); err != nil {
+		return &store.ErrInternal{Message: err.Error()}
+	}
+	return nil
 }
 
 // GetMutators gets the list of mutators for a namespace.
@@ -45,12 +46,12 @@ func (s *Store) GetMutators(ctx context.Context, pred *store.SelectionPredicate)
 // GetMutatorByName gets a Mutator by name.
 func (s *Store) GetMutatorByName(ctx context.Context, name string) (*types.Mutator, error) {
 	if name == "" {
-		return nil, errors.New("must specify name of mutator")
+		return nil, &store.ErrNotValid{Err: errors.New("must specify name of mutator")}
 	}
 
 	resp, err := s.client.Get(ctx, GetMutatorsPath(ctx, name))
 	if err != nil {
-		return nil, err
+		return nil, &store.ErrInternal{Message: err.Error()}
 	}
 	if len(resp.Kvs) == 0 {
 		return nil, nil
@@ -59,7 +60,7 @@ func (s *Store) GetMutatorByName(ctx context.Context, name string) (*types.Mutat
 	mutatorBytes := resp.Kvs[0].Value
 	mutator := &types.Mutator{}
 	if err := unmarshal(mutatorBytes, mutator); err != nil {
-		return nil, err
+		return nil, &store.ErrDecode{Err: err}
 	}
 
 	return mutator, nil
@@ -68,26 +69,22 @@ func (s *Store) GetMutatorByName(ctx context.Context, name string) (*types.Mutat
 // UpdateMutator updates a Mutator.
 func (s *Store) UpdateMutator(ctx context.Context, mutator *types.Mutator) error {
 	if err := mutator.Validate(); err != nil {
-		return err
+		return &store.ErrNotValid{Err: err}
 	}
 
 	mutatorBytes, err := proto.Marshal(mutator)
 	if err != nil {
-		return err
+		return &store.ErrEncode{Err: err}
 	}
 
 	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(mutator.Namespace)), ">", 0)
 	req := clientv3.OpPut(getMutatorPath(mutator), string(mutatorBytes))
 	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
 	if err != nil {
-		return err
+		return &store.ErrInternal{Message: err.Error()}
 	}
 	if !res.Succeeded {
-		return fmt.Errorf(
-			"could not create the mutator %s in namespace %s",
-			mutator.Name,
-			mutator.Namespace,
-		)
+		return &store.ErrNamespaceMissing{Namespace: mutator.Namespace}
 	}
 
 	return nil

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -69,8 +69,12 @@ func (e *ErrNotValid) Error() string {
 }
 
 // ErrInternal is returned when something generally bad happened while
-// interacting with the store. Other, more specific errors should preferably be
+// interacting with the store. Other, more specific errors should be
 // returned when appropriate.
+//
+// The backend will use ErrInternal to detect if an error is unrecoverable.
+// It should only be used to signal that the underlying database is not
+// functional
 type ErrInternal struct {
 	Message string
 }

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
@@ -24,10 +25,11 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 				return errors.New("no active configuration found")
 			}
 			activeConfig := map[string]string{
-				"api-url":   cli.Config.APIUrl(),
-				"namespace": cli.Config.Namespace(),
-				"format":    cli.Config.Format(),
-				"username":  helpers.GetCurrentUsername(cli.Config),
+				"api-url":        cli.Config.APIUrl(),
+				"namespace":      cli.Config.Namespace(),
+				"format":         cli.Config.Format(),
+				"username":       helpers.GetCurrentUsername(cli.Config),
+				"jwt_expires_at": strconv.Itoa(int(cli.Config.Tokens().GetExpiresAt())),
 			}
 
 			// Determine the format to use to output the data
@@ -71,6 +73,10 @@ func printToList(v interface{}, writer io.Writer) error {
 			{
 				Label: "Username",
 				Value: r["username"],
+			},
+			{
+				Label: "JWT Expiration Timestamp",
+				Value: r["jwt_expires_at"],
 			},
 		},
 	}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -99,7 +99,11 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	helpers.AddAllNamespace(cmd.Flags())
-	_ = cmd.Flags().StringP("format", "", cli.Config.Format(), fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
+	format := cli.Config.Format()
+	if format != config.FormatWrappedJSON && format != config.FormatYAML {
+		format = config.FormatYAML
+	}
+	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
 	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
 	_ = cmd.Flags().BoolP("types", "t", false, "list supported resource types")
 

--- a/cmd/sensu-backend/main.go
+++ b/cmd/sensu-backend/main.go
@@ -21,6 +21,7 @@ func main() {
 	}
 	rootCmd.AddCommand(cmd.StartCommand(backend.Initialize))
 	rootCmd.AddCommand(cmd.VersionCommand())
+	rootCmd.AddCommand(cmd.InitCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.WithError(err).Fatal("error executing sensu-backend")


### PR DESCRIPTION
## What is this change?

This change causes Sensu to shut down all of its internal backend daemons, and restart them, when an error from the store is marked as `ErrInternal`. These errors generally indicate that service has been lost, so Sensu should not keep trying to serve any requests. This will allow clients to select a different backend that may be working properly.

## Why is this change necessary?

It was discovered under load testing that clients would sometimes remain "stuck" on a server that had failed. In some cases the server never re-established itself as a member of the etcd cluster, leading to clients being connected but never working again, until the connection was severed and the client connected to a different backend.

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This is a bugfix, no documentation changes are required.

## How did you verify this change?

I've smoke tested it on my laptop by starting up the system and executing checks, but I will need to test this on the performance cluster to verify that the failure mode works as we desire.

## Is this change a patch?

Yes