### PR TITLE
Require that handlers have a command set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Require that pipe handlers have a command set.
+
 ## [5.19.0] - 2020-03-26
 
 ### Added

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -78,7 +78,12 @@ func (h *Handler) validateType() error {
 	}
 
 	switch h.Type {
-	case "pipe", "set", "grpc":
+	case "pipe":
+		if strings.TrimSpace(h.Command) == "" {
+			return errors.New("missing command")
+		}
+		return nil
+	case "set", "grpc":
 		return nil
 	case "tcp", "udp":
 		return h.Socket.Validate()

--- a/api/core/v2/handler_test.go
+++ b/api/core/v2/handler_test.go
@@ -52,7 +52,8 @@ func TestHandlerValidate(t *testing.T) {
 				ObjectMeta: ObjectMeta{
 					Name: "foo",
 				},
-				Type: "pipe",
+				Type:    "pipe",
+				Command: "sl",
 			},
 			Error: "namespace must be set",
 		},
@@ -62,7 +63,8 @@ func TestHandlerValidate(t *testing.T) {
 					Name:      "foo",
 					Namespace: "default",
 				},
-				Type: "pipe",
+				Type:    "pipe",
+				Command: "sl",
 			},
 		},
 		{
@@ -190,10 +192,19 @@ func TestHandlerValidate(t *testing.T) {
 			},
 			Error: "unknown handler type: magic",
 		},
+		{
+			Handler: Handler{
+				ObjectMeta: ObjectMeta{
+					Name: "foo",
+				},
+				Type: "pipe",
+			},
+			Error: "missing command",
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%v", test.Handler), func(t *testing.T) {
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			if err := test.Handler.Validate(); err != nil {
 				if len(test.Error) > 0 {
 					require.Equal(t, test.Error, err.Error())

--- a/cli/commands/handler/create_test.go
+++ b/cli/commands/handler/create_test.go
@@ -42,7 +42,7 @@ func TestCreateCommandRunEClosureWithFlags(t *testing.T) {
 	client.On("CreateHandler", mock.Anything).Return(nil)
 
 	cmd := CreateCommand(cli)
-	require.NoError(t, cmd.Flags().Set("type", "pipe"))
+	require.NoError(t, cmd.Flags().Set("type", "set"))
 	require.NoError(t, cmd.Flags().Set("timeout", "15"))
 	require.NoError(t, cmd.Flags().Set("mutator", ""))
 	require.NoError(t, cmd.Flags().Set("handlers", "slack,pagerduty"))
@@ -61,7 +61,7 @@ func TestCreateCommandRunEClosureWithAPIErr(t *testing.T) {
 	client.On("CreateHandler", mock.Anything).Return(errors.New("nope"))
 
 	cmd := CreateCommand(cli)
-	require.NoError(t, cmd.Flags().Set("type", "pipe"))
+	require.NoError(t, cmd.Flags().Set("type", "set"))
 	require.NoError(t, cmd.Flags().Set("timeout", "15"))
 	require.NoError(t, cmd.Flags().Set("mutator", ""))
 	require.NoError(t, cmd.Flags().Set("handlers", "slack,pagerduty"))


### PR DESCRIPTION
## What is this change?

This commit changes handler validation for pipe handlers. Pipe
handlers now require a command to be set, or their validation will
fail.

## Why is this change necessary?

Closes #2696 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Only unit tests.

## Is this change a patch?

Yes