### PR TITLE
Support postgres health from sensu-go

### DIFF
--- a/api/core/v2/health.go
+++ b/api/core/v2/health.go
@@ -25,6 +25,18 @@ type ClusterHealth struct {
 	Healthy bool
 }
 
+// PostgresHealth holds postgres store status info.
+type PostgresHealth struct {
+	// Name is the name of the postgres resource.
+	Name string
+
+	// Active indicates if the store is configured to use the postgres configuration.
+	Active bool
+
+	// Healthy indicates if the postgres store is connected and can query the events table.
+	Healthy bool
+}
+
 func (h ClusterHealth) MarshalJSON() ([]byte, error) {
 	if h.MemberIDHex == "" {
 		h.MemberIDHex = fmt.Sprintf("%x", h.MemberID)
@@ -42,6 +54,8 @@ type HealthResponse struct {
 	ClusterHealth []*ClusterHealth
 	// Header is the response header for the entire cluster response.
 	Header *etcdserverpb.ResponseHeader
+	// PostgresHealth is the list of health status for each postgres config.
+	PostgresHealth []*PostgresHealth `json:"PostgresHealth,omitempty"`
 }
 
 // FixtureHealthResponse returns a HealthResponse fixture for testing.

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -64,6 +64,7 @@ type Config struct {
 	Authenticator       *authentication.Authenticator
 	ClusterVersion      string
 	GraphQLService      *graphql.Service
+	HealthRouter        *routers.HealthRouter
 }
 
 // New creates a new APId.
@@ -240,9 +241,7 @@ func PublicSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	)
 
 	mountRouters(subrouter,
-		routers.NewHealthRouter(
-			actions.NewHealthController(cfg.Store, cfg.Cluster, cfg.EtcdClientTLSConfig),
-		),
+		cfg.HealthRouter,
 		routers.NewVersionRouter(actions.NewVersionController(cfg.ClusterVersion)),
 		routers.NewTessenMetricRouter(actions.NewTessenMetricController(cfg.Bus)),
 	)

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -11,12 +11,15 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/provider"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 const (
 	eventsPathPrefix = "events"
+	// Type is the type of an etcd store provider.
+	Type = "etcd"
 )
 
 var (
@@ -292,6 +295,19 @@ func (s *Store) UpdateEvent(ctx context.Context, event *corev2.Event) (*corev2.E
 	}
 
 	return event, prevEvent, nil
+}
+
+// GetProviderInfo returns the info of an etcd store provider.
+func (s *Store) GetProviderInfo() *provider.Info {
+	return &provider.Info{
+		TypeMeta: corev2.TypeMeta{
+			Type:       Type,
+			APIVersion: "store/v1",
+		},
+		ObjectMeta: corev2.ObjectMeta{
+			Name: Type,
+		},
+	}
 }
 
 func updateOccurrences(check *corev2.Check) {

--- a/backend/store/provider/provider.go
+++ b/backend/store/provider/provider.go
@@ -1,0 +1,17 @@
+package provider
+
+import (
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// Info represents the config of a store provider.
+type Info struct {
+	corev2.TypeMeta
+	corev2.ObjectMeta
+}
+
+// InfoGetter gets info about a store provider.
+type InfoGetter interface {
+	// GetProviderInfo gets info about a store provider.
+	GetProviderInfo() *Info
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds support for exported fields and functions to display postgres health information from sensu-enterprise-go.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/pull/871.

## Does your change need a Changelog entry?

No functionality is changed. 

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

https://github.com/gorilla/mux/issues/82#issuecomment-121411186

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/2223

## How did you verify this change?

QA crucible work will be created as part of the sensu-enterprise-go work.

## Is this change a patch?

Nope, feature work.