### PR TITLE
Rework TestCreds() errors and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.
 
+### Fixed
+- The `auth/test` endpoint now returns the correct error messages.
+
 ## [5.17.1] - 2020-01-31
 
 ### Fixed

--- a/backend/api/authentication.go
+++ b/backend/api/authentication.go
@@ -71,11 +71,12 @@ func (a *AuthenticationClient) TestCreds(ctx context.Context, username, password
 	if basic, ok := providers[basic.Type]; ok {
 		if _, err := basic.Authenticate(ctx, username, password); err == nil {
 			return nil
+		} else {
+			return err
 		}
-		return errors.New("basic provider is disabled")
 	}
 
-	return errors.New("invalid username and/or password")
+	return errors.New("basic provider is disabled")
 }
 
 // Logout logs a user out. The context must carry the user's access and refresh

--- a/backend/api/authentication_test.go
+++ b/backend/api/authentication_test.go
@@ -158,14 +158,13 @@ func TestTestCreds(t *testing.T) {
 			store := test.Store()
 			authn := NewAuthenticationClient(test.Authenticator(store))
 			err := authn.TestCreds(test.Context(), test.Username, test.Password)
-			if test.WantError && err == nil {
-				t.Fatal("want error, got nil")
-				if test.Error != nil && test.Error != err {
-					t.Fatalf("bad error: got %v, want %v", err, test.Error)
-				}
+
+			if test.WantError && test.Error != err {
+				t.Fatalf("bad error: got %v, want %v", err, test.Error)
 			}
+
 			if !test.WantError && err != nil {
-				t.Fatal(err)
+				t.Fatalf("expected no error, go %v", err)
 			}
 		})
 	}

--- a/backend/api/authentication_test.go
+++ b/backend/api/authentication_test.go
@@ -106,6 +106,8 @@ func TestCreateAccessToken(t *testing.T) {
 }
 
 func TestTestCreds(t *testing.T) {
+	mockError := errors.New("error")
+
 	tests := []struct {
 		Name          string
 		Username      string
@@ -122,22 +124,22 @@ func TestTestCreds(t *testing.T) {
 			Authenticator: defaultAuth,
 			Context:       context.Background,
 			WantError:     true,
-			Error:         corev2.ErrUnauthorized,
+			Error:         basic.ErrEmptyUsernamePassword,
 		},
 		{
-			Name:     "invalid credentials",
+			Name:     "bubble up authentication error",
 			Username: "foo",
 			Password: "P@ssw0rd!",
 			Store: func() store.Store {
+				s := &mockstore.MockStore{}
 				user := corev2.FixtureUser("foo")
-				store := &mockstore.MockStore{}
-				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, errors.New("error"))
-				return store
+				s.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, mockError)
+				return s
 			},
 			Authenticator: defaultAuth,
 			Context:       context.Background,
 			WantError:     true,
-			Error:         corev2.ErrUnauthorized,
+			Error:         mockError,
 		},
 		{
 			Name:     "success",
@@ -145,10 +147,10 @@ func TestTestCreds(t *testing.T) {
 			Password: "P@ssw0rd!",
 			Context:  context.Background,
 			Store: func() store.Store {
-				store := &mockstore.MockStore{}
+				s := &mockstore.MockStore{}
 				user := corev2.FixtureUser("foo")
-				store.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, nil)
-				return store
+				s.On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").Return(user, nil)
+				return s
 			},
 			Authenticator: defaultAuth,
 		},

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -13,6 +13,10 @@ import (
 // Type represents the type of the basic authentication provider
 const Type = "basic"
 
+// ErrEmptyUsernamePassword is the error returned by the provider when one tries
+// to authenticate with empty username and password.
+var ErrEmptyUsernamePassword = errors.New("the username and the password must not be empty")
+
 // Provider represents the basic internal authentication provider
 type Provider struct {
 	Store store.Store
@@ -24,7 +28,7 @@ type Provider struct {
 // Authenticate a user, with the provided credentials, against the Sensu store
 func (p *Provider) Authenticate(ctx context.Context, username, password string) (*corev2.Claims, error) {
 	if username == "" || password == "" {
-		return nil, errors.New("the username and the password must not be empty")
+		return nil, ErrEmptyUsernamePassword
 	}
 
 	user, err := p.Store.AuthenticateUser(ctx, username, password)


### PR DESCRIPTION
## Why is this change necessary?

Fix #3556 

## Does your change need a Changelog entry?

I suppose. Added.

## Were there any complications while making this change?

I started by simply swapping 2 lines to get the right errors out of `TestCreds()`, but I soon realized that the tests for this function were broken in the first place. So I tried to fix them a little bit.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Ran `sensuctl test-creds` and watched the backend's logs.

## Is this change a patch?

I thought it could have been, but Simon said no.