### PR TITLE
Bugfix for sensuctl cluster health

### DIFF
--- a/api/core/v2/context.go
+++ b/api/core/v2/context.go
@@ -36,6 +36,9 @@ const (
 
 	// PageSizeKey contains the page size used in pagination
 	PageSizeKey
+
+	// TimeoutKey contains a request timeout value
+	TimeoutKey
 )
 
 // ContextNamespace returns the namespace injected in the context

--- a/api/core/v2/context.go
+++ b/api/core/v2/context.go
@@ -36,9 +36,6 @@ const (
 
 	// PageSizeKey contains the page size used in pagination
 	PageSizeKey
-
-	// TimeoutKey contains a request timeout value
-	TimeoutKey
 )
 
 // ContextNamespace returns the namespace injected in the context

--- a/backend/apid/routers/health.go
+++ b/backend/apid/routers/health.go
@@ -40,9 +40,9 @@ func (r *HealthRouter) health(w http.ResponseWriter, req *http.Request) {
 	}
 	ctx := req.Context()
 	if timeout > 0 {
-		tctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-		defer cancel()
-		ctx = tctx
+		// We're storing the timeout as a value so it can be used by several
+		// contexts in GetClusterHealth, which is a concurrent gatherer.
+		ctx = context.WithValue(ctx, "timeout", time.Duration(timeout)*time.Second)
 	}
 	clusterHealth := r.controller.GetClusterHealth(ctx)
 	_ = json.NewEncoder(w).Encode(clusterHealth)

--- a/backend/store/etcd/health_store.go
+++ b/backend/store/etcd/health_store.go
@@ -99,6 +99,13 @@ func (s *Store) GetClusterHealth(ctx context.Context, cluster clientv3.Cluster, 
 			select {
 			case healths <- s.getHealth(ctx, id, name, urls, etcdClientTLSConfig):
 			case <-ctx.Done():
+				health := &corev2.ClusterHealth{
+					MemberID: id,
+					Name:     name,
+					Healthy:  false,
+					Err:      "timeout",
+				}
+				healths <- health
 			}
 		}(member.ID, member.Name, member.ClientURLs)
 	}

--- a/backend/store/etcd/health_store_test.go
+++ b/backend/store/etcd/health_store_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/sensu/sensu-go/backend/store"
@@ -16,5 +17,12 @@ func TestGetClusterHealth(t *testing.T) {
 	testWithEtcdClient(t, func(store store.Store, client *clientv3.Client) {
 		healthResult := store.GetClusterHealth(context.Background(), client.Cluster, (*tls.Config)(nil))
 		assert.Empty(t, healthResult.ClusterHealth[0].Err)
+	})
+}
+
+func TestGetClusterHealthTimeout(t *testing.T) {
+	testWithEtcdClient(t, func(store store.Store, client *clientv3.Client) {
+		result := store.GetClusterHealth(context.WithValue(context.Background(), "timeout", time.Nanosecond), client.Cluster, (*tls.Config)(nil))
+		assert.NotEmpty(t, result.ClusterHealth[0].Err)
 	})
 }


### PR DESCRIPTION
This PR fixes a bug where shutdown members of a cluster would not be shown in `sensuctl cluster health`.