### PR TITLE
move initializationKey to EtcdRoot, and using old method as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 variables.
 - returns 401 instead of 500 when issues occur refreshing the access token.
 - Support Bonsai assets versions prefixed with the letter `v`.
+- read/writes `initializationKey` to/from `EtcdRoot`, while support legacy as fallback (read-only)
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -49,7 +49,9 @@ func (s *StoreInitializer) IsInitialized() (bool, error) {
 	r, err := s.client.Get(s.ctx, path.Join(EtcdRoot, initializationKey))
 	if err != nil {
 		fallback, err := s.client.Get(s.ctx, initializationKey)
-		if fallback.Count > 0 {
+		if err != nil {
+			return false, err
+		} else {
 			return fallback.Count > 0, nil
 		}
 

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -48,14 +48,17 @@ func (s *StoreInitializer) Lock() error {
 func (s *StoreInitializer) IsInitialized() (bool, error) {
 	r, err := s.client.Get(s.ctx, path.Join(EtcdRoot, initializationKey))
 	if err != nil {
+		return false, err
+	}
+
+	// if there is no result, test the fallback and return using same logic
+	if len(r.Kvs) == 0 {
 		fallback, err := s.client.Get(s.ctx, initializationKey)
 		if err != nil {
 			return false, err
 		} else {
 			return fallback.Count > 0, nil
 		}
-
-		return false, err
 	}
 
 	return r.Count > 0, nil


### PR DESCRIPTION
Signed-off-by: Vern Burton <me@vernburton.com>

## What is this change?

This moves the initialization key into `EtcdRoot`, while supporting a fallback to the old location.

`FlagAsInitialized` only gets moved into the new location as we only want to write new files into the new location.  `IsInitialized` gates `FlagAsInitialized`  so that it should never be fallen into.

## Why is this change necessary?

fixes #3560 

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

Nope


## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

```
$ go test ./... 
ok      github.com/sensu/sensu-go/backend/seeds 1.038s
```

## Is this change a patch?

No.  Targeting 5.18.0