### PR TITLE
Added a generic client POST function that can return the response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ created via `sensuctl create`.
 - Added `float_type` field to system type to store which float type (softfloat,
   hardfloat) a system is using.
 - Additional Tessen resource metrics can now be registered at runtime.
+- Added a generic client POST function that can return the response body.
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ created via `sensuctl create`.
 - Added `float_type` field to system type to store which float type (softfloat,
   hardfloat) a system is using.
 - Additional Tessen resource metrics can now be registered at runtime.
-- Added a generic client POST function that can return the response body.
+- Added a generic client POST function that can return the response.
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -133,6 +133,21 @@ func (client *RestClient) Post(path string, obj interface{}) error {
 	return nil
 }
 
+// PostBody sends a POST request with obj as the payload to the given path
+// and additionally returns the response body
+func (client *RestClient) PostBody(path string, obj interface{}) ([]byte, error) {
+	res, err := client.R().SetBody(obj).Post(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode() >= 400 {
+		return nil, UnmarshalError(res)
+	}
+
+	return res.Body(), nil
+}
+
 // Put sends a PUT request with obj as the payload to the given path
 func (client *RestClient) Put(path string, obj interface{}) error {
 	res, err := client.R().SetBody(obj).Put(path)

--- a/cli/client/generic.go
+++ b/cli/client/generic.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 
+	"github.com/go-resty/resty/v2"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
@@ -133,9 +134,9 @@ func (client *RestClient) Post(path string, obj interface{}) error {
 	return nil
 }
 
-// PostBody sends a POST request with obj as the payload to the given path
-// and additionally returns the response body
-func (client *RestClient) PostBody(path string, obj interface{}) ([]byte, error) {
+// PostWithResponse sends a POST request with obj as the payload to the given path
+// and additionally returns the response
+func (client *RestClient) PostWithResponse(path string, obj interface{}) (*resty.Response, error) {
 	res, err := client.R().SetBody(obj).Post(path)
 	if err != nil {
 		return nil, err
@@ -145,7 +146,7 @@ func (client *RestClient) PostBody(path string, obj interface{}) ([]byte, error)
 		return nil, UnmarshalError(res)
 	}
 
-	return res.Body(), nil
+	return res, nil
 }
 
 // Put sends a PUT request with obj as the payload to the given path

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -67,6 +67,8 @@ type GenericClient interface {
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
 	Put(path string, obj interface{}) error
+	// PostBody creates the given obj at the specified path, returning a response body
+	PostBody(path string, obj interface{}) ([]byte, error)
 
 	// PutResource puts a resource according to its URIPath.
 	PutResource(types.Wrapper) error

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/coreos/etcd/clientv3"
+	"github.com/go-resty/resty/v2"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
@@ -67,8 +68,8 @@ type GenericClient interface {
 	Post(path string, obj interface{}) error
 	// Put creates the given obj at the specified path
 	Put(path string, obj interface{}) error
-	// PostBody creates the given obj at the specified path, returning a response body
-	PostBody(path string, obj interface{}) ([]byte, error)
+	// PostWithResponse creates the given obj at the specified path, returning the response
+	PostWithResponse(path string, obj interface{}) (*resty.Response, error)
 
 	// PutResource puts a resource according to its URIPath.
 	PutResource(types.Wrapper) error

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"net/http"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
 )
@@ -31,10 +32,10 @@ func (c *MockClient) Post(path string, obj interface{}) error {
 	return args.Error(0)
 }
 
-// PostBody ...
-func (c *MockClient) PostBody(path string, obj interface{}) ([]byte, error) {
+// PostWithResponse ...
+func (c *MockClient) PostWithResponse(path string, obj interface{}) (*resty.Response, error) {
 	args := c.Called(path, obj)
-	return args.Get(0).([]byte), args.Error(1)
+	return args.Get(0).(*resty.Response), args.Error(1)
 }
 
 // Put ...

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -31,6 +31,12 @@ func (c *MockClient) Post(path string, obj interface{}) error {
 	return args.Error(0)
 }
 
+// PostBody ...
+func (c *MockClient) PostBody(path string, obj interface{}) ([]byte, error) {
+	args := c.Called(path, obj)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 // Put ...
 func (c *MockClient) Put(path string, obj interface{}) error {
 	args := c.Called(path, obj)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a generic client POST function that returns the response body.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/pull/919

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Deciding if we wanted to refactor `Post` to return a response body or create a new `PostBody` function.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Testing against https://github.com/sensu/sensu-enterprise-go/tree/sensuctl-prune

## Is this change a patch?

Nope.