### PR TITLE
Do not call filepath.Abs if the path is empty

### DIFF
--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -53,11 +53,15 @@ func (c *Config) SaveTokens(tokens *types.Tokens) error {
 
 // SaveTrustedCAFile saves the Trusted CA file
 func (c *Config) SaveTrustedCAFile(file string) error {
-	absolute, err := filepath.Abs(file)
-	if err != nil {
-		return err
+	if file != "" {
+		absolute, err := filepath.Abs(file)
+		if err != nil {
+			return err
+		}
+		c.Cluster.TrustedCAFile = absolute
+	} else {
+		c.Cluster.TrustedCAFile = ""
 	}
-	c.Cluster.TrustedCAFile = absolute
 
 	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }


### PR DESCRIPTION
`filepath.Abs` will always return the  current working directory if the provided path is empty (which happens whenever the flag is specified), which will end up configuring it to the CWD and causing sensuctl to load the CA file from that path even if it wasn't configured, e.g.:

```bash
$ s configure -n --url http://127.0.0.1:8080 --username admin --password 'P@ssw0rd!'
$ s check list
WARN[0000] Error reading CA file: read /Users/splourde/src/sensu-go: is a directory  component=cli-client
WARN[0000] Trying to use the system's default CA certificates  component=cli-client
[...]
```

Therefore, we should only call it whenever a file path was provided.