### PR TITLE
fixes typo in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - "18081:8081"
   backend3:
     image: sensu/sensu:latest
-    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --name backend3 --etcd-advertise-client-urls http://backend3:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend3:2380 --state-dir /var/lib/sensu/sensu-backend/etcd3 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug
+    command: sensu-backend start --etcd-listen-client-urls http://0.0.0.0:2379 --etcd-name backend3 --etcd-advertise-client-urls http://backend3:2379 --etcd-initial-cluster backend1=http://backend1:2380,backend2=http://backend2:2380,backend3=http://backend3:2380 --etcd-initial-cluster-state new --etcd-initial-advertise-peer-urls http://backend3:2380 --state-dir /var/lib/sensu/sensu-backend/etcd3 --etcd-listen-peer-urls http://0.0.0.0:2380 --log-level debug
     hostname: backend3
     restart: always
     ports:


### PR DESCRIPTION
## What is this change?

Quick fix to docker-compose - backend3 command had wrong arg preventing it from coming up.


## Why is this change necessary?

To make docker-compose up work as intended

## Does your change need a Changelog entry?

Nope.

## Do you need clarification on anything?

Nope


## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope ;)

## How did you verify this change?

ran `docker-compose up` and backend3 ran properly

## Is this change a patch?

I ... don't think so. 