### PR TITLE
Bugfix for implicit namespace access in Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed a memory leak in the entity cache
 - Users with implicit permissions to a namespace can now display resources
 within that namespace via the Web UI.
+- Explicit access to namespaces can only be granted via cluster-wide RBAC
+resources.
 
 ## [5.16.1] - 2019-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed a memory leak in the entity cache
+- Users with implicit permissions to a namespace can now display resources
+within that namespace via the Web UI.
 
 ## [5.16.1] - 2019-12-18
 

--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sirupsen/logrus"
 )
 
 type ruleVisitor interface {
@@ -20,7 +21,7 @@ type NamespaceClient struct {
 	auth   authorization.Authorizer
 }
 
-// NewnamespaceClient creates a new NamespaceClient, given a store and authorizer.
+// NewNamespaceClient creates a new NamespaceClient, given a store and authorizer.
 func NewNamespaceClient(store store.ResourceStore, auth authorization.Authorizer) *NamespaceClient {
 	return &NamespaceClient{
 		client: GenericClient{
@@ -115,9 +116,94 @@ func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespa
 // FetchNamespace fetches a namespace resource from the backend, if authorized.
 func (a *NamespaceClient) FetchNamespace(ctx context.Context, name string) (*corev2.Namespace, error) {
 	var namespace corev2.Namespace
-	if err := a.client.Get(ctx, name, &namespace); err != nil {
+	visitor, ok := a.auth.(ruleVisitor)
+	if !ok {
+		if err := a.client.Get(ctx, name, &namespace); err != nil {
+			return nil, err
+		}
+		return &namespace, nil
+	}
+	if err := a.client.Store.GetResource(ctx, name, &namespace); err != nil {
 		return nil, err
 	}
+
+	attrs := &authorization.Attributes{
+		APIGroup:     a.client.APIGroup,
+		APIVersion:   a.client.APIVersion,
+		Resource:     a.client.Kind.RBACName(),
+		ResourceName: name,
+		Namespace:    name,
+		Verb:         "get",
+	}
+	if err := addAuthUser(ctx, attrs); err != nil {
+		return nil, err
+	}
+	logger = logger.WithFields(logrus.Fields{
+		"zz_request": map[string]string{
+			"apiGroup":     attrs.APIGroup,
+			"apiVersion":   attrs.APIVersion,
+			"namespace":    attrs.Namespace,
+			"resource":     attrs.Resource,
+			"resourceName": attrs.ResourceName,
+			"username":     attrs.User.Username,
+			"verb":         attrs.Verb,
+		},
+	})
+
+	var funcErr error
+	var authorized bool
+
+	visitor.VisitRulesFor(ctx, attrs, func(binding rbac.RoleBinding, rule corev2.Rule, err error) (cont bool) {
+		if err != nil {
+			funcErr = err
+			logger.WithError(err).Warning("could not retrieve the ClusterRoleBindings or RoleBindings")
+			return false
+		}
+
+		// If the rule verb doesn't match "get", ignore this rule and continue
+		if !rule.VerbMatches("get") {
+			return true
+		}
+
+		// If this rule doesn't applies to namespaces, determine if the user has
+		// implicit access via a resource within that namespace
+		if !rule.ResourceMatches(corev2.NamespacesResource) {
+			// Find namespaces with implicit access
+			if binding.GetObjectMeta().Namespace == name {
+				logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
+				authorized = true
+				return false
+			}
+			return true
+		}
+
+		// If this rule applies to namespaces, determine if all resources of type "namespace" are allowed
+		if len(rule.ResourceNames) == 0 {
+			logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
+			authorized = true
+			return false
+		}
+
+		// // If this rule applies to namespaces, and only certain namespaces are
+		// specified, determine if it matches this current namespace
+		if rule.ResourceNameMatches(name) {
+			logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
+			authorized = true
+			return false
+		}
+
+		return true
+	})
+
+	if funcErr != nil {
+		return nil, fmt.Errorf("error getting namespace: %s", funcErr)
+	}
+
+	if !authorized {
+		logger.Debug("unauthorized request")
+		return nil, authorization.ErrUnauthorized
+	}
+
 	return &namespace, nil
 }
 

--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -109,7 +109,6 @@ func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespa
 		}
 
 		// Only ClusterRoleBindings can grant explicit access to a namespace
-		fmt.Println(binding.GetObjectMeta().Namespace)
 		if binding.GetObjectMeta().Namespace == "" {
 			// If this rule applies to namespaces, determine if all resources of type "namespace" are allowed
 			if len(rule.ResourceNames) == 0 {
@@ -209,19 +208,22 @@ func (a *NamespaceClient) FetchNamespace(ctx context.Context, name string) (*cor
 			return true
 		}
 
-		// If this rule applies to namespaces, determine if all resources of type "namespace" are allowed
-		if len(rule.ResourceNames) == 0 {
-			logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
-			authorized = true
-			return false
-		}
+		// Only ClusterRoleBindings can grant explicit access to a namespace
+		if binding.GetObjectMeta().Namespace == "" {
+			// If this rule applies to namespaces, determine if all resources of type "namespace" are allowed
+			if len(rule.ResourceNames) == 0 {
+				logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
+				authorized = true
+				return false
+			}
 
-		// If this rule applies to namespaces, and only certain namespaces are
-		// specified, determine if it matches this current namespace
-		if rule.ResourceNameMatches(name) {
-			logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
-			authorized = true
-			return false
+			// If this rule applies to namespaces, and only certain namespaces are
+			// specified, determine if it matches this current namespace
+			if rule.ResourceNameMatches(name) {
+				logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)
+				authorized = true
+				return false
+			}
 		}
 
 		return true

--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -58,6 +58,7 @@ func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespa
 	for _, namespace := range resources {
 		namespaceMap[namespace.Name] = namespace
 	}
+
 	attrs := &authorization.Attributes{
 		APIGroup:   a.client.APIGroup,
 		APIVersion: a.client.APIVersion,
@@ -65,10 +66,20 @@ func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespa
 		Namespace:  corev2.ContextNamespace(ctx),
 		Verb:       "list",
 	}
-
 	if err := addAuthUser(ctx, attrs); err != nil {
 		return nil, err
 	}
+	logger = logger.WithFields(logrus.Fields{
+		"zz_request": map[string]string{
+			"apiGroup":     attrs.APIGroup,
+			"apiVersion":   attrs.APIVersion,
+			"namespace":    attrs.Namespace,
+			"resource":     attrs.Resource,
+			"resourceName": attrs.ResourceName,
+			"username":     attrs.User.Username,
+			"verb":         attrs.Verb,
+		},
+	})
 
 	var funcErr error
 
@@ -83,31 +94,52 @@ func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespa
 		if !rule.VerbMatches("get") {
 			return true
 		}
+
+		// If this rule doesn't applies to namespaces, determine if the user has
+		// implicit access via a resource within that namespace
 		if !rule.ResourceMatches(corev2.NamespacesResource) {
 			// Find namespaces with implicit access
 			ns := binding.GetObjectMeta().Namespace
 			if namespace, ok := namespaceMap[ns]; ok {
+				logger.Debugf("namespace %s implicitely authorized by the binding %s", namespace.Name, binding.GetObjectMeta().Name)
 				namespaces = append(namespaces, namespace)
 				delete(namespaceMap, ns)
 			}
 			return true
 		}
-		if len(rule.ResourceNames) == 0 {
-			// All resources of type "namespace" are allowed
-			namespaces = resources
-			return false
-		}
-		for name, namespace := range namespaceMap {
-			if rule.ResourceNameMatches(name) {
-				namespaces = append(namespaces, namespace)
-				delete(namespaceMap, name)
+
+		// Only ClusterRoleBindings can grant explicit access to a namespace
+		fmt.Println(binding.GetObjectMeta().Namespace)
+		if binding.GetObjectMeta().Namespace == "" {
+			// If this rule applies to namespaces, determine if all resources of type "namespace" are allowed
+			if len(rule.ResourceNames) == 0 {
+				// All resources of type "namespace" are allowed
+				logger.Debugf("all namespaces explicitely authorized by the binding %s", binding.GetObjectMeta().Name)
+				namespaces = resources
+				return false
+			}
+
+			// If this rule applies to namespaces, and only certain namespaces are
+			// specified, determine if it matches this current namespace
+			for name, namespace := range namespaceMap {
+				if rule.ResourceNameMatches(name) {
+					logger.Debugf("namespace %s explicitely authorized by the binding %s", namespace.Name, binding.GetObjectMeta().Name)
+					namespaces = append(namespaces, namespace)
+					delete(namespaceMap, name)
+				}
 			}
 		}
+
 		return true
 	})
 
 	if funcErr != nil {
 		return nil, fmt.Errorf("error listing namespaces: %s", funcErr)
+	}
+
+	if len(namespaces) == 0 {
+		logger.Debug("unauthorized request")
+		return nil, authorization.ErrUnauthorized
 	}
 
 	return namespaces, nil
@@ -184,7 +216,7 @@ func (a *NamespaceClient) FetchNamespace(ctx context.Context, name string) (*cor
 			return false
 		}
 
-		// // If this rule applies to namespaces, and only certain namespaces are
+		// If this rule applies to namespaces, and only certain namespaces are
 		// specified, determine if it matches this current namespace
 		if rule.ResourceNameMatches(name) {
 			logger.Debugf("request authorized by the binding %s", binding.GetObjectMeta().Name)

--- a/backend/api/namespace_test.go
+++ b/backend/api/namespace_test.go
@@ -138,6 +138,44 @@ func TestNamespaceGet(t *testing.T) {
 			wantNamespace: true,
 			wantErr:       false,
 		},
+		{
+			name:      "explicit access can only be granted via cluster resources",
+			namespace: "dev",
+			attrs: &authorization.Attributes{
+				User: corev2.User{
+					Username: "foo",
+					Groups:   []string{"local-admins"},
+				},
+			},
+			roles: []*corev2.Role{
+				{
+					ObjectMeta: corev2.NewObjectMeta("local-admin", "dev"),
+					Rules: []corev2.Rule{
+						{
+							Verbs:     []string{corev2.VerbAll},
+							Resources: []string{corev2.ResourceAll},
+						},
+					},
+				},
+			},
+			roleBindings: []*corev2.RoleBinding{
+				{
+					Subjects: []corev2.Subject{
+						{
+							Type: "Group",
+							Name: "local-admins",
+						},
+					},
+					RoleRef: corev2.RoleRef{
+						Type: "Role",
+						Name: "local-admin",
+					},
+					ObjectMeta: corev2.NewObjectMeta("local-admin", "dev"),
+				},
+			},
+			wantNamespace: false,
+			wantErr:       true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -422,7 +460,7 @@ func TestNamespaceList(t *testing.T) {
 			},
 		},
 		{
-			Name: "explicit access should only work via ClusterRoleBindings",
+			Name: "explicit access can only be granted via cluster resources",
 			Attrs: &authorization.Attributes{
 				APIGroup:   "core",
 				APIVersion: "v2",

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -2,13 +2,10 @@ package routers
 
 import (
 	"context"
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/mock"
@@ -34,310 +31,52 @@ func TestNamespacesRouter(t *testing.T) {
 	}
 }
 
-func namespaceToResource(ns []*corev2.Namespace) []corev2.Resource {
-	result := make([]corev2.Resource, len(ns))
-	for i := range ns {
-		result[i] = ns[i]
-	}
-	return result
-}
-
 func TestNamespaceRouterList(t *testing.T) {
 	namespaces := []*corev2.Namespace{
-		corev2.FixtureNamespace("a"),
-		corev2.FixtureNamespace("b"),
-		corev2.FixtureNamespace("c"),
-		corev2.FixtureNamespace("d"),
-		corev2.FixtureNamespace("e"),
-		corev2.FixtureNamespace("f"),
+		corev2.FixtureNamespace("default"),
 	}
-	tests := []struct {
-		Name                string
-		Attrs               *authorization.Attributes
-		ClusterRoles        []*corev2.ClusterRole
-		ClusterRoleBindings []*corev2.ClusterRoleBinding
-		Roles               []*corev2.Role
-		RoleBindings        []*corev2.RoleBinding
-		AllNamespaces       []*corev2.Namespace
-		ExpNamespaces       []corev2.Resource
-		ExpError            bool
-	}{
-		{
-			Name: "all access",
-			Attrs: &authorization.Attributes{
-				APIGroup:     "core",
-				APIVersion:   "v2",
-				Namespace:    "",
-				Resource:     corev2.NamespacesResource,
-				ResourceName: "",
-				User: corev2.User{
-					Username: "admin",
-					Groups:   []string{"cluster-admins"},
-				},
-			},
-			ClusterRoles: []*corev2.ClusterRole{
-				{
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-					Rules: []corev2.Rule{
-						{
-							Verbs:     []string{corev2.VerbAll},
-							Resources: []string{corev2.ResourceAll},
-						},
-					},
-				},
-			},
-			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "cluster-admins",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "ClusterRole",
-						Name: "cluster-admin",
-					},
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-				},
-			},
-			RoleBindings:  []*corev2.RoleBinding{},
-			AllNamespaces: namespaces,
-			ExpNamespaces: namespaceToResource(namespaces),
-		},
-		{
-			Name: "no access",
-			Attrs: &authorization.Attributes{
-				APIGroup:     "core",
-				APIVersion:   "v2",
-				Namespace:    "default",
-				Resource:     corev2.NamespacesResource,
-				ResourceName: "",
-				User: corev2.User{
-					Username: "regular-user",
-					Groups:   []string{"plebs"},
-				},
-			},
-			ClusterRoles: []*corev2.ClusterRole{
-				{
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-					Rules: []corev2.Rule{
-						{
-							Verbs:     []string{corev2.VerbAll},
-							Resources: []string{corev2.ResourceAll},
-						},
-					},
-				},
-			},
-			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "cluster-admins",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "ClusterRole",
-						Name: "cluster-admin",
-					},
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-				},
-			},
-			RoleBindings:  []*corev2.RoleBinding{},
-			AllNamespaces: namespaces,
-			ExpNamespaces: []corev2.Resource{},
-		},
-		{
-			Name: "partial access",
-			Attrs: &authorization.Attributes{
-				APIGroup:     "core",
-				APIVersion:   "v2",
-				Namespace:    "default",
-				Resource:     corev2.NamespacesResource,
-				ResourceName: "",
-				User: corev2.User{
-					Username: "regular-user",
-					Groups:   []string{"plebs"},
-				},
-			},
-			ClusterRoles: []*corev2.ClusterRole{
-				{
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-					Rules: []corev2.Rule{
-						{
-							Verbs:     []string{corev2.VerbAll},
-							Resources: []string{corev2.ResourceAll},
-						},
-					},
-				},
-			},
-			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "cluster-admins",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "ClusterRole",
-						Name: "cluster-admin",
-					},
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-				},
-			},
-			Roles: []*corev2.Role{
-				{
-					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
-					Rules: []corev2.Rule{
-						{
-							Verbs:         []string{"get"},
-							Resources:     []string{corev2.NamespacesResource},
-							ResourceNames: []string{"a", "c", "e"},
-						},
-					},
-				},
-			},
-			RoleBindings: []*corev2.RoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "plebs",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "Role",
-						Name: "pleb",
-					},
-					ObjectMeta: corev2.NewObjectMeta("pleb", "default"),
-				},
-			},
-			AllNamespaces: namespaces,
-			ExpNamespaces: []corev2.Resource{
-				namespaces[0],
-				namespaces[2],
-				namespaces[4],
-			},
-		},
-		{
-			Name: "implicit access via resources in namespace",
-			Attrs: &authorization.Attributes{
-				APIGroup:     "core",
-				APIVersion:   "v2",
-				Namespace:    "a",
-				Resource:     corev2.ChecksResource,
-				ResourceName: "",
-				User: corev2.User{
-					Username: "regular-user",
-					Groups:   []string{"plebs"},
-				},
-			},
-			ClusterRoles: []*corev2.ClusterRole{
-				{
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-					Rules: []corev2.Rule{
-						{
-							Verbs:     []string{corev2.VerbAll},
-							Resources: []string{corev2.ResourceAll},
-						},
-					},
-				},
-			},
-			ClusterRoleBindings: []*corev2.ClusterRoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "cluster-admins",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "ClusterRole",
-						Name: "cluster-admin",
-					},
-					ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
-				},
-			},
-			Roles: []*corev2.Role{
-				{
-					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
-					Rules: []corev2.Rule{
-						{
-							Verbs:     []string{"get"},
-							Resources: []string{corev2.ChecksResource},
-						},
-					},
-				},
-			},
-			RoleBindings: []*corev2.RoleBinding{
-				{
-					Subjects: []corev2.Subject{
-						{
-							Type: "Group",
-							Name: "plebs",
-						},
-					},
-					RoleRef: corev2.RoleRef{
-						Type: "Role",
-						Name: "pleb",
-					},
-					ObjectMeta: corev2.NewObjectMeta("pleb", "a"),
-				},
-			},
-			AllNamespaces: namespaces,
-			ExpNamespaces: []corev2.Resource{
-				namespaces[0],
+	clusterRole := corev2.ClusterRole{
+		ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+		Rules: []corev2.Rule{
+			{
+				Verbs:     []string{corev2.VerbAll},
+				Resources: []string{corev2.ResourceAll},
 			},
 		},
 	}
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			store := new(mockstore.MockStore)
-			store.On("ListClusterRoles", mock.Anything, mock.Anything).Return(test.ClusterRoles, nil)
-			store.On("ListClusterRoleBindings", mock.Anything, mock.Anything).Return(test.ClusterRoleBindings, nil)
-			store.On("ListRoles", mock.Anything, mock.Anything).Return(test.Roles, nil)
-			store.On("ListRoleBindings", mock.Anything, mock.Anything).Return(test.RoleBindings, nil)
-			store.On("ListResources", mock.Anything, corev2.NamespacesResource, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-				resources := args[2].(*[]*corev2.Namespace)
-				*resources = append(*resources, test.AllNamespaces...)
-			}).Return(nil)
-			setupGetClusterRoleAndGetRole(store, test.ClusterRoles, test.Roles)
-
-			ctx := context.Background()
-			ctx = context.WithValue(ctx, corev2.ClaimsKey, corev2.FixtureClaims(test.Attrs.User.Username, test.Attrs.User.Groups))
-
-			auth := &rbac.Authorizer{Store: store}
-			router := NewNamespacesRouter(store, auth)
-
-			got, err := router.list(ctx, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			sort.Slice(got, sortFunc(got))
-
-			if got, want := got, test.ExpNamespaces; !reflect.DeepEqual(got, want) {
-				t.Fatalf("bad namespaces: got %+v, want %+v", got, want)
-			}
-		})
-	}
-}
-
-func sortFunc(namespaces []corev2.Resource) func(i, j int) bool {
-	return func(i, j int) bool {
-		return namespaces[i].GetObjectMeta().Name < namespaces[j].GetObjectMeta().Name
-	}
-}
-
-func setupGetClusterRoleAndGetRole(store *mockstore.MockStore, clusterRoles []*corev2.ClusterRole, roles []*corev2.Role) {
-	for _, role := range clusterRoles {
-		store.On("GetClusterRole", mock.Anything, role.Name).Return(role, nil)
+	clusterRoleBinding := corev2.ClusterRoleBinding{
+		Subjects: []corev2.Subject{
+			{
+				Type: "Group",
+				Name: "cluster-admins",
+			},
+		},
+		RoleRef: corev2.RoleRef{
+			Type: "ClusterRole",
+			Name: "cluster-admin",
+		},
+		ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
 	}
 
-	for _, role := range roles {
-		store.On("GetRole", mock.Anything, role.Name).Return(role, nil)
+	store := new(mockstore.MockStore)
+	store.On("ListClusterRoleBindings", mock.Anything, mock.Anything).Return([]*corev2.ClusterRoleBinding{&clusterRoleBinding}, nil)
+	store.On("GetClusterRole", mock.Anything, mock.Anything).Return(&clusterRole, nil)
+	store.On("ListRoleBindings", mock.Anything, mock.Anything).Return([]*corev2.RoleBinding{}, nil)
+	store.On("ListResources", mock.Anything, corev2.NamespacesResource, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		resources := args[2].(*[]*corev2.Namespace)
+		*resources = append(*resources, namespaces...)
+	}).Return(nil)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, corev2.ClaimsKey, corev2.FixtureClaims("foo", []string{"cluster-admins"}))
+
+	auth := &rbac.Authorizer{Store: store}
+	router := NewNamespacesRouter(store, auth)
+	got, err := router.list(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected namespaces to be returned")
 	}
 }

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -156,7 +156,7 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	})
 
 	if !authorized {
-		logger.Debugf("unauthorized request")
+		logger.Debug("unauthorized request")
 	}
 
 	return authorized, visitErr


### PR DESCRIPTION
## What is this change?

This PR fixes a bug where a user with implicit access to a namespace couldn't access that namespace via the Web UI.

Long story short, the Web UI uses the [FetchNamespace](https://github.com/sensu/sensu-go/blob/9aa87c9060ae41198733373d49a22f32d9db08cc/backend/api/namespace.go#L116) method which was never retrofitted with the implicit namespace feature, probably because `sensuctl` doesn't use that API so we forgot to back-port it.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-enterprise-go/issues/821

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added unit tests + manual testing.

## Is this change a patch?

Yep!