### PR TITLE
Provide support for api filtering on /silenced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ variables.
 the default sensuctl configuration.
 - read/writes `initializationKey` to/from `EtcdRoot`, while support legacy as fallback (read-only)
 - check for a non-200 response when fetching assets
+- `/silenced` now supports API filtering (commercial feature).
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/backend/apid/actions/silenced.go
+++ b/backend/apid/actions/silenced.go
@@ -28,7 +28,7 @@ func NewSilencedController(store store.SilencedStore) SilencedController {
 	}
 }
 
-// Query returns resources available to the viewer.
+// List returns resources available to the viewer.
 func (c SilencedController) List(ctx context.Context, sub, check string) ([]*corev2.Silenced, error) {
 	var results []*types.Silenced
 	var serr error

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -46,9 +46,8 @@ func (r *SilencedRouter) Mount(parent *mux.Router) {
 	routes.Get(r.handlers.GetResource)
 	routes.Post(r.create)
 	routes.Put(r.createOrReplace)
-
-	routes.Router.HandleFunc(routes.PathPrefix, listHandler(r.list)).Methods(http.MethodGet)
-	routes.Router.HandleFunc("/{resource:silenced}", listHandler(r.list)).Methods(http.MethodGet)
+	routes.List(r.handlers.ListResources, corev2.SilencedFields)
+	routes.ListAllNamespaces(r.handlers.ListResources, "/{resource:silenced}", corev2.SilencedFields)
 
 	// Custom routes for listing by subscription and checks for a specific
 	// namespace, in addition to all namespaces for checks.

--- a/backend/apid/routers/silenced_test.go
+++ b/backend/apid/routers/silenced_test.go
@@ -22,11 +22,13 @@ func TestSilencedRouter(t *testing.T) {
 	parentRouter := mux.NewRouter().PathPrefix(corev2.URLPrefix).Subrouter()
 	router.Mount(parentRouter)
 
+	empty := &corev2.Silenced{}
 	fixture := corev2.FixtureSilenced("*:bar")
 
 	tests := []routerTestCase{}
 	tests = append(tests, getTestCases(fixture)...)
 	tests = append(tests, deleteTestCases(fixture)...)
+	tests = append(tests, listTestCases(empty)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
 	}
@@ -70,28 +72,6 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 		controllerFunc controllerFunc
 		wantStatusCode int
 	}{
-		{
-			name:   "it returns 500 if the store encounters an error while listing silenced entries",
-			method: http.MethodGet,
-			path:   empty.URIPath(),
-			controllerFunc: func(c *mockSilencedController) {
-				c.On("List", mock.Anything, "", "").
-					Return([]*corev2.Silenced{}, actions.NewErrorf(actions.InternalErr)).
-					Once()
-			},
-			wantStatusCode: http.StatusInternalServerError,
-		},
-		{
-			name:   "it returns 200 and lists resources",
-			method: http.MethodGet,
-			path:   empty.URIPath(),
-			controllerFunc: func(c *mockSilencedController) {
-				c.On("List", mock.Anything, "", "").
-					Return([]*corev2.Silenced{fixture}, nil).
-					Once()
-			},
-			wantStatusCode: http.StatusOK,
-		},
 		{
 			name:           "it returns 400 if the payload to create is not decodable",
 			method:         http.MethodPost,


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds support for API filtering in /silenced per the [documented behavior](https://docs.sensu.io/sensu-go/latest/api/overview/#field-selector).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3553

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Tested all endpoints from [Silenced API docs](https://docs.sensu.io/sensu-go/latest/api/silenced/).

## Is this change a patch?

No, merging to master.