### PR TITLE
Added a generic client POST function that can pass query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ created via `sensuctl create`.
 - Added agent discovery of libc type, VM system/role, and cloud provider.
 - Added `float_type` field to system type to store which float type (softfloat,
   hardfloat) a system is using.
+- Added a generic client POST function that can pass query params.
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -122,6 +123,20 @@ func (client *RestClient) List(path string, objs interface{}, options *ListOptio
 // Post sends a POST request with obj as the payload to the given path
 func (client *RestClient) Post(path string, obj interface{}) error {
 	res, err := client.R().SetBody(obj).Post(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}
+
+// PostWithParams sends a POST request with obj as the payload to the given path with query params
+func (client *RestClient) PostWithParams(path string, obj interface{}, params url.Values) error {
+	res, err := client.R().SetBody(obj).SetQueryParamsFromValues(params).Post(path)
 	if err != nil {
 		return err
 	}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/coreos/etcd/clientv3"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -67,6 +68,8 @@ type GenericClient interface {
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
 	Put(path string, obj interface{}) error
+	// PostWithParams sends a POST request with obj as the payload to the given path with query params
+	PostWithParams(path string, obj interface{}, params url.Values) error
 
 	// PutResource puts a resource according to its URIPath.
 	PutResource(types.Wrapper) error

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
@@ -28,6 +29,12 @@ func (c *MockClient) List(path string, objs interface{}, options *client.ListOpt
 // Post ...
 func (c *MockClient) Post(path string, obj interface{}) error {
 	args := c.Called(path, obj)
+	return args.Error(0)
+}
+
+// PostWithParams ...
+func (c *MockClient) PostWithParams(path string, obj interface{}, params url.Values) error {
+	args := c.Called(path, obj, params)
 	return args.Error(0)
 }
 

--- a/cli/commands/root/root.go
+++ b/cli/commands/root/root.go
@@ -31,7 +31,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().Bool("insecure-skip-tls-verify", false, "skip TLS certificate verification (not recommended!)")
 	cmd.PersistentFlags().String("config-dir", path.UserConfigDir("sensuctl"), "path to directory containing configuration files")
 	cmd.PersistentFlags().String("cache-dir", path.UserCacheDir("sensuctl"), "path to directory containing cache & temporary files")
-	cmd.PersistentFlags().String("namespace", config.DefaultNamespace, "namespace in which we perform actions")
+	cmd.PersistentFlags().String("namespace", config.DefaultNamespace, "namespace in which we perform actions, it is a fallback value and will be ignored by cluster-wide resources")
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a generic client POST function that can pass query params, `PostWithParams`. I decided to add a new function to be used for commercial `sensuctl prune` functionality rather than refactoring all calls that use the original `Post` function.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/879.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Internal change, no docs change necessary.

## How did you verify this change?

Tested against branch for https://github.com/sensu/sensu-enterprise-go/issues/879.

## Is this change a patch?

Nope, required for feature work.