### PR TITLE
Add unique IDs to events

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -307,8 +307,11 @@ func (a *Agent) newKeepalive() *transport.Message {
 	}
 	entity := a.getAgentEntity()
 
+	uid, _ := uuid.NewRandom()
+
 	keepalive := &corev2.Event{
 		ObjectMeta: corev2.NewObjectMeta("", entity.Namespace),
+		ID:         uid[:],
 	}
 
 	keepalive.Check = &corev2.Check{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -270,8 +270,8 @@ func (a *Agent) receiveLoop(ctx context.Context, cancel context.CancelFunc, conn
 
 func logEvent(e *corev2.Event) {
 	fields := logrus.Fields{
-		"event_id": e.GetUUID().String(),
-		"entity":   e.Entity.Name,
+		"event_uuid": e.GetUUID().String(),
+		"entity":     e.Entity.Name,
 	}
 	if e.HasCheck() {
 		fields["check"] = e.Check.Name

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -268,11 +268,24 @@ func (a *Agent) receiveLoop(ctx context.Context, cancel context.CancelFunc, conn
 	}
 }
 
+func logEvent(e *corev2.Event) {
+	fields := logrus.Fields{
+		"event_id": e.GetUUID().String(),
+		"entity":   e.Entity.Name,
+	}
+	if e.HasCheck() {
+		fields["check"] = e.Check.Name
+	}
+	if e.HasMetrics() {
+		fields["metrics"] = true
+	}
+	logger.WithFields(fields).Info("sending event to backend")
+}
+
 func (a *Agent) sendLoop(ctx context.Context, cancel context.CancelFunc, conn transport.Transport) error {
 	defer cancel()
 	keepalive := time.NewTicker(time.Duration(a.config.KeepaliveInterval) * time.Second)
 	defer keepalive.Stop()
-	logger.Info("sending keepalive")
 	if err := conn.Send(a.newKeepalive()); err != nil {
 		logger.WithError(err).Error("error sending message over websocket")
 		return err
@@ -286,13 +299,11 @@ func (a *Agent) sendLoop(ctx context.Context, cancel context.CancelFunc, conn tr
 			}
 			return nil
 		case msg := <-a.sendq:
-			logger.Info("sending event")
 			if err := conn.Send(msg); err != nil {
 				logger.WithError(err).Error("error sending message over websocket")
 				return err
 			}
 		case <-keepalive.C:
-			logger.Info("sending keepalive")
 			if err := conn.Send(a.newKeepalive()); err != nil {
 				logger.WithError(err).Error("error sending message over websocket")
 				return err
@@ -322,6 +333,8 @@ func (a *Agent) newKeepalive() *transport.Message {
 	}
 	keepalive.Entity = a.getAgentEntity()
 	keepalive.Timestamp = time.Now().Unix()
+
+	logEvent(keepalive)
 
 	msgBytes, err := a.marshal(keepalive)
 	if err != nil {

--- a/agent/api.go
+++ b/agent/api.go
@@ -131,7 +131,7 @@ func addEvent(a *Agent) http.HandlerFunc {
 			return
 		}
 
-		logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+		logEvent(event)
 
 		if _, err := a.apiQueue.Send(compressMessage(payload)); err != nil {
 			logger.WithError(err).Error("error queueing message")

--- a/agent/api.go
+++ b/agent/api.go
@@ -131,6 +131,8 @@ func addEvent(a *Agent) http.HandlerFunc {
 			return
 		}
 
+		logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+
 		if _, err := a.apiQueue.Send(compressMessage(payload)); err != nil {
 			logger.WithError(err).Error("error queueing message")
 			http.Error(w, "error queueing message", http.StatusInternalServerError)

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -270,7 +270,7 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 		Payload: msg,
 	}
 
-	logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+	logEvent(event)
 
 	a.sendMessage(tm)
 }

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/agent/transformers"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/asset"
@@ -229,6 +230,10 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 
 	event.Entity = a.getAgentEntity()
 	event.Timestamp = time.Now().Unix()
+	id, err := uuid.NewRandom()
+	if err == nil {
+		event.ID = id[:]
+	}
 
 	// Instantiate metrics in the event if the check is attempting to extract metrics
 	if check.OutputMetricFormat != "" || len(check.OutputMetricHandlers) != 0 {
@@ -264,6 +269,9 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 		Type:    transport.MessageTypeEvent,
 		Payload: msg,
 	}
+
+	logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+
 	a.sendMessage(tm)
 }
 

--- a/agent/event.go
+++ b/agent/event.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	time "github.com/echlebek/timeproxy"
+	"github.com/google/uuid"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev1 "github.com/sensu/sensu-go/types/v1"
@@ -52,6 +53,13 @@ func prepareEvent(a *Agent, event *corev2.Event) error {
 	// so it can be properly handled by the backend. Othewise we need to inject
 	// the agent's entity into this event
 	a.getEntities(event)
+
+	if len(event.ID) == 0 {
+		id, err := uuid.NewRandom()
+		if err == nil {
+			event.ID = id[:]
+		}
+	}
 
 	// The entity should pass validation at this point
 	return event.Entity.Validate()

--- a/agent/event_test.go
+++ b/agent/event_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	time "github.com/echlebek/timeproxy"
+	"github.com/google/uuid"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	v2 "github.com/sensu/sensu-go/api/core/v2"
 	corev1 "github.com/sensu/sensu-go/types/v1"
@@ -281,6 +282,9 @@ func Test_prepareEvent(t *testing.T) {
 			}
 			if ns := tt.args.event.GetNamespace(); ns != tt.wantNamespace {
 				t.Errorf("prepareEvent() ObjectMeta.GetNamespace() = %v, want %v", ns, tt.wantNamespace)
+			}
+			if id := tt.args.event.GetUUID(); id == uuid.Nil {
+				t.Errorf("bad uuid: %s", id.String())
 			}
 		})
 	}

--- a/agent/sockets.go
+++ b/agent/sockets.go
@@ -166,7 +166,7 @@ func (a *Agent) handleTCPMessages(c net.Conn) {
 			return
 		}
 
-		logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+		logEvent(&event)
 
 		tm := &transport.Message{
 			Type:    transport.MessageTypeEvent,
@@ -249,7 +249,7 @@ func (a *Agent) handleUDPMessages(ctx context.Context, c net.PacketConn) {
 				return
 			}
 
-			logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+			logEvent(&event)
 
 			tm := &transport.Message{
 				Type:    transport.MessageTypeEvent,

--- a/agent/sockets.go
+++ b/agent/sockets.go
@@ -166,6 +166,8 @@ func (a *Agent) handleTCPMessages(c net.Conn) {
 			return
 		}
 
+		logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+
 		tm := &transport.Message{
 			Type:    transport.MessageTypeEvent,
 			Payload: payload,
@@ -246,6 +248,9 @@ func (a *Agent) handleUDPMessages(ctx context.Context, c net.PacketConn) {
 			if err != nil {
 				return
 			}
+
+			logger.WithField("event_id", event.GetUUID().String()).Info("sending event to backend")
+
 			tm := &transport.Message{
 				Type:    transport.MessageTypeEvent,
 				Payload: payload,

--- a/api/core/v2/adhoc.pb.go
+++ b/api/core/v2/adhoc.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type AdhocRequest struct {
 	// Subscriptions is the list of entity subscriptions.
@@ -51,7 +52,7 @@ func (m *AdhocRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_AdhocRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +163,7 @@ func (this *AdhocRequest) Equal(that interface{}) bool {
 func (m *AdhocRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -170,59 +171,65 @@ func (m *AdhocRequest) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AdhocRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AdhocRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Subscriptions) > 0 {
-		for _, s := range m.Subscriptions {
-			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
+		i -= size
+		i = encodeVarintAdhoc(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x2a
+	if len(m.Reason) > 0 {
+		i -= len(m.Reason)
+		copy(dAtA[i:], m.Reason)
+		i = encodeVarintAdhoc(dAtA, i, uint64(len(m.Reason)))
+		i--
+		dAtA[i] = 0x22
 	}
 	if len(m.Creator) > 0 {
-		dAtA[i] = 0x1a
-		i++
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
 		i = encodeVarintAdhoc(dAtA, i, uint64(len(m.Creator)))
-		i += copy(dAtA[i:], m.Creator)
+		i--
+		dAtA[i] = 0x1a
 	}
-	if len(m.Reason) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintAdhoc(dAtA, i, uint64(len(m.Reason)))
-		i += copy(dAtA[i:], m.Reason)
+	if len(m.Subscriptions) > 0 {
+		for iNdEx := len(m.Subscriptions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Subscriptions[iNdEx])
+			copy(dAtA[i:], m.Subscriptions[iNdEx])
+			i = encodeVarintAdhoc(dAtA, i, uint64(len(m.Subscriptions[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
 	}
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintAdhoc(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAdhoc(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAdhoc(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedAdhocRequest(r randyAdhoc, easy bool) *AdhocRequest {
 	this := &AdhocRequest{}
@@ -342,14 +349,7 @@ func (m *AdhocRequest) Size() (n int) {
 }
 
 func sovAdhoc(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAdhoc(x uint64) (n int) {
 	return sovAdhoc(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/any.pb.go
+++ b/api/core/v2/any.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Any struct {
 	TypeUrl              string   `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
@@ -45,7 +46,7 @@ func (m *Any) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Any.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +134,7 @@ func (this *Any) Equal(that interface{}) bool {
 func (m *Any) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -141,36 +142,46 @@ func (m *Any) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Any) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Any) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.TypeUrl) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAny(dAtA, i, uint64(len(m.TypeUrl)))
-		i += copy(dAtA[i:], m.TypeUrl)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Value) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
 		i = encodeVarintAny(dAtA, i, uint64(len(m.Value)))
-		i += copy(dAtA[i:], m.Value)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.TypeUrl) > 0 {
+		i -= len(m.TypeUrl)
+		copy(dAtA[i:], m.TypeUrl)
+		i = encodeVarintAny(dAtA, i, uint64(len(m.TypeUrl)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAny(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAny(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedAny(r randyAny, easy bool) *Any {
 	this := &Any{}
@@ -279,14 +290,7 @@ func (m *Any) Size() (n int) {
 }
 
 func sovAny(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAny(x uint64) (n int) {
 	return sovAny(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/apikey.pb.go
+++ b/api/core/v2/apikey.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // An APIKey is an api key specification.
 type APIKey struct {
@@ -51,7 +52,7 @@ func (m *APIKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_APIKey.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +170,7 @@ func NewAPIKeyFromFace(that APIKeyFace) *APIKey {
 func (m *APIKey) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -177,43 +178,54 @@ func (m *APIKey) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *APIKey) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *APIKey) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintApikey(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if len(m.Username) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintApikey(dAtA, i, uint64(len(m.Username)))
-		i += copy(dAtA[i:], m.Username)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.CreatedAt != 0 {
-		dAtA[i] = 0x18
-		i++
 		i = encodeVarintApikey(dAtA, i, uint64(m.CreatedAt))
+		i--
+		dAtA[i] = 0x18
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Username) > 0 {
+		i -= len(m.Username)
+		copy(dAtA[i:], m.Username)
+		i = encodeVarintApikey(dAtA, i, uint64(len(m.Username)))
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintApikey(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintApikey(dAtA []byte, offset int, v uint64) int {
+	offset -= sovApikey(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedAPIKey(r randyApikey, easy bool) *APIKey {
 	this := &APIKey{}
@@ -324,14 +336,7 @@ func (m *APIKey) Size() (n int) {
 }
 
 func sovApikey(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozApikey(x uint64) (n int) {
 	return sovApikey(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/asset.pb.go
+++ b/api/core/v2/asset.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Asset defines an asset and optionally a list of assets (builds) that agents install as a dependency for a check, handler, mutator, etc.
 type Asset struct {
@@ -60,7 +61,7 @@ func (m *Asset) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Asset.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +112,7 @@ func (m *AssetBuild) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_AssetBuild.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +371,7 @@ func NewAssetBuildFromFace(that AssetBuildFace) *AssetBuild {
 func (m *Asset) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -378,84 +379,92 @@ func (m *Asset) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Asset) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Asset) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.URL) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintAsset(dAtA, i, uint64(len(m.URL)))
-		i += copy(dAtA[i:], m.URL)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Sha512) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintAsset(dAtA, i, uint64(len(m.Sha512)))
-		i += copy(dAtA[i:], m.Sha512)
+	if len(m.Headers) > 0 {
+		for k := range m.Headers {
+			v := m.Headers[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintAsset(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintAsset(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintAsset(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintAsset(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x42
+	if len(m.Builds) > 0 {
+		for iNdEx := len(m.Builds) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Builds[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintAsset(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x32
+		}
 	}
 	if len(m.Filters) > 0 {
-		for _, s := range m.Filters {
+		for iNdEx := len(m.Filters) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Filters[iNdEx])
+			copy(dAtA[i:], m.Filters[iNdEx])
+			i = encodeVarintAsset(dAtA, i, uint64(len(m.Filters[iNdEx])))
+			i--
 			dAtA[i] = 0x2a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if len(m.Builds) > 0 {
-		for _, msg := range m.Builds {
-			dAtA[i] = 0x32
-			i++
-			i = encodeVarintAsset(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
+	if len(m.Sha512) > 0 {
+		i -= len(m.Sha512)
+		copy(dAtA[i:], m.Sha512)
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.Sha512)))
+		i--
+		dAtA[i] = 0x1a
 	}
-	dAtA[i] = 0x42
-	i++
-	i = encodeVarintAsset(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if len(m.URL) > 0 {
+		i -= len(m.URL)
+		copy(dAtA[i:], m.URL)
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.URL)))
+		i--
+		dAtA[i] = 0x12
 	}
-	i += n1
-	if len(m.Headers) > 0 {
-		for k, _ := range m.Headers {
-			dAtA[i] = 0x4a
-			i++
-			v := m.Headers[k]
-			mapSize := 1 + len(k) + sovAsset(uint64(len(k))) + 1 + len(v) + sovAsset(uint64(len(v)))
-			i = encodeVarintAsset(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintAsset(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintAsset(dAtA, i, uint64(len(v)))
-			i += copy(dAtA[i:], v)
-		}
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *AssetBuild) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -463,68 +472,74 @@ func (m *AssetBuild) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AssetBuild) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AssetBuild) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.URL) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintAsset(dAtA, i, uint64(len(m.URL)))
-		i += copy(dAtA[i:], m.URL)
-	}
-	if len(m.Sha512) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintAsset(dAtA, i, uint64(len(m.Sha512)))
-		i += copy(dAtA[i:], m.Sha512)
-	}
-	if len(m.Filters) > 0 {
-		for _, s := range m.Filters {
-			dAtA[i] = 0x2a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Headers) > 0 {
-		for k, _ := range m.Headers {
-			dAtA[i] = 0x4a
-			i++
+		for k := range m.Headers {
 			v := m.Headers[k]
-			mapSize := 1 + len(k) + sovAsset(uint64(len(k))) + 1 + len(v) + sovAsset(uint64(len(v)))
-			i = encodeVarintAsset(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintAsset(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			dAtA[i] = 0x12
-			i++
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
 			i = encodeVarintAsset(dAtA, i, uint64(len(v)))
-			i += copy(dAtA[i:], v)
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintAsset(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintAsset(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x4a
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Filters) > 0 {
+		for iNdEx := len(m.Filters) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Filters[iNdEx])
+			copy(dAtA[i:], m.Filters[iNdEx])
+			i = encodeVarintAsset(dAtA, i, uint64(len(m.Filters[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
-	return i, nil
+	if len(m.Sha512) > 0 {
+		i -= len(m.Sha512)
+		copy(dAtA[i:], m.Sha512)
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.Sha512)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.URL) > 0 {
+		i -= len(m.URL)
+		copy(dAtA[i:], m.URL)
+		i = encodeVarintAsset(dAtA, i, uint64(len(m.URL)))
+		i--
+		dAtA[i] = 0x12
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAsset(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAsset(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedAsset(r randyAsset, easy bool) *Asset {
 	this := &Asset{}
@@ -535,7 +550,7 @@ func NewPopulatedAsset(r randyAsset, easy bool) *Asset {
 	for i := 0; i < v1; i++ {
 		this.Filters[i] = string(randStringAsset(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v2 := r.Intn(5)
 		this.Builds = make([]*AssetBuild, v2)
 		for i := 0; i < v2; i++ {
@@ -544,7 +559,7 @@ func NewPopulatedAsset(r randyAsset, easy bool) *Asset {
 	}
 	v3 := NewPopulatedObjectMeta(r, easy)
 	this.ObjectMeta = *v3
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v4 := r.Intn(10)
 		this.Headers = make(map[string]string)
 		for i := 0; i < v4; i++ {
@@ -566,7 +581,7 @@ func NewPopulatedAssetBuild(r randyAsset, easy bool) *AssetBuild {
 	for i := 0; i < v5; i++ {
 		this.Filters[i] = string(randStringAsset(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v6 := r.Intn(10)
 		this.Headers = make(map[string]string)
 		for i := 0; i < v6; i++ {
@@ -728,14 +743,7 @@ func (m *AssetBuild) Size() (n int) {
 }
 
 func sovAsset(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAsset(x uint64) (n int) {
 	return sovAsset(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/authentication.pb.go
+++ b/api/core/v2/authentication.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Tokens contains the structure for exchanging tokens with the API
 type Tokens struct {
@@ -50,7 +51,7 @@ func (m *Tokens) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Tokens.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +153,7 @@ func (this *Tokens) Equal(that interface{}) bool {
 func (m *Tokens) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -160,41 +161,51 @@ func (m *Tokens) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Tokens) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Tokens) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Access) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.Access)))
-		i += copy(dAtA[i:], m.Access)
-	}
-	if m.ExpiresAt != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintAuthentication(dAtA, i, uint64(m.ExpiresAt))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Refresh) > 0 {
-		dAtA[i] = 0x1a
-		i++
+		i -= len(m.Refresh)
+		copy(dAtA[i:], m.Refresh)
 		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.Refresh)))
-		i += copy(dAtA[i:], m.Refresh)
+		i--
+		dAtA[i] = 0x1a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.ExpiresAt != 0 {
+		i = encodeVarintAuthentication(dAtA, i, uint64(m.ExpiresAt))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if len(m.Access) > 0 {
+		i -= len(m.Access)
+		copy(dAtA[i:], m.Access)
+		i = encodeVarintAuthentication(dAtA, i, uint64(len(m.Access)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAuthentication(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAuthentication(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedTokens(r randyAuthentication, easy bool) *Tokens {
 	this := &Tokens{}
@@ -306,14 +317,7 @@ func (m *Tokens) Size() (n int) {
 }
 
 func sovAuthentication(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAuthentication(x uint64) (n int) {
 	return sovAuthentication(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/check.pb.go
+++ b/api/core/v2/check.pb.go
@@ -12,6 +12,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -23,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A CheckRequest represents a request to execute a check
 type CheckRequest struct {
@@ -58,7 +59,7 @@ func (m *CheckRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_CheckRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +143,7 @@ func (m *AssetList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_AssetList.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +199,7 @@ func (m *ProxyRequests) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return xxx_messageInfo_ProxyRequests.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +325,7 @@ func (m *CheckConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_CheckConfig.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +462,7 @@ func (m *Check) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Check.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -505,7 +506,7 @@ func (m *CheckHistory) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_CheckHistory.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -1546,7 +1547,7 @@ func NewCheckFromFace(that CheckFace) *Check {
 func (m *CheckRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1554,102 +1555,106 @@ func (m *CheckRequest) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CheckRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Config != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Config.Size()))
-		n1, err := m.Config.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Assets) > 0 {
-		for _, msg := range m.Assets {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Secrets[iNdEx])
+			copy(dAtA[i:], m.Secrets[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Secrets[iNdEx])))
+			i--
+			dAtA[i] = 0x32
 		}
 	}
-	if len(m.Hooks) > 0 {
-		for _, msg := range m.Hooks {
-			dAtA[i] = 0x1a
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+	if len(m.HookAssets) > 0 {
+		for k := range m.HookAssets {
+			v := m.HookAssets[k]
+			baseI := i
+			if v != nil {
+				{
+					size, err := v.MarshalToSizedBuffer(dAtA[:i])
+					if err != nil {
+						return 0, err
+					}
+					i -= size
+					i = encodeVarintCheck(dAtA, i, uint64(size))
+				}
+				i--
+				dAtA[i] = 0x12
 			}
-			i += n
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintCheck(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintCheck(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x2a
 		}
 	}
 	if m.Issued != 0 {
-		dAtA[i] = 0x20
-		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.Issued))
+		i--
+		dAtA[i] = 0x20
 	}
-	if len(m.HookAssets) > 0 {
-		for k, _ := range m.HookAssets {
-			dAtA[i] = 0x2a
-			i++
-			v := m.HookAssets[k]
-			msgSize := 0
-			if v != nil {
-				msgSize = v.Size()
-				msgSize += 1 + sovCheck(uint64(msgSize))
-			}
-			mapSize := 1 + len(k) + sovCheck(uint64(len(k))) + msgSize
-			i = encodeVarintCheck(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			if v != nil {
-				dAtA[i] = 0x12
-				i++
-				i = encodeVarintCheck(dAtA, i, uint64(v.Size()))
-				n2, err := v.MarshalTo(dAtA[i:])
+	if len(m.Hooks) > 0 {
+		for iNdEx := len(m.Hooks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Hooks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
 				if err != nil {
 					return 0, err
 				}
-				i += n2
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
 			}
+			i--
+			dAtA[i] = 0x1a
 		}
 	}
-	if len(m.Secrets) > 0 {
-		for _, s := range m.Secrets {
-			dAtA[i] = 0x32
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if len(m.Assets) > 0 {
+		for iNdEx := len(m.Assets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Assets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Config != nil {
+		{
+			size, err := m.Config.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCheck(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *AssetList) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1657,32 +1662,40 @@ func (m *AssetList) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AssetList) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AssetList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
 	if len(m.Assets) > 0 {
-		for _, msg := range m.Assets {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Assets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Assets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *ProxyRequests) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1690,50 +1703,50 @@ func (m *ProxyRequests) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ProxyRequests) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ProxyRequests) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.EntityAttributes) > 0 {
-		for _, s := range m.EntityAttributes {
-			dAtA[i] = 0xa
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.SplayCoverage != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.SplayCoverage))
+		i--
+		dAtA[i] = 0x18
 	}
 	if m.Splay {
-		dAtA[i] = 0x10
-		i++
+		i--
 		if m.Splay {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x10
 	}
-	if m.SplayCoverage != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.SplayCoverage))
+	if len(m.EntityAttributes) > 0 {
+		for iNdEx := len(m.EntityAttributes) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EntityAttributes[iNdEx])
+			copy(dAtA[i:], m.EntityAttributes[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.EntityAttributes[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *CheckConfig) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1741,273 +1754,264 @@ func (m *CheckConfig) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CheckConfig) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Command) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.Command)))
-		i += copy(dAtA[i:], m.Command)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Handlers) > 0 {
-		for _, s := range m.Handlers {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Secrets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if m.HighFlapThreshold != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.HighFlapThreshold))
-	}
-	if m.Interval != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Interval))
-	}
-	if m.LowFlapThreshold != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.LowFlapThreshold))
-	}
-	if m.Publish {
-		dAtA[i] = 0x48
-		i++
-		if m.Publish {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
-			dAtA[i] = 0x52
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.Subscriptions) > 0 {
-		for _, s := range m.Subscriptions {
-			dAtA[i] = 0x5a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.ExtendedAttributes) > 0 {
-		dAtA[i] = 0x62
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.ExtendedAttributes)))
-		i += copy(dAtA[i:], m.ExtendedAttributes)
-	}
-	if len(m.ProxyEntityName) > 0 {
-		dAtA[i] = 0x6a
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.ProxyEntityName)))
-		i += copy(dAtA[i:], m.ProxyEntityName)
-	}
-	if len(m.CheckHooks) > 0 {
-		for _, msg := range m.CheckHooks {
-			dAtA[i] = 0x72
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if m.Stdin {
-		dAtA[i] = 0x78
-		i++
-		if m.Stdin {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.Subdue != nil {
-		dAtA[i] = 0x82
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Subdue.Size()))
-		n3, err := m.Subdue.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
-	}
-	if len(m.Cron) > 0 {
-		dAtA[i] = 0x8a
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.Cron)))
-		i += copy(dAtA[i:], m.Cron)
-	}
-	if m.Ttl != 0 {
-		dAtA[i] = 0x90
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Ttl))
-	}
-	if m.Timeout != 0 {
-		dAtA[i] = 0x98
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Timeout))
-	}
-	if m.ProxyRequests != nil {
-		dAtA[i] = 0xa2
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.ProxyRequests.Size()))
-		n4, err := m.ProxyRequests.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n4
-	}
-	if m.RoundRobin {
-		dAtA[i] = 0xa8
-		i++
-		dAtA[i] = 0x1
-		i++
-		if m.RoundRobin {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.OutputMetricFormat) > 0 {
-		dAtA[i] = 0xb2
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricFormat)))
-		i += copy(dAtA[i:], m.OutputMetricFormat)
-	}
-	if len(m.OutputMetricHandlers) > 0 {
-		for _, s := range m.OutputMetricHandlers {
-			dAtA[i] = 0xba
-			i++
+			i--
 			dAtA[i] = 0x1
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i--
+			dAtA[i] = 0xea
 		}
-	}
-	if len(m.EnvVars) > 0 {
-		for _, s := range m.EnvVars {
-			dAtA[i] = 0xc2
-			i++
-			dAtA[i] = 0x1
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	dAtA[i] = 0xd2
-	i++
-	dAtA[i] = 0x1
-	i++
-	i = encodeVarintCheck(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n5, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n5
-	if m.MaxOutputSize != 0 {
-		dAtA[i] = 0xd8
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.MaxOutputSize))
 	}
 	if m.DiscardOutput {
-		dAtA[i] = 0xe0
-		i++
-		dAtA[i] = 0x1
-		i++
+		i--
 		if m.DiscardOutput {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
 	}
-	if len(m.Secrets) > 0 {
-		for _, msg := range m.Secrets {
-			dAtA[i] = 0xea
-			i++
+	if m.MaxOutputSize != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.MaxOutputSize))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd8
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintCheck(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x1
+	i--
+	dAtA[i] = 0xd2
+	if len(m.EnvVars) > 0 {
+		for iNdEx := len(m.EnvVars) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EnvVars[iNdEx])
+			copy(dAtA[i:], m.EnvVars[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.EnvVars[iNdEx])))
+			i--
 			dAtA[i] = 0x1
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.OutputMetricHandlers) > 0 {
+		for iNdEx := len(m.OutputMetricHandlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.OutputMetricHandlers[iNdEx])
+			copy(dAtA[i:], m.OutputMetricHandlers[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricHandlers[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xba
+		}
+	}
+	if len(m.OutputMetricFormat) > 0 {
+		i -= len(m.OutputMetricFormat)
+		copy(dAtA[i:], m.OutputMetricFormat)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricFormat)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb2
+	}
+	if m.RoundRobin {
+		i--
+		if m.RoundRobin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.ProxyRequests != nil {
+		{
+			size, err := m.ProxyRequests.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
-			i += n
+			i -= size
+			i = encodeVarintCheck(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa2
+	}
+	if m.Timeout != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Timeout))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.Ttl != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Ttl))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
+	}
+	if len(m.Cron) > 0 {
+		i -= len(m.Cron)
+		copy(dAtA[i:], m.Cron)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Cron)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.Subdue != nil {
+		{
+			size, err := m.Subdue.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCheck(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.Stdin {
+		i--
+		if m.Stdin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x78
+	}
+	if len(m.CheckHooks) > 0 {
+		for iNdEx := len(m.CheckHooks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.CheckHooks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x72
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.ProxyEntityName) > 0 {
+		i -= len(m.ProxyEntityName)
+		copy(dAtA[i:], m.ProxyEntityName)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ProxyEntityName)))
+		i--
+		dAtA[i] = 0x6a
 	}
-	return i, nil
+	if len(m.ExtendedAttributes) > 0 {
+		i -= len(m.ExtendedAttributes)
+		copy(dAtA[i:], m.ExtendedAttributes)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ExtendedAttributes)))
+		i--
+		dAtA[i] = 0x62
+	}
+	if len(m.Subscriptions) > 0 {
+		for iNdEx := len(m.Subscriptions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Subscriptions[iNdEx])
+			copy(dAtA[i:], m.Subscriptions[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Subscriptions[iNdEx])))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
+	if len(m.RuntimeAssets) > 0 {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
+			dAtA[i] = 0x52
+		}
+	}
+	if m.Publish {
+		i--
+		if m.Publish {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.LowFlapThreshold != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.LowFlapThreshold))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.Interval != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Interval))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.HighFlapThreshold != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.HighFlapThreshold))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Handlers) > 0 {
+		for iNdEx := len(m.Handlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Handlers[iNdEx])
+			copy(dAtA[i:], m.Handlers[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Handlers[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Command) > 0 {
+		i -= len(m.Command)
+		copy(dAtA[i:], m.Command)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Command)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Check) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -2015,393 +2019,384 @@ func (m *Check) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Check) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Check) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Command) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.Command)))
-		i += copy(dAtA[i:], m.Command)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Handlers) > 0 {
-		for _, s := range m.Handlers {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if m.HighFlapThreshold != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.HighFlapThreshold))
-	}
-	if m.Interval != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Interval))
-	}
-	if m.LowFlapThreshold != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.LowFlapThreshold))
-	}
-	if m.Publish {
-		dAtA[i] = 0x48
-		i++
-		if m.Publish {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
-			dAtA[i] = 0x52
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.Subscriptions) > 0 {
-		for _, s := range m.Subscriptions {
-			dAtA[i] = 0x5a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.ProxyEntityName) > 0 {
-		dAtA[i] = 0x6a
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.ProxyEntityName)))
-		i += copy(dAtA[i:], m.ProxyEntityName)
-	}
-	if len(m.CheckHooks) > 0 {
-		for _, msg := range m.CheckHooks {
-			dAtA[i] = 0x72
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if m.Stdin {
-		dAtA[i] = 0x78
-		i++
-		if m.Stdin {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.Subdue != nil {
-		dAtA[i] = 0x82
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Subdue.Size()))
-		n6, err := m.Subdue.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n6
-	}
-	if len(m.Cron) > 0 {
-		dAtA[i] = 0x8a
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.Cron)))
-		i += copy(dAtA[i:], m.Cron)
-	}
-	if m.Ttl != 0 {
-		dAtA[i] = 0x90
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Ttl))
-	}
-	if m.Timeout != 0 {
-		dAtA[i] = 0x98
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Timeout))
-	}
-	if m.ProxyRequests != nil {
-		dAtA[i] = 0xa2
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.ProxyRequests.Size()))
-		n7, err := m.ProxyRequests.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n7
-	}
-	if m.RoundRobin {
-		dAtA[i] = 0xa8
-		i++
-		dAtA[i] = 0x1
-		i++
-		if m.RoundRobin {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.Duration != 0 {
-		dAtA[i] = 0xb1
-		i++
-		dAtA[i] = 0x1
-		i++
-		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Duration))))
-		i += 8
-	}
-	if m.Executed != 0 {
-		dAtA[i] = 0xb8
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Executed))
-	}
-	if len(m.History) > 0 {
-		for _, msg := range m.History {
-			dAtA[i] = 0xc2
-			i++
-			dAtA[i] = 0x1
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if m.Issued != 0 {
-		dAtA[i] = 0xc8
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Issued))
-	}
-	if len(m.Output) > 0 {
-		dAtA[i] = 0xd2
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.Output)))
-		i += copy(dAtA[i:], m.Output)
-	}
-	if len(m.State) > 0 {
-		dAtA[i] = 0xda
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.State)))
-		i += copy(dAtA[i:], m.State)
-	}
-	if m.Status != 0 {
-		dAtA[i] = 0xe0
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Status))
-	}
-	if m.TotalStateChange != 0 {
-		dAtA[i] = 0xe8
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.TotalStateChange))
-	}
-	if m.LastOK != 0 {
-		dAtA[i] = 0xf0
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.LastOK))
-	}
-	if m.Occurrences != 0 {
-		dAtA[i] = 0xf8
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Occurrences))
-	}
-	if m.OccurrencesWatermark != 0 {
-		dAtA[i] = 0x80
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.OccurrencesWatermark))
-	}
-	if len(m.Silenced) > 0 {
-		for _, s := range m.Silenced {
-			dAtA[i] = 0x8a
-			i++
-			dAtA[i] = 0x2
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.Hooks) > 0 {
-		for _, msg := range m.Hooks {
-			dAtA[i] = 0x92
-			i++
-			dAtA[i] = 0x2
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.OutputMetricFormat) > 0 {
+	if len(m.ExtendedAttributes) > 0 {
+		i -= len(m.ExtendedAttributes)
+		copy(dAtA[i:], m.ExtendedAttributes)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ExtendedAttributes)))
+		i--
+		dAtA[i] = 0x6
+		i--
 		dAtA[i] = 0x9a
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricFormat)))
-		i += copy(dAtA[i:], m.OutputMetricFormat)
 	}
-	if len(m.OutputMetricHandlers) > 0 {
-		for _, s := range m.OutputMetricHandlers {
-			dAtA[i] = 0xa2
-			i++
-			dAtA[i] = 0x2
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Secrets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.EnvVars) > 0 {
-		for _, s := range m.EnvVars {
-			dAtA[i] = 0xaa
-			i++
+			i--
 			dAtA[i] = 0x2
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i--
+			dAtA[i] = 0xca
 		}
-	}
-	dAtA[i] = 0xb2
-	i++
-	dAtA[i] = 0x2
-	i++
-	i = encodeVarintCheck(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n8, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n8
-	if m.MaxOutputSize != 0 {
-		dAtA[i] = 0xb8
-		i++
-		dAtA[i] = 0x2
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.MaxOutputSize))
 	}
 	if m.DiscardOutput {
-		dAtA[i] = 0xc0
-		i++
-		dAtA[i] = 0x2
-		i++
+		i--
 		if m.DiscardOutput {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xc0
 	}
-	if len(m.Secrets) > 0 {
-		for _, msg := range m.Secrets {
-			dAtA[i] = 0xca
-			i++
+	if m.MaxOutputSize != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.MaxOutputSize))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0xb8
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintCheck(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x2
+	i--
+	dAtA[i] = 0xb2
+	if len(m.EnvVars) > 0 {
+		for iNdEx := len(m.EnvVars) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EnvVars[iNdEx])
+			copy(dAtA[i:], m.EnvVars[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.EnvVars[iNdEx])))
+			i--
 			dAtA[i] = 0x2
-			i++
-			i = encodeVarintCheck(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.OutputMetricHandlers) > 0 {
+		for iNdEx := len(m.OutputMetricHandlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.OutputMetricHandlers[iNdEx])
+			copy(dAtA[i:], m.OutputMetricHandlers[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricHandlers[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
+	if len(m.OutputMetricFormat) > 0 {
+		i -= len(m.OutputMetricFormat)
+		copy(dAtA[i:], m.OutputMetricFormat)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.OutputMetricFormat)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x9a
+	}
+	if len(m.Hooks) > 0 {
+		for iNdEx := len(m.Hooks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Hooks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x92
+		}
+	}
+	if len(m.Silenced) > 0 {
+		for iNdEx := len(m.Silenced) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Silenced[iNdEx])
+			copy(dAtA[i:], m.Silenced[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Silenced[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if m.OccurrencesWatermark != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.OccurrencesWatermark))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Occurrences != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Occurrences))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.LastOK != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.LastOK))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xf0
+	}
+	if m.TotalStateChange != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.TotalStateChange))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe8
+	}
+	if m.Status != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
+	}
+	if len(m.State) > 0 {
+		i -= len(m.State)
+		copy(dAtA[i:], m.State)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.State)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	if len(m.Output) > 0 {
+		i -= len(m.Output)
+		copy(dAtA[i:], m.Output)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Output)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.Issued != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Issued))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc8
+	}
+	if len(m.History) > 0 {
+		for iNdEx := len(m.History) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.History[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if m.Executed != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Executed))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.Duration != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Duration))))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb1
+	}
+	if m.RoundRobin {
+		i--
+		if m.RoundRobin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.ProxyRequests != nil {
+		{
+			size, err := m.ProxyRequests.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
-			i += n
+			i -= size
+			i = encodeVarintCheck(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa2
+	}
+	if m.Timeout != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Timeout))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x98
+	}
+	if m.Ttl != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Ttl))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
+	}
+	if len(m.Cron) > 0 {
+		i -= len(m.Cron)
+		copy(dAtA[i:], m.Cron)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Cron)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
+	}
+	if m.Subdue != nil {
+		{
+			size, err := m.Subdue.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCheck(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.Stdin {
+		i--
+		if m.Stdin {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x78
+	}
+	if len(m.CheckHooks) > 0 {
+		for iNdEx := len(m.CheckHooks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.CheckHooks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCheck(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x72
 		}
 	}
-	if len(m.ExtendedAttributes) > 0 {
-		dAtA[i] = 0x9a
-		i++
-		dAtA[i] = 0x6
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(len(m.ExtendedAttributes)))
-		i += copy(dAtA[i:], m.ExtendedAttributes)
+	if len(m.ProxyEntityName) > 0 {
+		i -= len(m.ProxyEntityName)
+		copy(dAtA[i:], m.ProxyEntityName)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.ProxyEntityName)))
+		i--
+		dAtA[i] = 0x6a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Subscriptions) > 0 {
+		for iNdEx := len(m.Subscriptions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Subscriptions[iNdEx])
+			copy(dAtA[i:], m.Subscriptions[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Subscriptions[iNdEx])))
+			i--
+			dAtA[i] = 0x5a
+		}
 	}
-	return i, nil
+	if len(m.RuntimeAssets) > 0 {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
+			dAtA[i] = 0x52
+		}
+	}
+	if m.Publish {
+		i--
+		if m.Publish {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.LowFlapThreshold != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.LowFlapThreshold))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.Interval != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Interval))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.HighFlapThreshold != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.HighFlapThreshold))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Handlers) > 0 {
+		for iNdEx := len(m.Handlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Handlers[iNdEx])
+			copy(dAtA[i:], m.Handlers[iNdEx])
+			i = encodeVarintCheck(dAtA, i, uint64(len(m.Handlers[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Command) > 0 {
+		i -= len(m.Command)
+		copy(dAtA[i:], m.Command)
+		i = encodeVarintCheck(dAtA, i, uint64(len(m.Command)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *CheckHistory) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -2409,41 +2404,49 @@ func (m *CheckHistory) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CheckHistory) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CheckHistory) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Status != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintCheck(dAtA, i, uint64(m.Status))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Executed != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintCheck(dAtA, i, uint64(m.Executed))
+		i--
+		dAtA[i] = 0x10
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Status != 0 {
+		i = encodeVarintCheck(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x8
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintCheck(dAtA []byte, offset int, v uint64) int {
+	offset -= sovCheck(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedCheckRequest(r randyCheck, easy bool) *CheckRequest {
 	this := &CheckRequest{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Config = NewPopulatedCheckConfig(r, easy)
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v1 := r.Intn(5)
 		this.Assets = make([]Asset, v1)
 		for i := 0; i < v1; i++ {
@@ -2451,7 +2454,7 @@ func NewPopulatedCheckRequest(r randyCheck, easy bool) *CheckRequest {
 			this.Assets[i] = *v2
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v3 := r.Intn(5)
 		this.Hooks = make([]HookConfig, v3)
 		for i := 0; i < v3; i++ {
@@ -2463,7 +2466,7 @@ func NewPopulatedCheckRequest(r randyCheck, easy bool) *CheckRequest {
 	if r.Intn(2) == 0 {
 		this.Issued *= -1
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v5 := r.Intn(10)
 		this.HookAssets = make(map[string]*AssetList)
 		for i := 0; i < v5; i++ {
@@ -2483,7 +2486,7 @@ func NewPopulatedCheckRequest(r randyCheck, easy bool) *CheckRequest {
 
 func NewPopulatedAssetList(r randyCheck, easy bool) *AssetList {
 	this := &AssetList{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v7 := r.Intn(5)
 		this.Assets = make([]Asset, v7)
 		for i := 0; i < v7; i++ {
@@ -2540,7 +2543,7 @@ func NewPopulatedCheckConfig(r randyCheck, easy bool) *CheckConfig {
 		this.ExtendedAttributes[i] = byte(r.Intn(256))
 	}
 	this.ProxyEntityName = string(randStringCheck(r))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v14 := r.Intn(5)
 		this.CheckHooks = make([]HookList, v14)
 		for i := 0; i < v14; i++ {
@@ -2549,7 +2552,7 @@ func NewPopulatedCheckConfig(r randyCheck, easy bool) *CheckConfig {
 		}
 	}
 	this.Stdin = bool(bool(r.Intn(2) == 0))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Subdue = NewPopulatedTimeWindowWhen(r, easy)
 	}
 	this.Cron = string(randStringCheck(r))
@@ -2558,7 +2561,7 @@ func NewPopulatedCheckConfig(r randyCheck, easy bool) *CheckConfig {
 		this.Ttl *= -1
 	}
 	this.Timeout = uint32(r.Uint32())
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.ProxyRequests = NewPopulatedProxyRequests(r, easy)
 	}
 	this.RoundRobin = bool(bool(r.Intn(2) == 0))
@@ -2580,7 +2583,7 @@ func NewPopulatedCheckConfig(r randyCheck, easy bool) *CheckConfig {
 		this.MaxOutputSize *= -1
 	}
 	this.DiscardOutput = bool(bool(r.Intn(2) == 0))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v19 := r.Intn(5)
 		this.Secrets = make([]*Secret, v19)
 		for i := 0; i < v19; i++ {
@@ -2616,7 +2619,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		this.Subscriptions[i] = string(randStringCheck(r))
 	}
 	this.ProxyEntityName = string(randStringCheck(r))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v23 := r.Intn(5)
 		this.CheckHooks = make([]HookList, v23)
 		for i := 0; i < v23; i++ {
@@ -2625,7 +2628,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		}
 	}
 	this.Stdin = bool(bool(r.Intn(2) == 0))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Subdue = NewPopulatedTimeWindowWhen(r, easy)
 	}
 	this.Cron = string(randStringCheck(r))
@@ -2634,7 +2637,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		this.Ttl *= -1
 	}
 	this.Timeout = uint32(r.Uint32())
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.ProxyRequests = NewPopulatedProxyRequests(r, easy)
 	}
 	this.RoundRobin = bool(bool(r.Intn(2) == 0))
@@ -2646,7 +2649,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 	if r.Intn(2) == 0 {
 		this.Executed *= -1
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v25 := r.Intn(5)
 		this.History = make([]CheckHistory, v25)
 		for i := 0; i < v25; i++ {
@@ -2679,7 +2682,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 	for i := 0; i < v27; i++ {
 		this.Silenced[i] = string(randStringCheck(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v28 := r.Intn(5)
 		this.Hooks = make([]*Hook, v28)
 		for i := 0; i < v28; i++ {
@@ -2704,7 +2707,7 @@ func NewPopulatedCheck(r randyCheck, easy bool) *Check {
 		this.MaxOutputSize *= -1
 	}
 	this.DiscardOutput = bool(bool(r.Intn(2) == 0))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v32 := r.Intn(5)
 		this.Secrets = make([]*Secret, v32)
 		for i := 0; i < v32; i++ {
@@ -3196,14 +3199,7 @@ func (m *CheckHistory) Size() (n int) {
 }
 
 func sovCheck(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCheck(x uint64) (n int) {
 	return sovCheck(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/entity.pb.go
+++ b/api/core/v2/entity.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Entity is the Entity supplying the event. The default Entity for any
 // Event is the running Agent process--if the Event is sent by an Agent.
@@ -64,7 +65,7 @@ func (m *Entity) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Entity.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +114,7 @@ func (m *System) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_System.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +213,7 @@ func (m *Network) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Network.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -263,7 +264,7 @@ func (m *NetworkInterface) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return xxx_messageInfo_NetworkInterface.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -325,7 +326,7 @@ func (m *Deregistration) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_Deregistration.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -726,7 +727,7 @@ func NewEntityFromFace(that EntityFace) *Entity {
 func (m *Entity) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -734,130 +735,128 @@ func (m *Entity) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Entity) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Entity) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.EntityClass) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.EntityClass)))
-		i += copy(dAtA[i:], m.EntityClass)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintEntity(dAtA, i, uint64(m.System.Size()))
-	n1, err := m.System.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if len(m.Subscriptions) > 0 {
-		for _, s := range m.Subscriptions {
-			dAtA[i] = 0x22
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if len(m.KeepaliveHandlers) > 0 {
+		for iNdEx := len(m.KeepaliveHandlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.KeepaliveHandlers[iNdEx])
+			copy(dAtA[i:], m.KeepaliveHandlers[iNdEx])
+			i = encodeVarintEntity(dAtA, i, uint64(len(m.KeepaliveHandlers[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x82
 		}
 	}
-	if m.LastSeen != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(m.LastSeen))
+	if len(m.SensuAgentVersion) > 0 {
+		i -= len(m.SensuAgentVersion)
+		copy(dAtA[i:], m.SensuAgentVersion)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.SensuAgentVersion)))
+		i--
+		dAtA[i] = 0x7a
 	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintEntity(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x72
+	if len(m.Redact) > 0 {
+		for iNdEx := len(m.Redact) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Redact[iNdEx])
+			copy(dAtA[i:], m.Redact[iNdEx])
+			i = encodeVarintEntity(dAtA, i, uint64(len(m.Redact[iNdEx])))
+			i--
+			dAtA[i] = 0x6a
+		}
+	}
+	if len(m.ExtendedAttributes) > 0 {
+		i -= len(m.ExtendedAttributes)
+		copy(dAtA[i:], m.ExtendedAttributes)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.ExtendedAttributes)))
+		i--
+		dAtA[i] = 0x62
+	}
+	if len(m.User) > 0 {
+		i -= len(m.User)
+		copy(dAtA[i:], m.User)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.User)))
+		i--
+		dAtA[i] = 0x5a
+	}
+	{
+		size, err := m.Deregistration.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintEntity(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x3a
 	if m.Deregister {
-		dAtA[i] = 0x30
-		i++
+		i--
 		if m.Deregister {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x30
 	}
-	dAtA[i] = 0x3a
-	i++
-	i = encodeVarintEntity(dAtA, i, uint64(m.Deregistration.Size()))
-	n2, err := m.Deregistration.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.LastSeen != 0 {
+		i = encodeVarintEntity(dAtA, i, uint64(m.LastSeen))
+		i--
+		dAtA[i] = 0x28
 	}
-	i += n2
-	if len(m.User) > 0 {
-		dAtA[i] = 0x5a
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.User)))
-		i += copy(dAtA[i:], m.User)
-	}
-	if len(m.ExtendedAttributes) > 0 {
-		dAtA[i] = 0x62
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.ExtendedAttributes)))
-		i += copy(dAtA[i:], m.ExtendedAttributes)
-	}
-	if len(m.Redact) > 0 {
-		for _, s := range m.Redact {
-			dAtA[i] = 0x6a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if len(m.Subscriptions) > 0 {
+		for iNdEx := len(m.Subscriptions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Subscriptions[iNdEx])
+			copy(dAtA[i:], m.Subscriptions[iNdEx])
+			i = encodeVarintEntity(dAtA, i, uint64(len(m.Subscriptions[iNdEx])))
+			i--
+			dAtA[i] = 0x22
 		}
 	}
-	dAtA[i] = 0x72
-	i++
-	i = encodeVarintEntity(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n3, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n3
-	if len(m.SensuAgentVersion) > 0 {
-		dAtA[i] = 0x7a
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.SensuAgentVersion)))
-		i += copy(dAtA[i:], m.SensuAgentVersion)
-	}
-	if len(m.KeepaliveHandlers) > 0 {
-		for _, s := range m.KeepaliveHandlers {
-			dAtA[i] = 0x82
-			i++
-			dAtA[i] = 0x1
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	{
+		size, err := m.System.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
+		i -= size
+		i = encodeVarintEntity(dAtA, i, uint64(size))
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	i--
+	dAtA[i] = 0x1a
+	if len(m.EntityClass) > 0 {
+		i -= len(m.EntityClass)
+		copy(dAtA[i:], m.EntityClass)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.EntityClass)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *System) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -865,69 +864,83 @@ func (m *System) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *System) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *System) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Hostname) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.Hostname)))
-		i += copy(dAtA[i:], m.Hostname)
-	}
-	if len(m.OS) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.OS)))
-		i += copy(dAtA[i:], m.OS)
-	}
-	if len(m.Platform) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.Platform)))
-		i += copy(dAtA[i:], m.Platform)
-	}
-	if len(m.PlatformFamily) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.PlatformFamily)))
-		i += copy(dAtA[i:], m.PlatformFamily)
-	}
-	if len(m.PlatformVersion) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.PlatformVersion)))
-		i += copy(dAtA[i:], m.PlatformVersion)
-	}
-	dAtA[i] = 0x32
-	i++
-	i = encodeVarintEntity(dAtA, i, uint64(m.Network.Size()))
-	n4, err := m.Network.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n4
-	if len(m.Arch) > 0 {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.Arch)))
-		i += copy(dAtA[i:], m.Arch)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.ARMVersion != 0 {
-		dAtA[i] = 0x40
-		i++
 		i = encodeVarintEntity(dAtA, i, uint64(m.ARMVersion))
+		i--
+		dAtA[i] = 0x40
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Arch) > 0 {
+		i -= len(m.Arch)
+		copy(dAtA[i:], m.Arch)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.Arch)))
+		i--
+		dAtA[i] = 0x3a
 	}
-	return i, nil
+	{
+		size, err := m.Network.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintEntity(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x32
+	if len(m.PlatformVersion) > 0 {
+		i -= len(m.PlatformVersion)
+		copy(dAtA[i:], m.PlatformVersion)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.PlatformVersion)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.PlatformFamily) > 0 {
+		i -= len(m.PlatformFamily)
+		copy(dAtA[i:], m.PlatformFamily)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.PlatformFamily)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Platform) > 0 {
+		i -= len(m.Platform)
+		copy(dAtA[i:], m.Platform)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.Platform)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.OS) > 0 {
+		i -= len(m.OS)
+		copy(dAtA[i:], m.OS)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.OS)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Hostname) > 0 {
+		i -= len(m.Hostname)
+		copy(dAtA[i:], m.Hostname)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.Hostname)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Network) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -935,32 +948,40 @@ func (m *Network) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Network) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Network) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
 	if len(m.Interfaces) > 0 {
-		for _, msg := range m.Interfaces {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintEntity(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Interfaces) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Interfaces[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintEntity(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *NetworkInterface) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -968,47 +989,49 @@ func (m *NetworkInterface) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *NetworkInterface) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *NetworkInterface) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if len(m.MAC) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.MAC)))
-		i += copy(dAtA[i:], m.MAC)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Addresses) > 0 {
-		for _, s := range m.Addresses {
+		for iNdEx := len(m.Addresses) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Addresses[iNdEx])
+			copy(dAtA[i:], m.Addresses[iNdEx])
+			i = encodeVarintEntity(dAtA, i, uint64(len(m.Addresses[iNdEx])))
+			i--
 			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.MAC) > 0 {
+		i -= len(m.MAC)
+		copy(dAtA[i:], m.MAC)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.MAC)))
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Deregistration) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1016,30 +1039,39 @@ func (m *Deregistration) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Deregistration) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Deregistration) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Handler) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintEntity(dAtA, i, uint64(len(m.Handler)))
-		i += copy(dAtA[i:], m.Handler)
-	}
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	if len(m.Handler) > 0 {
+		i -= len(m.Handler)
+		copy(dAtA[i:], m.Handler)
+		i = encodeVarintEntity(dAtA, i, uint64(len(m.Handler)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintEntity(dAtA []byte, offset int, v uint64) int {
+	offset -= sovEntity(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedEntity(r randyEntity, easy bool) *Entity {
 	this := &Entity{}
@@ -1105,7 +1137,7 @@ func NewPopulatedSystem(r randyEntity, easy bool) *System {
 
 func NewPopulatedNetwork(r randyEntity, easy bool) *Network {
 	this := &Network{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v9 := r.Intn(5)
 		this.Interfaces = make([]NetworkInterface, v9)
 		for i := 0; i < v9; i++ {
@@ -1375,14 +1407,7 @@ func (m *Deregistration) Size() (n int) {
 }
 
 func sovEntity(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEntity(x uint64) (n int) {
 	return sovEntity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"path"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	stringsutil "github.com/sensu/sensu-go/util/strings"
 )
 
@@ -70,6 +72,12 @@ func (e *Event) Validate() error {
 
 	if e.Name != "" {
 		return errors.New("events cannot be named")
+	}
+
+	if len(e.ID) > 0 {
+		if _, err := uuid.FromBytes(e.ID); err != nil {
+			return fmt.Errorf("event ID is invalid: %s", err)
+		}
 	}
 
 	return nil
@@ -412,4 +420,11 @@ func (e *Event) SetObjectMeta(meta ObjectMeta) {
 
 func (e *Event) RBACName() string {
 	return "events"
+}
+
+// GetUUID parses a UUID from the ID bytes. It does not check errors, assuming
+// that the event has already passed validation.
+func (e *Event) GetUUID() uuid.UUID {
+	id, _ := uuid.FromBytes(e.ID)
+	return id
 }

--- a/api/core/v2/event.pb.go
+++ b/api/core/v2/event.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // An Event is the encapsulating type sent across the Sensu websocket transport.
 type Event struct {
@@ -35,7 +36,9 @@ type Event struct {
 	// Metrics are zero or more Sensu metrics
 	Metrics *Metrics `protobuf:"bytes,4,opt,name=metrics,proto3" json:"metrics,omitempty"`
 	// Metadata contains name, namespace, labels and annotations
-	ObjectMeta           `protobuf:"bytes,5,opt,name=metadata,proto3,embedded=metadata" json:"metadata"`
+	ObjectMeta `protobuf:"bytes,5,opt,name=metadata,proto3,embedded=metadata" json:"metadata"`
+	// ID is the unique identifier of the event.
+	ID                   []byte   `protobuf:"bytes,6,opt,name=ID,proto3" json:"id"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -55,7 +58,7 @@ func (m *Event) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Event.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -81,14 +84,14 @@ func init() {
 func init() { proto.RegisterFile("event.proto", fileDescriptor_2d17a9d3f0ddf27e) }
 
 var fileDescriptor_2d17a9d3f0ddf27e = []byte{
-	// 322 bytes of a gzipped FileDescriptorProto
+	// 347 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x4e, 0x2d, 0x4b, 0xcd,
 	0x2b, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x2d, 0x4e, 0xcd, 0x2b, 0x2e, 0xd5, 0x4b,
 	0xce, 0x2f, 0x4a, 0xd5, 0x2b, 0x33, 0x92, 0x32, 0x49, 0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b,
 	0xce, 0xcf, 0xd5, 0x4f, 0xcf, 0x4f, 0xcf, 0xd7, 0x07, 0xab, 0x4a, 0x2a, 0x4d, 0x73, 0x28, 0x33,
 	0xd4, 0x33, 0xd2, 0x33, 0x04, 0x0b, 0x82, 0xc5, 0xc0, 0x2c, 0x88, 0x21, 0x52, 0x3c, 0xa9, 0x79,
 	0x25, 0x99, 0x25, 0x95, 0x50, 0x1e, 0x77, 0x72, 0x46, 0x6a, 0x72, 0x36, 0x94, 0xc3, 0x9b, 0x9b,
-	0x5a, 0x52, 0x94, 0x99, 0x5c, 0x0c, 0xe5, 0x72, 0xe5, 0xa6, 0x96, 0x24, 0x42, 0xd8, 0x4a, 0xb3,
+	0x5a, 0x52, 0x94, 0x99, 0x5c, 0x0c, 0xe5, 0x72, 0xe5, 0xa6, 0x96, 0x24, 0x42, 0xd8, 0x4a, 0x9b,
 	0x99, 0xb8, 0x58, 0x5d, 0x41, 0x4e, 0x11, 0x92, 0xe1, 0xe2, 0x2c, 0xc9, 0xcc, 0x4d, 0x2d, 0x2e,
 	0x49, 0xcc, 0x2d, 0x90, 0x60, 0x54, 0x60, 0xd4, 0x60, 0x0e, 0x42, 0x08, 0x08, 0x19, 0x73, 0xb1,
 	0x41, 0xcc, 0x97, 0x60, 0x52, 0x60, 0xd4, 0xe0, 0x36, 0x12, 0xd5, 0x43, 0x71, 0xb3, 0x9e, 0x2b,
@@ -98,11 +101,12 @@ var fileDescriptor_2d17a9d3f0ddf27e = []byte{
 	0xea, 0x82, 0x29, 0x16, 0xf2, 0xe6, 0xe2, 0x00, 0x79, 0x2a, 0x25, 0xb1, 0x24, 0x51, 0x82, 0x15,
 	0xac, 0x51, 0x12, 0x4d, 0xa3, 0x7f, 0x52, 0x56, 0x6a, 0x72, 0x89, 0x6f, 0x6a, 0x49, 0xa2, 0x93,
 	0xc8, 0x89, 0x7b, 0xf2, 0x0c, 0x17, 0xee, 0xc9, 0x33, 0xbe, 0xba, 0x27, 0x0f, 0xd7, 0x16, 0x04,
-	0x67, 0x59, 0x71, 0x74, 0x2c, 0x90, 0x67, 0x58, 0xb1, 0x40, 0x9e, 0xd1, 0x49, 0xe1, 0xc7, 0x43,
-	0x39, 0xc6, 0x15, 0x8f, 0xe4, 0x18, 0x77, 0x3c, 0x92, 0x63, 0x3c, 0xf1, 0x48, 0x8e, 0xf1, 0xc2,
-	0x23, 0x39, 0xc6, 0x07, 0x8f, 0xe4, 0x18, 0x67, 0x3c, 0x96, 0x63, 0x88, 0x62, 0x2a, 0x33, 0x4a,
-	0x62, 0x03, 0x07, 0xa3, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x1a, 0x45, 0x76, 0x01, 0xd0, 0x01,
-	0x00, 0x00,
+	0x67, 0x09, 0x89, 0x71, 0x31, 0x79, 0xba, 0x48, 0xb0, 0x29, 0x30, 0x6a, 0xf0, 0x38, 0xb1, 0xbd,
+	0xba, 0x27, 0xcf, 0x94, 0x99, 0x12, 0xc4, 0xe4, 0xe9, 0x62, 0xc5, 0xd1, 0xb1, 0x40, 0x9e, 0x61,
+	0xc5, 0x02, 0x79, 0x46, 0x27, 0x85, 0x1f, 0x0f, 0xe5, 0x18, 0x57, 0x3c, 0x92, 0x63, 0xdc, 0xf1,
+	0x48, 0x8e, 0xf1, 0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18, 0x1f, 0x3c, 0x92, 0x63, 0x9c,
+	0xf1, 0x58, 0x8e, 0x21, 0x8a, 0xa9, 0xcc, 0x28, 0x89, 0x0d, 0x1c, 0xbc, 0xc6, 0x80, 0x00, 0x00,
+	0x00, 0xff, 0xff, 0x81, 0xd2, 0xcd, 0xd9, 0xe8, 0x01, 0x00, 0x00,
 }
 
 func (this *Event) Equal(that interface{}) bool {
@@ -139,6 +143,9 @@ func (this *Event) Equal(that interface{}) bool {
 	if !this.ObjectMeta.Equal(&that1.ObjectMeta) {
 		return false
 	}
+	if !bytes.Equal(this.ID, that1.ID) {
+		return false
+	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return false
 	}
@@ -152,6 +159,7 @@ type EventFace interface {
 	GetCheck() *Check
 	GetMetrics() *Metrics
 	GetObjectMeta() ObjectMeta
+	GetID() []byte
 }
 
 func (this *Event) Proto() github_com_golang_protobuf_proto.Message {
@@ -182,6 +190,10 @@ func (this *Event) GetObjectMeta() ObjectMeta {
 	return this.ObjectMeta
 }
 
+func (this *Event) GetID() []byte {
+	return this.ID
+}
+
 func NewEventFromFace(that EventFace) *Event {
 	this := &Event{}
 	this.Timestamp = that.GetTimestamp()
@@ -189,13 +201,14 @@ func NewEventFromFace(that EventFace) *Event {
 	this.Check = that.GetCheck()
 	this.Metrics = that.GetMetrics()
 	this.ObjectMeta = that.GetObjectMeta()
+	this.ID = that.GetID()
 	return this
 }
 
 func (m *Event) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -203,67 +216,90 @@ func (m *Event) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Event) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Event) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Timestamp != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Timestamp))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if m.Entity != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Entity.Size()))
-		n1, err := m.Entity.MarshalTo(dAtA[i:])
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintEvent(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0x32
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
-		i += n1
+		i -= size
+		i = encodeVarintEvent(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x2a
+	if m.Metrics != nil {
+		{
+			size, err := m.Metrics.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintEvent(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
 	}
 	if m.Check != nil {
+		{
+			size, err := m.Check.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintEvent(dAtA, i, uint64(size))
+		}
+		i--
 		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Check.Size()))
-		n2, err := m.Check.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	}
+	if m.Entity != nil {
+		{
+			size, err := m.Entity.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintEvent(dAtA, i, uint64(size))
 		}
-		i += n2
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.Metrics != nil {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintEvent(dAtA, i, uint64(m.Metrics.Size()))
-		n3, err := m.Metrics.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
+	if m.Timestamp != 0 {
+		i = encodeVarintEvent(dAtA, i, uint64(m.Timestamp))
+		i--
+		dAtA[i] = 0x8
 	}
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintEvent(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n4, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n4
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintEvent(dAtA []byte, offset int, v uint64) int {
+	offset -= sovEvent(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedEvent(r randyEvent, easy bool) *Event {
 	this := &Event{}
@@ -271,19 +307,24 @@ func NewPopulatedEvent(r randyEvent, easy bool) *Event {
 	if r.Intn(2) == 0 {
 		this.Timestamp *= -1
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Entity = NewPopulatedEntity(r, easy)
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Check = NewPopulatedCheck(r, easy)
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Metrics = NewPopulatedMetrics(r, easy)
 	}
 	v1 := NewPopulatedObjectMeta(r, easy)
 	this.ObjectMeta = *v1
+	v2 := r.Intn(100)
+	this.ID = make([]byte, v2)
+	for i := 0; i < v2; i++ {
+		this.ID[i] = byte(r.Intn(256))
+	}
 	if !easy && r.Intn(10) != 0 {
-		this.XXX_unrecognized = randUnrecognizedEvent(r, 6)
+		this.XXX_unrecognized = randUnrecognizedEvent(r, 7)
 	}
 	return this
 }
@@ -307,9 +348,9 @@ func randUTF8RuneEvent(r randyEvent) rune {
 	return rune(ru + 61)
 }
 func randStringEvent(r randyEvent) string {
-	v2 := r.Intn(100)
-	tmps := make([]rune, v2)
-	for i := 0; i < v2; i++ {
+	v3 := r.Intn(100)
+	tmps := make([]rune, v3)
+	for i := 0; i < v3; i++ {
 		tmps[i] = randUTF8RuneEvent(r)
 	}
 	return string(tmps)
@@ -331,11 +372,11 @@ func randFieldEvent(dAtA []byte, r randyEvent, fieldNumber int, wire int) []byte
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateEvent(dAtA, uint64(key))
-		v3 := r.Int63()
+		v4 := r.Int63()
 		if r.Intn(2) == 0 {
-			v3 *= -1
+			v4 *= -1
 		}
-		dAtA = encodeVarintPopulateEvent(dAtA, uint64(v3))
+		dAtA = encodeVarintPopulateEvent(dAtA, uint64(v4))
 	case 1:
 		dAtA = encodeVarintPopulateEvent(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))
@@ -383,6 +424,10 @@ func (m *Event) Size() (n int) {
 	}
 	l = m.ObjectMeta.Size()
 	n += 1 + l + sovEvent(uint64(l))
+	l = len(m.ID)
+	if l > 0 {
+		n += 1 + l + sovEvent(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -390,14 +435,7 @@ func (m *Event) Size() (n int) {
 }
 
 func sovEvent(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozEvent(x uint64) (n int) {
 	return sovEvent(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -589,6 +627,40 @@ func (m *Event) Unmarshal(dAtA []byte) error {
 			}
 			if err := m.ObjectMeta.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowEvent
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthEvent
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthEvent
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = append(m.ID[:0], dAtA[iNdEx:postIndex]...)
+			if m.ID == nil {
+				m.ID = []byte{}
 			}
 			iNdEx = postIndex
 		default:

--- a/api/core/v2/event.proto
+++ b/api/core/v2/event.proto
@@ -35,4 +35,7 @@ message Event {
 
   // Metadata contains name, namespace, labels and annotations
   ObjectMeta metadata = 5 [(gogoproto.embed) = true, (gogoproto.jsontag) = "metadata", (gogoproto.nullable) = false];
+
+  // ID is the unique identifier of the event.
+  bytes ID = 6 [(gogoproto.jsontag) = "id"];
 }

--- a/api/core/v2/extension.pb.go
+++ b/api/core/v2/extension.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Extension is a registered sensu extension.
 type Extension struct {
@@ -49,7 +50,7 @@ func (m *Extension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Extension.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +158,7 @@ func NewExtensionFromFace(that ExtensionFace) *Extension {
 func (m *Extension) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -165,38 +166,49 @@ func (m *Extension) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Extension) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Extension) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintExtension(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if len(m.URL) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintExtension(dAtA, i, uint64(len(m.URL)))
-		i += copy(dAtA[i:], m.URL)
-	}
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	if len(m.URL) > 0 {
+		i -= len(m.URL)
+		copy(dAtA[i:], m.URL)
+		i = encodeVarintExtension(dAtA, i, uint64(len(m.URL)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintExtension(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintExtension(dAtA []byte, offset int, v uint64) int {
+	offset -= sovExtension(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedExtension(r randyExtension, easy bool) *Extension {
 	this := &Extension{}
@@ -300,14 +312,7 @@ func (m *Extension) Size() (n int) {
 }
 
 func sovExtension(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozExtension(x uint64) (n int) {
 	return sovExtension(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/filter.pb.go
+++ b/api/core/v2/filter.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // EventFilter is a filter specification.
 type EventFilter struct {
@@ -57,7 +58,7 @@ func (m *EventFilter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_EventFilter.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +209,7 @@ func NewEventFilterFromFace(that EventFilterFace) *EventFilter {
 func (m *EventFilter) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -216,78 +217,79 @@ func (m *EventFilter) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *EventFilter) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *EventFilter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintFilter(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	i += n1
-	if len(m.Action) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintFilter(dAtA, i, uint64(len(m.Action)))
-		i += copy(dAtA[i:], m.Action)
-	}
-	if len(m.Expressions) > 0 {
-		for _, s := range m.Expressions {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if len(m.RuntimeAssets) > 0 {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintFilter(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
+			dAtA[i] = 0x42
 		}
 	}
 	if m.When != nil {
+		{
+			size, err := m.When.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintFilter(dAtA, i, uint64(size))
+		}
+		i--
 		dAtA[i] = 0x32
-		i++
-		i = encodeVarintFilter(dAtA, i, uint64(m.When.Size()))
-		n2, err := m.When.MarshalTo(dAtA[i:])
+	}
+	if len(m.Expressions) > 0 {
+		for iNdEx := len(m.Expressions) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Expressions[iNdEx])
+			copy(dAtA[i:], m.Expressions[iNdEx])
+			i = encodeVarintFilter(dAtA, i, uint64(len(m.Expressions[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Action) > 0 {
+		i -= len(m.Action)
+		copy(dAtA[i:], m.Action)
+		i = encodeVarintFilter(dAtA, i, uint64(len(m.Action)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
-		i += n2
+		i -= size
+		i = encodeVarintFilter(dAtA, i, uint64(size))
 	}
-	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
-			dAtA[i] = 0x42
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintFilter(dAtA []byte, offset int, v uint64) int {
+	offset -= sovFilter(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedEventFilter(r randyFilter, easy bool) *EventFilter {
 	this := &EventFilter{}
@@ -299,7 +301,7 @@ func NewPopulatedEventFilter(r randyFilter, easy bool) *EventFilter {
 	for i := 0; i < v2; i++ {
 		this.Expressions[i] = string(randStringFilter(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.When = NewPopulatedTimeWindowWhen(r, easy)
 	}
 	v3 := r.Intn(10)
@@ -420,14 +422,7 @@ func (m *EventFilter) Size() (n int) {
 }
 
 func sovFilter(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozFilter(x uint64) (n int) {
 	return sovFilter(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/handler.pb.go
+++ b/api/core/v2/handler.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Handler is a handler specification.
 type Handler struct {
@@ -68,7 +69,7 @@ func (m *Handler) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Handler.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +113,7 @@ func (m *HandlerSocket) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return xxx_messageInfo_HandlerSocket.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +386,7 @@ func NewHandlerFromFace(that HandlerFace) *Handler {
 func (m *Handler) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -393,133 +394,124 @@ func (m *Handler) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Handler) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Handler) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintHandler(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	i += n1
-	if len(m.Type) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(len(m.Type)))
-		i += copy(dAtA[i:], m.Type)
-	}
-	if len(m.Mutator) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(len(m.Mutator)))
-		i += copy(dAtA[i:], m.Mutator)
-	}
-	if len(m.Command) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(len(m.Command)))
-		i += copy(dAtA[i:], m.Command)
-	}
-	if m.Timeout != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(m.Timeout))
-	}
-	if m.Socket != nil {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(m.Socket.Size()))
-		n2, err := m.Socket.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n2
-	}
-	if len(m.Handlers) > 0 {
-		for _, s := range m.Handlers {
-			dAtA[i] = 0x3a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Secrets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintHandler(dAtA, i, uint64(size))
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.Filters) > 0 {
-		for _, s := range m.Filters {
-			dAtA[i] = 0x42
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.EnvVars) > 0 {
-		for _, s := range m.EnvVars {
-			dAtA[i] = 0x4a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i--
+			dAtA[i] = 0x72
 		}
 	}
 	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintHandler(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
 			dAtA[i] = 0x6a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if len(m.Secrets) > 0 {
-		for _, msg := range m.Secrets {
-			dAtA[i] = 0x72
-			i++
-			i = encodeVarintHandler(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
+	if len(m.EnvVars) > 0 {
+		for iNdEx := len(m.EnvVars) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EnvVars[iNdEx])
+			copy(dAtA[i:], m.EnvVars[iNdEx])
+			i = encodeVarintHandler(dAtA, i, uint64(len(m.EnvVars[iNdEx])))
+			i--
+			dAtA[i] = 0x4a
+		}
+	}
+	if len(m.Filters) > 0 {
+		for iNdEx := len(m.Filters) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Filters[iNdEx])
+			copy(dAtA[i:], m.Filters[iNdEx])
+			i = encodeVarintHandler(dAtA, i, uint64(len(m.Filters[iNdEx])))
+			i--
+			dAtA[i] = 0x42
+		}
+	}
+	if len(m.Handlers) > 0 {
+		for iNdEx := len(m.Handlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Handlers[iNdEx])
+			copy(dAtA[i:], m.Handlers[iNdEx])
+			i = encodeVarintHandler(dAtA, i, uint64(len(m.Handlers[iNdEx])))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
+	if m.Socket != nil {
+		{
+			size, err := m.Socket.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
-			i += n
+			i -= size
+			i = encodeVarintHandler(dAtA, i, uint64(size))
 		}
+		i--
+		dAtA[i] = 0x32
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Timeout != 0 {
+		i = encodeVarintHandler(dAtA, i, uint64(m.Timeout))
+		i--
+		dAtA[i] = 0x28
 	}
-	return i, nil
+	if len(m.Command) > 0 {
+		i -= len(m.Command)
+		copy(dAtA[i:], m.Command)
+		i = encodeVarintHandler(dAtA, i, uint64(len(m.Command)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Mutator) > 0 {
+		i -= len(m.Mutator)
+		copy(dAtA[i:], m.Mutator)
+		i = encodeVarintHandler(dAtA, i, uint64(len(m.Mutator)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintHandler(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintHandler(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *HandlerSocket) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -527,35 +519,44 @@ func (m *HandlerSocket) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *HandlerSocket) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *HandlerSocket) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Host) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintHandler(dAtA, i, uint64(len(m.Host)))
-		i += copy(dAtA[i:], m.Host)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Port != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintHandler(dAtA, i, uint64(m.Port))
+		i--
+		dAtA[i] = 0x10
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Host) > 0 {
+		i -= len(m.Host)
+		copy(dAtA[i:], m.Host)
+		i = encodeVarintHandler(dAtA, i, uint64(len(m.Host)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintHandler(dAtA []byte, offset int, v uint64) int {
+	offset -= sovHandler(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedHandler(r randyHandler, easy bool) *Handler {
 	this := &Handler{}
@@ -565,7 +566,7 @@ func NewPopulatedHandler(r randyHandler, easy bool) *Handler {
 	this.Mutator = string(randStringHandler(r))
 	this.Command = string(randStringHandler(r))
 	this.Timeout = uint32(r.Uint32())
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		this.Socket = NewPopulatedHandlerSocket(r, easy)
 	}
 	v2 := r.Intn(10)
@@ -588,7 +589,7 @@ func NewPopulatedHandler(r randyHandler, easy bool) *Handler {
 	for i := 0; i < v5; i++ {
 		this.RuntimeAssets[i] = string(randStringHandler(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v6 := r.Intn(5)
 		this.Secrets = make([]*Secret, v6)
 		for i := 0; i < v6; i++ {
@@ -766,14 +767,7 @@ func (m *HandlerSocket) Size() (n int) {
 }
 
 func sovHandler(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozHandler(x uint64) (n int) {
 	return sovHandler(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/hook.pb.go
+++ b/api/core/v2/hook.pb.go
@@ -12,6 +12,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -23,7 +24,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // HookConfig is the specification of a hook
 type HookConfig struct {
@@ -56,7 +57,7 @@ func (m *HookConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_HookConfig.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +110,7 @@ func (m *Hook) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Hook.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +188,7 @@ func (m *HookList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_HookList.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -434,7 +435,7 @@ func NewHookConfigFromFace(that HookConfigFace) *HookConfig {
 func (m *HookConfig) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -442,64 +443,67 @@ func (m *HookConfig) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *HookConfig) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *HookConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintHook(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	i += n1
-	if len(m.Command) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintHook(dAtA, i, uint64(len(m.Command)))
-		i += copy(dAtA[i:], m.Command)
-	}
-	if m.Timeout != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintHook(dAtA, i, uint64(m.Timeout))
+	if len(m.RuntimeAssets) > 0 {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintHook(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
 	if m.Stdin {
-		dAtA[i] = 0x20
-		i++
+		i--
 		if m.Stdin {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x20
 	}
-	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
-			dAtA[i] = 0x2a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if m.Timeout != 0 {
+		i = encodeVarintHook(dAtA, i, uint64(m.Timeout))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Command) > 0 {
+		i -= len(m.Command)
+		copy(dAtA[i:], m.Command)
+		i = encodeVarintHook(dAtA, i, uint64(len(m.Command)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
+		i -= size
+		i = encodeVarintHook(dAtA, i, uint64(size))
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *Hook) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -507,55 +511,64 @@ func (m *Hook) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Hook) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Hook) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintHook(dAtA, i, uint64(m.HookConfig.Size()))
-	n2, err := m.HookConfig.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	if m.Duration != 0 {
-		dAtA[i] = 0x11
-		i++
-		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Duration))))
-		i += 8
-	}
-	if m.Executed != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintHook(dAtA, i, uint64(m.Executed))
-	}
-	if m.Issued != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintHook(dAtA, i, uint64(m.Issued))
-	}
-	if len(m.Output) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintHook(dAtA, i, uint64(len(m.Output)))
-		i += copy(dAtA[i:], m.Output)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Status != 0 {
-		dAtA[i] = 0x30
-		i++
 		i = encodeVarintHook(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x30
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Output) > 0 {
+		i -= len(m.Output)
+		copy(dAtA[i:], m.Output)
+		i = encodeVarintHook(dAtA, i, uint64(len(m.Output)))
+		i--
+		dAtA[i] = 0x2a
 	}
-	return i, nil
+	if m.Issued != 0 {
+		i = encodeVarintHook(dAtA, i, uint64(m.Issued))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Executed != 0 {
+		i = encodeVarintHook(dAtA, i, uint64(m.Executed))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Duration != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Duration))))
+		i--
+		dAtA[i] = 0x11
+	}
+	{
+		size, err := m.HookConfig.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintHook(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *HookList) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -563,45 +576,48 @@ func (m *HookList) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *HookList) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *HookList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Hooks) > 0 {
-		for _, s := range m.Hooks {
-			dAtA[i] = 0xa
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Type) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
 		i = encodeVarintHook(dAtA, i, uint64(len(m.Type)))
-		i += copy(dAtA[i:], m.Type)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Hooks) > 0 {
+		for iNdEx := len(m.Hooks) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Hooks[iNdEx])
+			copy(dAtA[i:], m.Hooks[iNdEx])
+			i = encodeVarintHook(dAtA, i, uint64(len(m.Hooks[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintHook(dAtA []byte, offset int, v uint64) int {
+	offset -= sovHook(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedHookConfig(r randyHook, easy bool) *HookConfig {
 	this := &HookConfig{}
@@ -817,14 +833,7 @@ func (m *HookList) Size() (n int) {
 }
 
 func sovHook(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozHook(x uint64) (n int) {
 	return sovHook(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/keepalive.pb.go
+++ b/api/core/v2/keepalive.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A KeepaliveRecord is a tuple of an entity name and the time at which the
 // entity's keepalive will next expire.
@@ -49,7 +50,7 @@ func (m *KeepaliveRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return xxx_messageInfo_KeepaliveRecord.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +158,7 @@ func NewKeepaliveRecordFromFace(that KeepaliveRecordFace) *KeepaliveRecord {
 func (m *KeepaliveRecord) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -165,37 +166,47 @@ func (m *KeepaliveRecord) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *KeepaliveRecord) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *KeepaliveRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintKeepalive(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if m.Time != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintKeepalive(dAtA, i, uint64(m.Time))
-	}
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	if m.Time != 0 {
+		i = encodeVarintKeepalive(dAtA, i, uint64(m.Time))
+		i--
+		dAtA[i] = 0x20
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintKeepalive(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintKeepalive(dAtA []byte, offset int, v uint64) int {
+	offset -= sovKeepalive(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedKeepaliveRecord(r randyKeepalive, easy bool) *KeepaliveRecord {
 	this := &KeepaliveRecord{}
@@ -301,14 +312,7 @@ func (m *KeepaliveRecord) Size() (n int) {
 }
 
 func sovKeepalive(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozKeepalive(x uint64) (n int) {
 	return sovKeepalive(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/meta.pb.go
+++ b/api/core/v2/meta.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // ObjectMeta is metadata all persisted objects have.
 type ObjectMeta struct {
@@ -62,7 +63,7 @@ func (m *ObjectMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_ObjectMeta.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +135,7 @@ func (m *TypeMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_TypeMeta.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -287,7 +288,7 @@ func (this *TypeMeta) Equal(that interface{}) bool {
 func (m *ObjectMeta) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -295,66 +296,78 @@ func (m *ObjectMeta) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ObjectMeta) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ObjectMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintMeta(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if len(m.Namespace) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintMeta(dAtA, i, uint64(len(m.Namespace)))
-		i += copy(dAtA[i:], m.Namespace)
-	}
-	if len(m.Labels) > 0 {
-		for k, _ := range m.Labels {
-			dAtA[i] = 0x1a
-			i++
-			v := m.Labels[k]
-			mapSize := 1 + len(k) + sovMeta(uint64(len(k))) + 1 + len(v) + sovMeta(uint64(len(v)))
-			i = encodeVarintMeta(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintMeta(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintMeta(dAtA, i, uint64(len(v)))
-			i += copy(dAtA[i:], v)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Annotations) > 0 {
-		for k, _ := range m.Annotations {
-			dAtA[i] = 0x22
-			i++
+		for k := range m.Annotations {
 			v := m.Annotations[k]
-			mapSize := 1 + len(k) + sovMeta(uint64(len(k))) + 1 + len(v) + sovMeta(uint64(len(v)))
-			i = encodeVarintMeta(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintMeta(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			dAtA[i] = 0x12
-			i++
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
 			i = encodeVarintMeta(dAtA, i, uint64(len(v)))
-			i += copy(dAtA[i:], v)
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintMeta(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintMeta(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x22
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Labels) > 0 {
+		for k := range m.Labels {
+			v := m.Labels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintMeta(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintMeta(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintMeta(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
-	return i, nil
+	if len(m.Namespace) > 0 {
+		i -= len(m.Namespace)
+		copy(dAtA[i:], m.Namespace)
+		i = encodeVarintMeta(dAtA, i, uint64(len(m.Namespace)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintMeta(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *TypeMeta) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -362,49 +375,59 @@ func (m *TypeMeta) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TypeMeta) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TypeMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Type) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintMeta(dAtA, i, uint64(len(m.Type)))
-		i += copy(dAtA[i:], m.Type)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.APIVersion) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.APIVersion)
+		copy(dAtA[i:], m.APIVersion)
 		i = encodeVarintMeta(dAtA, i, uint64(len(m.APIVersion)))
-		i += copy(dAtA[i:], m.APIVersion)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintMeta(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintMeta(dAtA []byte, offset int, v uint64) int {
+	offset -= sovMeta(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedObjectMeta(r randyMeta, easy bool) *ObjectMeta {
 	this := &ObjectMeta{}
 	this.Name = string(randStringMeta(r))
 	this.Namespace = string(randStringMeta(r))
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v1 := r.Intn(10)
 		this.Labels = make(map[string]string)
 		for i := 0; i < v1; i++ {
 			this.Labels[randStringMeta(r)] = randStringMeta(r)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v2 := r.Intn(10)
 		this.Annotations = make(map[string]string)
 		for i := 0; i < v2; i++ {
@@ -556,14 +579,7 @@ func (m *TypeMeta) Size() (n int) {
 }
 
 func sovMeta(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMeta(x uint64) (n int) {
 	return sovMeta(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/metrics.pb.go
+++ b/api/core/v2/metrics.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Metrics is an event metrics payload specification.
 type Metrics struct {
@@ -49,7 +50,7 @@ func (m *Metrics) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Metrics.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -111,7 +112,7 @@ func (m *MetricPoint) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_MetricPoint.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +184,7 @@ func (m *MetricTag) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_MetricTag.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -362,7 +363,7 @@ func (this *MetricTag) Equal(that interface{}) bool {
 func (m *Metrics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -370,47 +371,49 @@ func (m *Metrics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Metrics) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Metrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Handlers) > 0 {
-		for _, s := range m.Handlers {
-			dAtA[i] = 0xa
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Points) > 0 {
-		for _, msg := range m.Points {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintMetrics(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Points) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Points[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMetrics(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Handlers) > 0 {
+		for iNdEx := len(m.Handlers) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Handlers[iNdEx])
+			copy(dAtA[i:], m.Handlers[iNdEx])
+			i = encodeVarintMetrics(dAtA, i, uint64(len(m.Handlers[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *MetricPoint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -418,49 +421,58 @@ func (m *MetricPoint) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MetricPoint) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MetricPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if m.Value != 0 {
-		dAtA[i] = 0x11
-		i++
-		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
-		i += 8
-	}
-	if m.Timestamp != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintMetrics(dAtA, i, uint64(m.Timestamp))
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Tags) > 0 {
-		for _, msg := range m.Tags {
-			dAtA[i] = 0x22
-			i++
-			i = encodeVarintMetrics(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Tags) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tags[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMetrics(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x22
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Timestamp != 0 {
+		i = encodeVarintMetrics(dAtA, i, uint64(m.Timestamp))
+		i--
+		dAtA[i] = 0x18
 	}
-	return i, nil
+	if m.Value != 0 {
+		i -= 8
+		encoding_binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Value))))
+		i--
+		dAtA[i] = 0x11
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *MetricTag) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -468,36 +480,46 @@ func (m *MetricTag) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MetricTag) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MetricTag) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Value) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
 		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Value)))
-		i += copy(dAtA[i:], m.Value)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintMetrics(dAtA []byte, offset int, v uint64) int {
+	offset -= sovMetrics(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedMetrics(r randyMetrics, easy bool) *Metrics {
 	this := &Metrics{}
@@ -506,7 +528,7 @@ func NewPopulatedMetrics(r randyMetrics, easy bool) *Metrics {
 	for i := 0; i < v1; i++ {
 		this.Handlers[i] = string(randStringMetrics(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v2 := r.Intn(5)
 		this.Points = make([]*MetricPoint, v2)
 		for i := 0; i < v2; i++ {
@@ -530,7 +552,7 @@ func NewPopulatedMetricPoint(r randyMetrics, easy bool) *MetricPoint {
 	if r.Intn(2) == 0 {
 		this.Timestamp *= -1
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v3 := r.Intn(5)
 		this.Tags = make([]*MetricTag, v3)
 		for i := 0; i < v3; i++ {
@@ -698,14 +720,7 @@ func (m *MetricTag) Size() (n int) {
 }
 
 func sovMetrics(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMetrics(x uint64) (n int) {
 	return sovMetrics(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/mutator.pb.go
+++ b/api/core/v2/mutator.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Mutator is a mutator specification.
 type Mutator struct {
@@ -58,7 +59,7 @@ func (m *Mutator) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Mutator.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +225,7 @@ func NewMutatorFromFace(that MutatorFace) *Mutator {
 func (m *Mutator) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -232,85 +233,86 @@ func (m *Mutator) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Mutator) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Mutator) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintMutator(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	i += n1
-	if len(m.Command) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintMutator(dAtA, i, uint64(len(m.Command)))
-		i += copy(dAtA[i:], m.Command)
-	}
-	if m.Timeout != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintMutator(dAtA, i, uint64(m.Timeout))
-	}
-	if len(m.EnvVars) > 0 {
-		for _, s := range m.EnvVars {
-			dAtA[i] = 0x22
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Secrets[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMutator(dAtA, i, uint64(size))
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i--
+			dAtA[i] = 0x4a
 		}
 	}
 	if len(m.RuntimeAssets) > 0 {
-		for _, s := range m.RuntimeAssets {
+		for iNdEx := len(m.RuntimeAssets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RuntimeAssets[iNdEx])
+			copy(dAtA[i:], m.RuntimeAssets[iNdEx])
+			i = encodeVarintMutator(dAtA, i, uint64(len(m.RuntimeAssets[iNdEx])))
+			i--
 			dAtA[i] = 0x42
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if len(m.Secrets) > 0 {
-		for _, msg := range m.Secrets {
-			dAtA[i] = 0x4a
-			i++
-			i = encodeVarintMutator(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
+	if len(m.EnvVars) > 0 {
+		for iNdEx := len(m.EnvVars) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.EnvVars[iNdEx])
+			copy(dAtA[i:], m.EnvVars[iNdEx])
+			i = encodeVarintMutator(dAtA, i, uint64(len(m.EnvVars[iNdEx])))
+			i--
+			dAtA[i] = 0x22
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Timeout != 0 {
+		i = encodeVarintMutator(dAtA, i, uint64(m.Timeout))
+		i--
+		dAtA[i] = 0x18
 	}
-	return i, nil
+	if len(m.Command) > 0 {
+		i -= len(m.Command)
+		copy(dAtA[i:], m.Command)
+		i = encodeVarintMutator(dAtA, i, uint64(len(m.Command)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintMutator(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintMutator(dAtA []byte, offset int, v uint64) int {
+	offset -= sovMutator(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedMutator(r randyMutator, easy bool) *Mutator {
 	this := &Mutator{}
@@ -328,7 +330,7 @@ func NewPopulatedMutator(r randyMutator, easy bool) *Mutator {
 	for i := 0; i < v3; i++ {
 		this.RuntimeAssets[i] = string(randStringMutator(r))
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v4 := r.Intn(5)
 		this.Secrets = make([]*Secret, v4)
 		for i := 0; i < v4; i++ {
@@ -453,14 +455,7 @@ func (m *Mutator) Size() (n int) {
 }
 
 func sovMutator(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMutator(x uint64) (n int) {
 	return sovMutator(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/namespace.pb.go
+++ b/api/core/v2/namespace.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Namespace represents a virtual cluster
 type Namespace struct {
@@ -46,7 +47,7 @@ func (m *Namespace) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Namespace.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +123,7 @@ func (this *Namespace) Equal(that interface{}) bool {
 func (m *Namespace) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -130,30 +131,39 @@ func (m *Namespace) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Namespace) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Namespace) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintNamespace(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintNamespace(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintNamespace(dAtA []byte, offset int, v uint64) int {
+	offset -= sovNamespace(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedNamespace(r randyNamespace, easy bool) *Namespace {
 	this := &Namespace{}
@@ -253,14 +263,7 @@ func (m *Namespace) Size() (n int) {
 }
 
 func sovNamespace(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozNamespace(x uint64) (n int) {
 	return sovNamespace(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/rbac.pb.go
+++ b/api/core/v2/rbac.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Rule holds information that describes an action that can be taken
 type Rule struct {
@@ -56,7 +57,7 @@ func (m *Rule) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Rule.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +121,7 @@ func (m *ClusterRole) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_ClusterRole.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +164,7 @@ func (m *Role) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Role.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -207,7 +208,7 @@ func (m *RoleRef) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_RoleRef.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +265,7 @@ func (m *Subject) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Subject.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -325,7 +326,7 @@ func (m *ClusterRoleBinding) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return xxx_messageInfo_ClusterRoleBinding.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +373,7 @@ func (m *RoleBinding) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_RoleBinding.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -823,7 +824,7 @@ func NewRoleBindingFromFace(that RoleBindingFace) *RoleBinding {
 func (m *Rule) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -831,65 +832,53 @@ func (m *Rule) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Rule) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Rule) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Verbs) > 0 {
-		for _, s := range m.Verbs {
-			dAtA[i] = 0xa
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.ResourceNames) > 0 {
+		for iNdEx := len(m.ResourceNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ResourceNames[iNdEx])
+			copy(dAtA[i:], m.ResourceNames[iNdEx])
+			i = encodeVarintRbac(dAtA, i, uint64(len(m.ResourceNames[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
 		}
 	}
 	if len(m.Resources) > 0 {
-		for _, s := range m.Resources {
+		for iNdEx := len(m.Resources) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Resources[iNdEx])
+			copy(dAtA[i:], m.Resources[iNdEx])
+			i = encodeVarintRbac(dAtA, i, uint64(len(m.Resources[iNdEx])))
+			i--
 			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if len(m.ResourceNames) > 0 {
-		for _, s := range m.ResourceNames {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+	if len(m.Verbs) > 0 {
+		for iNdEx := len(m.Verbs) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Verbs[iNdEx])
+			copy(dAtA[i:], m.Verbs[iNdEx])
+			i = encodeVarintRbac(dAtA, i, uint64(len(m.Verbs[iNdEx])))
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *ClusterRole) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -897,40 +886,50 @@ func (m *ClusterRole) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ClusterRole) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ClusterRole) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x1a
 	if len(m.Rules) > 0 {
-		for _, msg := range m.Rules {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintRbac(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Rules) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Rules[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintRbac(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Role) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -938,40 +937,50 @@ func (m *Role) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Role) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Role) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x22
 	if len(m.Rules) > 0 {
-		for _, msg := range m.Rules {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintRbac(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Rules) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Rules[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintRbac(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n2, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *RoleRef) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -979,32 +988,40 @@ func (m *RoleRef) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *RoleRef) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RoleRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Type) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintRbac(dAtA, i, uint64(len(m.Type)))
-		i += copy(dAtA[i:], m.Type)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
 		i = encodeVarintRbac(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintRbac(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Subject) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1012,32 +1029,40 @@ func (m *Subject) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Subject) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Subject) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Type) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintRbac(dAtA, i, uint64(len(m.Type)))
-		i += copy(dAtA[i:], m.Type)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
 		i = encodeVarintRbac(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = encodeVarintRbac(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *ClusterRoleBinding) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1045,48 +1070,60 @@ func (m *ClusterRoleBinding) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ClusterRoleBinding) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ClusterRoleBinding) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x22
+	{
+		size, err := m.RoleRef.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
 	if len(m.Subjects) > 0 {
-		for _, msg := range m.Subjects {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintRbac(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Subjects) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Subjects[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintRbac(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.RoleRef.Size()))
-	n3, err := m.RoleRef.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n3
-	dAtA[i] = 0x22
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n4, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n4
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *RoleBinding) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1094,52 +1131,66 @@ func (m *RoleBinding) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *RoleBinding) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RoleBinding) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x2a
+	{
+		size, err := m.RoleRef.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintRbac(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
 	if len(m.Subjects) > 0 {
-		for _, msg := range m.Subjects {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintRbac(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Subjects) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Subjects[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintRbac(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.RoleRef.Size()))
-	n5, err := m.RoleRef.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n5
-	dAtA[i] = 0x2a
-	i++
-	i = encodeVarintRbac(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n6, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n6
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintRbac(dAtA []byte, offset int, v uint64) int {
+	offset -= sovRbac(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedRule(r randyRbac, easy bool) *Rule {
 	this := &Rule{}
@@ -1166,7 +1217,7 @@ func NewPopulatedRule(r randyRbac, easy bool) *Rule {
 
 func NewPopulatedClusterRole(r randyRbac, easy bool) *ClusterRole {
 	this := &ClusterRole{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v4 := r.Intn(5)
 		this.Rules = make([]Rule, v4)
 		for i := 0; i < v4; i++ {
@@ -1184,7 +1235,7 @@ func NewPopulatedClusterRole(r randyRbac, easy bool) *ClusterRole {
 
 func NewPopulatedRole(r randyRbac, easy bool) *Role {
 	this := &Role{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v7 := r.Intn(5)
 		this.Rules = make([]Rule, v7)
 		for i := 0; i < v7; i++ {
@@ -1222,7 +1273,7 @@ func NewPopulatedSubject(r randyRbac, easy bool) *Subject {
 
 func NewPopulatedClusterRoleBinding(r randyRbac, easy bool) *ClusterRoleBinding {
 	this := &ClusterRoleBinding{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v10 := r.Intn(5)
 		this.Subjects = make([]Subject, v10)
 		for i := 0; i < v10; i++ {
@@ -1242,7 +1293,7 @@ func NewPopulatedClusterRoleBinding(r randyRbac, easy bool) *ClusterRoleBinding 
 
 func NewPopulatedRoleBinding(r randyRbac, easy bool) *RoleBinding {
 	this := &RoleBinding{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v14 := r.Intn(5)
 		this.Subjects = make([]Subject, v14)
 		for i := 0; i < v14; i++ {
@@ -1487,14 +1538,7 @@ func (m *RoleBinding) Size() (n int) {
 }
 
 func sovRbac(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozRbac(x uint64) (n int) {
 	return sovRbac(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/secret.pb.go
+++ b/api/core/v2/secret.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // A Secret is a secret specification.
 type Secret struct {
@@ -49,7 +50,7 @@ func (m *Secret) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Secret.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +154,7 @@ func NewSecretFromFace(that SecretFace) *Secret {
 func (m *Secret) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -161,36 +162,46 @@ func (m *Secret) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Secret) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Secret) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintSecret(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.Secret) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Secret)
+		copy(dAtA[i:], m.Secret)
 		i = encodeVarintSecret(dAtA, i, uint64(len(m.Secret)))
-		i += copy(dAtA[i:], m.Secret)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintSecret(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintSecret(dAtA []byte, offset int, v uint64) int {
+	offset -= sovSecret(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedSecret(r randySecret, easy bool) *Secret {
 	this := &Secret{}
@@ -295,14 +306,7 @@ func (m *Secret) Size() (n int) {
 }
 
 func sovSecret(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozSecret(x uint64) (n int) {
 	return sovSecret(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/silenced.pb.go
+++ b/api/core/v2/silenced.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // Silenced is the representation of a silence entry.
 type Silenced struct {
@@ -62,7 +63,7 @@ func (m *Silenced) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Silenced.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +233,7 @@ func NewSilencedFromFace(that SilencedFace) *Silenced {
 func (m *Silenced) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -240,76 +241,90 @@ func (m *Silenced) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Silenced) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Silenced) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintSilenced(dAtA, i, uint64(m.ObjectMeta.Size()))
-	n1, err := m.ObjectMeta.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	i += n1
-	if m.Expire != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(m.Expire))
+	if m.Begin != 0 {
+		i = encodeVarintSilenced(dAtA, i, uint64(m.Begin))
+		i--
+		dAtA[i] = 0x50
+	}
+	if len(m.Subscription) > 0 {
+		i -= len(m.Subscription)
+		copy(dAtA[i:], m.Subscription)
+		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Subscription)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.Reason) > 0 {
+		i -= len(m.Reason)
+		copy(dAtA[i:], m.Reason)
+		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Reason)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.Check) > 0 {
+		i -= len(m.Check)
+		copy(dAtA[i:], m.Check)
+		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Check)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Creator) > 0 {
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
+		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Creator)))
+		i--
+		dAtA[i] = 0x22
 	}
 	if m.ExpireOnResolve {
-		dAtA[i] = 0x18
-		i++
+		i--
 		if m.ExpireOnResolve {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x18
 	}
-	if len(m.Creator) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Creator)))
-		i += copy(dAtA[i:], m.Creator)
+	if m.Expire != 0 {
+		i = encodeVarintSilenced(dAtA, i, uint64(m.Expire))
+		i--
+		dAtA[i] = 0x10
 	}
-	if len(m.Check) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Check)))
-		i += copy(dAtA[i:], m.Check)
+	{
+		size, err := m.ObjectMeta.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintSilenced(dAtA, i, uint64(size))
 	}
-	if len(m.Reason) > 0 {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Reason)))
-		i += copy(dAtA[i:], m.Reason)
-	}
-	if len(m.Subscription) > 0 {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(len(m.Subscription)))
-		i += copy(dAtA[i:], m.Subscription)
-	}
-	if m.Begin != 0 {
-		dAtA[i] = 0x50
-		i++
-		i = encodeVarintSilenced(dAtA, i, uint64(m.Begin))
-	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintSilenced(dAtA []byte, offset int, v uint64) int {
+	offset -= sovSilenced(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedSilenced(r randySilenced, easy bool) *Silenced {
 	this := &Silenced{}
@@ -446,14 +461,7 @@ func (m *Silenced) Size() (n int) {
 }
 
 func sovSilenced(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozSilenced(x uint64) (n int) {
 	return sovSilenced(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/tessen.pb.go
+++ b/api/core/v2/tessen.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // TessenConfig is the representation of a tessen configuration.
 type TessenConfig struct {
@@ -47,7 +48,7 @@ func (m *TessenConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_TessenConfig.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +143,7 @@ func NewTessenConfigFromFace(that TessenConfigFace) *TessenConfig {
 func (m *TessenConfig) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -150,34 +151,42 @@ func (m *TessenConfig) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TessenConfig) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TessenConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
 	if m.OptOut {
-		dAtA[i] = 0x8
-		i++
+		i--
 		if m.OptOut {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x8
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintTessen(dAtA []byte, offset int, v uint64) int {
+	offset -= sovTessen(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedTessenConfig(r randyTessen, easy bool) *TessenConfig {
 	this := &TessenConfig{}
@@ -276,14 +285,7 @@ func (m *TessenConfig) Size() (n int) {
 }
 
 func sovTessen(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTessen(x uint64) (n int) {
 	return sovTessen(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/time_window.pb.go
+++ b/api/core/v2/time_window.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // TimeWindowWhen defines the "when" attributes for time windows
 type TimeWindowWhen struct {
@@ -46,7 +47,7 @@ func (m *TimeWindowWhen) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_TimeWindowWhen.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -101,7 +102,7 @@ func (m *TimeWindowDays) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_TimeWindowDays.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +204,7 @@ func (m *TimeWindowTimeRange) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return xxx_messageInfo_TimeWindowTimeRange.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -420,7 +421,7 @@ func (this *TimeWindowTimeRange) Equal(that interface{}) bool {
 func (m *TimeWindowWhen) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -428,28 +429,36 @@ func (m *TimeWindowWhen) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TimeWindowWhen) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TimeWindowWhen) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintTimeWindow(dAtA, i, uint64(m.Days.Size()))
-	n1, err := m.Days.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	{
+		size, err := m.Days.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *TimeWindowDays) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -457,116 +466,138 @@ func (m *TimeWindowDays) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TimeWindowDays) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TimeWindowDays) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.All) > 0 {
-		for _, msg := range m.All {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Sunday) > 0 {
-		for _, msg := range m.Sunday {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+	if len(m.Saturday) > 0 {
+		for iNdEx := len(m.Saturday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Saturday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
 			}
-			i += n
-		}
-	}
-	if len(m.Monday) > 0 {
-		for _, msg := range m.Monday {
-			dAtA[i] = 0x1a
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.Tuesday) > 0 {
-		for _, msg := range m.Tuesday {
-			dAtA[i] = 0x22
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.Wednesday) > 0 {
-		for _, msg := range m.Wednesday {
-			dAtA[i] = 0x2a
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.Thursday) > 0 {
-		for _, msg := range m.Thursday {
-			dAtA[i] = 0x32
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
+			i--
+			dAtA[i] = 0x42
 		}
 	}
 	if len(m.Friday) > 0 {
-		for _, msg := range m.Friday {
+		for iNdEx := len(m.Friday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Friday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
 			dAtA[i] = 0x3a
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
 		}
 	}
-	if len(m.Saturday) > 0 {
-		for _, msg := range m.Saturday {
-			dAtA[i] = 0x42
-			i++
-			i = encodeVarintTimeWindow(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+	if len(m.Thursday) > 0 {
+		for iNdEx := len(m.Thursday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Thursday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x32
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Wednesday) > 0 {
+		for iNdEx := len(m.Wednesday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Wednesday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
-	return i, nil
+	if len(m.Tuesday) > 0 {
+		for iNdEx := len(m.Tuesday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Tuesday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.Monday) > 0 {
+		for iNdEx := len(m.Monday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Monday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Sunday) > 0 {
+		for iNdEx := len(m.Sunday) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Sunday[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.All) > 0 {
+		for iNdEx := len(m.All) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.All[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintTimeWindow(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *TimeWindowTimeRange) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -574,36 +605,46 @@ func (m *TimeWindowTimeRange) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TimeWindowTimeRange) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TimeWindowTimeRange) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Begin) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintTimeWindow(dAtA, i, uint64(len(m.Begin)))
-		i += copy(dAtA[i:], m.Begin)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.End) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.End)
+		copy(dAtA[i:], m.End)
 		i = encodeVarintTimeWindow(dAtA, i, uint64(len(m.End)))
-		i += copy(dAtA[i:], m.End)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Begin) > 0 {
+		i -= len(m.Begin)
+		copy(dAtA[i:], m.Begin)
+		i = encodeVarintTimeWindow(dAtA, i, uint64(len(m.Begin)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintTimeWindow(dAtA []byte, offset int, v uint64) int {
+	offset -= sovTimeWindow(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedTimeWindowWhen(r randyTimeWindow, easy bool) *TimeWindowWhen {
 	this := &TimeWindowWhen{}
@@ -617,56 +658,56 @@ func NewPopulatedTimeWindowWhen(r randyTimeWindow, easy bool) *TimeWindowWhen {
 
 func NewPopulatedTimeWindowDays(r randyTimeWindow, easy bool) *TimeWindowDays {
 	this := &TimeWindowDays{}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v2 := r.Intn(5)
 		this.All = make([]*TimeWindowTimeRange, v2)
 		for i := 0; i < v2; i++ {
 			this.All[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v3 := r.Intn(5)
 		this.Sunday = make([]*TimeWindowTimeRange, v3)
 		for i := 0; i < v3; i++ {
 			this.Sunday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v4 := r.Intn(5)
 		this.Monday = make([]*TimeWindowTimeRange, v4)
 		for i := 0; i < v4; i++ {
 			this.Monday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v5 := r.Intn(5)
 		this.Tuesday = make([]*TimeWindowTimeRange, v5)
 		for i := 0; i < v5; i++ {
 			this.Tuesday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v6 := r.Intn(5)
 		this.Wednesday = make([]*TimeWindowTimeRange, v6)
 		for i := 0; i < v6; i++ {
 			this.Wednesday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v7 := r.Intn(5)
 		this.Thursday = make([]*TimeWindowTimeRange, v7)
 		for i := 0; i < v7; i++ {
 			this.Thursday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v8 := r.Intn(5)
 		this.Friday = make([]*TimeWindowTimeRange, v8)
 		for i := 0; i < v8; i++ {
 			this.Friday[i] = NewPopulatedTimeWindowTimeRange(r, easy)
 		}
 	}
-	if r.Intn(10) != 0 {
+	if r.Intn(5) != 0 {
 		v9 := r.Intn(5)
 		this.Saturday = make([]*TimeWindowTimeRange, v9)
 		for i := 0; i < v9; i++ {
@@ -856,14 +897,7 @@ func (m *TimeWindowTimeRange) Size() (n int) {
 }
 
 func sovTimeWindow(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTimeWindow(x uint64) (n int) {
 	return sovTimeWindow(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/tls.pb.go
+++ b/api/core/v2/tls.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // TLSOptions holds TLS options that are used across the varying Sensu
 // components
@@ -50,7 +51,7 @@ func (m *TLSOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_TLSOptions.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +177,7 @@ func (this *TLSOptions) Equal(that interface{}) bool {
 func (m *TLSOptions) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -184,62 +185,73 @@ func (m *TLSOptions) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TLSOptions) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TLSOptions) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.CertFile) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintTls(dAtA, i, uint64(len(m.CertFile)))
-		i += copy(dAtA[i:], m.CertFile)
-	}
-	if len(m.KeyFile) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintTls(dAtA, i, uint64(len(m.KeyFile)))
-		i += copy(dAtA[i:], m.KeyFile)
-	}
-	if len(m.TrustedCAFile) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintTls(dAtA, i, uint64(len(m.TrustedCAFile)))
-		i += copy(dAtA[i:], m.TrustedCAFile)
-	}
-	if m.InsecureSkipVerify {
-		dAtA[i] = 0x20
-		i++
-		if m.InsecureSkipVerify {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.ClientAuthType {
-		dAtA[i] = 0x28
-		i++
+		i--
 		if m.ClientAuthType {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x28
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.InsecureSkipVerify {
+		i--
+		if m.InsecureSkipVerify {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
 	}
-	return i, nil
+	if len(m.TrustedCAFile) > 0 {
+		i -= len(m.TrustedCAFile)
+		copy(dAtA[i:], m.TrustedCAFile)
+		i = encodeVarintTls(dAtA, i, uint64(len(m.TrustedCAFile)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.KeyFile) > 0 {
+		i -= len(m.KeyFile)
+		copy(dAtA[i:], m.KeyFile)
+		i = encodeVarintTls(dAtA, i, uint64(len(m.KeyFile)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.CertFile) > 0 {
+		i -= len(m.CertFile)
+		copy(dAtA[i:], m.CertFile)
+		i = encodeVarintTls(dAtA, i, uint64(len(m.CertFile)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintTls(dAtA []byte, offset int, v uint64) int {
+	offset -= sovTls(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedTLSOptions(r randyTls, easy bool) *TLSOptions {
 	this := &TLSOptions{}
@@ -357,14 +369,7 @@ func (m *TLSOptions) Size() (n int) {
 }
 
 func sovTls(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozTls(x uint64) (n int) {
 	return sovTls(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/api/core/v2/user.pb.go
+++ b/api/core/v2/user.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // User describes an authenticated user
 type User struct {
@@ -48,7 +49,7 @@ func (m *User) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_User.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +164,7 @@ func (this *User) Equal(that interface{}) bool {
 func (m *User) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -171,61 +172,65 @@ func (m *User) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *User) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *User) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Username) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintUser(dAtA, i, uint64(len(m.Username)))
-		i += copy(dAtA[i:], m.Username)
-	}
-	if len(m.Password) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintUser(dAtA, i, uint64(len(m.Password)))
-		i += copy(dAtA[i:], m.Password)
-	}
-	if len(m.Groups) > 0 {
-		for _, s := range m.Groups {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.Disabled {
-		dAtA[i] = 0x20
-		i++
+		i--
 		if m.Disabled {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x20
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Groups) > 0 {
+		for iNdEx := len(m.Groups) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Groups[iNdEx])
+			copy(dAtA[i:], m.Groups[iNdEx])
+			i = encodeVarintUser(dAtA, i, uint64(len(m.Groups[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
-	return i, nil
+	if len(m.Password) > 0 {
+		i -= len(m.Password)
+		copy(dAtA[i:], m.Password)
+		i = encodeVarintUser(dAtA, i, uint64(len(m.Password)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Username) > 0 {
+		i -= len(m.Username)
+		copy(dAtA[i:], m.Username)
+		i = encodeVarintUser(dAtA, i, uint64(len(m.Username)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintUser(dAtA []byte, offset int, v uint64) int {
+	offset -= sovUser(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func NewPopulatedUser(r randyUser, easy bool) *User {
 	this := &User{}
@@ -345,14 +350,7 @@ func (m *User) Size() (n int) {
 }
 
 func sovUser(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozUser(x uint64) (n int) {
 	return sovUser(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 
@@ -112,6 +113,14 @@ func (a EventController) Delete(ctx context.Context, entity, check string) error
 func (a EventController) CreateOrReplace(ctx context.Context, event *corev2.Event) error {
 	if err := event.Validate(); err != nil {
 		return NewError(InvalidArgument, err)
+	}
+
+	if len(event.ID) == 0 {
+		id, err := uuid.NewRandom()
+		if err != nil {
+			return NewError(InternalErr, err)
+		}
+		event.ID = id[:]
 	}
 
 	// Publish to event pipeline

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -210,11 +210,27 @@ func eventKey(event *corev2.Event) string {
 	return path.Join(event.Entity.Namespace, event.Check.Name, event.Entity.Name)
 }
 
+func logEvent(e *corev2.Event) {
+	fields := logrus.Fields{
+		"event_uuid": e.GetUUID().String(),
+		"entity":     e.Entity.Name,
+	}
+	if e.HasCheck() {
+		fields["check"] = e.Check.Name
+	}
+	if e.HasMetrics() {
+		fields["metrics"] = true
+	}
+	logger.WithFields(fields).Info("eventd received event")
+}
+
 func (e *Eventd) handleMessage(msg interface{}) error {
 	event, ok := msg.(*corev2.Event)
 	if !ok {
 		return errors.New("received non-Event on event channel")
 	}
+
+	logEvent(event)
 
 	// Validate the received event
 	if err := event.Validate(); err != nil {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/liveness"
@@ -382,6 +383,12 @@ func createKeepaliveEvent(rawEvent *types.Event) *types.Event {
 		Timestamp:  time.Now().Unix(),
 		Entity:     rawEvent.Entity,
 		Check:      keepaliveCheck,
+		ID:         rawEvent.ID,
+	}
+
+	if len(keepaliveEvent.ID) == 0 {
+		uid, _ := uuid.NewRandom()
+		keepaliveEvent.ID = uid[:]
 	}
 
 	return keepaliveEvent

--- a/cli/commands/event/info.go
+++ b/cli/commands/event/info.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/list"
@@ -95,6 +96,11 @@ func printToList(v interface{}, writer io.Writer) error {
 		cfg.Rows = append(cfg.Rows, silencedBy)
 	}
 
+	var uuidVal string
+	if id := event.GetUUID(); id != uuid.Nil {
+		// Only populate the uuid if it's nonzero
+		uuidVal = id.String()
+	}
 	cfg.Rows = append(cfg.Rows, []*list.Row{
 		{
 			Label: "Timestamp",
@@ -102,7 +108,7 @@ func printToList(v interface{}, writer io.Writer) error {
 		},
 		{
 			Label: "UUID",
-			Value: event.GetUUID().String(),
+			Value: uuidVal,
 		}}...)
 
 	return list.Print(writer, cfg)

--- a/cli/commands/event/info.go
+++ b/cli/commands/event/info.go
@@ -84,10 +84,6 @@ func printToList(v interface{}, writer io.Writer) error {
 				Label: "Silenced",
 				Value: strconv.FormatBool(len(event.Check.Silenced) > 0),
 			},
-			{
-				Label: "Timestamp",
-				Value: time.Unix(event.Timestamp, 0).String(),
-			},
 		},
 	}
 
@@ -96,8 +92,18 @@ func printToList(v interface{}, writer io.Writer) error {
 			Label: "Silenced By",
 			Value: strings.Join(event.Check.Silenced, ", "),
 		}
-		cfg.Rows = append(cfg.Rows[:len(cfg.Rows)-1], silencedBy, cfg.Rows[len(cfg.Rows)-1])
+		cfg.Rows = append(cfg.Rows, silencedBy)
 	}
+
+	cfg.Rows = append(cfg.Rows, []*list.Row{
+		{
+			Label: "Timestamp",
+			Value: time.Unix(event.Timestamp, 0).String(),
+		},
+		{
+			Label: "ID",
+			Value: event.GetUUID().String(),
+		}}...)
 
 	return list.Print(writer, cfg)
 }

--- a/cli/commands/event/info.go
+++ b/cli/commands/event/info.go
@@ -101,7 +101,7 @@ func printToList(v interface{}, writer io.Writer) error {
 			Value: time.Unix(event.Timestamp, 0).String(),
 		},
 		{
-			Label: "ID",
+			Label: "UUID",
 			Value: event.GetUUID().String(),
 		}}...)
 

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -129,6 +129,16 @@ func printToTable(results interface{}, writer io.Writer) {
 				return time.String()
 			},
 		},
+		{
+			Title: "ID",
+			CellTransformer: func(data interface{}) string {
+				event, ok := data.(corev2.Event)
+				if !ok {
+					return cli.TypeError
+				}
+				return event.GetUUID().String()
+			},
+		},
 	})
 
 	table.Render(writer, results)

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
@@ -136,7 +137,11 @@ func printToTable(results interface{}, writer io.Writer) {
 				if !ok {
 					return cli.TypeError
 				}
-				return event.GetUUID().String()
+				if id := event.GetUUID(); id == uuid.Nil {
+					return ""
+				} else {
+					return id.String()
+				}
 			},
 		},
 	})

--- a/cli/commands/event/list.go
+++ b/cli/commands/event/list.go
@@ -130,7 +130,7 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
-			Title: "ID",
+			Title: "UUID",
 			CellTransformer: func(data interface{}) string {
 				event, ok := data.(corev2.Event)
 				if !ok {

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -16,6 +16,7 @@ func EventFields(event *types.Event, debug bool) map[string]interface{} {
 	fields := logrus.Fields{
 		"entity_name":      event.Entity.Name,
 		"entity_namespace": event.Entity.Namespace,
+		"uuid":             event.GetUUID().String(),
 	}
 
 	if event.HasCheck() {


### PR DESCRIPTION
## What is this change?

This CL adds event IDs to Sensu. The IDs are UUIDs, and are logged at various points throughout the event lifecycle. Support has also been added to sensuctl event list, and sensuctl event info.

## Why is this change necessary?

Closes #3125

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

Protobuf compiler library is now v3, marshal/unmarshal logic is slightly different. Wire format is unaffected.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes required, we need to add the event_id field to the API docs and reference. cc @hillaryfraley 

## How did you verify this change?

Manual testing by watching loging, viewing output of sensuctl.

## Is this change a patch?

No