### PR TITLE
sensuctl assets installed via Bonsai should have a namespace set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ by commerical secrets providers. Implemented for checks, mutators, and handlers.
 chart.
 - Fixed a bug where `sensuctl entity delete` was not returning an error
 when attempting to delete a non-existent entity.
+- sensuctl command assets installed via Bonsai will now use the "sensuctl"
+namespace.
 
 ## [5.16.1] - 2019-12-18
 

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	dbName      = "commands.db"
-	commandName = "entrypoint"
+	dbName                 = "commands.db"
+	commandName            = "entrypoint"
+	sensuctlAssetNamespace = "sensuctl"
 )
 
 var (
@@ -168,6 +169,8 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		return err
 	}
 
+	asset.Namespace = sensuctlAssetNamespace
+
 	if err := asset.Validate(); err != nil {
 		return err
 	}
@@ -198,7 +201,7 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 func (m *CommandManager) InstallCommandFromURL(alias, archiveURL, checksum string) error {
 	meta := corev2.ObjectMeta{
 		Name:      alias,
-		Namespace: "sensuctl",
+		Namespace: sensuctlAssetNamespace,
 	}
 	asset := corev2.Asset{
 		Builds: []*corev2.AssetBuild{

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -401,8 +401,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 				}
 				asset := corev2.Asset{
 					ObjectMeta: corev2.ObjectMeta{
-						Name:      bAsset.name,
-						Namespace: bAsset.namespace,
+						Name: bAsset.name,
 						Annotations: map[string]string{
 							"io.sensu.bonsai.type":     "sensuctl",
 							"io.sensu.bonsai.provider": "sensuctl/command",


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Sets the namespace field on Bonsai-installed sensuctl command assets to `sensuctl`.

## Why is this change necessary?

It is currently impossible to install sensuctl command assets via Bonsai.

## Does your change need a Changelog entry?

Yes.

## How did you verify this change?

Altered a test to ensure it fails when a namespace is not set. Hard-code the namespace in the Bonsai-install logic.

## Is this change a patch?

Yes but we're going to ship it with the next minor release.