### PR TITLE
Improve sensuctl cluster health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 when it is not operating as an etcd member. The flag is also used by the new
 sensu-backend init tool.
 - Added the cluster's distribution to Tessen data.
+- Added a new field, ClusterIDHex, to the ClusterHealth datatype.
 
 ### Fixed
 - Add a timeout to etcd requests when retrieving the nodes health.
@@ -29,12 +30,16 @@ before checking if the asset has 1 or more builds.
 does not exist.
 - Fixed issue where keepalive events and events created through the agent's
 socket interface could be missing a namespace.
+- Fixed an issue where 'sensuctl cluster health' would hang indefinitely.
 
 ### Changed
 - The backend will no longer automatically be seeded with a default admin
 username and password. Users will need to run 'sensu-backend init' on every
 new installation.
 - Several deprecated flags were removed from sensu-backend.
+- 'sensuctl cluster health' will now use a 3s timeout when gathering cluster
+health information.
+- 'sensuctl cluster health' now collects cluster health information concurrently.
 
 ## [5.15.0] - 2019-11-18
 

--- a/api/core/v2/health.go
+++ b/api/core/v2/health.go
@@ -30,8 +30,7 @@ func (h ClusterHealth) MarshalJSON() ([]byte, error) {
 		h.MemberIDHex = fmt.Sprintf("%x", h.MemberID)
 	}
 	type Clone ClusterHealth
-	var clone *Clone
-	clone = (*Clone)(&h)
+	var clone *Clone = (*Clone)(&h)
 	return json.Marshal(clone)
 }
 

--- a/api/core/v2/health.go
+++ b/api/core/v2/health.go
@@ -1,6 +1,9 @@
 package v2
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 )
 
@@ -8,12 +11,28 @@ import (
 type ClusterHealth struct {
 	// MemberID is the etcd cluster member's ID.
 	MemberID uint64
+
+	// MemberIDHex is the hexadecimal representation of the member's ID.
+	MemberIDHex string
+
 	// Name is the cluster member's name.
 	Name string
-	// Err holds the string representation of any errors encountered while checking the member's health.
+
+	// Err contains any error encountered while checking the member's health.
 	Err string
+
 	// Healthy describes the health of the cluster member.
 	Healthy bool
+}
+
+func (h ClusterHealth) MarshalJSON() ([]byte, error) {
+	if h.MemberIDHex == "" {
+		h.MemberIDHex = fmt.Sprintf("%x", h.MemberID)
+	}
+	type Clone ClusterHealth
+	var clone *Clone
+	clone = (*Clone)(&h)
+	return json.Marshal(clone)
 }
 
 // HealthResponse contains cluster health and cluster alarms.

--- a/backend/apid/routers/cluster.go
+++ b/backend/apid/routers/cluster.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gorilla/mux"
@@ -69,8 +70,27 @@ func parsePeerAddrs(req *http.Request) ([]string, error) {
 	return strings.Split(peerAddrsValue, ","), nil
 }
 
+func parseTimeout(req *http.Request) (int, error) {
+	val := req.FormValue("timeout")
+	if len(val) == 0 {
+		return 0, nil
+	}
+	return strconv.Atoi(val)
+}
+
 func (r *ClusterRouter) list(w http.ResponseWriter, req *http.Request) {
-	resp, err := r.controller.MemberList(req.Context())
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
+	resp, err := r.controller.MemberList(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -79,12 +99,23 @@ func (r *ClusterRouter) list(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ClusterRouter) memberAdd(w http.ResponseWriter, req *http.Request) {
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
 	peerAddrs, err := parsePeerAddrs(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	resp, err := r.controller.MemberAdd(req.Context(), peerAddrs)
+	resp, err := r.controller.MemberAdd(ctx, peerAddrs)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -93,6 +124,17 @@ func (r *ClusterRouter) memberAdd(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ClusterRouter) memberRemove(w http.ResponseWriter, req *http.Request) {
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
 	id, err := parseID(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -107,6 +149,17 @@ func (r *ClusterRouter) memberRemove(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ClusterRouter) memberUpdate(w http.ResponseWriter, req *http.Request) {
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
 	id, err := parseID(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -117,7 +170,7 @@ func (r *ClusterRouter) memberUpdate(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	resp, err := r.controller.MemberUpdate(req.Context(), id, peerAddrs)
+	resp, err := r.controller.MemberUpdate(ctx, id, peerAddrs)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -126,7 +179,18 @@ func (r *ClusterRouter) memberUpdate(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *ClusterRouter) clusterID(w http.ResponseWriter, req *http.Request) {
-	resp, err := r.controller.ClusterID(req.Context())
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
+	resp, err := r.controller.ClusterID(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/apid/routers/cluster.go
+++ b/backend/apid/routers/cluster.go
@@ -140,7 +140,7 @@ func (r *ClusterRouter) memberRemove(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	resp, err := r.controller.MemberRemove(req.Context(), id)
+	resp, err := r.controller.MemberRemove(ctx, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/apid/routers/health.go
+++ b/backend/apid/routers/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/sensu/sensu-go/types"
@@ -31,7 +32,18 @@ func (r *HealthRouter) Mount(parent *mux.Router) {
 	parent.HandleFunc("/health", r.health).Methods(http.MethodGet)
 }
 
-func (r *HealthRouter) health(w http.ResponseWriter, _ *http.Request) {
-	clusterHealth := r.controller.GetClusterHealth(context.Background())
+func (r *HealthRouter) health(w http.ResponseWriter, req *http.Request) {
+	timeout, err := parseTimeout(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	ctx := req.Context()
+	if timeout > 0 {
+		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+		ctx = tctx
+	}
+	clusterHealth := r.controller.GetClusterHealth(ctx)
 	_ = json.NewEncoder(w).Encode(clusterHealth)
 }

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -115,10 +115,10 @@ func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, 
 	alarmResponse, err := s.client.Maintenance.AlarmList(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to fetch etcd alarm list")
+	} else {
+		logger.WithField("alarms", len(alarmResponse.Alarms)).Info("cluster alarms")
+		healthResponse.Alarms = alarmResponse.Alarms
 	}
 
-	logger.WithField("alarms", len(alarmResponse.Alarms)).Info("cluster alarms")
-
-	healthResponse.Alarms = alarmResponse.Alarms
 	return healthResponse
 }

--- a/cli/client/health.go
+++ b/cli/client/health.go
@@ -11,7 +11,7 @@ const healthPath = "/health"
 
 // Health returns the health of the cluster.
 func (c *RestClient) Health() (*corev2.HealthResponse, error) {
-	res, err := c.R().Get(healthPath)
+	res, err := c.R().Get(healthPath + "?timeout=3")
 	if err != nil {
 		return nil, fmt.Errorf("GET %q: %s", healthPath, err)
 	}


### PR DESCRIPTION
## What is this change?

* Fix a bug where the cluster health command would hang
indefinitely if one of the cluster members was not responding.

* Gather cluster health from members concurrently.

* Implement a static timeout of 3s for gathering cluster member
information from members.

* Add MemberIDHex field to the cluster health datatype, so that the
rendered JSON and YAML contain the hex representation as well as
the decimal representation.

## Why is this change necessary?

Refs #3423 
Closes #3036 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We'll need to update the API reference for ClusterHealth.

## How did you verify this change?

Unverified beyond smoke tests currently.

## Is this change a patch?

No