### PR TITLE
Set the outer ObjectMeta when decoding a wrapper struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 when it is not operating as an etcd member. The flag is also used by the new
 sensu-backend init tool.
 - Added the cluster's distribution to Tessen data.
+- Added the `--etcd-discovery` and `--etcd-discovery-srv` flags to
+`sensu-backend`. These are used to take advantage of the embedded etcd's
+auto-discovery features.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.
 - Show the correct default value for the format flag in `sensuctl dump` help
 usage.
-- Added the `--etcd-discovery` and `--etcd-discovery-srv` flags to
-`sensu-backend`. These are used to take advantage of the embedded etcd's
-auto-discovery features.
 - Installing sensuctl commands via Bonsai will now check for correct labels
 before checking if the asset has 1 or more builds.
 - Listing assets with no results returns an empty array.
@@ -29,6 +29,9 @@ before checking if the asset has 1 or more builds.
 does not exist.
 - Fixed issue where keepalive events and events created through the agent's
 socket interface could be missing a namespace.
+- Fixed several issues around the metadata of resources encoded using the
+wrapped-json format, where the metadata would go missing when listing
+resources or prevent resources from being created.
 
 ### Changed
 - The backend will no longer automatically be seeded with a default admin

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -35,14 +35,14 @@ func PrintJSON(r interface{}, io io.Writer) error {
 // then prints the result to the given writer. Unescapes any &, <, or >
 // characters it finds.
 func PrintWrappedJSON(r types.Resource, wr io.Writer) error {
-	w := wrapResource(r)
+	w := types.WrapResource(r)
 
 	buf := new(bytes.Buffer)
 	encoder := json.NewEncoder(buf)
 	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(false)
 
-	if err := encoder.Encode(w); err != nil {
+	if err := encoder.Encode(&w); err != nil {
 		return err
 	}
 

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -42,7 +42,7 @@ func PrintWrappedJSON(r types.Resource, wr io.Writer) error {
 	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(false)
 
-	if err := encoder.Encode(&w); err != nil {
+	if err := encoder.Encode(w); err != nil {
 		return err
 	}
 

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -33,8 +33,8 @@ func TestPrintWrappedJSON(t *testing.T) {
 	check := types.FixtureCheckConfig("check")
 	check.Command = "echo foo >> output.txt"
 
-	w := wrapResource(check)
-	output, err := json.Marshal(w)
+	w := types.WrapResource(check)
+	output, err := json.Marshal(&w)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
@@ -48,12 +48,12 @@ func TestPrintWrappedJSONList(t *testing.T) {
 	check1 := types.FixtureCheckConfig("check1")
 	check2 := types.FixtureCheckConfig("check2")
 
-	w1 := wrapResource(check1)
-	w2 := wrapResource(check2)
+	w1 := types.WrapResource(check1)
+	w2 := types.WrapResource(check2)
 
-	output1, err := json.Marshal(w1)
+	output1, err := json.Marshal(&w1)
 	assert.NoError(err)
-	output2, err := json.Marshal(w2)
+	output2, err := json.Marshal(&w2)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
@@ -70,10 +70,10 @@ func TestPrintFormatted(t *testing.T) {
 
 	check := types.FixtureCheckConfig("check")
 
-	w := wrapResource(check)
+	w := types.WrapResource(check)
 
 	// test wrapped-json format
-	output, err := json.Marshal(w)
+	output, err := json.Marshal(&w)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -34,7 +34,7 @@ func TestPrintWrappedJSON(t *testing.T) {
 	check.Command = "echo foo >> output.txt"
 
 	w := types.WrapResource(check)
-	output, err := json.Marshal(&w)
+	output, err := json.Marshal(w)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
@@ -51,9 +51,9 @@ func TestPrintWrappedJSONList(t *testing.T) {
 	w1 := types.WrapResource(check1)
 	w2 := types.WrapResource(check2)
 
-	output1, err := json.Marshal(&w1)
+	output1, err := json.Marshal(w1)
 	assert.NoError(err)
-	output2, err := json.Marshal(&w2)
+	output2, err := json.Marshal(w2)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
@@ -73,7 +73,7 @@ func TestPrintFormatted(t *testing.T) {
 	w := types.WrapResource(check)
 
 	// test wrapped-json format
-	output, err := json.Marshal(&w)
+	output, err := json.Marshal(w)
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)

--- a/cli/commands/helpers/yaml.go
+++ b/cli/commands/helpers/yaml.go
@@ -23,7 +23,7 @@ func PrintYAML(v interface{}, w io.Writer) (err error) {
 		}
 		for _, r := range resources {
 			i := types.WrapResource(r)
-			if err := enc.Encode(&i); err != nil {
+			if err := enc.Encode(i); err != nil {
 				return err
 			}
 		}
@@ -33,5 +33,5 @@ func PrintYAML(v interface{}, w io.Writer) (err error) {
 		v = types.WrapResource(r)
 	}
 
-	return enc.Encode(&v)
+	return enc.Encode(v)
 }

--- a/cli/commands/helpers/yaml.go
+++ b/cli/commands/helpers/yaml.go
@@ -1,46 +1,11 @@
 package helpers
 
 import (
-	"bytes"
-	"encoding/json"
 	"io"
 
 	"github.com/sensu/sensu-go/types"
 	yaml "gopkg.in/yaml.v2"
 )
-
-// wrapper is used to get the precise yaml encoding behaviour we want
-type wrapper struct {
-	Type       string                 `json:"type" yaml:"type"`
-	APIVersion string                 `json:"api_version" yaml:"api_version"`
-	ObjectMeta map[string]interface{} `json:"metadata" yaml:"metadata"`
-	Spec       map[string]interface{} `json:"spec" yaml:"spec"`
-}
-
-func wrapResource(r types.Resource) wrapper {
-	wrapped := types.WrapResource(r)
-	value := toMap(wrapped.Value)
-	delete(value, "metadata")
-	w := wrapper{
-		Type:       wrapped.Type,
-		APIVersion: wrapped.APIVersion,
-		ObjectMeta: toMap(wrapped.ObjectMeta),
-		Spec:       value,
-	}
-	return w
-}
-
-// toMap produces a map from a struct by serializing it to JSON and then
-// deserializing the JSON into a map. This is done to preserve business logic
-// expressed in customer marshalers, and JSON struct tag semantics.
-func toMap(v interface{}) map[string]interface{} {
-	b, _ := json.Marshal(v)
-	result := map[string]interface{}{}
-	dec := json.NewDecoder(bytes.NewReader(b))
-	dec.UseNumber()
-	_ = dec.Decode(&result)
-	return result
-}
 
 // PrintYAML serializes the value v to yaml and writes the result to w.
 func PrintYAML(v interface{}, w io.Writer) (err error) {
@@ -57,15 +22,16 @@ func PrintYAML(v interface{}, w io.Writer) (err error) {
 			return nil
 		}
 		for _, r := range resources {
-			if err := enc.Encode(wrapResource(r)); err != nil {
+			i := types.WrapResource(r)
+			if err := enc.Encode(&i); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
 	if r, ok := v.(types.Resource); ok {
-		v = wrapResource(r)
+		v = types.WrapResource(r)
 	}
 
-	return enc.Encode(v)
+	return enc.Encode(&v)
 }

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -57,7 +57,7 @@ func toMap(v interface{}) (map[string]interface{}, error) {
 }
 
 // MarshalJSON implements json.Marshaler
-func (w *Wrapper) MarshalJSON() ([]byte, error) {
+func (w Wrapper) MarshalJSON() ([]byte, error) {
 	wrapper := struct {
 		TypeMeta
 		ObjectMeta ObjectMeta             `json:"metadata"`
@@ -80,7 +80,7 @@ func (w *Wrapper) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML implements yaml.Marshaler
-func (w *Wrapper) MarshalYAML() (interface{}, error) {
+func (w Wrapper) MarshalYAML() (interface{}, error) {
 	wrapper := struct {
 		Type       string                 `yaml:"type"`
 		APIVersion string                 `yaml:"api_version"`


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes a bug in the Wrapper's UnmarshalJSON method, which would cause wrapped resources to not properly display their metadata or prevent them from being created.

It also adds more comments and unit tests to the same UnmarshalJSON method.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-enterprise-go/issues/704
Fixes https://github.com/sensu/sensu-go/issues/3442
Fixes https://github.com/sensu/sensu-go/issues/3444

## Does your change need a Changelog entry?

Added!

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope.

## How did you verify this change?

Manually tested that it fixed the reported bugs and added unit tests to cover these cases.

## Is this change a patch?

Yep, but we are not proceeding with a patch release for 5.15.