### PR TITLE
Bugfix/user panic

### DIFF
--- a/cli/commands/helpers/user.go
+++ b/cli/commands/helpers/user.go
@@ -14,8 +14,8 @@ func GetCurrentUsername(cfg config.Config) string {
 	}
 
 	accessToken := tokens.Access
-	token, err := jwt.ParseWithClaims(accessToken, &corev2.Claims{}, nil)
-	if err != nil || token == nil {
+	token, _ := jwt.ParseWithClaims(accessToken, &corev2.Claims{}, nil)
+	if token == nil {
 		return ""
 	}
 	claims := token.Claims.(*corev2.Claims)

--- a/cli/commands/helpers/user.go
+++ b/cli/commands/helpers/user.go
@@ -14,7 +14,10 @@ func GetCurrentUsername(cfg config.Config) string {
 	}
 
 	accessToken := tokens.Access
-	token, _ := jwt.ParseWithClaims(accessToken, &corev2.Claims{}, nil)
+	token, err := jwt.ParseWithClaims(accessToken, &corev2.Claims{}, nil)
+	if err != nil || token == nil {
+		return ""
+	}
 	claims := token.Claims.(*corev2.Claims)
 	return claims.StandardClaims.Subject
 }


### PR DESCRIPTION
Fixes a nil panic that could occur after `sensuctl logout` is called. Not a regression as this was caught before 5.19.0:

```
ubuntu@backend-0:~$ sensuctl version
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xcef4c8]
goroutine 1 [running]:
github.com/sensu/sensu-go/cli/commands/helpers.GetCurrentUsername(0x1498d20, 0xc0001af4a0, 0x1297bff, 0x9)
        /go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20200325193752-c0b8eb7a07cd/cli/commands/helpers/user.go:18 +0xc8
github.com/sensu/sensu-enterprise-go/cli/commands/prune.Command(0xc0002b2330, 0xc0002f8780)
        /go/src/github.com/sensu/sensu-enterprise-go/cli/commands/prune/prune.go:57 +0x234
github.com/sensu/sensu-enterprise-go/cli/commands.AddCommands(0xc000283400, 0xc0002b2330)
        /go/src/github.com/sensu/sensu-enterprise-go/cli/commands/commands.go:29 +0xb8
main.main()
        /go/src/github.com/sensu/sensu-enterprise-go/cmd/sensuctl/main.go:34 +0xbe
```