### PR TITLE
Change struct alignment to support 32-bit systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ manager cannot be obtained, and returns instead an error after 60 seconds.
   below `high_flap_threshold` instead of below `low_flap_threshold`.
 - Stopped using the etcd embedded client, which seems to trigger nil pointer
 panics when used against an etcd that is shutting down.
+- 64-bit align the `Resource` struct in the store cache to fix a crash on
+32-bit systems.
 
 ## [5.18.0] - 2020-02-24
 

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -88,7 +88,10 @@ type cacheWatcher struct {
 // Resource is a cache of resources. The cache uses a watcher on a certain
 // type of resources in order to keep itself up to date. Cache resources can be
 // efficiently retrieved from the cache by namespace.
+// `sync/atomic` expects the first word in an allocated struct to be 64-bit
+// aligned on both ARM and x86-32. See https://goo.gl/zW7dgq for more details.
 type Resource struct {
+	count      int64
 	watcher    <-chan store.WatchEventResource
 	cache      cache
 	cacheMu    sync.Mutex
@@ -97,7 +100,6 @@ type Resource struct {
 	synthesize bool
 	resourceT  corev2.Resource
 	client     *clientv3.Client
-	count      int64
 }
 
 // getResources retrieves the resources from the store


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Changes the cache Resource struct to be 64-bit aligned.

## Why is this change necessary?

This is necessary to support 32-bit systems.

Fixes https://github.com/sensu/sensu-go/issues/3546.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required.

## How did you verify this change?

Tested that the backend no longer crashes on `linux/armv7`.

## Is this change a patch?

Yes.