### PR TITLE
Upgrade mholt/archiver

### DIFF
--- a/asset/expander.go
+++ b/asset/expander.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -32,6 +33,10 @@ type Expander interface {
 // - tar-gzip
 type archiveExpander struct{}
 
+type namer interface {
+	Name() string
+}
+
 // Expand an archive to a target directory.
 func (a *archiveExpander) Expand(archive io.ReadSeeker, targetDirectory string) error {
 	// detect the type of archive the asset is
@@ -40,14 +45,15 @@ func (a *archiveExpander) Expand(archive io.ReadSeeker, targetDirectory string) 
 		return err
 	}
 
-	var ar archiver.Archiver
+	var ar archiver.Unarchiver
 
 	// If the file is not an archive, exit with an error.
 	switch ft.MIME.Value {
 	case "application/x-tar":
-		ar = archiver.Tar
+		ar = archiver.NewTar()
 	case "application/gzip":
-		ar = archiver.TarGz
+		ar = archiver.NewTarGz()
+
 	default:
 		return fmt.Errorf(
 			"given file of format '%s' does not appear valid",
@@ -55,8 +61,13 @@ func (a *archiveExpander) Expand(archive io.ReadSeeker, targetDirectory string) 
 		)
 	}
 
+	namer, ok := archive.(namer)
+	if !ok {
+		return errors.New("couldn't get path to archive")
+	}
+
 	// Extract the archive to the desired path
-	if err := ar.Read(archive, targetDirectory); err != nil {
+	if err := ar.Unarchive(namer.Name(), targetDirectory); err != nil {
 		return fmt.Errorf("error extracting asset: %s", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -50,12 +50,12 @@ require (
 	github.com/mattn/go-isatty v0.0.2 // indirect
 	github.com/mattn/go-runewidth v0.0.2 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
-	github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea
+	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/nwaples/rardecode v0.0.0-20170112110516-f22b7ef81a0a // indirect
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
-	github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 // indirect
+	github.com/pierrec/lz4 v2.4.0+incompatible // indirect
 	github.com/pierrec/xxHash v0.1.1 // indirect
 	github.com/prometheus/client_golang v1.2.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
@@ -72,6 +72,7 @@ require (
 	github.com/ulikunitz/xz v0.5.4 // indirect
 	github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc // indirect
 	github.com/willf/pad v0.0.0-20160331131008-b3d780601022
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/bbolt v1.3.2
 	go.uber.org/multierr v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea h1:sTSgY/Yq/PjW+6517MjjKGwsKi7T3LZlg9YlS2t1ODM=
-github.com/mholt/archiver v0.0.0-20180816053333-85d3d0b511ea/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
+github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1wBi7mF09cbNkU=
+github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -196,8 +196,8 @@ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsq
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018 h1:evK2lBbc5w4EFMMs3onLGK1IqzGD3d0RsSGtLJGj+qg=
-github.com/pierrec/lz4 v0.0.0-20171218195038-2fcda4cb7018/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.4.0+incompatible h1:06usnXXDNcPvCHDkmPpkidf4jTc52UKld7UPfqKatY4=
+github.com/pierrec/lz4 v2.4.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/xxHash v0.1.1 h1:KP4NrV9023xp3M4FkTYfcXqWigsOCImL1ANJ7sh5vg4=
 github.com/pierrec/xxHash v0.1.1/go.mod h1:w2waW5Zoa/Wc4Yqe0wgrIYAGKqRMf7czn2HNKXmuL+I=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -278,6 +278,8 @@ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc h1:9lDbC6
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
 github.com/willf/pad v0.0.0-20160331131008-b3d780601022 h1:W5wMm7sF44Z3K9bpq+CHOMOipvLHN1ElD6nyQbbiy/0=
 github.com/willf/pad v0.0.0-20160331131008-b3d780601022/go.mod h1:+pVHwmjc9CH7ugBFxESIwQkXkVj0gUj4cFp63TLwP1Y=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=


### PR DESCRIPTION
This commit upgrades mholt/archiver, which should bring performance
improvements, and bring us in line with other libraries that use
the latest major version.

Some minor refactoring was performed to deal with API drift.

Signed-off-by: Eric Chlebek <eric@sensu.io>