### PR TITLE
Pass an initialization function to start cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Support Bonsai assets versions prefixed with the letter `v`.
 
+## [5.17.2] - TBD
+
+### Fixed
+- Fixed a bug where on an internal restart, enterprise HTTP routes could fail
+to intialize.
+
 ## [5.17.1] - 2020-01-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Support Bonsai assets versions prefixed with the letter `v`.
-
-## [5.17.2] - TBD
-
-### Fixed
 - Fixed a bug where on an internal restart, enterprise HTTP routes could fail
 to intialize.
 

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -251,7 +251,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				}()
 			}
 
-			return sensuBackend.Run()
+			return sensuBackend.RunWithInitializer(initialize)
 		},
 	}
 


### PR DESCRIPTION
## What is this change?

This commit changes the way the sensu-backend starts. The call
to Run has been replaced with a call to RunWithInitializer. This
allows the commerical backend to pass its initializer to the OSS
start command.

Without this change, the commerical backend could lose its
enterprise-specific HTTP routes when the backend experienced an
internal restart.

## Why is this change necessary?

Closes #3566 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required.

## How did you verify this change?

I did manual tests with the enterprise codebase, both without this patch for reproduction verfication, and with the patch, and observed that the patch appears to fix the problem.

## Is this change a patch?

Yes