### PR TITLE
Fix logging under windows services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ the default sensuctl configuration.
 - `/silenced` now supports API filtering (commercial feature).
 - Fix event payload validation on the backend events API.
 - The `auth/test` endpoint now returns the correct error messages.
+- The `log-level` configuration option is now properly applied when running the
+Sensu Agent Windows service.
 
 ### Changed
 - Updated Go version from 1.13.5 to 1.13.7.

--- a/agent/cmd/service_windows.go
+++ b/agent/cmd/service_windows.go
@@ -59,15 +59,14 @@ func (s *Service) start(ctx context.Context, args []string, changes chan<- svc.S
 		}
 		defer logFile.Close()
 
-		logger := logrus.New()
-		logger.SetFormatter(&logrus.JSONFormatter{})
-		logger.SetOutput(logFile)
-		entry := logger.WithFields(logrus.Fields{
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+		logrus.SetOutput(logFile)
+		logger := logrus.WithFields(logrus.Fields{
 			"component": "cmd",
 		})
 
 		args = []string{binPath, "start", "-c", configFile}
-		command := newStartCommand(ctx, args, entry)
+		command := newStartCommand(ctx, args, logger)
 		accepts := svc.AcceptShutdown | svc.AcceptStop
 		changes <- svc.Status{State: svc.Running, Accepts: accepts}
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Fixes an issue where `log-level` would not be applied when Sensu Agent is run under a Windows service.

## Why is this change necessary?

Fixes #3407 

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes - no new documentation is required.

## How did you verify this change?

Tested on my Windows machine.

## Is this change a patch?

It could be considered a patch and I've targeted the release branch as a result.