### PR TITLE
Return 401 when refresh has issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- returns 401 instead of 500 when issues occur refreshing the access token.
+
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.
 

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -114,7 +114,7 @@ func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
 		}
 
 		logger.WithError(err).Info("unexpected error while authorizing refresh token")
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 


### PR DESCRIPTION
## What is this change?
Returns 401 rather than 500 when there is an `err` when refreshing

fixes #3408 

## Why is this change necessary?

It creates an expected response when there is an issue with a refresh token regenerating an access_token.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

I don't think so.


## Were there any complications while making this change?

N/A

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe so.

## How did you verify this change?

I didn't.  Although, I am moving from one `http` const to another.

## Is this change a patch?

As it was defined as low hanging and has aged, I don't believe this needs to be backported.