### PR TITLE
Add --keepalive-critical-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 when it is not operating as an etcd member. The flag is also used by the new
 sensu-backend init tool.
 - Added the cluster's distribution to Tessen data.
+- Added `--keepalive-critical-timeout` to define the time after which a
+critical keepalive event should be created for an agent.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ sensu-backend init tool.
 - Added the cluster's distribution to Tessen data.
 - Added `--keepalive-critical-timeout` to define the time after which a
 critical keepalive event should be created for an agent.
+- Added `--keepalive-warning-timeout` which is an alias of `--keepalive-timeout`
+for backwards compatibility.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -31,9 +31,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// KeepaliveCriticalTimeoutLabel is the label key used to store the keepalive critical timeout.
-const KeepaliveCriticalTimeoutLabel = "keepalive-critical-timeout"
-
 // GetDefaultAgentName returns the default agent name
 func GetDefaultAgentName() string {
 	defaultAgentName, err := os.Hostname()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -185,7 +185,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	if err := corev2.ValidateName(a.config.AgentName); err != nil {
 		return fmt.Errorf("invalid agent name: %v", err)
 	}
-	if timeout := a.config.KeepaliveTimeout; timeout < 5 {
+	if timeout := a.config.KeepaliveWarningTimeout; timeout < 5 {
 		return fmt.Errorf("bad keepalive timeout: %d (minimum value is 5 seconds)", timeout)
 	}
 	if timeout := a.config.KeepaliveCriticalTimeout; timeout > 0 && timeout < 5 {
@@ -314,7 +314,7 @@ func (a *Agent) newKeepalive() *transport.Message {
 	keepalive.Check = &corev2.Check{
 		ObjectMeta: corev2.NewObjectMeta("keepalive", entity.Namespace),
 		Interval:   a.config.KeepaliveInterval,
-		Timeout:    a.config.KeepaliveTimeout,
+		Timeout:    a.config.KeepaliveWarningTimeout,
 		Ttl:        int64(a.config.KeepaliveCriticalTimeout),
 	}
 	keepalive.Entity = a.getAgentEntity()

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -38,7 +39,7 @@ const (
 	flagEventsRateLimit          = "events-rate-limit"
 	flagEventsBurstLimit         = "events-burst-limit"
 	flagKeepaliveInterval        = "keepalive-interval"
-	flagKeepaliveTimeout         = "keepalive-timeout"
+	flagKeepaliveWarningTimeout  = "keepalive-warning-timeout"
 	flagKeepaliveCriticalTimeout = "keepalive-critical-timeout"
 	flagNamespace                = "namespace"
 	flagPassword                 = "password"
@@ -69,7 +70,8 @@ const (
 	flagCertFile              = "cert-file"
 	flagKeyFile               = "key-file"
 
-	deprecatedFlagAgentID = "id"
+	deprecatedFlagAgentID          = "id"
+	deprecatedFlagKeepaliveTimeout = "keepalive-timeout"
 )
 
 func newVersionCommand() *cobra.Command {
@@ -115,7 +117,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 			cfg.EventsAPIRateLimit = rate.Limit(viper.GetFloat64(flagEventsRateLimit))
 			cfg.EventsAPIBurstLimit = viper.GetInt(flagEventsBurstLimit)
 			cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
-			cfg.KeepaliveTimeout = uint32(viper.GetInt(flagKeepaliveTimeout))
+			cfg.KeepaliveWarningTimeout = uint32(viper.GetInt(flagKeepaliveWarningTimeout))
 			cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
 			cfg.Namespace = viper.GetString(flagNamespace)
 			cfg.Password = viper.GetString(flagPassword)
@@ -140,6 +142,9 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 			cfg.TLS.InsecureSkipVerify = viper.GetBool(flagInsecureSkipTLSVerify)
 			cfg.TLS.CertFile = viper.GetString(flagCertFile)
 			cfg.TLS.KeyFile = viper.GetString(flagKeyFile)
+
+			fmt.Println("warning timeout")
+			fmt.Println(cfg.KeepaliveWarningTimeout)
 
 			agentName := viper.GetString(flagAgentName)
 			if agentName != "" {
@@ -218,7 +223,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	viper.SetDefault(flagEventsRateLimit, agent.DefaultEventsAPIRateLimit)
 	viper.SetDefault(flagEventsBurstLimit, agent.DefaultEventsAPIBurstLimit)
 	viper.SetDefault(flagKeepaliveInterval, agent.DefaultKeepaliveInterval)
-	viper.SetDefault(flagKeepaliveTimeout, corev2.DefaultKeepaliveTimeout)
+	viper.SetDefault(flagKeepaliveWarningTimeout, corev2.DefaultKeepaliveTimeout)
 	viper.SetDefault(flagKeepaliveCriticalTimeout, 0)
 	viper.SetDefault(flagNamespace, agent.DefaultNamespace)
 	viper.SetDefault(flagPassword, agent.DefaultPassword)
@@ -266,7 +271,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	cmd.Flags().StringSlice(flagSubscriptions, viper.GetStringSlice(flagSubscriptions), "comma-delimited list of agent subscriptions")
 	cmd.Flags().String(flagUser, viper.GetString(flagUser), "agent user")
 	cmd.Flags().StringSlice(flagBackendURL, viper.GetStringSlice(flagBackendURL), "ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times)")
-	cmd.Flags().Uint32(flagKeepaliveTimeout, uint32(viper.GetInt(flagKeepaliveTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
+	cmd.Flags().Uint32(flagKeepaliveWarningTimeout, uint32(viper.GetInt(flagKeepaliveWarningTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
 	cmd.Flags().Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
 	cmd.Flags().Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	cmd.Flags().Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
@@ -291,6 +296,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 
 	deprecatedConfigAttributes(logger)
 	viper.RegisterAlias(deprecatedFlagAgentID, flagAgentName)
+	viper.RegisterAlias(deprecatedFlagKeepaliveTimeout, flagKeepaliveWarningTimeout)
 
 	return cmd
 }
@@ -306,6 +312,9 @@ func aliasNormalizeFunc(logger *logrus.Entry) func(*pflag.FlagSet, string) pflag
 		case deprecatedFlagAgentID:
 			deprecatedFlagMessage(name, flagAgentName, logger)
 			name = flagAgentName
+		case deprecatedFlagKeepaliveTimeout:
+			deprecatedFlagMessage(name, flagKeepaliveWarningTimeout, logger)
+			name = flagKeepaliveWarningTimeout
 		}
 		return pflag.NormalizedName(name)
 	}
@@ -315,7 +324,8 @@ func aliasNormalizeFunc(logger *logrus.Entry) func(*pflag.FlagSet, string) pflag
 // message if set
 func deprecatedConfigAttributes(logger *logrus.Entry) {
 	attributes := map[string]string{
-		deprecatedFlagAgentID: flagAgentName,
+		deprecatedFlagAgentID:          flagAgentName,
+		deprecatedFlagKeepaliveTimeout: flagKeepaliveWarningTimeout,
 	}
 
 	for old, new := range attributes {

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -39,6 +39,7 @@ const (
 	flagEventsBurstLimit         = "events-burst-limit"
 	flagKeepaliveInterval        = "keepalive-interval"
 	flagKeepaliveTimeout         = "keepalive-timeout"
+	flagKeepaliveCriticalTimeout = "keepalive-critical-timeout"
 	flagNamespace                = "namespace"
 	flagPassword                 = "password"
 	flagRedact                   = "redact"
@@ -115,6 +116,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 			cfg.EventsAPIBurstLimit = viper.GetInt(flagEventsBurstLimit)
 			cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
 			cfg.KeepaliveTimeout = uint32(viper.GetInt(flagKeepaliveTimeout))
+			cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
 			cfg.Namespace = viper.GetString(flagNamespace)
 			cfg.Password = viper.GetString(flagPassword)
 			cfg.Socket.Host = viper.GetString(flagSocketHost)
@@ -217,6 +219,7 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	viper.SetDefault(flagEventsBurstLimit, agent.DefaultEventsAPIBurstLimit)
 	viper.SetDefault(flagKeepaliveInterval, agent.DefaultKeepaliveInterval)
 	viper.SetDefault(flagKeepaliveTimeout, corev2.DefaultKeepaliveTimeout)
+	viper.SetDefault(flagKeepaliveCriticalTimeout, 0)
 	viper.SetDefault(flagNamespace, agent.DefaultNamespace)
 	viper.SetDefault(flagPassword, agent.DefaultPassword)
 	viper.SetDefault(flagRedact, corev2.DefaultRedactFields)
@@ -263,7 +266,8 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 	cmd.Flags().StringSlice(flagSubscriptions, viper.GetStringSlice(flagSubscriptions), "comma-delimited list of agent subscriptions")
 	cmd.Flags().String(flagUser, viper.GetString(flagUser), "agent user")
 	cmd.Flags().StringSlice(flagBackendURL, viper.GetStringSlice(flagBackendURL), "ws/wss URL of Sensu backend server (to specify multiple backends use this flag multiple times)")
-	cmd.Flags().Uint32(flagKeepaliveTimeout, uint32(viper.GetInt(flagKeepaliveTimeout)), "number of seconds until agent is considered dead by backend")
+	cmd.Flags().Uint32(flagKeepaliveTimeout, uint32(viper.GetInt(flagKeepaliveTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
+	cmd.Flags().Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
 	cmd.Flags().Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	cmd.Flags().Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	cmd.Flags().Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -143,8 +142,10 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 			cfg.TLS.CertFile = viper.GetString(flagCertFile)
 			cfg.TLS.KeyFile = viper.GetString(flagKeyFile)
 
-			fmt.Println("warning timeout")
-			fmt.Println(cfg.KeepaliveWarningTimeout)
+			if cfg.KeepaliveCriticalTimeout != 0 && cfg.KeepaliveCriticalTimeout < cfg.KeepaliveWarningTimeout {
+				logger.Fatalf("if set, --%s must be greater than --%s",
+					flagKeepaliveCriticalTimeout, flagKeepaliveWarningTimeout)
+			}
 
 			agentName := viper.GetString(flagAgentName)
 			if agentName != "" {

--- a/agent/config.go
+++ b/agent/config.go
@@ -116,10 +116,10 @@ type Config struct {
 	// KeepaliveInterval is the interval between keepalive events.
 	KeepaliveInterval uint32
 
-	// KeepaliveTimeout is the time after which a sensu-agent is considered dead
+	// KeepaliveWarningTimeout is the time after which a sensu-agent is considered dead
 	// by the backend to create a warning event. See DefaultKeepaliveTimeout in
 	// corev2 package for default value.
-	KeepaliveTimeout uint32
+	KeepaliveWarningTimeout uint32
 
 	// KeepaliveCriticalTimeout is the time after which a sensu-agent is considered dead
 	// by the backend to create a critical event.
@@ -201,14 +201,14 @@ func FixtureConfig() (*Config, func()) {
 			Host: DefaultAPIHost,
 			Port: DefaultAPIPort,
 		},
-		BackendURLs:         []string{},
-		CacheDir:            cacheDir,
-		EventsAPIRateLimit:  DefaultEventsAPIRateLimit,
-		EventsAPIBurstLimit: DefaultEventsAPIBurstLimit,
-		KeepaliveInterval:   DefaultKeepaliveInterval,
-		KeepaliveTimeout:    corev2.DefaultKeepaliveTimeout,
-		Namespace:           DefaultNamespace,
-		Password:            DefaultPassword,
+		BackendURLs:             []string{},
+		CacheDir:                cacheDir,
+		EventsAPIRateLimit:      DefaultEventsAPIRateLimit,
+		EventsAPIBurstLimit:     DefaultEventsAPIBurstLimit,
+		KeepaliveInterval:       DefaultKeepaliveInterval,
+		KeepaliveWarningTimeout: corev2.DefaultKeepaliveTimeout,
+		Namespace:               DefaultNamespace,
+		Password:                DefaultPassword,
 		Socket: &SocketConfig{
 			Host: DefaultSocketHost,
 			Port: DefaultSocketPort,

--- a/agent/config.go
+++ b/agent/config.go
@@ -117,9 +117,13 @@ type Config struct {
 	KeepaliveInterval uint32
 
 	// KeepaliveTimeout is the time after which a sensu-agent is considered dead
-	// by the backend. See DefaultKeepaliveTimeout in corev2 package for default
-	// value.
+	// by the backend to create a warning event. See DefaultKeepaliveTimeout in
+	// corev2 package for default value.
 	KeepaliveTimeout uint32
+
+	// KeepaliveCriticalTimeout is the time after which a sensu-agent is considered dead
+	// by the backend to create a critical event.
+	KeepaliveCriticalTimeout uint32
 
 	// Labels are key-value pairs that users can provide to agent entities
 	Labels map[string]string

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/prometheus/client_golang/prometheus"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/keepalived"
 	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
@@ -343,6 +344,12 @@ func parseKey(key string) (namespace, check, entity string, err error) {
 // handleFailure creates a check event with a warn status and publishes it to
 // TopicEvent.
 func (e *Eventd) handleFailure(event *corev2.Event) error {
+	// don't update the event with ttl output for keepalives,
+	// there is a different mechanism for that
+	if event.Check.Name == keepalived.KeepaliveCheckName {
+		return nil
+	}
+
 	entity := event.Entity
 	ctx := context.WithValue(context.Background(), corev2.NamespaceKey, entity.Namespace)
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -299,6 +299,7 @@ func createKeepaliveEvent(rawEvent *types.Event) *types.Event {
 		},
 		Interval: check.Interval,
 		Timeout:  check.Timeout,
+		Ttl:      check.Ttl,
 		Handlers: []string{KeepaliveHandlerName},
 		Executed: time.Now().Unix(),
 		Issued:   time.Now().Unix(),
@@ -423,8 +424,21 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 
 	// this is a real keepalive event, emit it.
 	event := createKeepaliveEvent(currentEvent)
-	event.Check.Status = 1
-	event.Check.Output = fmt.Sprintf("No keepalive sent from %s for %v seconds (>= %v)", entity.Name, time.Now().Unix()-entity.LastSeen, event.Check.Timeout)
+	timeSinceLastSeen := time.Now().Unix() - entity.LastSeen
+	warningTimeout := int64(event.Check.Timeout)
+	criticalTimeout := event.Check.Ttl
+	var timeout int64
+	if warningTimeout != 0 && timeSinceLastSeen >= warningTimeout {
+		// warning keepalive
+		timeout = warningTimeout
+		event.Check.Status = 1
+	}
+	if criticalTimeout != 0 && timeSinceLastSeen >= criticalTimeout {
+		// critical keepalive
+		timeout = criticalTimeout
+		event.Check.Status = 2
+	}
+	event.Check.Output = fmt.Sprintf("No keepalive sent from %s for %v seconds (>= %v)", entity.Name, timeSinceLastSeen, timeout)
 
 	if err := k.bus.Publish(messaging.TopicEventRaw, event); err != nil {
 		lager.WithError(err).Error("error publishing event")

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -51,7 +51,7 @@ func main() {
 			FlushInterval: 10,
 		}
 		cfg.KeepaliveInterval = uint32(*flagKeepaliveInterval)
-		cfg.KeepaliveTimeout = uint32(*flagKeepaliveTimeout)
+		cfg.KeepaliveWarningTimeout = uint32(*flagKeepaliveTimeout)
 		cfg.Namespace = agent.DefaultNamespace
 		cfg.Password = agent.DefaultPassword
 		cfg.Socket.Host = agent.DefaultAPIHost


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Added a new flag, `--keepalive-critical-timeout` to define the time after which a critical keepalive event should be created for a dead agent.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2747

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Just some product input on the complications below.

## Were there any complications while making this change?

Yes, these complications were discussed with @echlebek (the keeper of the keepalives) which I will outline, but we will need some product direction. 

While critical keepalive events are a 1.x parity feature, the implementation of keepalives in Sensu Go is vastly different than that of Classic. The [liveness package](https://github.com/sensu/sensu-go/blob/master/backend/liveness/liveness.go) implements switches with etcd leases that get flipped on life and death events for agent entities. This approach is durable, allowing the keepalive feature to function properly with the loss of a backend or the loss of cluster quorum.

### Refactor switches to accept multiple ttls
Switches currently only accept a single ttl value, where the critical keepalive feature requires a second value. Refactoring of this complex code would be required in order to rework it for critical keepalives, which is possible, but would make the liveness package more error prone. Additionally, iterative calculations will need to be performed on both values to ensure that each keepalive event fires at the right time. This approach offers the highest granularity at the highest cost of complexity.

### Instantiate multiple switches
Rather than refactoring the switches, we could instantiate a second switch for the critical keepalive (in addition to the warning switch that already exists). We believe multiple switches could cause concurrency problems on life and death events, and could cause keepalive events not to fire in certain circumstances. This approach would be simpler to implement but is not recommended.

### Use time since last seen
Time since last seen is most in line with the [classic implementation](https://github.com/sensu/sensu/blob/012c2c0fd35e22817ad030626f75172b4b67cd1e/lib/sensu/server/process.rb#L1112-L1144). I've implemented some simple logic to determine when a warning or critical event should be created/overwritten based on the keepalive check timeout (warning) and the keepalive check ttl (critical). This event will only fire on the original warning timeout, rather than the critical timeout so some granularity is lost in cases where the critical timeout is less than the warning timeout. This is the simplest approach to implement (is implemented in this PR) but offers the lowest granularity.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/1990

## How did you verify this change?

e2e testing was performed for all use cases described in https://github.com/sensu/sensu-go/issues/2747#issuecomment-558407864 and the following test was added to TestRail: https://sensuinc.testrail.io/index.php?/cases/view/13574.

## Is this change a patch?

This feature will go into master.