### PR TITLE
Return proper HTTP status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- The proper HTTP status codes are returned for unauthenticated & permission
+denied errors in the REST API.
+
 ## [5.18.1] - 2020-03-10
 
 ### Fixed

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -96,7 +96,7 @@ func HTTPStatusFromCode(code actions.ErrCode) int {
 	case actions.PaymentRequired:
 		return http.StatusPaymentRequired
 	case actions.PermissionDenied:
-		return http.StatusForbidden
+		return http.StatusNotFound
 	case actions.Unauthenticated:
 		return http.StatusUnauthorized
 	}

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -95,6 +95,10 @@ func HTTPStatusFromCode(code actions.ErrCode) int {
 		return http.StatusConflict
 	case actions.PaymentRequired:
 		return http.StatusPaymentRequired
+	case actions.PermissionDenied:
+		return http.StatusForbidden
+	case actions.Unauthenticated:
+		return http.StatusUnauthorized
 	}
 
 	logger.WithField("code", code).Error("unknown error code")


### PR DESCRIPTION
## What is this change?

It fixes a bug where controllers that return either `actions.PermissionDenied` or `actions.Unauthenticated` would actually respond with an internal server error (500).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3634

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified

## Is this change a patch?

Yep