### PR TITLE
Initialize the sensu_go_events_processed metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Initialize the sensu_go_events_processed counter with zthe `success` label so
+it's always displayed.
+
 ## [5.16.0] - 2019-12-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Fixed
-- Initialize the sensu_go_events_processed counter with zthe `success` label so
+- Initialize the sensu_go_events_processed counter with the `success` label so
 it's always displayed.
 
 ## [5.16.0] - 2019-12-11

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -121,6 +121,8 @@ func New(ctx context.Context, c Config, opts ...Option) (*Eventd, error) {
 		}
 	}
 
+	// Initialize the most likely labels
+	EventsProcessed.WithLabelValues(EventsProcessedLabelSuccess)
 	_ = prometheus.Register(EventsProcessed)
 
 	return e, nil


### PR DESCRIPTION
## What is this change?

It initializes the `sensu_go_events_processed` metric with the `success` label so the metric is always displayed in the `/metrics` endpoint.

## Why is this change necessary?

To avoid any confusion!

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested it.

## Is this change a patch?

Yep