### PR TITLE
requiring subscriptions/subscribers on check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ variables.
 the default sensuctl configuration.
 - read/writes `initializationKey` to/from `EtcdRoot`, while support legacy as fallback (read-only)
 - check for a non-200 response when fetching assets
+- ensuring that check/check_config have subscriptions
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/agent/config.go
+++ b/agent/config.go
@@ -213,6 +213,7 @@ func FixtureConfig() (*Config, func()) {
 		KeepaliveWarningTimeout: corev2.DefaultKeepaliveTimeout,
 		Namespace:               DefaultNamespace,
 		Password:                DefaultPassword,
+		Subscriptions: 		     []string{"linux"},
 		Socket: &SocketConfig{
 			Host: DefaultSocketHost,
 			Port: DefaultSocketPort,

--- a/agent/sockets_test.go
+++ b/agent/sockets_test.go
@@ -42,6 +42,7 @@ func TestHandleTCPMessages(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -94,6 +95,7 @@ func TestHandleTCPMessagesWithClient(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Client: "proxyEnt",
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -146,6 +148,7 @@ func TestHandleTCPMessagesWithAgent(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: cfg.AgentName,
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -197,6 +200,7 @@ func TestHandleTCPMessagesNoSource(t *testing.T) {
 	payload := corev1.CheckResult{
 		Name:   "app_01",
 		Output: "could not connect to something",
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -250,6 +254,7 @@ func TestHandleUDPMessages(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -347,6 +352,7 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Subscribers: []string{"linux"},
 	}
 	bytes, _ := json.Marshal(payload)
 

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -196,6 +196,10 @@ func (c *Check) Validate() error {
 		return errors.New("invalid flap thresholds")
 	}
 
+	if len(c.Subscriptions)	== 0 {
+		return errors.New("subscriptions can not be empty")
+	}
+
 	if err := ValidateEnvVars(c.EnvVars); err != nil {
 		return err
 	}

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -106,6 +106,10 @@ func (c *CheckConfig) Validate() error {
 		return errors.New("namespace must be set")
 	}
 
+	if len(c.Subscriptions)	== 0 {
+		return errors.New("subscriptions can not be empty")
+	}
+
 	if c.Ttl > 0 && c.Ttl <= int64(c.Interval) {
 		return errors.New("ttl must be greater than check interval")
 	}

--- a/api/core/v2/check_config_test.go
+++ b/api/core/v2/check_config_test.go
@@ -39,6 +39,7 @@ func TestCheckConfig(t *testing.T) {
 
 	// Valid check
 	c.Ttl = 90
+	c.Subscriptions = []string{"linux"}
 	assert.NoError(t, c.Validate())
 }
 
@@ -56,6 +57,16 @@ func TestCheckConfigHasNonNilHandlers(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(b, &c))
 	require.NotNil(t, c.Handlers)
+}
+
+func TestCheckConfigHasEmptySubscriptionsError(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = []string{}
+	b, err := json.Marshal(&c)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &c))
+	err = c.Validate()
+	require.EqualError(t, err, "subscriptions can not be empty")
 }
 
 func TestCheckConfigFlapThresholdValidation(t *testing.T) {

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -17,7 +17,7 @@ func TestCheckValidate(t *testing.T) {
 	c.Interval = 10
 
 	c.Name = "test"
-
+	c.Subscriptions = []string{"linux"}
 	assert.NoError(t, c.Validate())
 }
 
@@ -98,6 +98,16 @@ func TestCheckHasNonNilSubscriptions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(b, &c))
 	require.NotNil(t, c.Subscriptions)
+}
+
+func TestCheckHasEmptySubscriptionsError(t *testing.T) {
+	c := FixtureCheck("foo")
+	c.Subscriptions = []string{}
+	b, err := json.Marshal(&c)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &c))
+	err = c.Validate()
+	require.EqualError(t, err, "subscriptions can not be empty")
 }
 
 func TestCheckHasNonNilHandlers(t *testing.T) {

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -67,6 +67,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 				Name:      "keepalive",
 				Namespace: "default",
 			},
+			Subscriptions: []string{"linux"},
 			Interval: 1,
 			Timeout:  5,
 		},


### PR DESCRIPTION
There is not point of creating a check if nothing can subscribe to it.  This changes `check.Validate()` to check if the length of the `Subscriptions` slice is not equal to zero.

Signed-off-by: Vern Burton <me@vernburton.com>

## What is this change?

fixes #2932 


## Why is this change necessary?

It creates an organized experience that ensures that checks can be subscribed by entities.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

The testing changes was larger than I expected.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Created tests cases to ensure that error message was as expected

## Is this change a patch?

No.