### PR TITLE
Fix trusted ca file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 certain circonstances.
 - Fix a bug with tar assets that contain hardlinked files.
 - Assets name may contain capital letters.
+- When `--trusted-ca-file` is used to configure sensuctl, it now detects and saves
+the absolute file path in the cluster config.
 
 ## [5.17.0] - 2020-01-28
 

--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -53,7 +53,11 @@ func (c *Config) SaveTokens(tokens *types.Tokens) error {
 
 // SaveTrustedCAFile saves the Trusted CA file
 func (c *Config) SaveTrustedCAFile(file string) error {
-	c.Cluster.TrustedCAFile = file
+	absolute, err := filepath.Abs(file)
+	if err != nil {
+		return err
+	}
+	c.Cluster.TrustedCAFile = absolute
 
 	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }


### PR DESCRIPTION
I woke up in the middle of the night (international travel, yay!) and saw some chatter about this being the last thing needed for the 5.17.1 release. Didn't want to block anyone and I was wide awake anyway 🤷‍♀ 

## What is this change?

When `--trusted-ca-file` is used to configure sensuctl, it now detects and saves the absolute file path in the cluster config, rather than the relative path.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3520

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Ran `sensuctl configure --url http://127.0.0.1:8080  --password P@ssw0rd! --namespace default --username admin -n --trusted-ca-file CA.pem` from multiple directories, verifying `.config/sensu/sensuctl/cluster` was updated with the correct absolute filepath.

## Is this change a patch?

Yup!