### PR TITLE
Fix event payload validation on the backend events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ the default sensuctl configuration.
 - read/writes `initializationKey` to/from `EtcdRoot`, while support legacy as fallback (read-only)
 - check for a non-200 response when fetching assets
 - `/silenced` now supports API filtering (commercial feature).
+- Fix event payload validation on the backend events API.
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/backend/apid/handlers/create.go
+++ b/backend/apid/handlers/create.go
@@ -19,7 +19,7 @@ func (h Handlers) CreateResource(r *http.Request) (interface{}, error) {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	if err := CheckMeta(payload.Interface(), mux.Vars(r)); err != nil {
+	if err := CheckMeta(payload.Interface(), mux.Vars(r), "id"); err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 

--- a/backend/apid/handlers/handlers.go
+++ b/backend/apid/handlers/handlers.go
@@ -16,7 +16,7 @@ type Handlers struct {
 
 // CheckMeta inspects the resource metadata and ensures it matches what was
 // specified in the request URL
-func CheckMeta(resource interface{}, vars map[string]string) error {
+func CheckMeta(resource interface{}, vars map[string]string, idVar string) error {
 	v, ok := resource.(interface{ GetObjectMeta() corev2.ObjectMeta })
 	if !ok {
 		// We are not dealing with a corev2.Resource interface
@@ -27,10 +27,6 @@ func CheckMeta(resource interface{}, vars map[string]string) error {
 	if err != nil {
 		return err
 	}
-	id, err := url.PathUnescape(vars["id"])
-	if err != nil {
-		return err
-	}
 
 	if meta.Namespace != namespace && namespace != "" {
 		return fmt.Errorf(
@@ -38,6 +34,17 @@ func CheckMeta(resource interface{}, vars map[string]string) error {
 			meta.Namespace,
 			namespace,
 		)
+	}
+
+	// The URL path name that holds the resource ID might differ, but fallback
+	// to "id" if not provided
+	if idVar == "" {
+		idVar = "id"
+	}
+
+	id, err := url.PathUnescape(vars[idVar])
+	if err != nil {
+		return err
 	}
 
 	if meta.Name != id && id != "" {

--- a/backend/apid/handlers/handlers_test.go
+++ b/backend/apid/handlers/handlers_test.go
@@ -35,7 +35,7 @@ func TestCheckMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckMeta(tt.resource, tt.vars); (err != nil) != tt.wantErr {
+			if err := CheckMeta(tt.resource, tt.vars, "id"); (err != nil) != tt.wantErr {
 				t.Errorf("checkMeta() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/backend/apid/handlers/update.go
+++ b/backend/apid/handlers/update.go
@@ -19,7 +19,7 @@ func (h Handlers) CreateOrUpdateResource(r *http.Request) (interface{}, error) {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	if err := CheckMeta(payload.Interface(), mux.Vars(r)); err != nil {
+	if err := CheckMeta(payload.Interface(), mux.Vars(r), "id"); err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 

--- a/backend/apid/routers/events_test.go
+++ b/backend/apid/routers/events_test.go
@@ -63,6 +63,9 @@ func TestEventsRouter(t *testing.T) {
 		controllerFunc controllerFunc
 		wantStatusCode int
 	}{
+		//
+		// GET
+		//
 		{
 			name:   "it returns 404 if a resource is not found",
 			method: http.MethodGet,
@@ -150,6 +153,9 @@ func TestEventsRouter(t *testing.T) {
 			},
 			wantStatusCode: http.StatusCreated,
 		},
+		//
+		// PUT
+		//
 		{
 			name:           "it returns 400 if the payload to update is not decodable",
 			method:         http.MethodPut,
@@ -220,6 +226,37 @@ func TestEventsRouter(t *testing.T) {
 			wantStatusCode: http.StatusCreated,
 		},
 		{
+			name:           "it returns 400 if the entity name to PUT does not match the URL parameter",
+			method:         http.MethodPut,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "bar", "namespace": "default"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the entity namespace to PUT does not match the URL parameter",
+			method:         http.MethodPut,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "dev"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the check name to PUT does not match the URL parameter",
+			method:         http.MethodPut,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "default"}}, "check": {"metadata": {"name": "check-mem", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the check namespace to PUT does not match the URL parameter",
+			method:         http.MethodPut,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "default"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"dev"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		//
+		// POST
+		//
+		{
 			name:           "it returns 400 if the payload to update is not decodable (post)",
 			method:         http.MethodPost,
 			path:           fixture.URIPath(),
@@ -234,14 +271,14 @@ func TestEventsRouter(t *testing.T) {
 			wantStatusCode: http.StatusBadRequest,
 		},
 		{
-			name:           "it returns 400 if the event metadata to update is invalid (post)",
+			name:           "it returns 400 if the event metadata to POST is invalid (post)",
 			method:         http.MethodPost,
 			path:           fixture.URIPath(),
 			body:           []byte(`{"entity": {}, "check": {"metadata": {"namespace":"acme"}}}`),
 			wantStatusCode: http.StatusBadRequest,
 		},
 		{
-			name:   "it returns 400 if the event to update is not valid (post)",
+			name:   "it returns 400 if the event to update is invalid (post)",
 			method: http.MethodPost,
 			path:   fixture.URIPath(),
 			body:   marshal(fixture),
@@ -276,6 +313,37 @@ func TestEventsRouter(t *testing.T) {
 			},
 			wantStatusCode: http.StatusCreated,
 		},
+		{
+			name:           "it returns 400 if the entity name to POST does not match the URL parameter",
+			method:         http.MethodPost,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "bar", "namespace": "default"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the entity namespace to POST does not match the URL parameter",
+			method:         http.MethodPost,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "dev"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the check name to POST does not match the URL parameter",
+			method:         http.MethodPost,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "default"}}, "check": {"metadata": {"name": "check-mem", "namespace":"default"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name:           "it returns 400 if the check namespace to POST does not match the URL parameter",
+			method:         http.MethodPost,
+			path:           fixture.URIPath(),
+			body:           []byte(`{"entity": {"metadata": {"name": "foo", "namespace": "default"}}, "check": {"metadata": {"name": "check-cpu", "namespace":"dev"}}}`),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		//
+		// DELETE
+		//
 		{
 			name:   "it returns 404 if the event to delete does not exist",
 			method: http.MethodDelete,

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -62,7 +62,7 @@ func (r *SilencedRouter) create(req *http.Request) (interface{}, error) {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	if err := handlers.CheckMeta(entry, mux.Vars(req)); err != nil {
+	if err := handlers.CheckMeta(entry, mux.Vars(req), "id"); err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -76,7 +76,7 @@ func (r *SilencedRouter) createOrReplace(req *http.Request) (interface{}, error)
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	if err := handlers.CheckMeta(entry, mux.Vars(req)); err != nil {
+	if err := handlers.CheckMeta(entry, mux.Vars(req), "id"); err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 


### PR DESCRIPTION
It makes sure the entity & check names/namespaces match whatever is specified in the URL path. We previously assumed the name of the resources were always hold within the URL path variable `id`, which isn't the case for events.

Basically, the following requests now return an error:

```sh
# bad entity name
$ curl -i -XPOST -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -H "Content-Type: application/json" \
   -d '{"entity":{"metadata":{"name":"1-424242","namespace":"default"},"entity_class":"proxy"},"check":{"metadata":{"name":"helloworld","namespace":"default"},"status":0,"output":"everything is a-ok!"}}' \
   http://127.0.0.1:8080/api/core/v2/namespaces/default/events/foo/foo
[...]
{"message":"the name of the resource (1-424242) does not match the name of the URI (foo)","code":1}

# bad entity namespace
$ curl -i -XPOST -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -H "Content-Type: application/json" \
   -d '{"entity":{"metadata":{"name":"i-424242","namespace":"dev"},"entity_class":"proxy"},"check":{"metadata":{"name":"helloworld","namespace":"default"},"status":0,"output":"everything is a-ok!"}}' \
   http://127.0.0.1:8080/api/core/v2/namespaces/default/events/i-424242/helloworld
[...]
{"message":"the namespace of the resource (dev) does not match the namespace of the URI (default)","code":1}                                                                                               

# bad check name
$ curl -i -XPOST -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -H "Content-Type: application/json" \
   -d '{"entity":{"metadata":{"name":"i-424242","namespace":"default"},"entity_class":"proxy"},"check":{"metadata":{"name":"helloworld","namespace":"default"},"status":0,"output":"everything is a-ok!"}}' \
   http://127.0.0.1:8080/api/core/v2/namespaces/default/events/i-424242/foo
[...]
{"message":"the name of the resource (helloworld) does not match the name of the URI (foo)","code":1}

# bad check namespace
$ curl -i -XPOST -H "Authorization: Bearer $SENSU_ACCESS_TOKEN" -H "Content-Type: application/json" \
   -d '{"entity":{"metadata":{"name":"i-424242","namespace":"default"},"entity_class":"proxy"},"check":{"metadata":{"name":"helloworld","namespace":"dev"},"status":0,"output":"everything is a-ok!"}}' \
   http://127.0.0.1:8080/api/core/v2/namespaces/default/events/i-424242/helloworld
[...]
{"message":"the namespace of the resource (dev) does not match the namespace of the URI (default)","code":1}
```

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/3258

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope, bugfix

## How did you verify this change?

Added unit tests to cover that fix

## Is this change a patch?

Yep, but targeting 5.18