### PR TITLE
checking status code when fetching assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 variables.
 - returns 401 instead of 500 when issues occur refreshing the access token.
 - Support Bonsai assets versions prefixed with the letter `v`.
+- check for a non-200 response when fetching assets
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -46,6 +46,9 @@ func httpGet(ctx context.Context, path string, headers map[string]string) (io.Re
 	if err != nil {
 		return nil, fmt.Errorf("error fetching asset: %s", err)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error fetching asset: Response Code %d", resp.StatusCode)
+	}
 
 	return resp.Body, nil
 }

--- a/asset/fetcher_test.go
+++ b/asset/fetcher_test.go
@@ -71,3 +71,17 @@ func TestHTTPGet(t *testing.T) {
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)
 }
+
+func TestHTTPGetNon200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, []string{"bar"}, r.Header["Foo"])
+		assert.Equal(t, []string{"hello", "sup"}, r.Header["Hi"])
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	headers := map[string]string{"foo": "bar", "hi": "hello, sup"}
+	closer, err := httpGet(context.Background(), ts.URL, headers)
+	assert.Nil(t, closer)
+	assert.EqualError(t, err, "error fetching asset: Response Code 404")
+}


### PR DESCRIPTION
Signed-off-by: Vern Burton <me@vernburton.com>

## What is this change?

Adding a non-200 status code check when fetching assets.


## Why is this change necessary?

fixes #3302 

## Does your change need a Changelog entry?

Yep.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No required.

## How did you verify this change?

Added test case.

## Is this change a patch?

Nope.