### PR TITLE
Make entity_class optional in /events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.
+- Default `event.entity.entity_class` to `proxy` in the POST/PUT `/events` API.
 
 ## [5.17.1] - 2020-01-31
 

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -111,6 +111,10 @@ func (a EventController) Delete(ctx context.Context, entity, check string) error
 // CreateOrReplace creates the event indicated by the supplied entity and check.
 // If an event already exists for the entity and check, it updates that event.
 func (a EventController) CreateOrReplace(ctx context.Context, event *corev2.Event) error {
+	if event.Entity != nil && event.Entity.EntityClass == "" {
+		event.Entity.EntityClass = corev2.EntityProxyClass
+	}
+
 	if err := event.Validate(); err != nil {
 		return NewError(InvalidArgument, err)
 	}

--- a/backend/apid/actions/events_test.go
+++ b/backend/apid/actions/events_test.go
@@ -263,6 +263,9 @@ func TestEventCreateOrReplace(t *testing.T) {
 	badEvent := corev2.FixtureEvent("entity1", "check1")
 	badEvent.Check.Name = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
+	eventNoClass := corev2.FixtureEvent("entity1", "check1")
+	eventNoClass.Entity.EntityClass = ""
+
 	testCases := []struct {
 		name            string
 		ctx             context.Context
@@ -299,6 +302,12 @@ func TestEventCreateOrReplace(t *testing.T) {
 			busErr:          errors.New("where's the wizard"),
 			expectedErr:     true,
 			expectedErrCode: InternalErr,
+		},
+		{
+			name:        "Default entity class",
+			ctx:         defaultCtx,
+			argument:    eventNoClass,
+			expectedErr: false,
 		},
 	}
 

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -250,15 +250,6 @@ func ValidateResources(resources []types.Wrapper, namespace string) error {
 		if resource.GetObjectMeta().Namespace == "" {
 			resource.SetNamespace(namespace)
 		}
-		if verr := resource.Validate(); verr != nil {
-			errCount++
-			fmt.Fprintf(os.Stderr, "error validating resource %d (%s): %s\n", i, resource.URIPath(), verr)
-			if errCount >= 10 {
-				err = errors.New("too many errors")
-				break
-			}
-			err = errors.New("resource validation failed")
-		}
 	}
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Default `event.entity.entity_class` to `proxy` in the POST/PUT `/events` API.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3525

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Unit test added. Tested the payload in the original issue.

## Is this change a patch?

Milestone is 5.18.0 so merging this into master.