### PR TITLE
Add store metrics to tessen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ created via `sensuctl create`.
   hardfloat) a system is using.
 - Additional Tessen resource metrics can now be registered at runtime.
 - Added a generic client POST function that can return the response.
+- Tessen now reports the type of store used for events ("etcd or "postgres").
 
 ### Changed
 - Updated the store so that it may _create_ wrapped resources.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -407,10 +407,11 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	tessen, err := tessend.New(
 		b.runCtx,
 		tessend.Config{
-			Store:    stor,
-			RingPool: ringPool,
-			Client:   b.Client,
-			Bus:      bus,
+			Store:      stor,
+			EventStore: eventStoreProxy,
+			RingPool:   ringPool,
+			Client:     b.Client,
+			Bus:        bus,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", tessen.Name(), err)

--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store/provider"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -50,6 +51,19 @@ func (e *EventStoreProxy) GetEventByEntityCheck(ctx context.Context, entity, che
 
 func (e *EventStoreProxy) UpdateEvent(ctx context.Context, event *types.Event) (old, new *types.Event, err error) {
 	return e.do().UpdateEvent(ctx, event)
+}
+
+func (e *EventStoreProxy) GetProviderInfo() *provider.Info {
+	p, ok := e.do().(provider.InfoGetter)
+	if ok {
+		return p.GetProviderInfo()
+	}
+	return &provider.Info{
+		TypeMeta: corev2.TypeMeta{
+			Type:       "etcd",
+			APIVersion: "core/v2",
+		},
+	}
 }
 
 type closer interface {

--- a/backend/tessend/data.go
+++ b/backend/tessend/data.go
@@ -48,3 +48,16 @@ type LicenseFile struct {
 type Wrapper struct {
 	Value LicenseFile `json:"spec"`
 }
+
+// StoreConfig contains information about what services Sensu is using to store
+// information.
+type StoreConfig struct {
+	// ConfigStore indicates the storage backend used to store Sensu configuration.
+	ConfigStore string `json:"config_store"`
+
+	// StateStore indicates the storage backend used to store Sensu state.
+	StateStore string `json:"state_store"`
+
+	// EventStore indicates the storage backend used to store Sensu events.
+	EventStore string `json:"event_store"`
+}


### PR DESCRIPTION
## What is this change?

This commit annotates tessen metrics with the store provider (either "etcd", or "postgres", for now).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/557

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Build sensu-go with the change, ran sensu-backend, and queried the metric in Tessen.

## Is this change a patch?

No