### PR TITLE
Update store to marshal wrapped resources on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 created via `sensuctl create`.
 - Added `created_by` to object metadata and populate that field via the HTTP API.
 
+### Changed
+- Updated the store so that it may _create_ wrapped resources.
+
 ### Fixed
 - Check history is now in FIFO order, not ordered by executed timestamp.
 - Fixed bug where flapping would incorrectly end when `total_state_change` was

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -71,7 +71,7 @@ func TestCreate(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Creating a wrapped resource should work
-		err = Create(ctx, s.client, "/default/foo", "default", types.Wrapper{Value: obj})
+		err = Create(ctx, s.client, "/default/bar", "default", types.Wrapper{Value: obj})
 		assert.NoError(t, err)
 
 		// Creating this same key should return an error that it already exist

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -70,6 +70,10 @@ func TestCreate(t *testing.T) {
 		err := Create(ctx, s.client, "/default/foo", "default", obj)
 		assert.NoError(t, err)
 
+		// Creating a wrapped resource should work
+		err = Create(ctx, s.client, "/default/foo", "default", types.Wrapper{Value: obj})
+		assert.NoError(t, err)
+
 		// Creating this same key should return an error that it already exist
 		err = Create(ctx, s.client, "/default/foo", "default", obj)
 		switch err := err.(type) {


### PR DESCRIPTION
## What is this change?

Updates the behaviour of the store's `Create` method to marshal Wrapped objects using the JSON. Matches the behaviour of the `CreateOrUpdate` method.

## Why is this change necessary?

Required for sensu/sensu-enterprise-go#870

## Does your change need a Changelog entry?

Why not.

## Do you need clarification on anything?


Chesterton's fence. If there was a good reason the method did not have the same behaviour I couldn't find it.

## How did you verify this change?

Integration & manual.
