### PR TITLE
Additional Tessen resource metrics can now be registered at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ created via `sensuctl create`.
 - Added agent discovery of libc type, VM system/role, and cloud provider.
 - Added `float_type` field to system type to store which float type (softfloat,
   hardfloat) a system is using.
+- Additional Tessen resource metrics can now be registered at runtime.
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It allows tessen resource metrics to be registered at runtime. This is essential for adding count for commercial resources.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/902 & https://github.com/sensu/sensu-enterprise-go/issues/903

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested this commit on sensu-enterprise-go.

## Is this change a patch?

Nope