### PR TITLE
Support Bonsai assets versions prefixed with v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Support Bonsai assets versions prefixed with the letter `v`.
+
 ## [5.17.1] - 2020-01-31
 
 ### Fixed

--- a/bonsai/bonsai.go
+++ b/bonsai/bonsai.go
@@ -10,6 +10,20 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
+const (
+	// NameAnnotation represents a Bonsai asset name
+	NameAnnotation = "io.sensu.bonsai.name"
+
+	// NamespaceAnnotation represents a Bonsai asset namenamespace
+	NamespaceAnnotation = "io.sensu.bonsai.namespace"
+
+	// URLAnnotation represents the Bonsai API URL
+	URLAnnotation = "io.sensu.bonsai.api_url"
+
+	// VersionAnnotation represents a Bonsai asset version
+	VersionAnnotation = "io.sensu.bonsai.version"
+)
+
 // Asset stores information about an asset (metadata, versions, etc.) from Bonsai
 type Asset struct {
 	// Name is the full name (including namespace) of the asset
@@ -86,6 +100,10 @@ func (b *Asset) BonsaiVersion(version *goversion.Version) (*goversion.Version, e
 	if version == nil {
 		// No version was requested, therefore return the latest version
 		v := b.LatestVersion()
+		if v == nil {
+			return nil, fmt.Errorf("asset %q does not have any available versions", b.Name)
+		}
+
 		fmt.Println("no version specified, using latest:", v.Original())
 		return v, nil
 	} else if ok, v := b.HasVersion(version); ok {
@@ -134,6 +152,10 @@ func (b *Asset) ValidVersions() []*goversion.Version {
 // LatestVersion will return the highest semver-compliant version.
 func (b *Asset) LatestVersion() *goversion.Version {
 	versions := b.ValidVersions()
+	if len(versions) == 0 {
+		return nil
+	}
+
 	sort.Sort(goversion.Collection(versions))
 	return versions[len(versions)-1]
 }

--- a/bonsai/bonsai.go
+++ b/bonsai/bonsai.go
@@ -104,7 +104,6 @@ func (b *Asset) BonsaiVersion(version *goversion.Version) (*goversion.Version, e
 			return nil, fmt.Errorf("asset %q does not have any available versions", b.Name)
 		}
 
-		fmt.Println("no version specified, using latest:", v.Original())
 		return v, nil
 	} else if ok, v := b.HasVersion(version); ok {
 		// The request version exists, but return the *goversion.Version provided by

--- a/bonsai/bonsai_test.go
+++ b/bonsai/bonsai_test.go
@@ -1,0 +1,105 @@
+package bonsai
+
+import (
+	"reflect"
+	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+func TestAsset_BonsaiVersion(t *testing.T) {
+	type fields struct {
+		Name     string
+		Versions []*AssetVersionGrouping
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		version string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "latest version is returned if none was specified",
+			fields: fields{
+				Name: "testasset",
+				Versions: []*AssetVersionGrouping{
+					&AssetVersionGrouping{Version: "0.1.0"},
+					&AssetVersionGrouping{Version: "0.2.0"},
+					&AssetVersionGrouping{Version: "v0.1.0"},
+				},
+			},
+			want: "0.2.0",
+		},
+		{
+			name: "exact requested version is returned",
+			fields: fields{
+				Name: "testasset",
+				Versions: []*AssetVersionGrouping{
+					&AssetVersionGrouping{Version: "0.1.0"},
+					&AssetVersionGrouping{Version: "0.2.0"},
+					&AssetVersionGrouping{Version: "v0.1.0"},
+				},
+			},
+			version: "0.2.0",
+			want:    "0.2.0",
+		},
+		{
+			name: "requested version ignores the v prefix",
+			fields: fields{
+				Name: "testasset",
+				Versions: []*AssetVersionGrouping{
+					&AssetVersionGrouping{Version: "0.1.0"},
+					&AssetVersionGrouping{Version: "0.2.0"},
+					&AssetVersionGrouping{Version: "v0.1.0"},
+				},
+			},
+			version: "v0.2.0",
+			want:    "0.2.0",
+		},
+		{
+			name: "requested version ignores the missing v prefix",
+			fields: fields{
+				Name: "testasset",
+				Versions: []*AssetVersionGrouping{
+					&AssetVersionGrouping{Version: "0.1.0"},
+					&AssetVersionGrouping{Version: "v0.2.0"},
+					&AssetVersionGrouping{Version: "v0.1.0"},
+				},
+			},
+			version: "0.2.0",
+			want:    "v0.2.0",
+		},
+		{
+			name: "inexistant requested version returns an error",
+			fields: fields{
+				Name: "testasset",
+				Versions: []*AssetVersionGrouping{
+					&AssetVersionGrouping{Version: "0.1.0"},
+					&AssetVersionGrouping{Version: "v0.2.0"},
+					&AssetVersionGrouping{Version: "v0.1.0"},
+				},
+			},
+			version: "0.3.0",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Asset{
+				Name:     tt.fields.Name,
+				Versions: tt.fields.Versions,
+			}
+			version, _ := goversion.NewVersion(tt.version)
+			got, err := b.BonsaiVersion(version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Asset.BonsaiVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			want, _ := goversion.NewVersion(tt.want)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Asset.BonsaiVersion() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/bonsai/bonsai_test.go
+++ b/bonsai/bonsai_test.go
@@ -103,3 +103,40 @@ func TestAsset_BonsaiVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestAsset_LatestVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		Versions []*AssetVersionGrouping
+		want     string
+	}{
+		{
+			name:     "no version is returned if there are no available versions",
+			Versions: []*AssetVersionGrouping{},
+		},
+		{
+			name: "the only version is returned",
+			Versions: []*AssetVersionGrouping{
+				&AssetVersionGrouping{Version: "0.1.0"},
+			},
+			want: "0.1.0",
+		},
+		{
+			name: "the latest version is returned",
+			Versions: []*AssetVersionGrouping{
+				&AssetVersionGrouping{Version: "0.1.0"},
+				&AssetVersionGrouping{Version: "v0.1.0"},
+			},
+			want: "v0.1.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Asset{Versions: tt.Versions}
+			want, _ := goversion.NewVersion(tt.want)
+			if got := b.LatestVersion(); !reflect.DeepEqual(got, want) {
+				t.Errorf("Asset.LatestVersion() = %v, want %v", got.Original(), want.Original())
+			}
+		})
+	}
+}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -144,22 +144,22 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 	}
 
 	if version == nil {
-		fmt.Println("no version specified, using latest:", bonsaiAsset.LatestVersion())
 		version = bonsaiAsset.LatestVersion()
+		fmt.Println("no version specified, using latest:", version.Original())
 	} else if !bonsaiAsset.HasVersion(version) {
 		availableVersions := bonsaiAsset.ValidVersions()
 		sort.Sort(goversion.Collection(availableVersions))
 		availableVersionStrs := []string{}
 		for _, v := range availableVersions {
-			availableVersionStrs = append(availableVersionStrs, v.String())
+			availableVersionStrs = append(availableVersionStrs, v.Original())
 		}
 		return fmt.Errorf("version \"%s\" of asset \"%s/%s\" does not exist\navailable versions: %s",
 			version, bAsset.Namespace, bAsset.Name, strings.Join(availableVersionStrs, ", "))
 	}
 
-	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version)
+	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version.Original())
 
-	assetJSON, err := m.bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.String())
+	assetJSON, err := m.bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.Original())
 	if err != nil {
 		return err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -143,23 +142,14 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		return err
 	}
 
-	if version == nil {
-		version = bonsaiAsset.LatestVersion()
-		fmt.Println("no version specified, using latest:", version.Original())
-	} else if !bonsaiAsset.HasVersion(version) {
-		availableVersions := bonsaiAsset.ValidVersions()
-		sort.Sort(goversion.Collection(availableVersions))
-		availableVersionStrs := []string{}
-		for _, v := range availableVersions {
-			availableVersionStrs = append(availableVersionStrs, v.Original())
-		}
-		return fmt.Errorf("version \"%s\" of asset \"%s/%s\" does not exist\navailable versions: %s",
-			version, bAsset.Namespace, bAsset.Name, strings.Join(availableVersionStrs, ", "))
+	bonsaiVersion, err := bonsaiAsset.BonsaiVersion(version)
+	if err != nil {
+		return err
 	}
 
-	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version.Original())
+	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
 
-	assetJSON, err := m.bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.Original())
+	assetJSON, err := m.bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
 	if err != nil {
 		return err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -147,6 +147,10 @@ func (m *CommandManager) InstallCommandFromBonsai(alias, bonsaiAssetName string)
 		return err
 	}
 
+	if version == nil {
+		fmt.Println("no version specified, using latest:", bonsaiVersion.Original())
+	}
+
 	fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
 
 	assetJSON, err := m.bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -500,6 +500,43 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 					Return(string(assetJSON), nil)
 			},
 		},
+		{
+			name:            "valid asset with version specified using the v prefix",
+			alias:           "testaliasprefixed",
+			bonsaiAssetName: bAsset.fullName,
+			bonsaiClientFunc: func(m *MockBonsaiClient) {
+				bonsaiAsset := &bonsai.Asset{
+					Name: bAsset.fullName,
+					Versions: []*bonsai.AssetVersionGrouping{
+						{Version: "v1.0.0"},
+					},
+				}
+				asset := corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name:      bAsset.name,
+						Namespace: bAsset.namespace,
+						Annotations: map[string]string{
+							"io.sensu.bonsai.type":     "sensuctl",
+							"io.sensu.bonsai.provider": "sensuctl/command",
+						},
+					},
+					Builds: []*corev2.AssetBuild{
+						{
+							URL:    bAsset.url,
+							Sha512: bAsset.sha512,
+						},
+					},
+				}
+				assetJSON, err := json.Marshal(asset)
+				if err != nil {
+					t.Fatal(err)
+				}
+				m.On("FetchAsset", bAsset.namespace, bAsset.name).
+					Return(bonsaiAsset, nil)
+				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, "v1.0.0").
+					Return(string(assetJSON), nil)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -139,11 +139,12 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 		{
 			name:            "non-existent version",
 			wantErr:         true,
-			errMatch:        fmt.Sprintf("version \"%s\" of asset \"%s\" does not exist", bAsset.version, bAsset.fullName),
+			errMatch:        fmt.Sprintf("version %q of asset %q does not exist", bAsset.version, bAsset.fullName),
 			alias:           "testalias",
 			bonsaiAssetName: bAsset.fullNameWithVersion,
 			bonsaiClientFunc: func(m *MockBonsaiClient) {
 				bonsaiAsset := &bonsai.Asset{
+					Name: fmt.Sprintf("%s/%s", bAsset.namespace, bAsset.name),
 					Versions: []*bonsai.AssetVersionGrouping{
 						{Version: "0.1.0"},
 					},

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -62,6 +62,10 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			return err
 		}
 
+		if version == nil {
+			fmt.Println("no version specified, using latest:", bonsaiVersion.Original())
+		}
+
 		fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
 
 		asset, err := bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -60,22 +60,22 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		if version == nil {
-			fmt.Println("no version specified, using latest:", bonsaiAsset.LatestVersion())
 			version = bonsaiAsset.LatestVersion()
+			fmt.Println("no version specified, using latest:", version.Original())
 		} else if !bonsaiAsset.HasVersion(version) {
 			availableVersions := bonsaiAsset.ValidVersions()
 			sort.Sort(goversion.Collection(availableVersions))
 			availableVersionStrs := []string{}
 			for _, v := range availableVersions {
-				availableVersionStrs = append(availableVersionStrs, v.String())
+				availableVersionStrs = append(availableVersionStrs, v.Original())
 			}
 			return fmt.Errorf("version \"%s\" of asset \"%s/%s\" does not exist\navailable versions: %s",
-				version, bAsset.Namespace, bAsset.Name, strings.Join(availableVersionStrs, ", "))
+				version.Original(), bAsset.Namespace, bAsset.Name, strings.Join(availableVersionStrs, ", "))
 		}
 
-		fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version)
+		fmt.Printf("fetching bonsai asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version.Original())
 
-		asset, err := bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.String())
+		asset, err := bonsaiClient.FetchAssetVersion(bAsset.Namespace, bAsset.Name, version.Original())
 		if err != nil {
 			return err
 		}
@@ -100,7 +100,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			return err
 		}
 
-		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version)
+		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, version.Original())
 		return nil
 	}
 }

--- a/cli/commands/asset/outdated.go
+++ b/cli/commands/asset/outdated.go
@@ -84,12 +84,12 @@ func outdatedCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []s
 
 				bonsaiAsset, err := bonsaiClient.FetchAsset(bonsaiNamespace, bonsaiName)
 				if err != nil {
-					return err
+					return fmt.Errorf("could not fetch asset %s: %s", asset.Name, err)
 				}
 
 				installedVersion, err := goversion.NewVersion(bonsaiVersion)
 				if err != nil {
-					return err
+					return fmt.Errorf("could not parse version %q of asset %s: %s", bonsaiVersion, asset.Name, err)
 				}
 
 				latestVersion := bonsaiAsset.LatestVersion()

--- a/cli/commands/asset/outdated.go
+++ b/cli/commands/asset/outdated.go
@@ -99,8 +99,8 @@ func outdatedCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []s
 						BonsaiName:      bonsaiName,
 						BonsaiNamespace: bonsaiNamespace,
 						AssetName:       asset.Name,
-						CurrentVersion:  installedVersion.String(),
-						LatestVersion:   latestVersion.String(),
+						CurrentVersion:  installedVersion.Original(),
+						LatestVersion:   latestVersion.Original(),
 					})
 				}
 			}

--- a/cli/commands/asset/outdated_test.go
+++ b/cli/commands/asset/outdated_test.go
@@ -1,14 +1,16 @@
 package asset
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/bonsai"
+	cliClient "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	client "github.com/sensu/sensu-go/cli/client/testing"
-	test "github.com/sensu/sensu-go/cli/commands/testing"
 )
 
 // Match a tabular output header
@@ -18,11 +20,11 @@ func TestOutdatedCommand(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 
-	config := cli.Config.(*client.MockConfig)
+	config := cli.Config.(*cliClient.MockConfig)
 	config.On("Format").Return("none")
 
 	assets := []corev2.Asset{}
-	client := cli.Client.(*client.MockClient)
+	client := cli.Client.(*cliClient.MockClient)
 	client.On("List", mock.Anything, &assets, mock.Anything, mock.Anything).Return(nil)
 
 	cmd := OutdatedCommand(cli)
@@ -31,4 +33,250 @@ func TestOutdatedCommand(t *testing.T) {
 	// Match a tabular output header with nothing else under it
 	assert.Regexp(tabularHeaderPattern+"$", out)
 	assert.Nil(err)
+}
+
+type mockedBonsaiClient struct {
+	mock.Mock
+}
+
+func (c *mockedBonsaiClient) FetchAsset(namespace, name string) (*bonsai.Asset, error) {
+	args := c.Called(namespace, name)
+	return args.Get(0).(*bonsai.Asset), args.Error(1)
+}
+
+func (c *mockedBonsaiClient) FetchAssetVersion(namespace, name, version string) (string, error) {
+	args := c.Called(namespace, name)
+	return args.String(0), args.Error(1)
+}
+
+func Test_outdatedAssets(t *testing.T) {
+	type clientFunc func(*mockedBonsaiClient)
+
+	bonsaiAsset := corev2.Asset{
+		ObjectMeta: corev2.ObjectMeta{
+			Name: "foo",
+			Annotations: map[string]string{
+				bonsai.URLAnnotation:       "http://127.0.0.1",
+				bonsai.VersionAnnotation:   "0.1.0",
+				bonsai.NamespaceAnnotation: "sensu",
+				bonsai.NameAnnotation:      "testasset",
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		assets     []corev2.Asset
+		clientFunc clientFunc
+		want       []bonsai.OutdatedAsset
+		wantErr    bool
+	}{
+		{
+			name: "asset without bonsai API URL annotation is ignored",
+			assets: []corev2.Asset{
+				*corev2.FixtureAsset("foo"),
+			},
+			want: []bonsai.OutdatedAsset{},
+		},
+		{
+			name: "asset without bonsai version returns an error",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation: "http://127.0.0.1",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "asset without bonsai namespace returns an error",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation:     "http://127.0.0.1",
+							bonsai.VersionAnnotation: "0.1.0",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "asset without bonsai name returns an error",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation:       "http://127.0.0.1",
+							bonsai.VersionAnnotation:   "0.1.0",
+							bonsai.NamespaceAnnotation: "sensu",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "asset without bonsai name returns an error",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation:       "http://127.0.0.1",
+							bonsai.VersionAnnotation:   "0.1.0",
+							bonsai.NamespaceAnnotation: "sensu",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "asset with an invalid version returns an error",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation:       "http://127.0.0.1",
+							bonsai.VersionAnnotation:   "invalid",
+							bonsai.NamespaceAnnotation: "sensu",
+							bonsai.NameAnnotation:      "testasset",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "bonsai client error",
+			assets: []corev2.Asset{bonsaiAsset},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(&bonsai.Asset{}, errors.New("error"))
+			},
+			wantErr: true,
+		},
+		{
+			name:   "invalid asset version in fetched asset",
+			assets: []corev2.Asset{bonsaiAsset},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(
+						&bonsai.Asset{Versions: []*bonsai.AssetVersionGrouping{&bonsai.AssetVersionGrouping{Version: "invalid"}}},
+						nil,
+					)
+			},
+			wantErr: true,
+		},
+		{
+			name:   "up-to-date assset is not marked as outdated",
+			assets: []corev2.Asset{bonsaiAsset},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(
+						&bonsai.Asset{Versions: []*bonsai.AssetVersionGrouping{&bonsai.AssetVersionGrouping{Version: "0.1.0"}}},
+						nil,
+					)
+			},
+			want: []bonsai.OutdatedAsset{},
+		},
+		{
+			name:   "older asset is marked as outdated",
+			assets: []corev2.Asset{bonsaiAsset},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(
+						&bonsai.Asset{Versions: []*bonsai.AssetVersionGrouping{&bonsai.AssetVersionGrouping{Version: "0.2.0"}}},
+						nil,
+					)
+			},
+			want: []bonsai.OutdatedAsset{
+				bonsai.OutdatedAsset{
+					BonsaiName:      "testasset",
+					BonsaiNamespace: "sensu",
+					AssetName:       "foo",
+					CurrentVersion:  "0.1.0",
+					LatestVersion:   "0.2.0",
+				},
+			},
+		},
+		{
+			name:   "new prefixed version in Bonsai is still considered",
+			assets: []corev2.Asset{bonsaiAsset},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(
+						&bonsai.Asset{Versions: []*bonsai.AssetVersionGrouping{&bonsai.AssetVersionGrouping{Version: "v0.2.0"}}},
+						nil,
+					)
+			},
+			want: []bonsai.OutdatedAsset{
+				bonsai.OutdatedAsset{
+					BonsaiName:      "testasset",
+					BonsaiNamespace: "sensu",
+					AssetName:       "foo",
+					CurrentVersion:  "0.1.0",
+					LatestVersion:   "v0.2.0",
+				},
+			},
+		},
+		{
+			name: "local prefixed assets are still considered outdated with new Bonsai version that's not prefixed",
+			assets: []corev2.Asset{
+				corev2.Asset{
+					ObjectMeta: corev2.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							bonsai.URLAnnotation:       "http://127.0.0.1",
+							bonsai.VersionAnnotation:   "v0.1.0",
+							bonsai.NamespaceAnnotation: "sensu",
+							bonsai.NameAnnotation:      "testasset",
+						},
+					},
+				},
+			},
+			clientFunc: func(c *mockedBonsaiClient) {
+				c.On("FetchAsset", "sensu", "testasset").
+					Return(
+						&bonsai.Asset{Versions: []*bonsai.AssetVersionGrouping{&bonsai.AssetVersionGrouping{Version: "0.2.0"}}},
+						nil,
+					)
+			},
+			want: []bonsai.OutdatedAsset{
+				bonsai.OutdatedAsset{
+					BonsaiName:      "testasset",
+					BonsaiNamespace: "sensu",
+					AssetName:       "foo",
+					CurrentVersion:  "v0.1.0",
+					LatestVersion:   "0.2.0",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockedBonsaiClient{}
+			if tt.clientFunc != nil {
+				tt.clientFunc(client)
+			}
+
+			got, err := outdatedAssets(tt.assets, client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("outdatedAssets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("outdatedAssets() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds supports for Bonsai assets that use the version format `vX.Y.Z`, in addition to semver (`X.Y.Z`).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3425

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

I tried my best to make sure I didn't forget anything; it appears this package is only used in sensuctl but I might be forgetting something.

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested it and added a unit test where available.

## Is this change a patch?

Yep