### PR TITLE
[GraphQL] Deprecate putWrapped mutation

### DIFF
--- a/backend/apid/graphql/schema/mutations.gql.go
+++ b/backend/apid/graphql/schema/mutations.gql.go
@@ -730,7 +730,7 @@ func _ObjectTypeMutationConfigFn() graphql1.ObjectConfig {
 						Type:         graphql1.Boolean,
 					},
 				},
-				DeprecationReason: "",
+				DeprecationReason: "No longer supported and will be removed in a future release.",
 				Description:       "Create or overrwrite resource from given wrapped resource.",
 				Name:              "putWrapped",
 				Type:              graphql1.NewNonNull(graphql.OutputType("PutWrappedPayload")),

--- a/backend/apid/graphql/schema/mutations.graphql
+++ b/backend/apid/graphql/schema/mutations.graphql
@@ -17,7 +17,7 @@ type Mutation {
     resource instead.
     """
     upsert: Boolean = true,
-  ): PutWrappedPayload!
+  ): PutWrappedPayload! @deprecated(reason: "No longer supported and will be removed in a future release.")
 
   #
   # Checks


### PR DESCRIPTION
The `putWrapped` mutation is unused by the open-source web application and when used in the commercial release can lead to failures.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
