### PR TITLE
Updated Readme.md with OSS Dockerfile repo info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "g
 $ go build -ldflags '-X "github.com/sensu/sensu-go/version.Version=5.14.0" -X "github.com/sensu/sensu-go/version.BuildDate=2019-10-08" -X "github.com/sensu/sensu-go/version.BuildSHA='`git rev-parse HEAD`'"' -o bin/sensuctl ./cmd/sensuctl
 ```
 
+To build an open source only docker image without the 100 entity restriction and without Sensu enterprise features, please refer to [this repo](https://github.com/georgespatton/sensu-go-oss-docker) for instructions.
+
 ## Contributing
 
 For guidelines on how to contribute to this project, how to hack on Sensu, and


### PR DESCRIPTION
## What is this change?

Provide instructions on how to build a docker container of the open source version of Sensu.

## Why is this change necessary?

Sensu on Docker Hub is not the open source version but is built with Sensu Enterprise features.  For users who are looking to build a docker container without these features and node restrictions, I have referred them to a maintained Dockerfile to accomplish this build.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Tried directly on the sensu-go repo through this PR, but it was not accepted:

https://github.com/sensu/sensu-go/pull/3456

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is in the Readme.md file as part of the change.

## How did you verify this change?

See https://github.com/sensu/sensu-go/pull/3456 for how I validated the OSS Sensu Dockerfile.

## Is this change a patch?

No.