### PR TITLE
Apply managed_by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
 - Added `flapping` field to check history, along with `is_flapping_start` and
   `is_flapping_end` event properties for use by filters.
-- Fixed bug where flapping would incorrectly end when `total_state_change` was below
-  `high_flap_threshold` instead of below `low_flap_threshold`.
+- The `sensu.io/managed_by` label is now automatically applied to resources
+created via `sensuctl create`.
 
 ### Fixed
 - ensure that check/check config have a non-empty command
 - Check history is now in FIFO order, not ordered by executed timestamp.
+- Fixed bug where flapping would incorrectly end when `total_state_change` was
+  below `high_flap_threshold` instead of below `low_flap_threshold`.
 
 ## [5.18.0] - 2020-02-24
 

--- a/api/core/v2/meta.go
+++ b/api/core/v2/meta.go
@@ -1,5 +1,11 @@
 package v2
 
+const (
+	// ManagedByLabel is used to identify which client was used to create/update a
+	// resource
+	ManagedByLabel = "sensu.io/managed_by"
+)
+
 // NewObjectMeta makes a new ObjectMeta, with Labels and Annotations assigned
 // empty maps.
 func NewObjectMeta(name, namespace string) ObjectMeta {

--- a/cli/commands/create/create_test.go
+++ b/cli/commands/create/create_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"text/template"
@@ -265,5 +266,71 @@ func TestValidateResourcesStderr(t *testing.T) {
 	wantErr := `error validating resource #0 with name "check-cpu" and namespace "default": resource is nil`
 	if errMsg != wantErr {
 		t.Errorf("ValidateResources() err = %s, want %s", errMsg, wantErr)
+	}
+}
+
+func TestCreatedByLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource types.Wrapper
+		want     map[string]string
+	}{
+		{
+			name: "the label is set on both the inner and outer labels",
+			resource: types.WrapResource(&corev2.CheckConfig{
+				ObjectMeta: corev2.ObjectMeta{
+					Name: "foo",
+				},
+			}),
+			want: map[string]string{
+				corev2.ManagedByLabel: "sensuctl",
+			},
+		},
+		{
+			name: "the label is appended to an existing list of labels",
+			resource: types.WrapResource(&corev2.CheckConfig{
+				ObjectMeta: corev2.ObjectMeta{
+					Labels: map[string]string{
+						"region": "us-west-2",
+					},
+				},
+			}),
+			want: map[string]string{
+				"region":              "us-west-2",
+				corev2.ManagedByLabel: "sensuctl",
+			},
+		},
+		{
+			name: "the label overwrites any existing value",
+			resource: types.WrapResource(&corev2.CheckConfig{
+				ObjectMeta: corev2.ObjectMeta{
+					Labels: map[string]string{
+						corev2.ManagedByLabel: "web-ui",
+					},
+				},
+			}),
+			want: map[string]string{
+				corev2.ManagedByLabel: "sensuctl",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdin bytes.Buffer
+			bytes, _ := json.Marshal(&tt.resource)
+			stdin.Write(bytes)
+
+			got, err := ParseResources(&stdin)
+			if err != nil {
+				t.Errorf("ParseResources() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got[0].ObjectMeta.Labels, tt.want) {
+				t.Errorf("ParseResources() inner labels = %v, want %v", got[0].ObjectMeta.Labels, tt.want)
+			}
+			if !reflect.DeepEqual(got[0].Value.GetObjectMeta().Labels, tt.want) {
+				t.Errorf("ParseResources() outer labels = %v, want %v", got[0].Value.GetObjectMeta().Labels, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What is this change?

It automatically applies the `sensu.io/managed_by` label to resources created via `sensuctl create`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3594

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

It was surprisingly easy, I'm still wondering if I forgot something.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs required at the moment.

## How did you verify this change?

Manually tested with both core & commercial (wrapped) resources. Also added unit test coverage.

## Is this change a patch?

Nope