### PR TITLE
Allow publishing keepalives via the HTTP API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Keepalives can now be published via the HTTP API.
+
 ## [5.19.0] - 2020-03-26
 
 ### Added

--- a/backend/apid/actions/events.go
+++ b/backend/apid/actions/events.go
@@ -139,5 +139,11 @@ func (a EventController) CreateOrReplace(ctx context.Context, event *corev2.Even
 		return NewError(InternalErr, err)
 	}
 
+	if event.HasCheck() && event.Check.Name == "keepalive" {
+		if err := a.bus.Publish(messaging.TopicKeepalive, event); err != nil {
+			return NewError(InternalErr, err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
## What is this change?

Users can use the HTTP API to publish keepalives. If the published event's check name is "keepalive", then the event will be handled by keepalived.

## Why is this change necessary?

Closes #2288

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs updates may be required. CC @hillaryfraley.

## How did you verify this change?

```
[eric@cube sensu-go]$ sensuctl entity list
   ID    Class    OS     Subscriptions             Last Seen            
 ────── ─────── ─────── ─────────────── ─────────────────────────────── 
  cube   agent   linux   entity:cube     2020-03-05 15:46:07 -0800 PST  
  me     proxy           test            N/A                            
[eric@cube sensu-go]$ curl -X PUT -H 'Authorization: Key <redacted>' --data @keepalive.json http://localhost:8080/api/core/v2/namespaces/default/events/me/keepalive -H 'Content-Type: application/json'
[eric@cube sensu-go]$ sensuctl entity list
   ID    Class    OS     Subscriptions             Last Seen            
 ────── ─────── ─────── ─────────────── ─────────────────────────────── 
  cube   agent   linux   entity:cube     2020-03-05 15:46:07 -0800 PST  
  me     proxy           test            2020-03-27 13:53:58 -0700 PDT  
```

## Is this change a patch?

Yes