### PR TITLE
Support quoted strings in token substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Keepalives can now be published via the HTTP API.
+- Token substitution templates can now express escape-quoted strings.
 
 ## [5.19.0] - 2020-03-26
 

--- a/agent/token.go
+++ b/agent/token.go
@@ -8,6 +8,97 @@ import (
 	"text/template"
 )
 
+func substituteToken(key string, data interface{}, message *json.RawMessage) (*json.RawMessage, error) {
+	if message == nil {
+		return nil, nil
+	}
+	if len(*message) == 0 {
+		return message, nil
+	}
+	switch (*message)[0] {
+	case '"':
+		return substituteString(key, data, message)
+	case '[':
+		return substituteArray(key, data, message)
+	case '{':
+		var object map[string]*json.RawMessage
+		if err := json.Unmarshal([]byte(*message), &object); err != nil {
+			return nil, fmt.Errorf("couldn't evaluate template for %s: %s (object)", key, err)
+		}
+		for k, v := range object {
+			value, err := substituteToken(k, data, v)
+			if err != nil {
+				return nil, err
+			}
+			object[k] = value
+		}
+		b, _ := json.Marshal(object)
+		return (*json.RawMessage)(&b), nil
+	default:
+		return message, nil
+	}
+}
+
+func substituteString(key string, data interface{}, message *json.RawMessage) (*json.RawMessage, error) {
+	var t string
+	if err := json.Unmarshal([]byte(*message), &t); err != nil {
+		return nil, fmt.Errorf("couldn't evaluate template for %s: %s (string)", key, err)
+	}
+
+	tmpl := template.New(key)
+	tmpl.Funcs(funcMap())
+
+	var err error
+	tmpl, err = tmpl.Parse(t)
+	if err != nil {
+		return nil, fmt.Errorf("%s: could not parse the template: %s", key, err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return nil, fmt.Errorf("could not execute the template: %s", err)
+	}
+
+	// Verify if the output contains the "<no value>" string, indicating that a
+	// token was not properly substituted. If so, re-execute the template but this
+	// time with "missingkey=error" option so we get the actual token that was
+	// unmatched. For reference, this option can't be added by default otherwise
+	// the default values (defaultFunc) couldn't work
+	if strings.Contains(buf.String(), "<no value>") {
+		tmpl.Option("missingkey=error")
+
+		if err = tmpl.Execute(&buf, data); err == nil {
+			return nil, fmt.Errorf("%s: unmatched token: found an undefined value but could not identify the token", key)
+		}
+
+		return nil, fmt.Errorf("%s: unmatched token: %s", key, err)
+	}
+
+	templated, _ := json.Marshal(buf.String())
+
+	return (*json.RawMessage)(&templated), nil
+}
+
+func substituteArray(key string, data interface{}, message *json.RawMessage) (*json.RawMessage, error) {
+	var messages []*json.RawMessage
+	if err := json.Unmarshal([]byte(*message), &messages); err != nil {
+		return nil, fmt.Errorf("couldn't evaluate template for %s: %s (array)", key, err)
+	}
+
+	for i := range messages {
+		templated, err := substituteToken(key, data, messages[i])
+		if err != nil {
+			return nil, fmt.Errorf("couldn't evaluate template for %s: %s (array %d)", key, err, i)
+		}
+		messages[i] = templated
+	}
+
+	b, _ := json.Marshal(messages)
+
+	return (*json.RawMessage)(&b), nil
+}
+
 // TokenSubstitution evaluates the input template, that possibly contains
 // tokens, with the provided data object and returns a slice of bytes
 // representing the result along with any error encountered
@@ -17,59 +108,12 @@ func TokenSubstitution(data, input interface{}) ([]byte, error) {
 		return nil, fmt.Errorf("could not marshal the provided template: %s", err)
 	}
 
-	var rawMap map[string]*json.RawMessage
-
-	if err := json.Unmarshal(inputBytes, &rawMap); err != nil {
+	rawMessage, err := substituteToken("", data, (*json.RawMessage)(&inputBytes))
+	if err != nil {
 		return nil, err
 	}
 
-	for k, v := range rawMap {
-		if v == nil || len(*v) == 0 || (*v)[0] != '"' {
-			// null value, or not a string
-			continue
-		}
-		tmpl := template.New(k)
-		tmpl.Funcs(funcMap())
-
-		var value string
-
-		if err := json.Unmarshal([]byte(*v), &value); err != nil {
-			return nil, fmt.Errorf("parsing %s: %s", k, err)
-		}
-
-		var err error
-		tmpl, err = tmpl.Parse(value)
-		if err != nil {
-			return nil, fmt.Errorf("could not parse the template: %s", err)
-		}
-
-		var buf bytes.Buffer
-		err = tmpl.Execute(&buf, data)
-		if err != nil {
-			return nil, fmt.Errorf("could not execute the template: %s", err)
-		}
-
-		// Verify if the output contains the "<no value>" string, indicating that a
-		// token was not properly substituted. If so, re-execute the template but this
-		// time with "missingkey=error" option so we get the actual token that was
-		// unmatched. For reference, this option can't be added by default otherwise
-		// the default values (defaultFunc) couldn't work
-		if strings.Contains(buf.String(), "<no value>") {
-			tmpl.Option("missingkey=error")
-
-			if err = tmpl.Execute(&buf, data); err == nil {
-				return nil, fmt.Errorf("%s: unmatched token: found an undefined value but could not identify the token", k)
-			}
-
-			return nil, fmt.Errorf("%s: unmatched token: %s", k, err)
-		}
-
-		templated, _ := json.Marshal(buf.String())
-
-		rawMap[k] = (*json.RawMessage)(&templated)
-	}
-
-	return json.Marshal(rawMap)
+	return []byte(*rawMessage), nil
 }
 
 // funcMap defines the available custom functions in templates

--- a/agent/token_test.go
+++ b/agent/token_test.go
@@ -133,3 +133,29 @@ func TestTokenSubstitution(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenSubstitutionLabels(t *testing.T) {
+	data := corev2.Check{
+		ObjectMeta: corev2.ObjectMeta{
+			Labels: map[string]string{"foo": "bar"},
+		},
+	}
+	input := corev2.CheckConfig{
+		ObjectMeta: corev2.ObjectMeta{
+			Labels: map[string]string{
+				"foo": `{{ .labels.foo }}`,
+			},
+		},
+	}
+	result, err := TokenSubstitution(dynamic.Synthesize(data), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := corev2.CheckConfig{}
+	if err := json.Unmarshal(result, &check); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := check.Labels["foo"], "bar"; got != want {
+		t.Fatalf("bad sub: got %q, want %q", got, want)
+	}
+}

--- a/agent/token_test.go
+++ b/agent/token_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/testing/testutil"
-	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/types/dynamic"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,91 +20,100 @@ func TestTokenSubstitution(t *testing.T) {
 	}{
 		{
 			name:            "empty data",
-			data:            &types.Entity{},
-			input:           *types.FixtureCheckConfig("check"),
+			data:            &corev2.Entity{},
+			input:           *corev2.FixtureCheckConfig("check"),
 			expectedCommand: "command",
 			expectedError:   false,
 		},
 		{
 			name:            "empty input",
-			data:            types.FixtureEntity("entity"),
-			input:           types.CheckConfig{},
+			data:            corev2.FixtureEntity("entity"),
+			input:           corev2.CheckConfig{},
 			expectedCommand: "",
 			expectedError:   false,
 		},
 		{
 			name:            "invalid input",
-			data:            types.FixtureEntity("entity"),
+			data:            corev2.FixtureEntity("entity"),
 			input:           make(chan int),
 			expectedCommand: "",
 			expectedError:   true,
 		},
 		{
 			name:            "invalid template",
-			data:            types.FixtureEntity("entity"),
-			input:           types.CheckConfig{Command: "{{nil}}"},
+			data:            corev2.FixtureEntity("entity"),
+			input:           corev2.CheckConfig{Command: "{{nil}}"},
 			expectedCommand: "",
 			expectedError:   true,
 		},
 		{
 			name:            "simple template",
-			data:            types.FixtureEntity("entity"),
-			input:           types.CheckConfig{Command: "{{ .name }}"},
+			data:            corev2.FixtureEntity("entity"),
+			input:           corev2.CheckConfig{Command: "{{ .name }}"},
 			expectedCommand: "entity",
 			expectedError:   false,
 		},
 		{
 			name:            "default value for existing field",
 			data:            map[string]interface{}{"Name": "foo", "Check": map[string]interface{}{"Name": "check_foo"}},
-			input:           types.CheckConfig{Command: `{{ .Name | default "bar" }}`},
+			input:           corev2.CheckConfig{Command: `{{ .Name | default "bar" }}`},
 			expectedCommand: "foo",
 			expectedError:   false,
 		},
 		{
 			name:            "default value for missing field",
 			data:            map[string]interface{}{"Name": "foo", "Check": map[string]interface{}{"Name": "check_foo"}},
-			input:           types.CheckConfig{Command: `{{ .Check.Foo | default "bar" }}`},
+			input:           corev2.CheckConfig{Command: `{{ .Check.Foo | default "bar" }}`},
 			expectedCommand: "bar",
 			expectedError:   false,
 		},
 		{
 			name:            "default int value for missing field",
 			data:            map[string]interface{}{"Name": "foo", "Check": map[string]interface{}{"Name": "check_foo"}},
-			input:           types.CheckConfig{Command: `{{ .Check.Foo | default 1 }}`},
+			input:           corev2.CheckConfig{Command: `{{ .Check.Foo | default 1 }}`},
 			expectedCommand: "1",
 			expectedError:   false,
 		},
 		{
 			name:          "unmatched token",
 			data:          map[string]interface{}{"Name": "foo"},
-			input:         types.CheckConfig{Command: `{{ .System.Hostname }}`},
+			input:         corev2.CheckConfig{Command: `{{ .System.Hostname }}`},
 			expectedError: true,
 		},
 		{
 			name:            "extra escape character",
 			data:            map[string]interface{}{"Name": "foo", "Check": map[string]interface{}{"Name": "check_foo"}},
-			input:           types.CheckConfig{Command: `{{ .Name | default \"bar\" }}`},
+			input:           corev2.CheckConfig{Command: `{{ .Name | default \"bar\" }}`},
 			expectedCommand: "",
 			expectedError:   true,
 		},
 		{
 			name: "multiple tokens and valid json",
-			data: types.FixtureEntity("entity"),
-			input: types.CheckConfig{Command: `{{ .name }}; {{ "hello" }}; {{ .entity_class }}`,
-				ProxyRequests: &types.ProxyRequests{EntityAttributes: []string{`entity.entity_class == \"proxy\"`}},
+			data: corev2.FixtureEntity("entity"),
+			input: corev2.CheckConfig{Command: `{{ .name }}; {{ "hello" }}; {{ .entity_class }}`,
+				ProxyRequests: &corev2.ProxyRequests{EntityAttributes: []string{`entity.entity_class == \"proxy\"`}},
 			},
 			expectedCommand: "entity; hello; host",
 			expectedError:   false,
 		},
 		{
 			name: "labels",
-			data: types.Check{
-				ObjectMeta: types.ObjectMeta{
+			data: corev2.Check{
+				ObjectMeta: corev2.ObjectMeta{
 					Labels: map[string]string{"foo": "bar"},
 				},
 			},
-			input:           types.CheckConfig{Command: `echo {{ .labels.foo }}`},
+			input:           corev2.CheckConfig{Command: `echo {{ .labels.foo }}`},
 			expectedCommand: "echo bar",
+			expectedError:   false,
+		},
+		{
+			name: "quoted strings in template",
+			data: corev2.FixtureEntity("foo"),
+			input: corev2.CheckConfig{
+				Command: `{{ "\"hello\"" }}`,
+			},
+			expectedCommand: `"hello"`,
 			expectedError:   false,
 		},
 	}
@@ -115,7 +124,7 @@ func TestTokenSubstitution(t *testing.T) {
 			testutil.CompareError(err, tc.expectedError, t)
 
 			if !tc.expectedError {
-				checkResult := types.CheckConfig{}
+				checkResult := corev2.CheckConfig{}
 				err = json.Unmarshal(result, &checkResult)
 				assert.NoError(t, err)
 


### PR DESCRIPTION
## What is this change?

Users can now escape quotes in token substitution templates, so that they can express quoted strings in these templates. For instance,

```
{{ .labels.frobber | default "\"foobar\"" }}
```
Would previously cause an error, but now correctly evaluates.

## Why is this change necessary?

Closes #3640

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs changes required.

## How did you verify this change?

Good old unit tests.

## Is this change a patch?

Yes