### PR TITLE
create is a valid RBAC verb

### DIFF
--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -57,6 +57,7 @@ var allowedVerbs = []string{
 	VerbAll,
 	"get",
 	"list",
+	"create",
 	"update",
 	"delete",
 }

--- a/api/core/v2/rbac_test.go
+++ b/api/core/v2/rbac_test.go
@@ -154,6 +154,11 @@ func Test_validateVerbs(t *testing.T) {
 			verbs:   []string{"get", "put"},
 			wantErr: true,
 		},
+		{
+			name:    "explicit verbs",
+			verbs:   []string{"get", "list", "create", "update", "delete"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It allows RBAC rules with the `create` verb to be created.

![](https://media.giphy.com/media/nspvD8XYqUxP2/giphy.gif)

## Why is this change necessary?

Fixes a bug found during automated QA.

## Does your change need a Changelog entry?

Nope, unreleased bug.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

Yep