### PR TITLE
Use a default timeout of 3s when querying etcd health

### DIFF
--- a/backend/apid/routers/cluster.go
+++ b/backend/apid/routers/cluster.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const defaultTimeout = 3
+
 // ClusterController represents the controller needs of the ClusterRouter.
 type ClusterController interface {
 	// MemberList lists the current cluster membership.
@@ -73,7 +75,7 @@ func parsePeerAddrs(req *http.Request) ([]string, error) {
 func parseTimeout(req *http.Request) (int, error) {
 	val := req.FormValue("timeout")
 	if len(val) == 0 {
-		return 0, nil
+		return defaultTimeout, nil
 	}
 	return strconv.Atoi(val)
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It modifies the default timeout value used when querying etcd for its members or its health.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3621

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This parameter is currently undocumented, so I opened https://github.com/sensu/sensu-docs/issues/2323.

## How did you verify this change?

Manually tested.

## Is this change a patch?

Yep