### PR TITLE
Add more specific error checking for entity delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ by commerical secrets providers. Implemented for checks, mutators, and handlers.
 - [Web] Fixed a inconsistent crash that occurred in Firefox browsers.
 - [Web] Fixed bug where event history was duplicated in the event timeline
 chart.
+- Fixed a bug where `sensuctl entity delete` was not returning an error
+when attempting to delete a non-existent entity.
 
 ## [5.16.1] - 2019-12-18
 

--- a/backend/apid/actions/delete_events_by_entity.go
+++ b/backend/apid/actions/delete_events_by_entity.go
@@ -11,7 +11,8 @@ import (
 )
 
 type EntityDeleter struct {
-	Store store.Store
+	EntityStore store.EntityStore
+	EventStore  store.EventStore
 }
 
 func (d EntityDeleter) Delete(req *http.Request) (interface{}, error) {
@@ -21,7 +22,7 @@ func (d EntityDeleter) Delete(req *http.Request) (interface{}, error) {
 		return nil, NewError(InvalidArgument, err)
 	}
 
-	events, err := d.Store.GetEventsByEntity(req.Context(), entityName, &store.SelectionPredicate{})
+	events, err := d.EventStore.GetEventsByEntity(req.Context(), entityName, &store.SelectionPredicate{})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching events for entity: %s", err)
 	}
@@ -31,7 +32,7 @@ func (d EntityDeleter) Delete(req *http.Request) (interface{}, error) {
 			// improbable
 			continue
 		}
-		err := d.Store.DeleteEventByEntityCheck(req.Context(), entityName, event.Check.Name)
+		err := d.EventStore.DeleteEventByEntityCheck(req.Context(), entityName, event.Check.Name)
 		if err != nil {
 			logger := logger.WithFields(logrus.Fields{
 				"entity":    entityName,
@@ -42,7 +43,7 @@ func (d EntityDeleter) Delete(req *http.Request) (interface{}, error) {
 		}
 	}
 
-	result, err := d.Store.GetEntityByName(req.Context(), entityName)
+	result, err := d.EntityStore.GetEntityByName(req.Context(), entityName)
 	if err != nil {
 		return nil, NewError(InternalErr, err)
 	}
@@ -51,5 +52,5 @@ func (d EntityDeleter) Delete(req *http.Request) (interface{}, error) {
 		return nil, NewErrorf(NotFound)
 	}
 
-	return nil, d.Store.DeleteEntityByName(req.Context(), entityName)
+	return nil, d.EntityStore.DeleteEntityByName(req.Context(), entityName)
 }

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -35,8 +35,7 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 	}
 
 	deleter := actions.EntityDeleter{
-		EntityStore: r.store,
-		EventStore:  r.eventStore,
+		Store: r.store,
 	}
 
 	routes.Del(deleter.Delete)

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -35,7 +35,8 @@ func (r *EntitiesRouter) Mount(parent *mux.Router) {
 	}
 
 	deleter := actions.EntityDeleter{
-		Store: r.store,
+		EntityStore: r.store,
+		EventStore:  r.eventStore,
 	}
 
 	routes.Del(deleter.Delete)

--- a/backend/apid/routers/entities_test.go
+++ b/backend/apid/routers/entities_test.go
@@ -15,6 +15,7 @@ func TestEntitiesRouter(t *testing.T) {
 	s.On("GetEventsByEntity", mock.Anything, "foo", mock.Anything).Return([]*corev2.Event{corev2.FixtureEvent("foo", "bar")}, nil)
 	s.On("DeleteEventByEntityCheck", mock.Anything, "foo", "bar").Return(nil)
 	s.On("DeleteEntityByName", mock.Anything, "foo").Return(nil)
+	s.On("GetEntityByName", mock.Anything, "foo").Return(corev2.FixtureEntity("foo"), nil)
 	router := NewEntitiesRouter(s, s)
 	parentRouter := mux.NewRouter().PathPrefix(corev2.URLPrefix).Subrouter()
 	router.Mount(parentRouter)

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -434,7 +434,7 @@ var deleteResourceStoreErrTestCase = func(resource corev2.Resource) routerTestCa
 
 var deleteResourceSuccessTestCase = func(resource corev2.Resource) routerTestCase {
 	return routerTestCase{
-		name:   "it returns 204 if the resource was delete",
+		name:   "it returns 204 if the resource was deleted",
 		method: http.MethodDelete,
 		path:   resource.URIPath(),
 		body:   []byte(`{"metadata": {"namespace":"default","name":"foo"}}`),


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds more specific error checking for entity delete.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3501

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

https://github.com/sensu/sensu-go-qa-crucible/blob/e3fba2059f6a5fb9a5494b21c4816daafafdc23d/spec/backend/entities_spec.rb#L31-L42

## Is this change a patch?

Yes, but in an attempt not to scope creep, I will merge this into master.