### PR TITLE
Split rules ClusterRole and Role verbs & resources on comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed a memory leak in the entity cache
+- Split rules ClusterRole and Role verbs, resources and resource names on comma.
 
 ## [5.16.1] - 2019-12-18
 

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -2,8 +2,12 @@ package v2
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"path"
+	"strings"
+
+	stringsutil "github.com/sensu/sensu-go/util/strings"
 )
 
 const (
@@ -47,6 +51,14 @@ var CommonCoreResources = []string{
 	"hooks",
 	"mutators",
 	"silenced",
+}
+
+var allowedVerbs = []string{
+	VerbAll,
+	"get",
+	"list",
+	"update",
+	"delete",
 }
 
 // FixtureSubject creates a Subject for testing
@@ -135,6 +147,18 @@ func (r *ClusterRole) Validate() error {
 		return errors.New("ClusterRole cannot have a namespace")
 	}
 
+	for i := range r.Rules {
+		// Split the verbs, resources and resource names
+		r.Rules[i].Verbs = split(r.Rules[i].Verbs)
+		r.Rules[i].Resources = split(r.Rules[i].Resources)
+		r.Rules[i].ResourceNames = split(r.Rules[i].ResourceNames)
+
+		// Validate the verbs
+		if err := validateVerbs(r.Rules[i].Verbs); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -195,6 +219,18 @@ func (r *Role) Validate() error {
 
 	if len(r.Rules) == 0 {
 		return errors.New("a Role must have at least one rule")
+	}
+
+	for i := range r.Rules {
+		// Split the verbs, resources and resource names
+		r.Rules[i].Verbs = split(r.Rules[i].Verbs)
+		r.Rules[i].Resources = split(r.Rules[i].Resources)
+		r.Rules[i].ResourceNames = split(r.Rules[i].ResourceNames)
+
+		// Validate the verbs
+		if err := validateVerbs(r.Rules[i].Verbs); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -382,4 +418,27 @@ func (*ClusterRole) RBACName() string {
 
 func (*Role) RBACName() string {
 	return "roles"
+}
+
+// split splits each string within a list using the comma seperator
+func split(list []string) []string {
+	var splitted []string
+
+	for _, elem := range list {
+		v := strings.Split(elem, ",")
+		splitted = append(splitted, v...)
+	}
+
+	return splitted
+}
+
+// validateVerbs ensures the provided verbs are valid
+func validateVerbs(verbs []string) error {
+	for _, verb := range verbs {
+		if !stringsutil.InArray(verb, allowedVerbs) {
+			return fmt.Errorf("the verb %q is not valid", verb)
+		}
+	}
+
+	return nil
 }

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -151,7 +151,6 @@ func (r *ClusterRole) Validate() error {
 		// Split the verbs, resources and resource names
 		r.Rules[i].Verbs = split(r.Rules[i].Verbs)
 		r.Rules[i].Resources = split(r.Rules[i].Resources)
-		r.Rules[i].ResourceNames = split(r.Rules[i].ResourceNames)
 
 		// Validate the verbs
 		if err := validateVerbs(r.Rules[i].Verbs); err != nil {
@@ -225,7 +224,6 @@ func (r *Role) Validate() error {
 		// Split the verbs, resources and resource names
 		r.Rules[i].Verbs = split(r.Rules[i].Verbs)
 		r.Rules[i].Resources = split(r.Rules[i].Resources)
-		r.Rules[i].ResourceNames = split(r.Rules[i].ResourceNames)
 
 		// Validate the verbs
 		if err := validateVerbs(r.Rules[i].Verbs); err != nil {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds better validation around ClusterRole and Role rules, and also automatically split verbs, resources and resource names on commas, which often happen on YAML files and can lead to confusing errors (the rules are not applied when expected).

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/3471

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added unit tests.

## Is this change a patch?

Yep