### PR TITLE
Exit status 3 when backend already initialized

### DIFF
--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -170,7 +170,7 @@ func seedCluster(client *clientv3.Client, config seedConfig) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	if err := seeds.SeedCluster(ctx, store, config.SeedConfig); err != nil {
-		return fmt.Errorf("error initializing cluster: %s", err)
+		return err
 	}
 	return nil
 }

--- a/backend/seeds/seeds_test.go
+++ b/backend/seeds/seeds_test.go
@@ -22,7 +22,9 @@ func TestSeedInitialData(t *testing.T) {
 	require.NoError(t, err, "seeding process should not raise an error")
 
 	err = SeedInitialData(st)
-	require.NoError(t, err, "seeding process should be able to be run more than once without error")
+	if err != ErrAlreadyInitialized {
+		require.NoError(t, err, "seeding process should be able to be run more than once without error")
+	}
 
 	admin, err := st.GetUser(ctx, "admin")
 	require.NoError(t, err)

--- a/cmd/sensu-backend/main.go
+++ b/cmd/sensu-backend/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	_ "net/http/pprof"
+	"os"
 
 	"github.com/sensu/sensu-go/backend"
 	"github.com/sensu/sensu-go/backend/cmd"
+	"github.com/sensu/sensu-go/backend/seeds"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +26,9 @@ func main() {
 	rootCmd.AddCommand(cmd.InitCommand())
 
 	if err := rootCmd.Execute(); err != nil {
+		if err == seeds.ErrAlreadyInitialized {
+			os.Exit(3)
+		}
 		logger.WithError(err).Fatal("error executing sensu-backend")
 	}
 }


### PR DESCRIPTION
## What is this change?

`sensu-backend init` exits with status 3 if the backend has already been initialized.

## Why is this change necessary?

Closes #3448 

## Does your change need a Changelog entry?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This should be documented, but I'm not exactly sure where. @hillaryfraley 

## How did you verify this change?

I initialized sensu-backend successfully, and then tried to initialize it again. The command exited with status 3.

## Is this change a patch?

Yes