### PR TITLE
Don't do an entity read when entity is an agent

### DIFF
--- a/backend/eventd/entity.go
+++ b/backend/eventd/entity.go
@@ -15,6 +15,8 @@ func createProxyEntity(event *corev2.Event, s store.EntityStore) error {
 	// Override the entity name with proxy_entity_name if it was provided
 	if event.HasCheck() && event.Check.ProxyEntityName != "" {
 		entityName = event.Check.ProxyEntityName
+	} else if event.Entity.EntityClass == corev2.EntityAgentClass {
+		return nil
 	}
 
 	// Determine if the entity exists

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -248,10 +248,8 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 
 	// Create a proxy entity if required and update the event's entity with it,
 	// but only if the event's entity is not an agent.
-	if event.Entity.EntityClass != corev2.EntityAgentClass {
-		if err := createProxyEntity(event, e.store); err != nil {
-			return err
-		}
+	if err := createProxyEntity(event, e.store); err != nil {
+		return err
 	}
 
 	// Add any silenced subscriptions to the event

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -246,9 +246,12 @@ func (e *Eventd) handleMessage(msg interface{}) error {
 
 	ctx := context.WithValue(context.Background(), corev2.NamespaceKey, event.Entity.Namespace)
 
-	// Create a proxy entity if required and update the event's entity with it
-	if err := createProxyEntity(event, e.store); err != nil {
-		return err
+	// Create a proxy entity if required and update the event's entity with it,
+	// but only if the event's entity is not an agent.
+	if event.Entity.EntityClass != corev2.EntityAgentClass {
+		if err := createProxyEntity(event, e.store); err != nil {
+			return err
+		}
 	}
 
 	// Add any silenced subscriptions to the event


### PR DESCRIPTION
## Why is this change necessary?

This change avoids an etcd read in eventd when the event's entity is an agent.

It avoids trying to create a proxy entity, assuming instead that the event's entity is already full specified.

## Does your change need a Changelog entry?

No

## How did you verify this change?

Unverified.

## Is this change a patch?

Yes