### PR TITLE
Do not set namespace to global wrapped resources

### DIFF
--- a/cli/commands/create/create_test.go
+++ b/cli/commands/create/create_test.go
@@ -247,7 +247,7 @@ func TestValidateResourcesStderr(t *testing.T) {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		_, _ = io.Copy(&buf, r)
 		ch <- buf.String()
 	}()
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes a bug where sensuctl would attempt to set a namespace to cluster-wide resources, such as authentication providers.

## Why is this change necessary?

Fix a bug found in staging.

## Does your change need a Changelog entry?

Nope, it fixes an unreleased commit.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

The ValidateResource function was largely untested, so I had to take the time to write proper unit tests.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested with sensu-enterprise-go + unit tests.

## Is this change a patch?

Nope