### PR TITLE
ensuring that check/check_config has a valid command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ variables.
 the default sensuctl configuration.
 - read/writes `initializationKey` to/from `EtcdRoot`, while support legacy as fallback (read-only)
 - check for a non-200 response when fetching assets
+- ensure that check/check config have a non-empty command
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/agent/sockets_test.go
+++ b/agent/sockets_test.go
@@ -42,6 +42,7 @@ func TestHandleTCPMessages(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -94,6 +95,7 @@ func TestHandleTCPMessagesWithClient(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Client: "proxyEnt",
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -146,6 +148,7 @@ func TestHandleTCPMessagesWithAgent(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: cfg.AgentName,
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -197,6 +200,7 @@ func TestHandleTCPMessagesNoSource(t *testing.T) {
 	payload := corev1.CheckResult{
 		Name:   "app_01",
 		Output: "could not connect to something",
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -250,6 +254,7 @@ func TestHandleUDPMessages(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 
@@ -347,6 +352,7 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 		Name:   "app_01",
 		Output: "could not connect to something",
 		Source: "proxyEnt",
+		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
 

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -180,6 +180,10 @@ func (c *Check) Validate() error {
 		}
 	}
 
+	if c.Command == "" {
+		return errors.New("command can not be empty")
+	}
+
 	if c.ProxyRequests != nil {
 		if err := c.ProxyRequests.Validate(); err != nil {
 			return err

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -106,6 +106,10 @@ func (c *CheckConfig) Validate() error {
 		return errors.New("namespace must be set")
 	}
 
+	if c.Command == "" {
+		return errors.New("command can not be empty")
+	}
+
 	if c.Ttl > 0 && c.Ttl <= int64(c.Interval) {
 		return errors.New("ttl must be greater than check interval")
 	}

--- a/api/core/v2/check_config_test.go
+++ b/api/core/v2/check_config_test.go
@@ -58,6 +58,17 @@ func TestCheckConfigHasNonNilHandlers(t *testing.T) {
 	require.NotNil(t, c.Handlers)
 }
 
+func TestCheckConfigHasEmptyCommandError(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = []string{}
+	c.Command = ""
+	b, err := json.Marshal(&c)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &c))
+	err = c.Validate()
+	require.EqualError(t, err, "command can not be empty")
+}
+
 func TestCheckConfigFlapThresholdValidation(t *testing.T) {
 	c := FixtureCheckConfig("foo")
 	// zero-valued flap threshold is valid

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -17,6 +17,7 @@ func TestCheckValidate(t *testing.T) {
 	c.Interval = 10
 
 	c.Name = "test"
+	c.Command = "command"
 
 	assert.NoError(t, c.Validate())
 }
@@ -106,6 +107,17 @@ func TestCheckHasNonNilHandlers(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(b, &c))
 	require.NotNil(t, c.Handlers)
+}
+
+func TestCheckHasEmptyCommandError(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = []string{}
+	c.Command = ""
+	b, err := json.Marshal(&c)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &c))
+	err = c.Validate()
+	require.EqualError(t, err, "command can not be empty")
 }
 
 func TestCheckFlapThresholdValidation(t *testing.T) {

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -69,6 +69,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 			},
 			Interval: 1,
 			Timeout:  5,
+			Command: "command",
 		},
 		Entity:    entity,
 		Timestamp: time.Now().Unix(),

--- a/cli/commands/check/subcommands/set_command_test.go
+++ b/cli/commands/check/subcommands/set_command_test.go
@@ -23,7 +23,7 @@ func TestSetCommandCommand(t *testing.T) {
 		{"no args", []string{}, nil, nil, "Usage", true},
 		{"fetch error", []string{"foo", "echo foo"}, fmt.Errorf("error"), nil, "", true},
 		{"update error", []string{"bar", "echo bar"}, nil, fmt.Errorf("error"), "", true},
-		{"invalid input", []string{"checky", ""}, nil, nil, "", false},
+		{"invalid input", []string{"checky", "foo"}, nil, nil, "", false},
 		{"valid input", []string{"checky", "echo checky"}, nil, nil, "Updated", false},
 	}
 


### PR DESCRIPTION
Signed-off-by: Vern Burton <me@vernburton.com>

## What is this change?

This change ensures that check/check_config cannot have an empty `Command`.  

## Why is this change necessary?

fixes #2551

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.  

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope.

## How did you verify this change?

New test cases.

## Is this change a patch?

Nope.