### PR TITLE
Log the filter name that dropped an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ by commercial secrets providers. Implemented for checks, mutators, and handlers.
 - Added the `keepalive-handlers` configuration flag on the agent to specify the
 entity's keepalive handlers.
 - Added `event.entity.name` as a supported field selector.
+- Indicate in log messages which filter dropped an event.
 
 ### Fixed
 - Fixed a memory leak in the entity cache.

--- a/backend/pipeline/filter.go
+++ b/backend/pipeline/filter.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -77,9 +76,10 @@ func evaluateEventFilter(event *corev2.Event, filter *corev2.EventFilter, assets
 	return false
 }
 
-// filterEvent filters a Sensu event, determining if it will continue
-// through the Sensu pipeline. Returns true if the event should be filtered/denied.
-func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bool, error) {
+// filterEvent filters a Sensu event, determining if it will continue through
+// the Sensu pipeline. Returns the filter's name if the event was filtered and
+// any error encountered
+func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (string, error) {
 	// Prepare the logging
 	fields := utillogging.EventFields(event, false)
 	fields["handler"] = handler.Name
@@ -94,19 +94,19 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 			// Deny an event if it is neither an incident nor resolution.
 			if !event.IsIncident() && !event.IsResolution() {
 				logger.WithFields(fields).Debug("denying event that is not an incident/resolution")
-				return true, fmt.Errorf("dropped by filter %q", filterName)
+				return filterName, nil
 			}
 		case "has_metrics":
 			// Deny an event if it does not have metrics
 			if !event.HasMetrics() {
 				logger.WithFields(fields).Debug("denying event without metrics")
-				return true, fmt.Errorf("dropped by filter %q", filterName)
+				return filterName, nil
 			}
 		case "not_silenced":
 			// Deny event that is silenced.
 			if event.IsSilenced() {
 				logger.WithFields(fields).Debug("denying event that is silenced")
-				return true, fmt.Errorf("dropped by filter %q", filterName)
+				return filterName, nil
 			}
 		default:
 			// Retrieve the filter from the store with its name
@@ -117,7 +117,7 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 			if err != nil {
 				logger.WithFields(fields).WithError(err).
 					Warning("could not retrieve filter")
-				return false, err
+				return "", err
 			}
 
 			if filter != nil {
@@ -131,13 +131,13 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 					logger.WithFields(fields).WithError(err).Error("failed to retrieve assets for filter")
 					if _, ok := err.(*store.ErrInternal); ok {
 						// Fatal error
-						return false, err
+						return "", err
 					}
 				}
 				filtered := evaluateEventFilter(event, filter, assets)
 				if filtered {
 					logger.WithFields(fields).Debug("denying event with custom filter")
-					return true, fmt.Errorf("dropped by filter %q", filterName)
+					return filterName, nil
 				}
 				continue
 			}
@@ -149,7 +149,7 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 					Warning("could not retrieve filter")
 				if _, ok := err.(*store.ErrInternal); ok {
 					// Fatal error
-					return false, err
+					return "", err
 				}
 				continue
 			}
@@ -173,11 +173,11 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 			}
 			if filtered {
 				logger.WithFields(fields).Debug("denying event with custom filter extension")
-				return true, fmt.Errorf("dropped by filter %q", filterName)
+				return filterName, nil
 			}
 		}
 	}
 
 	logger.WithFields(fields).Debug("allowing event")
-	return false, nil
+	return "", nil
 }

--- a/backend/pipeline/filter.go
+++ b/backend/pipeline/filter.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -93,19 +94,19 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 			// Deny an event if it is neither an incident nor resolution.
 			if !event.IsIncident() && !event.IsResolution() {
 				logger.WithFields(fields).Debug("denying event that is not an incident/resolution")
-				return true, nil
+				return true, fmt.Errorf("dropped by filter %q", filterName)
 			}
 		case "has_metrics":
 			// Deny an event if it does not have metrics
 			if !event.HasMetrics() {
 				logger.WithFields(fields).Debug("denying event without metrics")
-				return true, nil
+				return true, fmt.Errorf("dropped by filter %q", filterName)
 			}
 		case "not_silenced":
 			// Deny event that is silenced.
 			if event.IsSilenced() {
 				logger.WithFields(fields).Debug("denying event that is silenced")
-				return true, nil
+				return true, fmt.Errorf("dropped by filter %q", filterName)
 			}
 		default:
 			// Retrieve the filter from the store with its name
@@ -136,7 +137,7 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 				filtered := evaluateEventFilter(event, filter, assets)
 				if filtered {
 					logger.WithFields(fields).Debug("denying event with custom filter")
-					return true, nil
+					return true, fmt.Errorf("dropped by filter %q", filterName)
 				}
 				continue
 			}
@@ -172,7 +173,7 @@ func (p *Pipeline) filterEvent(handler *corev2.Handler, event *corev2.Event) (bo
 			}
 			if filtered {
 				logger.WithFields(fields).Debug("denying event with custom filter extension")
-				return true, nil
+				return true, fmt.Errorf("dropped by filter %q", filterName)
 			}
 		}
 	}

--- a/backend/pipeline/filter_test.go
+++ b/backend/pipeline/filter_test.go
@@ -59,101 +59,101 @@ func TestPipelineFilter(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name     string
-		status   uint32
-		history  []types.CheckHistory
-		metrics  *types.Metrics
-		silenced []string
-		filters  []string
-		expected bool
+		name           string
+		status         uint32
+		history        []types.CheckHistory
+		metrics        *types.Metrics
+		silenced       []string
+		filters        []string
+		expectedFilter string
 	}{
 		{
-			name:     "Not Incident",
-			status:   0,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"is_incident"},
-			expected: true,
+			name:           "Not Incident",
+			status:         0,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"is_incident"},
+			expectedFilter: "is_incident",
 		},
 		{
-			name:     "Incident",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"is_incident"},
-			expected: false,
+			name:           "Incident",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"is_incident"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Metrics OK Status",
-			status:   0,
-			metrics:  &types.Metrics{},
-			silenced: []string{},
-			filters:  []string{"has_metrics"},
-			expected: false,
+			name:           "Metrics OK Status",
+			status:         0,
+			metrics:        &types.Metrics{},
+			silenced:       []string{},
+			filters:        []string{"has_metrics"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Metrics Warning Status",
-			status:   1,
-			metrics:  &types.Metrics{},
-			silenced: []string{},
-			filters:  []string{"has_metrics"},
-			expected: false,
+			name:           "Metrics Warning Status",
+			status:         1,
+			metrics:        &types.Metrics{},
+			silenced:       []string{},
+			filters:        []string{"has_metrics"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Allow Filter With No Match",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"allowFilterBar"},
-			expected: true,
+			name:           "Allow Filter With No Match",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"allowFilterBar"},
+			expectedFilter: "allowFilterBar",
 		},
 		{
-			name:     "Allow Filter With Match",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"allowFilterFoo"},
-			expected: false,
+			name:           "Allow Filter With Match",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"allowFilterFoo"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Deny Filter With No Match",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"denyFilterBar"},
-			expected: false,
+			name:           "Deny Filter With No Match",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"denyFilterBar"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Deny Filter With Match",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"denyFilterFoo"},
-			expected: true,
+			name:           "Deny Filter With Match",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"denyFilterFoo"},
+			expectedFilter: "denyFilterFoo",
 		},
 		{
-			name:     "Deny Filters With One Match",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"denyFilterBar", "denyFilterFoo"},
-			expected: true,
+			name:           "Deny Filters With One Match",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"denyFilterBar", "denyFilterFoo"},
+			expectedFilter: "denyFilterFoo",
 		},
 		{
-			name:     "Silenced With Metrics",
-			status:   1,
-			metrics:  &types.Metrics{},
-			silenced: []string{"entity1"},
-			filters:  []string{"has_metrics"},
-			expected: false,
+			name:           "Silenced With Metrics",
+			status:         1,
+			metrics:        &types.Metrics{},
+			silenced:       []string{"entity1"},
+			filters:        []string{"has_metrics"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Silenced Without Metrics",
-			status:   1,
-			metrics:  nil,
-			silenced: []string{"entity1"},
-			filters:  []string{"is_incident", "not_silenced"},
-			expected: true,
+			name:           "Silenced Without Metrics",
+			status:         1,
+			metrics:        nil,
+			silenced:       []string{"entity1"},
+			filters:        []string{"is_incident", "not_silenced"},
+			expectedFilter: "not_silenced",
 		},
 		{
 			name:   "Not Transitioned From Incident To Healthy",
@@ -162,10 +162,10 @@ func TestPipelineFilter(t *testing.T) {
 				types.CheckHistory{Status: 0},
 				types.CheckHistory{Status: 0},
 			},
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"is_incident"},
-			expected: true,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"is_incident"},
+			expectedFilter: "is_incident",
 		},
 		{
 			name:   "Transitioned From Incident To Healthy",
@@ -174,15 +174,15 @@ func TestPipelineFilter(t *testing.T) {
 				types.CheckHistory{Status: 1},
 				types.CheckHistory{Status: 0},
 			},
-			metrics:  nil,
-			silenced: []string{},
-			filters:  []string{"is_incident"},
-			expected: false,
+			metrics:        nil,
+			silenced:       []string{},
+			filters:        []string{"is_incident"},
+			expectedFilter: "",
 		},
 		{
-			name:     "Extension filter",
-			filters:  []string{"extension_filter"},
-			expected: true,
+			name:           "Extension filter",
+			filters:        []string{"extension_filter"},
+			expectedFilter: "extension_filter",
 		},
 	}
 
@@ -209,8 +209,8 @@ func TestPipelineFilter(t *testing.T) {
 				Metrics: tc.metrics,
 			}
 
-			filtered, _ := p.filterEvent(handler, event)
-			assert.Equal(t, tc.expected, filtered)
+			f, _ := p.filterEvent(handler, event)
+			assert.Equal(t, tc.expectedFilter, f)
 		})
 	}
 }
@@ -233,44 +233,44 @@ func TestPipelineWhenFilter(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name       string
-		filterName string
-		action     string
-		begin      time.Duration
-		end        time.Duration
-		expected   bool
+		name           string
+		filterName     string
+		action         string
+		begin          time.Duration
+		end            time.Duration
+		expectedFilter string
 	}{
 		{
-			name:       "in time window action allow",
-			filterName: "in_time_window_allow",
-			action:     types.EventFilterActionAllow,
-			begin:      -time.Minute * time.Duration(1),
-			end:        time.Minute * time.Duration(1),
-			expected:   false,
+			name:           "in time window action allow",
+			filterName:     "in_time_window_allow",
+			action:         types.EventFilterActionAllow,
+			begin:          -time.Minute * time.Duration(1),
+			end:            time.Minute * time.Duration(1),
+			expectedFilter: "",
 		},
 		{
-			name:       "outside time window action allow",
-			filterName: "outside_time_window_allow",
-			action:     types.EventFilterActionAllow,
-			begin:      time.Minute * time.Duration(10),
-			end:        time.Minute * time.Duration(20),
-			expected:   true,
+			name:           "outside time window action allow",
+			filterName:     "outside_time_window_allow",
+			action:         types.EventFilterActionAllow,
+			begin:          time.Minute * time.Duration(10),
+			end:            time.Minute * time.Duration(20),
+			expectedFilter: "outside_time_window_allow",
 		},
 		{
-			name:       "in time window action deny",
-			filterName: "in_time_window_deny",
-			action:     types.EventFilterActionDeny,
-			begin:      -time.Minute * time.Duration(1),
-			end:        time.Minute * time.Duration(1),
-			expected:   true,
+			name:           "in time window action deny",
+			filterName:     "in_time_window_deny",
+			action:         types.EventFilterActionDeny,
+			begin:          -time.Minute * time.Duration(1),
+			end:            time.Minute * time.Duration(1),
+			expectedFilter: "in_time_window_deny",
 		},
 		{
-			name:       "outside time window action deny",
-			filterName: "outside_time_window_deny",
-			action:     types.EventFilterActionDeny,
-			begin:      time.Minute * time.Duration(10),
-			end:        time.Minute * time.Duration(20),
-			expected:   false,
+			name:           "outside time window action deny",
+			filterName:     "outside_time_window_deny",
+			action:         types.EventFilterActionDeny,
+			begin:          time.Minute * time.Duration(10),
+			end:            time.Minute * time.Duration(20),
+			expectedFilter: "",
 		},
 	}
 
@@ -303,8 +303,8 @@ func TestPipelineWhenFilter(t *testing.T) {
 				Filters: []string{tc.filterName},
 			}
 
-			filtered, _ := p.filterEvent(handler, event)
-			assert.Equal(t, tc.expected, filtered)
+			f, _ := p.filterEvent(handler, event)
+			assert.Equal(t, tc.expectedFilter, f)
 		})
 	}
 }

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -61,17 +61,17 @@ func (p *Pipeline) HandleEvent(ctx context.Context, event *corev2.Event) error {
 		handler := u.Handler
 		fields["handler"] = handler.Name
 
-		filtered, err := p.filterEvent(handler, event)
-		if filtered {
-			logger.WithFields(fields).Infof("event filtered: %s", err)
-			continue
-		}
+		filter, err := p.filterEvent(handler, event)
 		if err != nil {
 			if _, ok := err.(*store.ErrInternal); ok {
 				// Fatal error
 				return err
 			}
 			logger.WithError(err).Warn("error filtering event")
+		}
+		if filter != "" {
+			logger.WithFields(fields).Infof("event filtered by filter %q", filter)
+			continue
 		}
 
 		eventData, err := p.mutateEvent(handler, event)

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -62,16 +62,16 @@ func (p *Pipeline) HandleEvent(ctx context.Context, event *corev2.Event) error {
 		fields["handler"] = handler.Name
 
 		filtered, err := p.filterEvent(handler, event)
+		if filtered {
+			logger.WithFields(fields).Infof("event filtered: %s", err)
+			continue
+		}
 		if err != nil {
 			if _, ok := err.(*store.ErrInternal); ok {
 				// Fatal error
 				return err
 			}
 			logger.WithError(err).Warn("error filtering event")
-		}
-		if filtered {
-			logger.WithFields(fields).Info("event filtered")
-			continue
 		}
 
 		eventData, err := p.mutateEvent(handler, event)


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds the filter name that dropped an event via the returned error, so it can be logged within a single log entry.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3107

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested

## Is this change a patch?

Nope