### PR TITLE
Add timeout when obtaining a file lock for the asset manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- sensu-backend no longers hang indefinitely if a file lock for the asset
+manager cannot be obtained, and returns instead an error after 60 seconds.
+
 ## [5.18.0] - 2020-02-24
 
 ### Added

--- a/asset/manager.go
+++ b/asset/manager.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/sensu/sensu-go/types"
 	bolt "go.etcd.io/bbolt"
@@ -39,7 +40,7 @@ func (m *Manager) StartAssetManager(ctx context.Context) (Getter, error) {
 	}
 
 	logger.WithField("cache", m.cacheDir).Debug("initializing cache directory")
-	db, err := bolt.Open(filepath.Join(m.cacheDir, dbName), 0600, &bolt.Options{})
+	db, err := bolt.Open(filepath.Join(m.cacheDir, dbName), 0600, &bolt.Options{Timeout: 60 * time.Second})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds a timeout to `bolt.Open` when we try to open the asset manager cache, similar to what we have for other bolt databases.

## Why is this change necessary?

It fixes a bug @cwjohnston experienced yesterday when two backends attempt to use the same `cache-dir`.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

Yep