### PR TITLE
checking subscriptions to ensure that they do not have empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ created via `sensuctl create`.
 or sensuctl. This should prevent users from using the dashboard port by
 mistake.
 
+## Fixed
+ - Subscriptions cannot have empty strings in them (#2932)
+
 ## [5.18.1] - 2020-03-10
 
 ### Fixed

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -179,6 +179,12 @@ func (c *Check) Validate() error {
 		}
 	}
 
+	for _, subscription := range c.Subscriptions {
+		if subscription == "" {
+			return fmt.Errorf("subscriptions cannot be empty strings")
+		}
+	}
+
 	// The entity can be empty but can't contain invalid characters (only
 	// alphanumeric string)
 	if c.ProxyEntityName != "" {

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -116,6 +116,12 @@ func (c *CheckConfig) Validate() error {
 		}
 	}
 
+	for _, subscription := range c.Subscriptions {
+		if subscription == "" {
+			return fmt.Errorf("subscriptions cannot be empty strings")
+		}
+	}
+
 	// The entity can be empty but can't contain invalid characters (only
 	// alphanumeric string)
 	if c.ProxyEntityName != "" {

--- a/api/core/v2/check_config_test.go
+++ b/api/core/v2/check_config_test.go
@@ -58,6 +58,27 @@ func TestCheckConfigHasNonNilHandlers(t *testing.T) {
 	require.NotNil(t, c.Handlers)
 }
 
+func TestCheckConfigHasNoEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = append(c.Subscriptions, "demo", "foo")
+	assert.NoError(t, c.Validate())
+}
+
+func TestCheckConfigErrIfHasEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = append(c.Subscriptions, "")
+
+	assert.Error(t, c.Validate())
+}
+
+func TestCheckConfigErrMsgIfHasEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheckConfig("foo")
+	c.Subscriptions = append(c.Subscriptions, "")
+
+	err := c.Validate()
+	assert.EqualError(t, err,  "subscriptions cannot be empty strings")
+}
+
 func TestCheckConfigFlapThresholdValidation(t *testing.T) {
 	c := FixtureCheckConfig("foo")
 	// zero-valued flap threshold is valid

--- a/api/core/v2/check_test.go
+++ b/api/core/v2/check_test.go
@@ -68,6 +68,27 @@ func TestMergeWith(t *testing.T) {
 	assert.False(t, newCheck.History[20].Flapping)
 }
 
+func TestCheckHasNoEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheck("foo")
+	c.Subscriptions = append(c.Subscriptions, "demo", "foo")
+	assert.NoError(t, c.Validate())
+}
+
+func TestCheckErrIfHasEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheck("foo")
+	c.Subscriptions = append(c.Subscriptions, "")
+
+	assert.Error(t, c.Validate())
+}
+
+func TestCheckErrMsgIfHasEmptyStringsInSub(t *testing.T) {
+	c := FixtureCheck("foo")
+	c.Subscriptions = append(c.Subscriptions, "")
+
+	err := c.Validate()
+	assert.EqualError(t, err,  "subscriptions cannot be empty strings")
+}
+
 func TestMergeWithFlappingEvent(t *testing.T) {
 	originalCheck := FixtureCheck("check")
 	originalCheck.Status = 1


### PR DESCRIPTION
## What is this change?

Subscriptions cannot have empty strings in them.

cc: @echlebek - let's try this again.

fixes #2932 

## Why is this change necessary?
It ensures that subscription elements are sane


## Does your change need a Changelog entry?

Yeah.

## Do you need clarification on anything?
N/A


## Were there any complications while making this change?
N/A

## Have you reviewed and updated the documentation for this change? Is new documentation required?
N/A

## How did you verify this change?
I added tests to ensure that it functions as planned.  

## Is this change a patch?
Nope.