### PR TITLE
Simplify the resource cache, fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a memory leak in the entity cache
+
 ## [5.16.1] - 2019-12-18
 
 ### Fixed

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -91,7 +91,6 @@ type cacheWatcher struct {
 type Resource struct {
 	watcher    <-chan store.WatchEventResource
 	cache      cache
-	updates    []store.WatchEventResource
 	cacheMu    sync.Mutex
 	watchers   []cacheWatcher
 	watchersMu sync.Mutex
@@ -143,15 +142,8 @@ func New(ctx context.Context, client *clientv3.Client, resource corev2.Resource,
 
 	cache := buildCache(resources, synthesize)
 
-	// Get a keybuilderFunc for this resource
-	keyBuilderFunc := func(ctx context.Context, name string) string {
-		return store.NewKeyBuilder(resource.StorePrefix()).WithContext(ctx).Build("")
-	}
-	typeOfResource := reflect.TypeOf(resource)
-
 	cacher := &Resource{
 		cache:      cache,
-		watcher:    etcd.GetResourceWatcher(ctx, client, keyBuilderFunc(ctx, ""), typeOfResource),
 		synthesize: synthesize,
 		resourceT:  resource,
 		client:     client,
@@ -237,17 +229,18 @@ func (r *Resource) notifyWatchers() {
 func (r *Resource) start(ctx context.Context) {
 	// 1s is the minimum scheduling interval, and so is the rate that
 	// the cache will update at.
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case event := <-r.watcher:
-			r.updates = append(r.updates, event)
 		case <-ticker.C:
-			if len(r.updates) > 0 {
-				r.updateCache(ctx)
+			updates, err := r.rebuild(ctx)
+			if err != nil {
+				logger.WithError(err).Error("couldn't rebuild cache")
+			}
+			if updates {
 				r.notifyWatchers()
 			}
 		}
@@ -255,107 +248,46 @@ func (r *Resource) start(ctx context.Context) {
 }
 
 // rebuild the cache using the store as the source of truth
-func (r *Resource) rebuild(ctx context.Context) error {
-	logger.Infof("rebuilding the cache for resource type %T", r.resourceT)
+func (r *Resource) rebuild(ctx context.Context) (bool, error) {
+	logger.Debugf("rebuilding the cache for resource type %T", r.resourceT)
 	resources, err := getResources(ctx, r.client, r.resourceT)
-	atomic.StoreInt64(&r.count, int64(len(resources)))
 	if err != nil {
-		return err
+		return false, err
 	}
+	atomic.StoreInt64(&r.count, int64(len(resources)))
 	newCache := buildCache(resources, r.synthesize)
+	var hasUpdates bool
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
 	for key, values := range newCache {
 		oldValues, ok := r.cache[key]
 		if !ok {
 			// Apparently we have an entire namespace's worth of values that
 			// just appeared out of nowhere...
-			r.updates = append(r.updates, makeNewUpdates(values)...)
+			hasUpdates = true
 			continue
-		}
-		for _, value := range values {
-			oldValue := resourceSlice(oldValues).Find(value)
-			if oldValue.Resource == nil {
-				r.updates = append(r.updates, store.WatchEventResource{
-					Resource: value.Resource,
-					Action:   store.WatchCreate,
-				})
-				continue
-			}
-			if !reflect.DeepEqual(oldValue.Resource, value.Resource) {
-				r.updates = append(r.updates, store.WatchEventResource{
-					Resource: value.Resource,
-					Action:   store.WatchUpdate,
-				})
-			}
 		}
 		for _, value := range oldValues {
 			newValue := resourceSlice(values).Find(value)
 			if newValue.Resource == nil {
-				r.updates = append(r.updates, store.WatchEventResource{
-					Resource: value.Resource,
-					Action:   store.WatchDelete,
-				})
+				hasUpdates = true
+				continue
+			}
+		}
+		for _, value := range values {
+			oldValue := resourceSlice(oldValues).Find(value)
+			if oldValue.Resource == nil {
+				hasUpdates = true
+				continue
+			}
+			if !reflect.DeepEqual(oldValue.Resource, value.Resource) {
+				hasUpdates = true
+				continue
 			}
 		}
 	}
 	r.cache = newCache
-	return nil
-}
-
-func (r *Resource) updateCache(ctx context.Context) {
-	r.cacheMu.Lock()
-	for _, event := range r.updates {
-		if event.Action == store.WatchError {
-			// Rebuild the cache
-			if err := r.rebuild(ctx); err != nil {
-				logger.WithError(err).Error("could not rebuild the cache")
-			}
-			continue
-		}
-
-		resource := event.Resource
-		if resource == nil || reflect.ValueOf(resource).IsNil() {
-			logger.Error("nil resource in watch event")
-			continue
-		}
-		key := getCacheKey(resource)
-
-		switch event.Action {
-		case store.WatchCreate:
-			// Append the new resource to the corresponding namespace
-			r.cache[key] = append(r.cache[key], getCacheValue(resource, r.synthesize))
-			atomic.AddInt64(&r.count, 1)
-		case store.WatchUpdate:
-			// Loop through the resources of the resource's namespace to find the
-			// exact resource and update it
-			for i := range r.cache[key] {
-				if r.cache[key][i].Resource.GetObjectMeta().Name == resource.GetObjectMeta().Name {
-					r.cache[key][i] = getCacheValue(resource, r.synthesize)
-					break
-				}
-			}
-		case store.WatchDelete:
-			// Loop through the resources of the resource's namespace to find the
-			// exact resource and delete it
-			for i := range r.cache[key] {
-				if r.cache[key][i].Resource.GetObjectMeta().Name == resource.GetObjectMeta().Name {
-					r.cache[key] = append(r.cache[key][:i], r.cache[key][i+1:]...)
-					atomic.AddInt64(&r.count, -1)
-					break
-				}
-			}
-		default:
-			logger.Error("error in resource watcher")
-		}
-	}
-
-	r.updates = nil
-
-	// Sort the resources alphabetically in each namespace
-	for _, v := range r.cache {
-		sort.Sort(resourceSlice(v))
-	}
-
-	r.cacheMu.Unlock()
+	return hasUpdates, nil
 }
 
 func makeNewUpdates(values []Value) []store.WatchEventResource {

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -189,6 +189,7 @@ func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn,
 
 	opts := []clientv3.OpOption{
 		clientv3.WithLimit(pred.Limit),
+		clientv3.WithSerializable(),
 	}
 
 	keyPrefix := keyBuilder(ctx, "")


### PR DESCRIPTION
## What is this change?

This commit fixes a memory leak in the resource cache by making it
avoid using etcd watchers. For reasons that are not clear, the
previous implementation was causing a memory leak under load.

It's unknown if the memory leak was a result of improperly using
the etcd client API, a bug in the etcd client API, or caused by
sensu-go in some other way.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #3486 
 
## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

The precise source of the memory leak was never determined.

## How did you verify this change?

Extensive performance testing.

## Is this change a patch?

Yes