### PR TITLE
Revert check command validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   `high_flap_threshold` instead of below `low_flap_threshold`.
 
 ### Fixed
-- ensure that check/check config have a non-empty command
 - Check history is now in FIFO order, not ordered by executed timestamp.
 
 ## [5.18.0] - 2020-02-24

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -187,10 +187,6 @@ func (c *Check) Validate() error {
 		}
 	}
 
-	if c.Command == "" && c.Name != KeepaliveCheckName && c.Name != RegistrationCheckName {
-		return errors.New("command can not be empty")
-	}
-
 	if c.ProxyRequests != nil {
 		if err := c.ProxyRequests.Validate(); err != nil {
 			return err

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -106,10 +106,6 @@ func (c *CheckConfig) Validate() error {
 		return errors.New("namespace must be set")
 	}
 
-	if c.Command == "" {
-		return errors.New("command can not be empty")
-	}
-
 	if c.Ttl > 0 && c.Ttl <= int64(c.Interval) {
 		return errors.New("ttl must be greater than check interval")
 	}

--- a/api/core/v2/check_config_test.go
+++ b/api/core/v2/check_config_test.go
@@ -58,17 +58,6 @@ func TestCheckConfigHasNonNilHandlers(t *testing.T) {
 	require.NotNil(t, c.Handlers)
 }
 
-func TestCheckConfigHasEmptyCommandError(t *testing.T) {
-	c := FixtureCheckConfig("foo")
-	c.Subscriptions = []string{}
-	c.Command = ""
-	b, err := json.Marshal(&c)
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal(b, &c))
-	err = c.Validate()
-	require.EqualError(t, err, "command can not be empty")
-}
-
 func TestCheckConfigFlapThresholdValidation(t *testing.T) {
 	c := FixtureCheckConfig("foo")
 	// zero-valued flap threshold is valid

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -136,17 +136,6 @@ func TestCheckHasNonNilHandlers(t *testing.T) {
 	require.NotNil(t, c.Handlers)
 }
 
-func TestCheckHasEmptyCommandError(t *testing.T) {
-	c := FixtureCheckConfig("foo")
-	c.Subscriptions = []string{}
-	c.Command = ""
-	b, err := json.Marshal(&c)
-	require.NoError(t, err)
-	require.NoError(t, json.Unmarshal(b, &c))
-	err = c.Validate()
-	require.EqualError(t, err, "command can not be empty")
-}
-
 func TestCheckFlapThresholdValidation(t *testing.T) {
 	c := FixtureCheck("foo")
 	// zero-valued flap threshold is valid


### PR DESCRIPTION
## What is this change?

Unfortunately, it seems that check command validation is simply too
much of a change at this point. It breaks several test cases in our
QA suite, breaks examples in the docs, and cannot be done in the
5.x series of sensu-go.

cc @tarcinil 

## Does your change need a Changelog entry?

An entry has been removed from CHANGELOG.md

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs updates not required.

## How did you verify this change?

Unverified.

## Is this change a patch?

No