### PR TITLE
Add the is_silenced field selector for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
 - Added ability to make the Resty HTTP Timeout configurable.
+- Added the `event.is_silenced` & `event.check.is_silenced` field selectors.
 
 ### Fixed
 - Keepalives can now be published via the HTTP API.

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -426,6 +426,8 @@ func EventFields(r Resource) map[string]string {
 	return map[string]string{
 		"event.name":                 resource.ObjectMeta.Name,
 		"event.namespace":            resource.ObjectMeta.Namespace,
+		"event.is_silenced":          isSilenced(resource),
+		"event.check.is_silenced":    isSilenced(resource),
 		"event.check.name":           resource.Check.Name,
 		"event.check.handlers":       strings.Join(resource.Check.Handlers, ","),
 		"event.check.publish":        strconv.FormatBool(resource.Check.Publish),
@@ -438,6 +440,13 @@ func EventFields(r Resource) map[string]string {
 		"event.entity.entity_class":  resource.Entity.EntityClass,
 		"event.entity.subscriptions": strings.Join(resource.Entity.Subscriptions, ","),
 	}
+}
+
+func isSilenced(e *Event) string {
+	if len(e.Check.Silenced) > 0 {
+		return "true"
+	}
+	return "false"
 }
 
 // SetNamespace sets the namespace of the resource.


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds both the `event.is_silenced` & `event.check.is_silenced` field selectors; maybe we should only add one, but I feel like `event.is_silenced` is better in terms of UX.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3552

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I will open a new docs issue once we know which fields we are adding.

## How did you verify this change?

Manually tested in sensu-enterprise-go.

## Is this change a patch?

Nope