### PR TITLE
Don't use the etcd embedded client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - sensu-backend no longers hang indefinitely if a file lock for the asset
 manager cannot be obtained, and returns instead an error after 60 seconds.
+- Check history is now in FIFO order, not ordered by executed timestamp.
+- Fixed bug where flapping would incorrectly end when `total_state_change` was
+  below `high_flap_threshold` instead of below `low_flap_threshold`.
+- Stopped using the etcd embedded client, which seems to trigger nil pointer
+panics when used against an etcd that is shutting down.
 
 ## [5.18.0] - 2020-02-24
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -176,7 +176,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	b.ctx = ctx
 	b.runCtx, b.runCancel = context.WithCancel(b.ctx)
 
-	b.Client, err = newClient(b.ctx, config, b)
+	b.Client, err = newClient(b.runCtx, config, b)
 	if err != nil {
 		return nil, err
 	}
@@ -228,8 +228,8 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store:                   stor,
-		Bus:                     bus,
+		Store: stor,
+		Bus:   bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
 		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
@@ -303,14 +303,14 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:                   bus,
-		Store:                 stor,
-		EventStore:            stor,
-		LivenessFactory:       liveness.EtcdFactory(b.runCtx, b.Client),
-		RingPool:              ringPool,
-		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
-		StoreTimeout:          2 * time.Minute,
+		Bus:             bus,
+		Store:           stor,
+		EventStore:      stor,
+		LivenessFactory: liveness.EtcdFactory(b.runCtx, b.Client),
+		RingPool:        ringPool,
+		BufferSize:      viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:     viper.GetInt(FlagKeepalivedWorkers),
+		StoreTimeout:    2 * time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -97,6 +97,7 @@ func TestBackendHTTPListener(t *testing.T) {
 				EtcdName:                     "default",
 				EtcdClientTLSInfo:            tlsInfo,
 				EtcdPeerTLSInfo:              tlsInfo,
+				EtcdUseEmbeddedClient:        true,
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			b, err := Initialize(ctx, cfg)

--- a/backend/config.go
+++ b/backend/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	EtcdElectionTimeout          uint
 	EtcdDiscovery                string
 	EtcdDiscoverySrv             string
+	EtcdUseEmbeddedClient        bool
 
 	// Etcd TLS configuration
 	EtcdClientTLSInfo     etcd.TLSInfo

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/embed"
+	"github.com/coreos/etcd/etcdserver/api/v3client"
 	"github.com/coreos/etcd/pkg/transport"
 	etcdTypes "github.com/coreos/etcd/pkg/types"
 	"github.com/coreos/pkg/capnslog"
@@ -270,17 +271,19 @@ func (e *Etcd) NewClient() (*clientv3.Client, error) {
 	})
 }
 
-// Healthy returns Etcd status information.
+// NewEmbeddedClient delivers a new embedded etcd client. Only for testing.
+func (e *Etcd) NewEmbeddedClient() *clientv3.Client {
+	return v3client.New(e.etcd.Server)
+}
+
+// Healthy returns Etcd status information. DEPRECATED.
 func (e *Etcd) Healthy() bool {
 	if len(e.cfg.AdvertiseClientURLs) == 0 {
 		return false
 	}
-	client, err := e.NewClient()
-	if err != nil {
-		return false
-	}
+	client := e.NewEmbeddedClient()
 	mapi := client.Maintenance
-	_, err = mapi.Status(context.TODO(), e.cfg.AdvertiseClientURLs[0])
+	_, err := mapi.Status(context.TODO(), e.cfg.AdvertiseClientURLs[0])
 	return err == nil
 }
 

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -262,7 +262,7 @@ func (e *Etcd) NewClient() (*clientv3.Client, error) {
 	}
 	return clientv3.New(clientv3.Config{
 		Endpoints:   e.cfg.AdvertiseClientURLs,
-		DialTimeout: 5 * time.Second,
+		DialTimeout: 60 * time.Second,
 		TLS:         tlsConfig,
 		DialOptions: []grpc.DialOption{
 			grpc.WithBlock(),

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -14,12 +14,9 @@ func TestNewEtcd(t *testing.T) {
 	e, cleanup := NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	assert.NoError(t, err)
-	kv := client.KV
-	assert.NotNil(t, kv)
+	client := e.NewEmbeddedClient()
 
-	putsResp, err := kv.Put(context.Background(), "key", "value")
+	putsResp, err := client.Put(context.Background(), "key", "value")
 	assert.NoError(t, err)
 	assert.NotNil(t, putsResp)
 
@@ -27,7 +24,7 @@ func TestNewEtcd(t *testing.T) {
 		assert.FailNow(t, "got nil put response from etcd")
 	}
 
-	getResp, err := kv.Get(context.Background(), "key")
+	getResp, err := client.Get(context.Background(), "key")
 	assert.NoError(t, err)
 	assert.NotNil(t, getResp)
 

--- a/backend/etcd/sequence_test.go
+++ b/backend/etcd/sequence_test.go
@@ -25,10 +25,7 @@ func TestSequence(t *testing.T) {
 	e, cleanup := NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -65,10 +62,7 @@ func TestSequences(t *testing.T) {
 	e, cleanup := NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 
 	got, err := Sequences(context.TODO(), client, "/sensu.io/foobars/seq", 5)
 	if err != nil {

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -29,10 +29,7 @@ func TestEventdMonitor(t *testing.T) {
 	ed, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := ed.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := ed.NewEmbeddedClient()
 
 	livenessFactory := liveness.EtcdFactory(context.Background(), client)
 

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -22,10 +22,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 
 	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
 	require.NoError(t, err)

--- a/backend/liveness/liveness_test.go
+++ b/backend/liveness/liveness_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 )
 
 var logger = logrus.New()
@@ -24,8 +23,7 @@ func TestSwitchSet(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -88,8 +86,7 @@ func TestDead(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -139,8 +136,7 @@ func TestBury(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -177,8 +173,7 @@ func TestBuryOnCallback(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -18,13 +18,12 @@ func TestEnqueue(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testenq", client, backendID)
-	err = queue.Enqueue(context.Background(), "test item")
+	err := queue.Enqueue(context.Background(), "test item")
 	assert.NoError(t, err)
 }
 
@@ -33,13 +32,12 @@ func TestDequeueSingleItem(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testdeq", client, backendID)
-	err = queue.Enqueue(context.Background(), "test single item dequeue")
+	err := queue.Enqueue(context.Background(), "test single item dequeue")
 	require.NoError(t, err)
 
 	item, err := queue.Dequeue(context.Background())
@@ -60,9 +58,8 @@ func TestDequeueFIFO(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testfifo", client, backendID)
@@ -88,13 +85,12 @@ func TestNack(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testnack", client, backendID)
-	err = queue.Enqueue(context.Background(), "test item")
+	err := queue.Enqueue(context.Background(), "test item")
 	require.NoError(t, err)
 
 	item, err := queue.Dequeue(context.Background())
@@ -114,13 +110,12 @@ func TestAck(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testack", client, backendID)
-	err = queue.Enqueue(context.Background(), "test item")
+	err := queue.Enqueue(context.Background(), "test item")
 	require.NoError(t, err)
 
 	item, err := queue.Dequeue(context.Background())
@@ -141,14 +136,13 @@ func TestOnce(t *testing.T) {
 
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testonce", client, backendID)
 
-	err = queue.Enqueue(context.Background(), "test item")
+	err := queue.Enqueue(context.Background(), "test item")
 	require.NoError(t, err)
 
 	item, err := queue.Dequeue(context.Background())
@@ -170,8 +164,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	backendID1 := etcd.NewBackendIDGetter(context.TODO(), client)
@@ -202,9 +195,8 @@ func TestDequeueParallel(t *testing.T) {
 	t.Parallel()
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
-	client, err := e.NewClient()
+	client := e.NewEmbeddedClient()
 	defer client.Close()
-	require.NoError(t, err)
 	backendID := etcd.NewBackendIDGetter(context.TODO(), client)
 	queue := New("testparallel", client, backendID)
 	items := map[string]struct{}{

--- a/backend/ringv2/pool_test.go
+++ b/backend/ringv2/pool_test.go
@@ -15,10 +15,7 @@ func TestPool(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	pool := NewPool(client)

--- a/backend/ringv2/ringv2_test.go
+++ b/backend/ringv2/ringv2_test.go
@@ -23,10 +23,7 @@ func TestAdd(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -45,10 +42,7 @@ func TestRemove(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -71,10 +65,7 @@ func TestWatchAddRemove(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -127,10 +118,7 @@ func TestWatchTrigger(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -164,10 +152,7 @@ func TestRingOrdering(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -215,10 +200,7 @@ func TestConcurrentRingOrdering(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -307,10 +289,7 @@ func eventTest(t *testing.T, want []Event) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -371,10 +350,7 @@ func TestWatchAfterAdd(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -402,10 +378,7 @@ func GetSetInterval(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())
@@ -439,10 +412,7 @@ func TestMultipleItems(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	ring := New(client, t.Name())

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -29,10 +29,7 @@ func TestEntityCacheIntegration(t *testing.T) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 
 	store := store.NewStore(client, e.Name())
 

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -21,8 +21,7 @@ func testWithEtcd(t *testing.T, f func(store.Store)) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 
 	s := NewStore(client, e.Name())
 
@@ -36,8 +35,7 @@ func testWithEtcdStore(t *testing.T, f func(*Store)) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 
 	s := NewStore(client, e.Name())
 
@@ -51,8 +49,7 @@ func testWithEtcdClient(t *testing.T, f func(store.Store, *clientv3.Client)) {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	require.NoError(t, err)
+	client := e.NewEmbeddedClient()
 
 	s := NewStore(client, e.Name())
 

--- a/backend/store/etcd/testutil/store.go
+++ b/backend/store/etcd/testutil/store.go
@@ -55,12 +55,7 @@ func NewStoreInstance() (*IntegrationTestStore, error) {
 		return nil, err
 	}
 
-	client, err := e.NewClient()
-	if err != nil {
-		_ = e.Shutdown()
-		removeTmp()
-		return nil, err
-	}
+	client := e.NewEmbeddedClient()
 
 	st := etcdstore.NewStore(client, e.Name())
 

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -30,10 +30,7 @@ func newTessendTest(t *testing.T) *Tessend {
 	e, cleanup := etcd.NewTestEtcd(t)
 	defer cleanup()
 
-	client, err := e.NewClient()
-	if err != nil {
-		t.Fatal(err)
-	}
+	client := e.NewEmbeddedClient()
 	defer client.Close()
 
 	s := &mockstore.MockStore{}


### PR DESCRIPTION
## What is this change?

It seems that in some circumstances, the etcd embedded client can
cause nil panics. For instance, when the embedded etcd is shut
down, the client cannot be safely used anymore.

Since this is an unacceptable state of affairs, we will revert to
using the gRPC client, which seems to be much more reliable.

## Why is this change necessary?

Closes #3550
Closes #3571

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

We created a build of sensu-go that restarts internally every couple of seconds. In a clustered configuration, this was leading to nil panics quite frequently.

When we moved from the etcd embedded client to the etcd grpc client, the crashes stopped occurring.

## Is this change a patch?

Yes