### PR TITLE
Add event payload validation to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ the default sensuctl configuration.
 - Default `event.entity.entity_class` to `proxy` in the POST/PUT `/events` API.
 - Proxy entities are now automatically created when events are published with an
 entity that does not exist.
+- Fixed event payload validation on the backend events API to validate the payload with the URL parameters on the /events/:entity/:check endpoint and reject events that do not match.
 
 ## [5.17.2] - 2020-02-19
 


### PR DESCRIPTION
## What is this change?

Add missing fix to the changelog -- Simon pointed out that this is missing in the sensu-docs release notes PR for 5.18:

```
It's totally possible I missed it but I think we are missing the following changelog entry:

Fix event payload validation on the backend events API - We now better validating the payload with the URL parameters on the /events/:entity/:check endpoint, and rejecting events that do not match.
```

## Why is this change necessary?

Fix is missing from the changelog

## Does your change need a Changelog entry?
Yes, added

## Do you need clarification on anything?
Need to confirm I understood the change correctly.


## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I added it to the release notes PR -- will commit when I'm sure my understanding is correct.

## How did you verify this change?
I have not.