### PR TITLE
Set event's namespace using route variables in POST /events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ within that namespace via the Web UI.
 resources.
 - Split rules ClusterRole and Role verbs, resources and resource names on comma.
 - Add support for the `--format` flag in the `sensuctl command list` subcommand.
+- Namespace can be ommited from event when performing an HTTP POST request to
+the `/events` endpoint.
 
 ## [5.16.1] - 2019-12-18
 

--- a/backend/apid/handlers/handlers.go
+++ b/backend/apid/handlers/handlers.go
@@ -51,7 +51,7 @@ func CheckMeta(resource interface{}, vars map[string]string) error {
 	return nil
 }
 
-// resource is used to set metadata values, e.g. in MetaPathValues()
+// Resource is used to set metadata values, e.g. in MetaPathValues()
 type Resource interface {
 	GetObjectMeta() corev2.ObjectMeta
 	SetNamespace(string)

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -75,8 +75,26 @@ func (r *EventsRouter) create(req *http.Request) (interface{}, error) {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	if err := handlers.CheckMeta(event.Entity, mux.Vars(req)); err != nil {
-		return nil, actions.NewError(actions.InvalidArgument, err)
+	vars := mux.Vars(req)
+
+	if event.Entity != nil {
+		if err := handlers.MetaPathValues(event.Entity, vars, "entity"); err != nil {
+			return nil, err
+		}
+
+		if err := handlers.CheckMeta(event.Entity, vars); err != nil {
+			return nil, actions.NewError(actions.InvalidArgument, err)
+		}
+	}
+
+	if event.Check != nil {
+		if err := handlers.MetaPathValues(event.Check, vars, "check"); err != nil {
+			return nil, err
+		}
+
+		if err := handlers.CheckMeta(event.Check, vars); err != nil {
+			return nil, actions.NewError(actions.InvalidArgument, err)
+		}
 	}
 
 	err := r.controller.CreateOrReplace(req.Context(), event)

--- a/backend/apid/routers/events_test.go
+++ b/backend/apid/routers/events_test.go
@@ -115,13 +115,6 @@ func TestEventsRouter(t *testing.T) {
 			wantStatusCode: http.StatusBadRequest,
 		},
 		{
-			name:           "it returns 400 if the event metadata to create is invalid",
-			method:         http.MethodPost,
-			path:           empty.URIPath(),
-			body:           []byte(`{"entity": {"namespace":"acme"}}`),
-			wantStatusCode: http.StatusBadRequest,
-		},
-		{
 			name:   "it returns 400 if the event to create is not valid",
 			method: http.MethodPost,
 			path:   empty.URIPath(),


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It allows users to omit the namespace in an event payload when using POST `/events`, like it's already the case for the PUT verb.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3482

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

Yep