### PR TITLE
Add format flag to "sensuctl command list"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed a memory leak in the entity cache
 - Split rules ClusterRole and Role verbs, resources and resource names on comma.
+- Add support for the `--format` flag in the `sensuctl command list` subcommand.
 
 ## [5.16.1] - 2019-12-18
 

--- a/cli/commands/command/list.go
+++ b/cli/commands/command/list.go
@@ -25,6 +25,8 @@ func ListCommand(cli *cli.SensuCli) *cobra.Command {
 		RunE:  listCommandExecute(cli),
 	}
 
+	helpers.AddFormatFlag(cmd.Flags())
+
 	return cmd
 }
 


### PR DESCRIPTION
## What is this change?

It adds support for the `--format` flag to the `sensuctl command list` subcommand.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3420

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested:

```
$ sensuctl command list --format yaml
type: CommandPlugin
api_version: cli/cmdmanager
metadata:
  name: echo
spec:
  alias: echo
  asset:
    builds:
    - filters: null
      headers: null
      sha512: 4ae5dfbe9ca0c7d4050ad334d3117176e0720462505335a8c2b7d6cb28985cccc235a32f670a02a9dd10b1ecf6d016cf2e966b7f3222c56d4bdabd53b0fabd8c
      url: http://localhost:8000/echo-asset-0.0.1.tar.gz
    filters: null
    headers: null
    metadata:
      name: echo
      namespace: sensuctl
$ sensuctl command list --format json
[
  {
    "alias": "echo",
    "asset": {
      "url": "http://localhost:8000/echo-asset-0.0.1.tar.gz",
      "sha512": "4ae5dfbe9ca0c7d4050ad334d3117176e0720462505335a8c2b7d6cb28985cccc235a32f670a02a9dd10b1ecf6d016cf2e966b7f3222c56d4bdabd53b0fabd8c",
      "filters": null,
      "builds": null,
      "metadata": {
        "name": "echo",
        "namespace": "sensuctl"
      },
      "headers": null
    }
  }
]
$ sensuctl command list --format wrapped-json
{
  "type": "CommandPlugin",
  "api_version": "cli/cmdmanager",
  "metadata": {
    "name": "echo"
  },
  "spec": {
    "alias": "echo",
    "asset": {
      "builds": [
        {
          "filters": null,
          "headers": null,
          "sha512": "4ae5dfbe9ca0c7d4050ad334d3117176e0720462505335a8c2b7d6cb28985cccc235a32f670a02a9dd10b1ecf6d016cf2e966b7f3222c56d4bdabd53b0fabd8c",
          "url": "http://localhost:8000/echo-asset-0.0.1.tar.gz"
        }
      ],
      "filters": null,
      "headers": null,
      "metadata": {
        "name": "echo",
        "namespace": "sensuctl"
      }
    }
  }
}
```
## Is this change a patch?

Yep