### PR TITLE
Only send secrets over the wire if mTLS is enabled

### DIFF
--- a/backend/secrets/provider.go
+++ b/backend/secrets/provider.go
@@ -17,8 +17,9 @@ type Provider interface {
 
 // ProviderManager manages the list of secrets providers.
 type ProviderManager struct {
-	mu        *sync.RWMutex
-	providers map[string]Provider
+	mu         *sync.RWMutex
+	providers  map[string]Provider
+	TLSenabled bool
 }
 
 // NewProviderManager instantiates a new provider manager.


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a bool that can be set by the enterprise code if mTLS is enabled. 
> Secrets are only transmitted over a TLS websocket connection; unencrypted connections must not transmit privileged information. (for agent side resources, TLS/mTLS? must be enabled)

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/792.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Local testing on enterprise branch.

## Is this change a patch?

No, required for feature work.