### PR TITLE
Lift backend ID out of tessen, into backend proper

### DIFF
--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -105,10 +105,14 @@ type Config struct {
 	RingPool   *ringv2.Pool
 	Client     *clientv3.Client
 	Bus        messaging.MessageBus
+	BackendID  string
 }
 
 // New creates a new TessenD.
 func New(ctx context.Context, c Config, opts ...Option) (*Tessend, error) {
+	if c.BackendID == "" {
+		c.BackendID = uuid.New().String()
+	}
 	t := &Tessend{
 		interval:    corev2.DefaultTessenInterval,
 		store:       c.Store,
@@ -116,7 +120,7 @@ func New(ctx context.Context, c Config, opts ...Option) (*Tessend, error) {
 		client:      c.Client,
 		errChan:     make(chan error, 1),
 		url:         tessenURL,
-		backendID:   uuid.New().String(),
+		backendID:   c.BackendID,
 		bus:         c.Bus,
 		messageChan: make(chan interface{}, 1),
 		duration:    perResourceDuration,


### PR DESCRIPTION
## What is this change?

This commit causes the backend to create an ID on startup, and
share it with tessen, instead of tessen creating its own ID. The
ID will be shared with other facilities, including facilities in
the enterprise product.

## Why is this change necessary?

We need to share backend IDs between different components of Sensu, not just tessen.

## Does your change need a Changelog entry?

No, this is an internal change.

## Were there any complications while making this change?

In a sense, this PR is a complication of another change.

## How did you verify this change?

I'd consider unit/integration tests to be sufficient.

## Is this change a patch?

No.