### PR TITLE
Print config file default location in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- The config file default path is now shown in the help for sensu-backend start
+and sensu-agent start.
+
 ## [5.19.0] - 2020-03-26
 
 ### Added

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -197,7 +198,9 @@ func newStartCommand(ctx context.Context, args []string, logger *logrus.Entry) *
 
 	// Set up distinct flagset for handling config file
 	configFlagSet := pflag.NewFlagSet("sensu", pflag.ContinueOnError)
-	_ = configFlagSet.StringP(flagConfigFile, "c", "", "path to sensu-agent config file")
+	configFileDefaultLocation := filepath.Join(path.SystemConfigDir(), "agent.yml")
+	configFileDefault := fmt.Sprintf("path to sensu-agent config file (default %q)", configFileDefaultLocation)
+	_ = configFlagSet.StringP(flagConfigFile, "c", "", configFileDefault)
 	configFlagSet.SetOutput(ioutil.Discard)
 	_ = configFlagSet.Parse(args[1:])
 

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -263,7 +263,9 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 func handleConfig(cmd *cobra.Command, server bool) error {
 	// Set up distinct flagset for handling config file
 	configFlagSet := pflag.NewFlagSet("sensu", pflag.ContinueOnError)
-	configFlagSet.StringP(flagConfigFile, "c", "", "path to sensu-backend config file")
+	configFileDefaultLocation := filepath.Join(path.SystemConfigDir(), "backend.yml")
+	configFileDefault := fmt.Sprintf("path to sensu-backend config file (default %q)", configFileDefaultLocation)
+	configFlagSet.StringP(flagConfigFile, "c", "", configFileDefault)
 	configFlagSet.SetOutput(ioutil.Discard)
 	_ = configFlagSet.Parse(os.Args[1:])
 
@@ -273,7 +275,7 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 
 	// use the default config path if flagConfigFile was used
 	if configFile == "" {
-		configFilePath = filepath.Join(path.SystemConfigDir(), "backend.yml")
+		configFilePath = configFileDefaultLocation
 	}
 
 	// Configure location of backend configuration


### PR DESCRIPTION
## What is this change?

When a user runs `sensu-backend start --help` or `sensu-agent start --help`, they can see the default path to the config file.

## Why is this change necessary?

Closes #2563

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

I ran the commands and verified they worked as desired.

## Is this change a patch?

Yes