### PR TITLE
Fix wrapped resource namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 variables.
 - returns 401 instead of 500 when issues occur refreshing the access token.
 - Support Bonsai assets versions prefixed with the letter `v`.
+- Fixed a bug where wrapped resources were not getting their namespaces set by
+the default sensuctl configuration.
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -171,8 +171,8 @@ var jsonRe = regexp.MustCompile(`^(\s)*[\{\[]`)
 // 3. If the stream is YAML, split it on '---' to support multiple yaml documents.
 // 3. Convert the YAML to JSON document-by-document.
 // 4. Unmarshal the JSON one resource at a time.
-func ParseResources(in io.Reader) ([]types.Wrapper, error) {
-	var resources []types.Wrapper
+func ParseResources(in io.Reader) ([]*types.Wrapper, error) {
+	var resources []*types.Wrapper
 	b, err := ioutil.ReadAll(in)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing resources: %s", err)
@@ -209,7 +209,7 @@ func ParseResources(in io.Reader) ([]types.Wrapper, error) {
 				describeError(count, rerr)
 				errCount++
 			}
-			resources = append(resources, w)
+			resources = append(resources, &w)
 			count++
 		}
 	}
@@ -222,7 +222,7 @@ func ParseResources(in io.Reader) ([]types.Wrapper, error) {
 
 // filterCheckSubdue nils out any check subdue fields that are supplied.
 // TODO(echlebek): this is temporary; remove it after fixing check subdue.
-func filterCheckSubdue(resources []types.Wrapper) {
+func filterCheckSubdue(resources []*types.Wrapper) {
 	for i := range resources {
 		switch val := resources[i].Value.(type) {
 		case *types.CheckConfig:
@@ -237,7 +237,7 @@ func filterCheckSubdue(resources []types.Wrapper) {
 
 // ValidateResources loops through a list of resources, appends a namespace
 // if one is not already declared, and validates the resource.
-func ValidateResources(resources []types.Wrapper, namespace string) error {
+func ValidateResources(resources []*types.Wrapper, namespace string) error {
 	var err error
 	errCount := 0
 	for i, r := range resources {
@@ -249,6 +249,7 @@ func ValidateResources(resources []types.Wrapper, namespace string) error {
 		}
 		if resource.GetObjectMeta().Namespace == "" {
 			resource.SetNamespace(namespace)
+			r.ObjectMeta.Namespace = namespace
 		}
 	}
 	return err
@@ -264,9 +265,9 @@ func describeError(index int, err error) {
 }
 
 // PutResources uses the GenericClient to PUT a resource at the inferred URI path.
-func PutResources(client client.GenericClient, resources []types.Wrapper) error {
+func PutResources(client client.GenericClient, resources []*types.Wrapper) error {
 	for i, resource := range resources {
-		if err := client.PutResource(resource); err != nil {
+		if err := client.PutResource(*resource); err != nil {
 			return fmt.Errorf("error putting resource %d (%s): %s", i, resource.Value.URIPath(), err)
 		}
 	}

--- a/cli/commands/delete/delete.go
+++ b/cli/commands/delete/delete.go
@@ -56,7 +56,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 }
 
 // DeleteResources deletes all of the parsed resources.
-func DeleteResources(client client.GenericClient, resources []types.Wrapper) error {
+func DeleteResources(client client.GenericClient, resources []*types.Wrapper) error {
 	for i, resource := range resources {
 		path := resource.Value.URIPath()
 		if err := client.Delete(path); err != nil {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Assigns the namespace of the wrapper if not set.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3559

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

`sensuctl create -f secret.yml `
```
---
type: Secret
api_version: secrets/v1
metadata:
  name: mando
spec:
  id: TEST_SECRET
  provider: env
```

## Is this change a patch?

Targetting 5.18.0 in master