### PR TITLE
Fix a bug that caused sensu-backend to restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - sensu-backend no longers hang indefinitely if a file lock for the asset
 manager cannot be obtained, and returns instead an error after 60 seconds.
-- Check history is now in FIFO order, not ordered by executed timestamp.
-- Fixed bug where flapping would incorrectly end when `total_state_change` was
-  below `high_flap_threshold` instead of below `low_flap_threshold`.
 - Stopped using the etcd embedded client, which seems to trigger nil pointer
 panics when used against an etcd that is shutting down.
 - 64-bit align the `Resource` struct in the store cache to fix a crash on
 32-bit systems.
+- Fixed a bug where sensu-backend would restart when agents disconnect.
 
 ## [5.18.0] - 2020-02-24
 

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -136,7 +136,9 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 				// No ClusterRoleBindings founds, let's continue with the RoleBindings
 				logger.WithError(err).Debug("no bindings found")
 			default:
-				logger.WithError(err).Warning("could not retrieve the ClusterRoleBindings or RoleBindings")
+				if ctx.Err() == nil {
+					logger.WithError(err).Warning("could not retrieve the ClusterRoleBindings or RoleBindings")
+				}
 				visitErr = err
 				return false
 			}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -234,8 +234,8 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store:                   stor,
-		Bus:                     bus,
+		Store: stor,
+		Bus:   bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
 		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
@@ -309,14 +309,14 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:                   bus,
-		Store:                 stor,
-		EventStore:            stor,
-		LivenessFactory:       liveness.EtcdFactory(b.runCtx, b.Client),
-		RingPool:              ringPool,
-		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
-		StoreTimeout:          2 * time.Minute,
+		Bus:             bus,
+		Store:           stor,
+		EventStore:      stor,
+		LivenessFactory: liveness.EtcdFactory(b.runCtx, b.Client),
+		RingPool:        ringPool,
+		BufferSize:      viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:     viper.GetInt(FlagKeepalivedWorkers),
+		StoreTimeout:    2 * time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)
@@ -505,6 +505,8 @@ func (b *Backend) runOnce() error {
 	if derr == nil {
 		derr = b.runCtx.Err()
 	}
+
+	_ = b.Client.Close()
 
 	return derr
 }


### PR DESCRIPTION
## What is this change?

```
    This commit fixes a bug that caused sensu-backend to restart
    whenever an agent terminates its connection. The bug was
    introduced in 572b4b5facc4a4f7b310dcf0eb34ef711e9583e5, but went
    unnoticed for the most part, due to the use of the embedded etcd
    client, which appears to have different cancellation semantics than
    the gRPC client.
    
    Now that the gRPC client has been put back into place, this error
    was exposed and made reproducible.
    
    The nature of the error is that when RBAC authorization returned
    an error, agentd would propagate the error back to its supervisor
    in all cases, leading to an internal backend restart.
    
    When a session's context is canceled, whether due to its client
    disconnecting or otherwise, agentd should not propagate any
    errors back to the backend supervisor.
```

## Why is this change necessary?

Closes #3571 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

Changelog had to be corrected.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs changes required.

## How did you verify this change?

Manual testing between backend and agent.

## Is this change a patch?

Yes