### PR TITLE
Bump Go version to 1.13.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ cache:
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.13.5
+  GOVERSION: 1.13.7
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ sensu_go_build_env: &sensu_go_build_env
   ####   /go/src/bitbucket.org/circleci/go-tool
   working_directory: /go/src/github.com/sensu/sensu-go
   docker:
-    - image: circleci/golang:1.13.5
+    - image: circleci/golang:1.13.7
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Updated Go version from 1.13.5 to 1.13.7.
+
 ## [5.17.1] - 2020-01-31
 
 ### Fixed


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It bumps the Go version used from `1.13.5` to `1.13.7`.

## Why is this change necessary?

To include some bug fixes & security fixes: https://golang.org/doc/devel/release.html#go1.13

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

CI

## Is this change a patch?

Nope