### PR TITLE
Add logic for created by to wrapper

### DIFF
--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -153,6 +153,9 @@ func (w *Wrapper) UnmarshalJSON(b []byte) error {
 	if outerMeta.Name != "" {
 		innerMeta.Name = outerMeta.Name
 	}
+	if outerMeta.CreatedBy != "" {
+		innerMeta.CreatedBy = outerMeta.CreatedBy
+	}
 	for k, v := range outerMeta.Labels {
 		if innerMeta.Labels == nil {
 			innerMeta.Labels = make(map[string]string)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds some logic for `created_by` in inner/outer object meta (required for wrapped enterprise resources).

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/893 and https://github.com/sensu/sensu-enterprise-go/pull/895.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

This was the complication for https://github.com/sensu/sensu-enterprise-go/issues/893.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Tested against enterprise branch. PR incoming.

## Is this change a patch?

Nope, part of feature work in master.