### PR TITLE
Bonsai client should log out to debug instead of info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ created via `sensuctl create`.
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.
+- Bonsai client now logs at debug level instead of info level.
 
 ## [5.18.1] - 2020-03-10
 

--- a/bonsai/asset.go
+++ b/bonsai/asset.go
@@ -14,7 +14,7 @@ func (c *RestClient) FetchAsset(namespace, name string) (*Asset, error) {
 		return nil, err
 	}
 
-	logger.WithField("request", req.URL.String()).Info("sending request to bonsai")
+	logger.WithField("request", req.URL.String()).Debug("sending request to bonsai")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -42,7 +42,7 @@ func (c *RestClient) FetchAssetVersion(namespace, name, version string) (string,
 		return "", err
 	}
 
-	logger.WithField("request", req.URL.String()).Info("sending request to bonsai")
+	logger.WithField("request", req.URL.String()).Debug("sending request to bonsai")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Sets the log level to debug for log messages in the Bonsai client.

## Why is this change necessary?

Fixes #3605 

## Does your change need a Changelog entry?

Yes.

## How did you verify this change?

Tested against my local cluster.

## Is this change a patch?

No.