### PR TITLE
Prevent panics if JSON or YAML resources cannot be parsed

### DIFF
--- a/cli/resource/parse.go
+++ b/cli/resource/parse.go
@@ -62,6 +62,7 @@ func Parse(in io.Reader) ([]*types.Wrapper, error) {
 				}
 				describeError(count, rerr)
 				errCount++
+				continue
 			}
 
 			// Mark the resource as managed by sensuctl in the outer labels


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It prevents a panic in sensuctl create/prune if the input that gets parsed does not contain a valid file.

## Why is this change necessary?

It fixes an unreleased bug that was introduced in the recent refactoring.

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested

## Is this change a patch?

Nope