### PR TITLE
adding /version to agent api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- [agent] Added `/version` API
+
 ### Fixed
 - sensuctl now supports the http_proxy, https_proxy, and no_proxy environment
 variables.

--- a/agent/api.go
+++ b/agent/api.go
@@ -23,7 +23,7 @@ type APIConfig struct {
 	Port int
 }
 
-// APIConfig contains the API configuration
+// sensuVersion contains the API response for version
 type sensuVersion struct {
 	Version string `json:"version"`
 }

--- a/agent/api.go
+++ b/agent/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/sensu/sensu-go/version"
 	"math"
 	"net/http"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/sensu/lasr"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/version"
 	"golang.org/x/time/rate"
 )
 

--- a/agent/api.go
+++ b/agent/api.go
@@ -76,7 +76,11 @@ func versionShow() http.HandlerFunc {
 			return
 		}
 
-		w.Write(json)
+		_, err = w.Write(json)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Vern Burton <me@vernburton.com>

## What is this change?

Adds `/version` endpoint to Agent API

Response
```
{"version":"5.17.1"}
```

## Why is this change necessary?

fixes #2879 

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Should this be expanded to other APIs?

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I haven't.  It might be useful to add some documentation for this endpoint.

## How did you verify this change?

Added Test Case

## Is this change a patch?

No.