### PR TITLE
Fix sensuctl proxy from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- sensuctl now supports the http_proxy, https_proxy, and no_proxy environment
+variables.
+
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.
 

--- a/bonsai/client.go
+++ b/bonsai/client.go
@@ -2,99 +2,78 @@ package bonsai
 
 import (
 	"crypto/tls"
+	"net/http"
+	"path"
+	"strings"
 	"time"
 
-	"github.com/go-resty/resty"
 	"github.com/sirupsen/logrus"
 )
 
-var logger *logrus.Entry
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "bonsai-client",
+})
 
 // DefaultEndpointURL is the default url for bonsai assets.
 const DefaultEndpointURL = "https://bonsai.sensu.io/api/v1/assets"
 
 // Config is the configuration for bonsai.
 type Config struct {
+	// EndpointURL is the URL of Bonsai.
 	EndpointURL string
+
+	// TLSConfig allows overriding client TLS configuration. Should only be
+	// needed for testing.
+	TLSConfig *tls.Config
 }
 
+// Client specifies the client interface of a bonsai client.
 type Client interface {
 	FetchAsset(string, string) (*Asset, error)
 	FetchAssetVersion(string, string, string) (string, error)
 }
 
-// RestClient wraps resty.Client
+// RestClient is a REST client for Bonsai.
 type RestClient struct {
-	resty  *resty.Client
-	config Config
+	httpClient http.Client
+	config     Config
 
 	configured bool
 }
 
-func init() {
-	logger = logrus.WithFields(logrus.Fields{
-		"component": "bonsai-client",
-	})
-}
-
 // New builds a new client with defaults
 func New(config Config) *RestClient {
-	restyInst := resty.New()
-
 	if config.EndpointURL == "" {
 		config.EndpointURL = DefaultEndpointURL
 	}
 
-	client := &RestClient{resty: restyInst, config: config}
+	client := &RestClient{config: config}
 
 	// set http client timeout
-	restyInst.SetTimeout(15 * time.Second)
+	client.httpClient.Timeout = 15 * time.Second
 
-	// Standardize redirect policy
-	restyInst.SetRedirectPolicy(resty.FlexibleRedirectPolicy(10))
-
-	// JSON
-	restyInst.SetHeader("Accept", "application/json")
-	restyInst.SetHeader("Content-Type", "application/json")
-
-	// logging
-	w := logger.Writer()
-	defer func() {
-		_ = w.Close()
-	}()
-	restyInst.SetLogger(w)
+	if config.TLSConfig != nil {
+		transport := new(http.Transport)
+		transport.TLSClientConfig = config.TLSConfig
+		client.httpClient.Transport = transport
+	}
 
 	return client
 }
 
-// R returns new resty.Request from configured client
-func (client *RestClient) R() *resty.Request {
-	client.configure()
-	request := client.resty.R()
-
-	return request
-}
-
-// SetTLSClientConfig assigns client TLS config
-func (client *RestClient) SetTLSClientConfig(c *tls.Config) {
-	client.resty.SetTLSClientConfig(c)
-}
-
-// Reset client so that it reconfigure on next request
-func (client *RestClient) Reset() {
-	client.configured = false
-}
-
-func (client *RestClient) configure() {
-	if client.configured {
-		return
+func (c *RestClient) newGetRequest(slugs ...string) (*http.Request, error) {
+	server := c.config.EndpointURL
+	if !strings.HasSuffix(server, "/") {
+		server = server + "/"
+	}
+	path := server + path.Join(slugs...)
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	restyInst := client.resty
-	config := client.config
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
-	// Set URL
-	restyInst.SetHostURL(config.EndpointURL)
-
-	client.configured = true
+	return req, nil
 }

--- a/bonsai/client_test.go
+++ b/bonsai/client_test.go
@@ -1,0 +1,77 @@
+package bonsai_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sensu/sensu-go/bonsai"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	logrus.SetOutput(ioutil.Discard)
+}
+
+func TestFetchAsset(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.String(), "/default/asset") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		asset := bonsai.Asset{
+			Name:        "asset",
+			Description: "some asset",
+			URL:         "http://example.com/default/asset",
+		}
+		_ = json.NewEncoder(w).Encode(asset)
+	}))
+	pool := x509.NewCertPool()
+	pool.AddCert(server.Certificate())
+	tlsConfig := &tls.Config{
+		RootCAs: pool,
+	}
+	client := bonsai.New(bonsai.Config{EndpointURL: server.URL, TLSConfig: tlsConfig})
+	asset, err := client.FetchAsset("default", "asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := asset.Name, "asset"; got != want {
+		t.Fatalf("bad asset name: got %q, want %q", got, want)
+	}
+	if _, err := client.FetchAsset("default", "notexists"); err == nil {
+		t.Fatal("expected non-nil error")
+	}
+}
+
+func TestFetchAssetVersion(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if !strings.HasSuffix(req.URL.String(), "/default/asset/v0.1.0/release_asset_builds") {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = fmt.Fprint(w, "asset definition")
+	}))
+	pool := x509.NewCertPool()
+	pool.AddCert(server.Certificate())
+	tlsConfig := &tls.Config{
+		RootCAs: pool,
+	}
+	client := bonsai.New(bonsai.Config{EndpointURL: server.URL, TLSConfig: tlsConfig})
+	defn, err := client.FetchAssetVersion("default", "asset", "v0.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := defn, "asset definition"; got != want {
+		t.Fatalf("bad asset defn: got %q, want %q", got, want)
+	}
+	if _, err := client.FetchAssetVersion("default", "asset", "v0.2.0"); err == nil {
+		t.Fatal("expected non-nil error")
+	}
+}

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/go-resty/resty"
+	"github.com/go-resty/resty/v2"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-resty/resty"
+	"github.com/go-resty/resty/v2"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/stretchr/testify/assert"

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-resty/resty"
+	"github.com/go-resty/resty/v2"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sirupsen/logrus"
 )
@@ -104,12 +104,7 @@ func New(config config.Config) *RestClient {
 		return nil
 	})
 
-	// logging
-	w := logger.Writer()
-	defer func() {
-		_ = w.Close()
-	}()
-	restyInst.SetLogger(w)
+	restyInst.SetLogger(logger)
 
 	return client
 }

--- a/cli/client/error.go
+++ b/cli/client/error.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty"
+	"github.com/go-resty/resty/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf // indirect
-	github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7
 	github.com/go-resty/resty/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf // indirect
 	github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7
+	github.com/go-resty/resty/v2 v2.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,9 @@ github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf h1:ofRt4uynuRg/S2LGi
 github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7 h1:lbvF7dIiXWPjUxm0zpBdesefB7W9WKJz24nsQoeoRXA=
 github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7/go.mod h1:xMECeum3O2uZ1/noW5020CuR+OfNI3xjv3MVVCNVGYI=
+github.com/go-resty/resty v1.12.0 h1:L1P5qymrXL5H/doXe2pKUr1wxovAI5ilm2LdVLbwThc=
+github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=
+github.com/go-resty/resty/v2 v2.1.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
@@ -334,6 +337,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 h1:p9xBe/w/OzkeYVKm234g55gMdD1nSIooTir5kV11kfA=
 golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/go.sum
+++ b/go.sum
@@ -80,9 +80,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf h1:ofRt4uynuRg/S2LGi1IM6mBu7HqzNrxYfoPLcFzteb0=
 github.com/go-ole/go-ole v0.0.0-20170209151332-de8695c8edbf/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
-github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7 h1:lbvF7dIiXWPjUxm0zpBdesefB7W9WKJz24nsQoeoRXA=
-github.com/go-resty/resty v0.0.0-20170925192930-9ac9c42358f7/go.mod h1:xMECeum3O2uZ1/noW5020CuR+OfNI3xjv3MVVCNVGYI=
-github.com/go-resty/resty v1.12.0 h1:L1P5qymrXL5H/doXe2pKUr1wxovAI5ilm2LdVLbwThc=
 github.com/go-resty/resty/v2 v2.1.0 h1:Z6IefCpUMfnvItVJaJXWv/pMiiD11So35QgwEELsldE=
 github.com/go-resty/resty/v2 v2.1.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=


### PR DESCRIPTION
## What is this change?

This commit upgrades the HTTP client library used by sensuctl. In
doing so, it adds support for proxying HTTP requests from the
environment variables http_proxy, and https_proxy, and no_proxy.

## Why is this change necessary?

Closes #3538 

## Were there any complications while making this change?

The go-resty library had to be upgraded to a new major version.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

I used a free proxy to send requests to a sensu-staging instance, and it worked.

## Is this change a patch?

Yes, but targeting for 5.18.