### PR TITLE
Don't fail on check TTL after keepalive fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ resources.
 - Add support for the `--format` flag in the `sensuctl command list` subcommand.
 - Namespace can be ommited from event when performing an HTTP POST request to
 the `/events` endpoint.
+- Fixed a bug where failing check TTL events could occur event if keepalive
+failures had already occurred.
 
 ## [5.16.1] - 2019-12-18
 

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -312,6 +312,18 @@ func (e *Eventd) dead(key string, prev liveness.State, leader bool) (bury bool) 
 		return false
 	}
 
+	keepalive, err := e.eventStore.GetEventByEntityCheck(ctx, entity, "keepalive")
+	if err != nil {
+		lager.WithError(err).Error("check ttl: error retrieving keepalive event")
+		return false
+	}
+
+	if keepalive != nil && keepalive.Check.Status > 0 {
+		// The keepalive is failing. We don't want to also alert for check TTL,
+		// or keep track of check TTL until the entity returns to life.
+		return true
+	}
+
 	event, err := e.eventStore.GetEventByEntityCheck(ctx, entity, check)
 	if err != nil {
 		lager.WithError(err).Error("check ttl: error retrieving event")

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -296,6 +296,7 @@ func TestBuryConditions(t *testing.T) {
 			key:  "default/foo/bar",
 			store: func(store *mockstore.MockStore) {
 				store.On("GetEntityByName", mock.Anything, "bar").Return((*corev2.Entity)(nil), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(corev2.FixtureEvent("bar", "keepalive"), nil)
 			},
 			bury: true,
 		},
@@ -304,6 +305,7 @@ func TestBuryConditions(t *testing.T) {
 			key:  "default/foo/bar",
 			store: func(store *mockstore.MockStore) {
 				store.On("GetEntityByName", mock.Anything, "bar").Return((*corev2.Entity)(nil), errors.New("!"))
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(corev2.FixtureEvent("bar", "keepalive"), nil)
 			},
 			bury: false,
 		},
@@ -313,6 +315,7 @@ func TestBuryConditions(t *testing.T) {
 			store: func(store *mockstore.MockStore) {
 				store.On("GetEntityByName", mock.Anything, "bar").Return(corev2.FixtureEntity("bar"), nil)
 				store.On("GetEventByEntityCheck", mock.Anything, "bar", "foo").Return((*corev2.Event)(nil), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(corev2.FixtureEvent("bar", "keepalive"), nil)
 			},
 			bury: true,
 		},
@@ -322,6 +325,7 @@ func TestBuryConditions(t *testing.T) {
 			store: func(store *mockstore.MockStore) {
 				store.On("GetEntityByName", mock.Anything, "bar").Return(corev2.FixtureEntity("bar"), nil)
 				store.On("GetEventByEntityCheck", mock.Anything, "bar", "foo").Return((*corev2.Event)(nil), errors.New("!"))
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(corev2.FixtureEvent("bar", "keepalive"), nil)
 			},
 			bury: false,
 		},
@@ -330,6 +334,34 @@ func TestBuryConditions(t *testing.T) {
 			key:  "default/foo/bar",
 			store: func(store *mockstore.MockStore) {
 				store.On("GetEntityByName", mock.Anything, "bar").Return(corev2.FixtureEntity("bar"), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "foo").Return(corev2.FixtureEvent("bar", "foo"), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(corev2.FixtureEvent("bar", "keepalive"), nil)
+			},
+			bury: false,
+		},
+		{
+			name: "bury when failing keepalive exists",
+			key:  "default/foo/bar",
+			store: func(store *mockstore.MockStore) {
+				store.On("GetEntityByName", mock.Anything, "bar").Return(corev2.FixtureEntity("bar"), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(&corev2.Event{
+					Check: &corev2.Check{
+						Status: 1,
+					},
+				}, nil)
+			},
+			bury: true,
+		},
+		{
+			name: "do not bury when passing keepalive exists",
+			key:  "default/foo/bar",
+			store: func(store *mockstore.MockStore) {
+				store.On("GetEntityByName", mock.Anything, "bar").Return(corev2.FixtureEntity("bar"), nil)
+				store.On("GetEventByEntityCheck", mock.Anything, "bar", "keepalive").Return(&corev2.Event{
+					Check: &corev2.Check{
+						Status: 0,
+					},
+				}, nil)
 				store.On("GetEventByEntityCheck", mock.Anything, "bar", "foo").Return(corev2.FixtureEvent("bar", "foo"), nil)
 			},
 			bury: false,


### PR DESCRIPTION
## What is this change?

This commit modifies how eventd responds to failing check TTL
events. Previously, check TTL events would occur even if failing
keepalive events had been recorded. Now, eventd will not issue
failing check TTL events if a keepalive event for the entity has
already occurred.

## Why is this change necessary?

Closes #3304

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs changes required.

## How did you verify this change?

I created a check with TTL greater than agent keepalive timeout, got it executing on an agent, and terminated the agent. I observed a keepalive failure occurred. I then observed in the backend logs that the check TTL switch had fired, but no failing event was created for the check.

On the flip side, if the keepalive timeout is longer than the check TTL, then a check TTL event does get created.

## Is this change a patch?

Yes