### PR TITLE
Block on grpc dial in sensu-backend init

### DIFF
--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -15,6 +15,7 @@ import (
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -118,6 +119,9 @@ func InitCommand() *cobra.Command {
 				Endpoints:   clientURLs,
 				DialTimeout: 5 * time.Second,
 				TLS:         tlsConfig,
+				DialOptions: []grpc.DialOption{
+					grpc.WithBlock(),
+				},
 			})
 
 			if err != nil {


### PR DESCRIPTION
## What is this change?

Adds connection blocking to the etcd client in sensu-backend init.

## Why is this change necessary?

Without this option, sensu-backend init might run before etcd is ready.

## Does your change need a Changelog entry?

No

## How did you verify this change?

Ran sensu-backend init and verified that the client blocks.

## Is this change a patch?

Yes