### PR TITLE
Allow capital letters in assetsname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - [Web] Fixed issue where silenced entries with a start date would result in a
 crash.
+- Assets name may contain capital letters.
 
 ## [5.17.0] - 2020-01-28
 

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	// AssetNameRegexStr used to validate name of asset
-	AssetNameRegexStr = `[a-z0-9\/\_\.\-\:]+`
+	AssetNameRegexStr = `[\w\/\_\.\-\:]+`
 
 	// AssetNameRegex used to validate name of asset
 	AssetNameRegex = regexp.MustCompile("^" + AssetNameRegexStr + "$")
@@ -119,7 +119,7 @@ func ValidateAssetName(name string) error {
 
 	if !AssetNameRegex.MatchString(name) {
 		return errors.New(
-			"name must be lowercase and may only contain forward slashes, underscores, dashes and numbers",
+			"name may only contain letters, forward slashes, underscores, dashes and numbers",
 		)
 	}
 

--- a/api/core/v2/asset_test.go
+++ b/api/core/v2/asset_test.go
@@ -58,6 +58,10 @@ func TestValidator(t *testing.T) {
 	asset = FixtureAsset("name")
 	asset.Sha512 = "nope"
 	assert.Error(asset.Validate())
+
+	// Bonsai assets with uppercases should pass
+	asset = FixtureAsset("Username/asset_name:0.0.1")
+	assert.NoError(asset.Validate())
 }
 
 func TestValidateName_GH3344(t *testing.T) {


### PR DESCRIPTION
## What is this change?

It modifies the asset regex to allow uppercase in assets name.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3522

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope, the docs was actually wrong but it's now valid! (https://docs.sensu.io/sensu-go/latest/reference/assets/#metadata-attributes)

## How did you verify this change?

Added a unit test and did a quick e2e test, which was successful using the asset mentioned in the original issue:

```
$ s event list
  Entity     Check                                                 Output                                                Status   Silenced             Timestamp
 ──────── ─────────── ───────────────────────────────────────────────────────────────────────────────────────────────── ──────── ────────── ───────────────────────────────
  scotch   cpu         CheckLoad OK - value = 0.00, 0.00, 0.00 | core_load_1=0.00, core_load_5=0.00, core_load_15=0.00        2   false      2020-01-30 12:00:57 -0500 EST
```

## Is this change a patch?

Yep, targeting the release/5.17 branch