### PR TITLE
Order event history in FIFO fashion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - ensure that check/check config have a non-empty command
+- Check history is now in FIFO order, not ordered by executed timestamp.
 
 ## [5.18.0] - 2020-02-24
 

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"sort"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -248,7 +247,6 @@ func (c *Check) MergeWith(prevCheck *Check) {
 	}
 
 	history = append(history, histEntry)
-	sort.Sort(ByExecuted(history))
 	if len(history) > 21 {
 		history = history[1:]
 	}
@@ -269,6 +267,7 @@ func ValidateOutputMetricFormat(format string) error {
 	return errors.New("output metric format is not valid")
 }
 
+// DEPRECATED, DO NOT USE! Events should be ordered FIFO.
 // ByExecuted implements the sort.Interface for []CheckHistory based on the
 // Executed field.
 //


### PR DESCRIPTION
This fixes a bug where check history ordering could differ from the
order that events are processed by sensu-backend.

## Why is this change necessary?

Closes #3583 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

A lengthy discussion was spawned :)

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We should assert that event history is ordered according to when events hit the backend, not when the check is executed. cc @hillaryfraley 

## How did you verify this change?

Only unit/integration testing.