### PR TITLE
OSS only Dockerfile based on Ubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ To build a OSS only docker image without the 100 entity restriction and without 
 ```
 $ cd docker-scripts
 $ sudo docker build .
+# sensu-backend initialization 
+$ sudo docker run -d <new_image> sensu-backend init
+# sensu-backend run post initialization
+$ sudo docker run -d <new_image> sensu-backend start
+# sensu-agent for running docker image as a client
+$ sudo docker run -d <new_image> sensu-agent start
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "g
 # sensuctl
 $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "github.com/sensu/sensu-go/version.BuildDate=2019-10-08" -X "github.com/sensu/sensu-go/version.BuildSHA='`git rev-parse HEAD`'"' -o bin/sensuctl ./cmd/sensuctl
 ```
+To build a OSS only docker image without the 100 entity restiction and without Sensu enterprise features, run these commands:
+```
+$ cd docker-scripts
+$ sudo docker build .
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "g
 # sensuctl
 $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "github.com/sensu/sensu-go/version.BuildDate=2019-10-08" -X "github.com/sensu/sensu-go/version.BuildSHA='`git rev-parse HEAD`'"' -o bin/sensuctl ./cmd/sensuctl
 ```
-To build a OSS only docker image without the 100 entity restiction and without Sensu enterprise features, run these commands:
+To build a OSS only docker image without the 100 entity restriction and without Sensu enterprise features, run these commands:
 ```
 $ cd docker-scripts
 $ sudo docker build .

--- a/docker-scripts/Dockerfile
+++ b/docker-scripts/Dockerfile
@@ -10,7 +10,7 @@ COPY ./sensu-entrypoint.sh /opt/sensu/bin/
 
 RUN apt update &&\
     apt -y upgrade &&\
-    apt -y install git wget 
+    apt -y install git wget
 
 #Download and install Go 1.13.3 for Go modules.
 RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz &&\
@@ -29,10 +29,8 @@ RUN git clone --depth=1 https://github.com/sensu/sensu-go.git &&\
 
 #State directory lives outside container for persistent data.
 VOLUME [/var/lib/sensu]
-#Port 3000 for Sensu Go UI and port 8081 for sensu-agent communication.  
-EXPOSE 3000 8081
+#Port 3000 for Sensu Go UI, 8080 for Sensu API, and port 8081 for sensu-agent websocket API communication.  
+EXPOSE 3000 8080 8081
 
-#From https://github.com/sensu/sensu-go/blob/master/docker-scripts/sensu-entrypoint.sh
-ENTRYPOINT ["/opt/sensu/bin/sensu-entrypoint.sh"]
 #Use Docker logs to see stdout of sensu-backend (ie. docker logs --details -f  `docker ps -q` )
-CMD ["sensu-backend"]
+CMD ["/opt/sensu/bin/sensu-backend","start"]

--- a/docker-scripts/Dockerfile
+++ b/docker-scripts/Dockerfile
@@ -34,5 +34,6 @@ VOLUME [/var/lib/sensu]
 #Port 3000 for Sensu Go UI, 8080 for Sensu API, and port 8081 for sensu-agent websocket API communication.  
 EXPOSE 3000 8080 8081
 
-#Use Docker logs to see stdout of sensu-backend (ie. docker logs --details -f  `docker ps -q` )
+#Run the container passing the binary and args to the container (ie. sudo docker run -d <new_image> sensu-backend init), see README.md for more examples.
+#Use Docker logs to see stdout of process passed (ie. sudo docker logs --details -f  `docker ps -q` ).
 CMD ["/opt/sensu/bin/sensu-entrypoint.sh"]

--- a/docker-scripts/Dockerfile
+++ b/docker-scripts/Dockerfile
@@ -35,4 +35,4 @@ VOLUME [/var/lib/sensu]
 EXPOSE 3000 8080 8081
 
 #Use Docker logs to see stdout of sensu-backend (ie. docker logs --details -f  `docker ps -q` )
-CMD ["/opt/sensu/bin/sensu-backend","start"]
+CMD ["/opt/sensu/bin/sensu-entrypoint.sh"]

--- a/docker-scripts/Dockerfile
+++ b/docker-scripts/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:18.04
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/opt/sensu
 ENV PATH=$GOPATH:/bin:$GOROOT/bin:/opt/sensu/bin/:$PATH
+#Using Go 1.13.3 for Go modules, change for your needs.
+ARG GO_VER=1.13.3
 
 WORKDIR /opt/sensu
 COPY ./sensu-entrypoint.sh /opt/sensu/bin/
@@ -12,10 +14,10 @@ RUN apt update &&\
     apt -y upgrade &&\
     apt -y install git wget
 
-#Download and install Go 1.13.3 for Go modules.
-RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz &&\
+#Download and install Go using the GO_VER argument.
+RUN wget https://dl.google.com/go/go$GO_VER.linux-amd64.tar.gz && tar -xvf go$GO_VER.linux-amd64.tar.gz &&\
     mv go /usr/local/ &&\
-    rm go1.13.3.linux-amd64.tar.gz
+    rm go$GO_VER.linux-amd64.tar.gz
 
 #Build OSS only sensu features, enterprise features are built in the Sensu supported images:
 #docker pull sensu/sensu (Alpine based container) or 

--- a/docker-scripts/Dockerfile
+++ b/docker-scripts/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:18.04
+
+#Build in this directory with sudo docker build . or docker build . (depending on your OS)
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/opt/sensu
+ENV PATH=$GOPATH:/bin:$GOROOT/bin:/opt/sensu/bin/:$PATH
+
+WORKDIR /opt/sensu
+COPY ./sensu-entrypoint.sh /opt/sensu/bin/
+
+RUN apt update &&\
+    apt -y upgrade &&\
+    apt -y install git wget 
+
+#Download and install Go 1.13.3 for Go modules.
+RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz && tar -xvf go1.13.3.linux-amd64.tar.gz &&\
+    mv go /usr/local/ &&\
+    rm go1.13.3.linux-amd64.tar.gz
+
+#Build OSS only sensu features, enterprise features are built in the Sensu supported images:
+#docker pull sensu/sensu (Alpine based container) or 
+#docker pull sensu/sensu-rhel (Red Hat based container)
+RUN git clone --depth=1 https://github.com/sensu/sensu-go.git &&\ 
+    cd sensu-go &&\
+    go build -o ../bin/sensu-agent ./cmd/sensu-agent &&\
+    go build -o ../bin/sensu-backend ./cmd/sensu-backend &&\
+    go build -o ../bin/sensuctl ./cmd/sensuctl &&\
+    rm -rf /opt/sensu/sensu-go
+
+#State directory lives outside container for persistent data.
+VOLUME [/var/lib/sensu]
+#Port 3000 for Sensu Go UI and port 8081 for sensu-agent communication.  
+EXPOSE 3000 8081
+
+#From https://github.com/sensu/sensu-go/blob/master/docker-scripts/sensu-entrypoint.sh
+ENTRYPOINT ["/opt/sensu/bin/sensu-entrypoint.sh"]
+#Use Docker logs to see stdout of sensu-backend (ie. docker logs --details -f  `docker ps -q` )
+CMD ["sensu-backend"]


### PR DESCRIPTION
## What is this change?

Create Dockerfile for those not needing enterprise features.

## Why is this change necessary?

For those that only need the non-enterprise OSS only features and who do not want the default 100 node restriction of Sensu Enterprise, this builds a docker container from Ubuntu 18.04 which uses the OSS features and none of the enterprise features.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

## Were there any complications while making this change?

Note that this is not using the docker-scripts/sensu-entrypoint.sh, just calling sensu-backend directly.  You could also use this for running sensu-agent for a docker container for agents.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

It may be useful to add the following to the README.md file:

"""To build a OSS only docker image, run these commands:
cd docker-scripts
sudo docker build ."""

Note I have added these to the README.md file.

## How did you verify this change?

cd docker-scripts
sudo docker build .
sudo docker run -d new_image_hash
 sudo docker logs new_container_hash

## Is this change a patch?

No.