### PR TITLE
Disallow agent connect on inexistent namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ created via `sensuctl create`.
 or sensuctl. This should prevent users from using the dashboard port by
 mistake.
 
+### Fixed
+- Fixed a bug where the agent could connect to a backend using a namespace that
+doesn't exist.
+
 ## [5.18.1] - 2020-03-10
 
 ### Fixed

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -98,11 +98,6 @@ type SessionConfig struct {
 // The Session is responsible for stopping itself, and does so when it
 // encounters a receive error.
 func NewSession(ctx context.Context, cfg SessionConfig, conn transport.Transport, bus messaging.MessageBus, store store.Store, unmarshal UnmarshalFunc, marshal MarshalFunc) (*Session, error) {
-	// Validate the agent namespace
-	if _, err := store.GetNamespace(ctx, cfg.Namespace); err != nil {
-		return nil, err
-	}
-
 	logger.WithFields(logrus.Fields{
 		"addr":          cfg.AgentAddr,
 		"namespace":     cfg.Namespace,

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -3,7 +3,6 @@ package agentd
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -106,35 +105,6 @@ func TestGoodSessionConfigProto(t *testing.T) {
 	session, err := NewSession(context.Background(), cfg, conn, bus, st, proto.Unmarshal, proto.Marshal)
 	assert.NotNil(t, session)
 	assert.NoError(t, err)
-}
-
-func TestBadSessionConfig(t *testing.T) {
-	conn := &testTransport{
-		sendCh: make(chan *transport.Message, 10),
-	}
-
-	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
-	require.NoError(t, err)
-	require.NoError(t, bus.Start())
-
-	st := &mockstore.MockStore{}
-	st.On(
-		"UpdateEntity",
-		mock.Anything,
-		mock.Anything,
-	).Return(nil)
-	st.On(
-		"GetNamespace",
-		mock.Anything,
-		mock.AnythingOfType("string"),
-	).Return(&corev2.Namespace{}, fmt.Errorf("error"))
-
-	cfg := SessionConfig{
-		Subscriptions: []string{"testing"},
-	}
-	session, err := NewSession(context.Background(), cfg, conn, bus, st, UnmarshalJSON, MarshalJSON)
-	assert.Nil(t, session)
-	assert.Error(t, err)
 }
 
 func TestSessionTerminateOnSendError(t *testing.T) {


### PR DESCRIPTION
## What is this change?

This commit causes sensu-backend to reject websocket upgrade
requests from agents that try to connect to a namespace that does
not exist.

## Why is this change necessary?

Closes #1028 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes not required.

## How did you verify this change?

Manual testing.

## Is this change a patch?

The agent<->backend semantics are subtly different now, so this is not a patch-level change.