### PR TITLE
Allow resty backend timeout to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added ability to make the Resty HTTP Timeout configurable.
 
 ### Added
 - Added `flapping` field to check history, along with `is_flapping_start` and

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -40,7 +40,7 @@ func New(config config.Config) *RestClient {
 	client := &RestClient{resty: restyInst, config: config}
 
 	// set http client timeout
-	restyInst.SetTimeout(15 * time.Second)
+	restyInst.SetTimeout(config.Timeout())
 
 	// Standardize redirect policy
 	restyInst.SetRedirectPolicy(resty.FlexibleRedirectPolicy(10))

--- a/cli/client/config/basic/basic.go
+++ b/cli/client/config/basic/basic.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/types"
@@ -34,6 +35,7 @@ type Cluster struct {
 	TrustedCAFile         string `json:"trusted-ca-file"`
 	InsecureSkipTLSVerify bool   `json:"insecure-skip-tls-verify"`
 	*types.Tokens
+	Timeout time.Duration `json:"timeout"`
 }
 
 // Profile contains the active configuration
@@ -109,6 +111,16 @@ func (c *Config) flags(flags *pflag.FlagSet) {
 
 	if value, err := flags.GetString("trusted-ca-file"); err == nil && value != "" {
 		c.Cluster.TrustedCAFile = value
+	}
+
+	if value, err := flags.GetString("timeout"); err == nil && value != "" {
+		duration, err := time.ParseDuration(value)
+		if err == nil {
+			c.Cluster.Timeout = duration
+		} else {
+			// Default to timeout of 15 seconds
+			c.Cluster.Timeout = 15 * time.Second
+		}
 	}
 }
 

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -1,6 +1,8 @@
 package basic
 
 import (
+	"time"
+
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/types"
 )
@@ -29,6 +31,14 @@ func (c *Config) Namespace() string {
 		return config.DefaultNamespace
 	}
 	return c.Profile.Namespace
+}
+
+// Timeout returns the configured timeout
+func (c *Config) Timeout() time.Duration {
+	if c.Cluster.Timeout == 0*time.Second {
+		return config.DefaultTimeout
+	}
+	return c.Cluster.Timeout
 }
 
 // Tokens returns the active cluster JWT

--- a/cli/client/config/basic/reader_test.go
+++ b/cli/client/config/basic/reader_test.go
@@ -2,6 +2,7 @@ package basic
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/types"
@@ -31,6 +32,16 @@ func TestNamespace(t *testing.T) {
 func TestNamespaceDefault(t *testing.T) {
 	conf := &Config{}
 	assert.Equal(t, config.DefaultNamespace, conf.Namespace())
+}
+
+func TestTimeout(t *testing.T) {
+	conf := &Config{Cluster: Cluster{Timeout: 30 * time.Second}}
+	assert.Equal(t, conf.Cluster.Timeout, conf.Timeout())
+}
+
+func TestTimeoutDefault(t *testing.T) {
+	conf := &Config{}
+	assert.Equal(t, config.DefaultTimeout, conf.Timeout())
 }
 
 func TestTokens(t *testing.T) {

--- a/cli/client/config/basic/writer.go
+++ b/cli/client/config/basic/writer.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/sensu/sensu-go/types"
 )
@@ -35,6 +36,13 @@ func (c *Config) SaveNamespace(namespace string) error {
 	c.Profile.Namespace = namespace
 
 	return write(c.Profile, filepath.Join(c.path, profileFilename))
+}
+
+// SaveTimeout saves the user's timeout to a configuration file
+func (c *Config) SaveTimeout(timeout time.Duration) error {
+	c.Cluster.Timeout = timeout
+
+	return write(c.Cluster, filepath.Join(c.path, clusterFilename))
 }
 
 // SaveTokens saves the JWT into a configuration file

--- a/cli/client/config/basic/writer_test.go
+++ b/cli/client/config/basic/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/pflag"
@@ -73,6 +74,21 @@ func TestSaveNamespace(t *testing.T) {
 	namespace := "json"
 	require.NoError(t, config.SaveNamespace(namespace))
 	assert.Equal(t, namespace, config.Namespace())
+}
+
+func TestSaveTimeout(t *testing.T) {
+	dir, cleanup := tmpDir(t)
+	defer cleanup()
+
+	// Set flags
+	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
+	flags.String("config-dir", dir, "")
+
+	config := Load(flags)
+
+	timeout := 30 * time.Second
+	require.NoError(t, config.SaveTimeout(timeout))
+	assert.Equal(t, timeout, config.Timeout())
 }
 
 func TestSaveTokens(t *testing.T) {

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -10,6 +12,9 @@ const (
 
 	// DefaultFormat is the default format output for printers.
 	DefaultFormat = FormatTabular
+
+	// DefaultTimeout is the default timeout
+	DefaultTimeout = 15 * time.Second
 
 	// FormatTabular indicates tabular format for printers.
 	FormatTabular = "tabular"
@@ -38,6 +43,7 @@ type Read interface {
 	InsecureSkipTLSVerify() bool
 	Namespace() string
 	Tokens() *types.Tokens
+	Timeout() time.Duration
 	TrustedCAFile() string
 }
 
@@ -49,4 +55,5 @@ type Write interface {
 	SaveNamespace(string) error
 	SaveTokens(*types.Tokens) error
 	SaveTrustedCAFile(string) error
+	SaveTimeout(time.Duration) error
 }

--- a/cli/client/config/inmemory/inmemory.go
+++ b/cli/client/config/inmemory/inmemory.go
@@ -1,6 +1,8 @@
 package inmemory
 
 import (
+	"time"
+
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/types"
 )
@@ -10,6 +12,7 @@ type Config struct {
 	url       string
 	format    string
 	namespace string
+	timeout   time.Duration
 	tokens    *types.Tokens
 }
 
@@ -39,6 +42,11 @@ func (c *Config) Namespace() string {
 	return c.namespace
 }
 
+// Timeout describes the timeout for communicating with the backend
+func (c *Config) Timeout() time.Duration {
+	return c.timeout
+}
+
 // Tokens describes the authorization tokens used to make requests
 func (c *Config) Tokens() *types.Tokens {
 	return c.tokens
@@ -59,6 +67,12 @@ func (c *Config) SaveFormat(val string) error {
 // SaveNamespace updates the current value
 func (c *Config) SaveNamespace(val string) error {
 	c.namespace = val
+	return nil
+}
+
+// SaveTimeout updates the current timeout value
+func (c *Config) SaveTimeout(val time.Duration) error {
+	c.timeout = val
 	return nil
 }
 

--- a/cli/client/config/mock.go
+++ b/cli/client/config/mock.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 
 	"github.com/stretchr/testify/mock"
@@ -38,6 +40,14 @@ func (m *MockConfig) Namespace() string {
 	return args.String(0)
 }
 
+// Timeout mocks the timeout config
+func (m *MockConfig) Timeout() time.Duration {
+	args := m.Called()
+	timeoutString := args.String(0)
+	d, _ := time.ParseDuration(timeoutString)
+	return d
+}
+
 // TrustedCAFile mocks the trusted CA file config
 func (m *MockConfig) TrustedCAFile() string {
 	args := m.Called()
@@ -65,6 +75,12 @@ func (m *MockConfig) SaveInsecureSkipTLSVerify(verify bool) error {
 // SaveNamespace mocks saving the namespace
 func (m *MockConfig) SaveNamespace(namespace string) error {
 	args := m.Called(namespace)
+	return args.Error(0)
+}
+
+// SaveTimeout mocks saving the timeout
+func (m *MockConfig) SaveTimeout(timeout time.Duration) error {
+	args := m.Called(timeout)
 	return args.Error(0)
 }
 

--- a/cli/client/config/mock.go
+++ b/cli/client/config/mock.go
@@ -43,9 +43,7 @@ func (m *MockConfig) Namespace() string {
 // Timeout mocks the timeout config
 func (m *MockConfig) Timeout() time.Duration {
 	args := m.Called()
-	timeoutString := args.String(0)
-	d, _ := time.ParseDuration(timeoutString)
-	return d
+	return args.Get(0).(time.Duration)
 }
 
 // TrustedCAFile mocks the trusted CA file config

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"time"
+
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/mock"
 )
@@ -43,6 +45,14 @@ func (m *MockConfig) TrustedCAFile() string {
 	return args.String(0)
 }
 
+// Timeout mocks the timeout config
+func (m *MockConfig) Timeout() time.Duration {
+	args := m.Called()
+	timeoutString := args.String(0)
+	d, _ := time.ParseDuration(timeoutString)
+	return d
+}
+
 // SaveAPIUrl mocks saving the API URL
 func (m *MockConfig) SaveAPIUrl(url string) error {
 	args := m.Called(url)
@@ -64,6 +74,12 @@ func (m *MockConfig) SaveInsecureSkipTLSVerify(verify bool) error {
 // SaveNamespace mocks saving the namespace
 func (m *MockConfig) SaveNamespace(namespace string) error {
 	args := m.Called(namespace)
+	return args.Error(0)
+}
+
+// SaveTimeout mocks saving the timeout
+func (m *MockConfig) SaveTimeout(timeout time.Duration) error {
+	args := m.Called(timeout)
 	return args.Error(0)
 }
 

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -48,9 +48,7 @@ func (m *MockConfig) TrustedCAFile() string {
 // Timeout mocks the timeout config
 func (m *MockConfig) Timeout() time.Duration {
 	args := m.Called()
-	timeoutString := args.String(0)
-	d, _ := time.ParseDuration(timeoutString)
-	return d
+	return args.Get(0).(time.Duration)
 }
 
 // SaveAPIUrl mocks saving the API URL

--- a/cli/commands/config/help.go
+++ b/cli/commands/config/help.go
@@ -16,6 +16,7 @@ func HelpCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd.AddCommand(
 		SetFormatCommand(cli),
 		SetNamespaceCommand(cli),
+		SetTimeoutCommand(cli),
 		ViewCommand(cli),
 	)
 

--- a/cli/commands/config/set_timeout.go
+++ b/cli/commands/config/set_timeout.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/hooks"
+	"github.com/spf13/cobra"
+)
+
+// SetTimeoutCommand given argument changes timeout for active profile
+func SetTimeoutCommand(cli *cli.SensuCli) *cobra.Command {
+	return &cobra.Command{
+		Use:          "set-timeout [TIMEOUT]",
+		Short:        "Set timeout for active profile in duration format (ex: 15s)",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			newTimeout := args[0]
+			newTimeoutDuration, err := time.ParseDuration(newTimeout)
+			if err != nil {
+				fmt.Fprintf(
+					cmd.OutOrStderr(),
+					"Unable to parse new timeout with error: %s\n",
+					err,
+				)
+				return err
+			}
+			if err := cli.Config.SaveTimeout(newTimeoutDuration); err != nil {
+				fmt.Fprintf(
+					cmd.OutOrStderr(),
+					"Unable to write new configuration file with error: %s\n",
+					err,
+				)
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "Updated")
+			return nil
+		},
+		Annotations: map[string]string{
+			// We want to be able to run this command regardless of whether the CLI
+			// has been configured.
+			hooks.ConfigurationRequirement: hooks.ConfigurationNotRequired,
+		},
+	}
+}

--- a/cli/commands/config/set_timeout_test.go
+++ b/cli/commands/config/set_timeout_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sensu/sensu-go/cli"
+	clienttest "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetTimeoutCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := &cli.SensuCli{}
+	cmd := SetTimeoutCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("set-timeout", cmd.Use)
+	assert.Regexp("Set timeout", cmd.Short)
+}
+
+func TestSetTimeoutBadsArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := &cli.SensuCli{}
+	cmd := SetTimeoutCommand(cli)
+
+	// No args...
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out, "output should display help usage")
+	assert.Error(err, "error should be returned")
+
+	// Too many args...
+	out, err = test.RunCmd(cmd, []string{"one", "two"})
+	assert.NotEmpty(out, "output should display help usage")
+	assert.Error(err, "error should be returned")
+}
+
+func TestSetTimeoutExec(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := SetTimeoutCommand(cli)
+
+	config := cli.Config.(*clienttest.MockConfig)
+	config.On("SaveTimeout", 15*time.Second).Return(nil)
+
+	out, err := test.RunCmd(cmd, []string{"15s"})
+	assert.Equal(out, "Updated\n")
+	assert.Nil(err, "Should not produce any errors")
+}
+
+func TestSetTimeoutWithWriteErr(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := SetTimeoutCommand(cli)
+
+	config := cli.Config.(*clienttest.MockConfig)
+	config.On("SaveTimeout", 15*time.Second).Return(errors.New("blah"))
+
+	out, err := test.RunCmd(cmd, []string{"15s"})
+	assert.Contains(out, "Unable to write")
+	assert.Nil(err, "Should not return an error")
+}

--- a/cli/commands/config/view.go
+++ b/cli/commands/config/view.go
@@ -28,6 +28,7 @@ func ViewCommand(cli *cli.SensuCli) *cobra.Command {
 				"api-url":        cli.Config.APIUrl(),
 				"namespace":      cli.Config.Namespace(),
 				"format":         cli.Config.Format(),
+				"timeout":        cli.Config.Timeout().String(),
 				"username":       helpers.GetCurrentUsername(cli.Config),
 				"jwt_expires_at": strconv.Itoa(int(cli.Config.Tokens().GetExpiresAt())),
 			}
@@ -69,6 +70,10 @@ func printToList(v interface{}, writer io.Writer) error {
 			{
 				Label: "Format",
 				Value: r["format"],
+			},
+			{
+				Label: "Timeout",
+				Value: r["timeout"],
 			},
 			{
 				Label: "Username",

--- a/cli/commands/config/view_test.go
+++ b/cli/commands/config/view_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	clienttest "github.com/sensu/sensu-go/cli/client/testing"
@@ -37,6 +38,7 @@ func TestViewExec(t *testing.T) {
 	config.On("Tokens").Return(
 		corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"),
 	)
+	config.On("Timeout").Return(time.Second * 15)
 
 	out, err := test.RunCmd(cmd, nil)
 	assert.Regexp("Active Configuration", out)

--- a/cli/commands/configure/configure_test.go
+++ b/cli/commands/configure/configure_test.go
@@ -3,6 +3,7 @@ package configure
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ func TestCommand(t *testing.T) {
 	mockConfig := cli.Config.(*client.MockConfig)
 	mockConfig.On("Format").Return(config.DefaultFormat)
 	mockConfig.On("APIUrl").Return("http://127.0.0.1:8080")
+	mockConfig.On("Timeout").Return(time.Second * 15)
 
 	cmd := Command(cli)
 
@@ -48,6 +50,7 @@ func TestCommandRunEClosureWithFlags(t *testing.T) {
 	mockConfig.On("SaveNamespace", mock.Anything).Return(nil)
 	mockConfig.On("SaveInsecureSkipTLSVerify", mock.Anything).Return(nil)
 	mockConfig.On("SaveTrustedCAFile", mock.Anything).Return(nil)
+	mockConfig.On("Timeout").Return(time.Second * 15)
 
 	// We need to call the "configure" command via the rootCmd so the global flags
 	// are set

--- a/cli/commands/root/root.go
+++ b/cli/commands/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"time"
+
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/commands/version"
@@ -32,6 +34,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().String("config-dir", path.UserConfigDir("sensuctl"), "path to directory containing configuration files")
 	cmd.PersistentFlags().String("cache-dir", path.UserCacheDir("sensuctl"), "path to directory containing cache & temporary files")
 	cmd.PersistentFlags().String("namespace", config.DefaultNamespace, "namespace in which we perform actions")
+	cmd.PersistentFlags().Duration("timeout", 15*time.Second, "timeout when communicating with sensu backend")
 
 	return cmd
 }


### PR DESCRIPTION
## What is this change?

Allow resty backend timeout to be configurable

## Why is this change necessary?

Closes #3635 

The timeout isn't configurable, as gets triggered on highly used installations.

## Does your change need a Changelog entry?

Yes, the changelog was updated in the "Unreleased" section

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation likely needs to be updated about this change.  Could someone point me to the right location?

## How did you verify this change?

Build sensuctl binary locally, and verified the setting was adjusted, and persisted in configuration file

## Is this change a patch?

No