### PR TITLE
Fix a bug where jwt secret was not initialized

### DIFF
--- a/backend/authentication/jwt/jwt_test.go
+++ b/backend/authentication/jwt/jwt_test.go
@@ -85,17 +85,6 @@ func TestInitSecret(t *testing.T) {
 	assert.NotEqual(t, nil, secret)
 }
 
-func TestInitSecretMissingSecret(t *testing.T) {
-	secret = nil
-	store := &mockstore.MockStore{}
-	store.On("GetJWTSecret").Return("", fmt.Errorf(""))
-	store.On("CreateJWTSecret").Return(nil)
-
-	err := InitSecret(store)
-	assert.NoError(t, err)
-	assert.NotEqual(t, nil, secret)
-}
-
 func TestInitSecretEtcdError(t *testing.T) {
 	secret = nil
 	store := &mockstore.MockStore{}

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -6,7 +6,6 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
-	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
@@ -47,18 +46,12 @@ func SeedCluster(ctx context.Context, store store.Store, config Config) error {
 			}
 		}()
 
-		// Initialize the JWT secret. This method is idempotent and needs to be ran
-		// at every startup so the JWT signatures remain valid
-		if err = jwt.InitSecret(store); err != nil {
-			return
-		}
-
 		// Check that the store hasn't already been seeded
 		initialized, err := initializer.IsInitialized()
 		if err != nil || initialized {
 			return
 		}
-		logger.Info("seeding etcd store w/ intial data")
+		logger.Info("seeding etcd store with intial data")
 
 		// Create the default namespace
 		if err = setupDefaultNamespace(store); err != nil {

--- a/backend/store/etcd/authentication.go
+++ b/backend/store/etcd/authentication.go
@@ -2,48 +2,59 @@ package etcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/sensu/sensu-go/backend/store"
+	utilbytes "github.com/sensu/sensu-go/util/bytes"
 )
 
 func getAuthenticationPath(id string) string {
 	return fmt.Sprintf("%s/authentication/%s", EtcdRoot, id)
 }
 
-// CreateJWTSecret creates a new JWT secret
+// CreateJWTSecret creates a new JWT secret. DEPRECATED. Returns non-nil error
+// in all circumstances. Use UpdateJWTSecret to replace an exist jwt secret.
 func (s *Store) CreateJWTSecret(secret []byte) error {
-	// We need to prepare a transaction to verify the version of the key
-	// corresponding to the user in etcd in order to ensure we only put the key
-	// if it does not exist
-	cmp := clientv3.Compare(clientv3.Version(getAuthenticationPath("secret")), "=", 0)
-	req := clientv3.OpPut(getAuthenticationPath("secret"), string(secret))
-	res, err := s.client.Txn(context.TODO()).If(cmp).Then(req).Commit()
-	if err != nil {
-		return err
-	}
-	if !res.Succeeded {
-		return fmt.Errorf("a secret already exist")
-	}
-
-	return nil
+	return errors.New("deprecated method, use GetJWTSecret instead")
 }
 
-// GetJWTSecret retrieves the JWT signing secret
+// GetJWTSecret retrieves the JWT signing secret, creating it if it does not
+// already exist.
 func (s *Store) GetJWTSecret() ([]byte, error) {
-	resp, err := s.client.Get(context.TODO(), getAuthenticationPath("secret"), clientv3.WithLimit(1))
+	randomBytes, err := utilbytes.Random(32)
 	if err != nil {
-		return nil, err
+		return nil, &store.ErrInternal{Message: err.Error()}
 	}
-	if len(resp.Kvs) != 1 {
-		return nil, fmt.Errorf("secret does not exist")
-	}
+	opGet := clientv3.OpGet(getAuthenticationPath("secret"), clientv3.WithLimit(1))
+	opPut := clientv3.OpPut(getAuthenticationPath("secret"), string(randomBytes))
+	cmp := clientv3.Compare(clientv3.Version(getAuthenticationPath("secret")), "=", 0)
 
-	return resp.Kvs[0].Value, nil
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+	defer cancel()
+
+	resp, err := s.client.Txn(ctx).If(cmp).Then(opPut).Else(opGet).Commit()
+	if err != nil {
+		return nil, &store.ErrInternal{Message: err.Error()}
+	}
+	if resp.Succeeded {
+		return randomBytes, nil
+	}
+	getResp := resp.Responses[0].GetResponseRange()
+	if len(getResp.Kvs) != 1 {
+		return nil, &store.ErrInternal{Message: "secret response is empty"}
+	}
+	return getResp.Kvs[0].Value, nil
 }
 
 // UpdateJWTSecret replaces the jwt secret with a new one.
 func (s *Store) UpdateJWTSecret(secret []byte) error {
-	_, err := s.client.Put(context.TODO(), getAuthenticationPath("secret"), string(secret))
-	return err
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
+	defer cancel()
+	if _, err := s.client.Put(ctx, getAuthenticationPath("secret"), string(secret)); err != nil {
+		return &store.ErrInternal{Message: err.Error()}
+	}
+	return nil
 }

--- a/backend/store/etcd/authentication_test.go
+++ b/backend/store/etcd/authentication_test.go
@@ -3,41 +3,59 @@
 package etcd
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/backend/store"
 	utilbytes "github.com/sensu/sensu-go/util/bytes"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthenticationStorage(t *testing.T) {
 	testWithEtcd(t, func(store store.Store) {
-		// Secret does not exist
-		_, err := store.GetJWTSecret()
-		assert.Error(t, err)
+		// Secret is created
+		secret, err := store.GetJWTSecret()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		// Create a secret
-		secret, _ := utilbytes.Random(32)
-		err = store.CreateJWTSecret(secret)
-		assert.NoError(t, err)
+		if got, want := len(secret), 32; got != want {
+			t.Fatalf("bad secret length: got %d, want %d", got, want)
+		}
 
-		// Retrieve the secret
+		time.Sleep(time.Second)
+
+		// Retrieve the secret again, it should be the same
 		result, err := store.GetJWTSecret()
-		assert.NoError(t, err)
-		assert.Equal(t, secret, result)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		// We should not be able to create it again
-		err = store.CreateJWTSecret(secret)
-		assert.Error(t, err)
+		if got, want := result, secret; !bytes.Equal(got, want) {
+			t.Errorf("bad secret result: got %x, want %x", got, want)
+		}
 
 		// We should be able to update it
-		newSecret, _ := utilbytes.Random(32)
-		err = store.UpdateJWTSecret(newSecret)
-		assert.NoError(t, err)
+		newSecret, err := utilbytes.Random(32)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := store.UpdateJWTSecret(newSecret); err != nil {
+			t.Fatal(err)
+		}
 
 		// The old and new secrets should not match
 		result, err = store.GetJWTSecret()
-		assert.NoError(t, err)
-		assert.NotEqual(t, result, secret)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := result, secret; bytes.Equal(got, want) {
+			t.Errorf("bad secret result: got %x, should not equal %x", got, want)
+		}
+		if got, want := result, newSecret; !bytes.Equal(got, want) {
+			t.Errorf("bad secret result: got %x, want %x", got, want)
+		}
 	})
 }


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where the jwt secret was not correctly
being loaded on startup. The result was that jwts were being
created with a 0-byte secret.

This regression occurred in commit 6df9362dfe57c605608a1da9e384a9900f5dc2a4

## Why is this change necessary?

jwt authentication is broken.

## Does your change need a Changelog entry?

No, this regression was not present in 5.15.

## How did you verify this change?
Made sure that a user could not log in with an existing token with a fresh Sensu instance.