### PR TITLE
Don't service dashboard requests from API clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ created via `sensuctl create`.
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.
 - Bonsai client now logs at debug level instead of info level.
+- The dashboard service now returns an error if the client User-Agent is curl
+or sensuctl. This should prevent users from using the dashboard port by
+mistake.
 
 ## [5.18.1] - 2020-03-10
 

--- a/cli/client/authentication.go
+++ b/cli/client/authentication.go
@@ -22,11 +22,8 @@ func (client *RestClient) CreateAccessToken(url, userid, password string) (*core
 		return nil, err
 	}
 
-	if res.StatusCode() == 401 {
+	if res.StatusCode() >= 400 {
 		return nil, errors.New(string(res.Body()))
-	} else if res.StatusCode() >= 400 {
-		// TODO: (JK) we may want to expose a bit more of the error here
-		return nil, errors.New("received an unexpected response from the API")
 	}
 
 	tokens := &corev2.Tokens{}

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,6 +51,8 @@ func New(config config.Config) *RestClient {
 
 	// Check that Access-Token has not expired
 	restyInst.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
+		c.SetHeader("User-Agent", "sensuctl/"+version.Semver())
+
 		// Guard against requests that are not sending auth details
 		if c.Token == "" || r.UserInfo != nil {
 			return nil


### PR DESCRIPTION
## What is this change?

This commit changes the dashboard service to write a status of 400
and an error message explaining that the user should not try to
connect to it with an API client.

For the purpose of this change, it is assumed that for the most
part, API clients will either be sensuctl or curl.

This should lead to less confusion, as users are prone to
connecting to the dashboard port with sensuctl or curl, and tend to
get confused when the service produces different results than what
is documented for the apid service running on a different port.

## Why is this change necessary?

Several users have tried in error to connect to the dashboard port with an API client, which tends to partially work. This produces confusion.

See #3498

Closes #3279 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

I tested that the web UI still works, and that sensuctl will now display an error when a user tries to connect to the dashboard port with it.

Additionally, I tested that sensu-enterprise-go works as expected.

## Is this change a patch?

No