### PR TITLE
Add sensuctl describe-type command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - [Web] Added the ability for labels and annotations with links to images to be
 displayed inline.
 - [Web] Added additional modes for those with colour blindness.
+- Added a new `sensuctl describe-type` command to list all resource types.
 
 ### Fixed
 - Require that pipe handlers have a command set.

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/configure"
 	"github.com/sensu/sensu-go/cli/commands/create"
 	"github.com/sensu/sensu-go/cli/commands/delete"
+	"github.com/sensu/sensu-go/cli/commands/describetype"
 	"github.com/sensu/sensu-go/cli/commands/dump"
 	"github.com/sensu/sensu-go/cli/commands/edit"
 	"github.com/sensu/sensu-go/cli/commands/entity"
@@ -67,6 +68,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		tessen.HelpCommand(cli),
 		dump.Command(cli),
 		command.HelpCommand(cli),
+		describetype.Command(cli),
 	)
 
 	for _, cmd := range rootCmd.Commands() {

--- a/cli/commands/describetype/describe_type.go
+++ b/cli/commands/describetype/describe_type.go
@@ -1,6 +1,7 @@
 package describetype
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -54,7 +55,17 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		var resources []apiResource
 
-		for _, resource := range resource.All {
+		if len(args) != 1 {
+			_ = cmd.Help()
+			return errors.New("invalid argument(s) received, expected a single one or a comma-separated list")
+		}
+
+		requested, err := resource.GetResourceRequests(args[0], resource.All)
+		if err != nil {
+			return err
+		}
+
+		for _, resource := range requested {
 			wrapped := types.WrapResource(resource)
 
 			// Short names are only supported for core/v2 resources

--- a/cli/commands/describetype/describe_type.go
+++ b/cli/commands/describetype/describe_type.go
@@ -109,13 +109,7 @@ func getFormat(cli *cli.SensuCli, cmd *cobra.Command) string {
 // global resources, and inspecting the resulting namespace
 func isNamespaced(r corev2.Resource) bool {
 	r.SetNamespace("~sensu")
-	if r.GetObjectMeta().Namespace != "~sensu" {
-		// SetNamespace() didn't have the intended side effect; assume this is a
-		// global resource.
-		return false
-	}
-
-	return true
+	return r.GetObjectMeta().Namespace == "~sensu"
 }
 
 func printToTable(results interface{}, writer io.Writer) {

--- a/cli/commands/describetype/describe_type.go
+++ b/cli/commands/describetype/describe_type.go
@@ -30,8 +30,8 @@ $ sensuctl describe-type all
 
 type apiResource struct {
 	Name       string `json:"name"`
-	ShortName  string `json:"short_name"`
-	APIVersion string `json:"api_version"`
+	ShortName  string `json:"short_name" yaml:"short_name"`
+	APIVersion string `json:"api_version" yaml:"api_version"`
 	Type       string `json:"type"`
 	Namespaced bool   `json:"namespaced"`
 }

--- a/cli/commands/describetype/describe_type.go
+++ b/cli/commands/describetype/describe_type.go
@@ -1,0 +1,166 @@
+package describetype
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/table"
+	"github.com/sensu/sensu-go/cli/resource"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+)
+
+var description = `sensuctl describe-type
+
+Describe a type by its fully qualified name:
+$ sensuctl describe-type core/v2.CheckConfig
+
+The command also supports describing types by their short names (for core/v2 types):
+$ sensuctl describe-type checks,handlers
+
+You can also use the 'all' qualifier to describe all available types:
+$ sensuctl describe-type all
+`
+
+type apiResource struct {
+	Name       string `json:"name"`
+	ShortName  string `json:"short_name"`
+	APIVersion string `json:"api_version"`
+	Type       string `json:"type"`
+	Namespaced bool   `json:"namespaced"`
+}
+
+// Command defines the describe-type command
+func Command(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe-type [RESOURCE TYPE],[RESOURCE TYPE]...",
+		Short: "Print details about the supported API resources types",
+		Long:  description,
+		RunE:  execute(cli),
+	}
+
+	format := cli.Config.Format()
+	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
+
+	return cmd
+}
+
+func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		var resources []apiResource
+
+		for _, resource := range resource.All {
+			wrapped := types.WrapResource(resource)
+
+			// Short names are only supported for core/v2 resources
+			shortName := ""
+			if wrapped.APIVersion == "core/v2" {
+				shortName = resource.RBACName()
+			}
+
+			r := apiResource{
+				Name:       fmt.Sprintf("%s.%s", wrapped.APIVersion, wrapped.Type),
+				ShortName:  shortName,
+				APIVersion: wrapped.APIVersion,
+				Type:       wrapped.Type,
+				Namespaced: isNamespaced(resource),
+			}
+			resources = append(resources, r)
+		}
+		switch getFormat(cli, cmd) {
+		case config.FormatJSON, config.FormatWrappedJSON:
+			return helpers.PrintJSON(resources, cmd.OutOrStdout())
+		case config.FormatYAML:
+			return helpers.PrintYAML(resources, cmd.OutOrStdout())
+		default:
+			printToTable(resources, cmd.OutOrStdout())
+			return nil
+		}
+	}
+}
+
+func getFormat(cli *cli.SensuCli, cmd *cobra.Command) string {
+	// get the configured format or the flag override
+	format := cli.Config.Format()
+	if flag := helpers.GetChangedStringValueFlag("format", cmd.Flags()); flag != "" {
+		format = flag
+	}
+	return format
+}
+
+// isNamespaced is a hack to determine whether a resource is global or
+// namespaced, by relying on the SetNamespace method, which is a no-op for
+// global resources, and inspecting the resulting namespace
+func isNamespaced(r corev2.Resource) bool {
+	r.SetNamespace("~sensu")
+	if r.GetObjectMeta().Namespace != "~sensu" {
+		// SetNamespace() didn't have the intended side effect; assume this is a
+		// global resource.
+		return false
+	}
+
+	return true
+}
+
+func printToTable(results interface{}, writer io.Writer) {
+	table := table.New([]*table.Column{
+		{
+			Title:       "Fully Qualified Name",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				r, ok := data.(apiResource)
+				if !ok {
+					return cli.TypeError
+				}
+				return r.Name
+			},
+		},
+		{
+			Title: "Short Name",
+			CellTransformer: func(data interface{}) string {
+				r, ok := data.(apiResource)
+				if !ok {
+					return cli.TypeError
+				}
+				return r.ShortName
+			},
+		},
+		{
+			Title: "API Version",
+			CellTransformer: func(data interface{}) string {
+				r, ok := data.(apiResource)
+				if !ok {
+					return cli.TypeError
+				}
+				return r.APIVersion
+			},
+		},
+		{
+			Title: "Type",
+			CellTransformer: func(data interface{}) string {
+				r, ok := data.(apiResource)
+				if !ok {
+					return cli.TypeError
+				}
+				return r.Type
+			},
+		},
+		{
+			Title: "Namespaced",
+			CellTransformer: func(data interface{}) string {
+				r, ok := data.(apiResource)
+				if !ok {
+					return cli.TypeError
+				}
+				return strconv.FormatBool(r.Namespaced)
+			},
+		},
+	})
+
+	table.Render(writer, results)
+}

--- a/cli/commands/describetype/describe_type_test.go
+++ b/cli/commands/describetype/describe_type_test.go
@@ -1,0 +1,45 @@
+package describetype
+
+import (
+	"testing"
+
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("describe-type", cmd.Use)
+}
+
+func TestCommandArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	out, err := test.RunCmd(cmd, []string{})
+	assert.NotEmpty(out)
+	assert.Error(err)
+
+	// invalid resources
+	out, err = test.RunCmd(cmd, []string{"check,foo"})
+	assert.Empty(out)
+	assert.Error(err)
+}
+
+func TestListFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewCLI()
+	cmd := Command(cli)
+
+	flag := cmd.Flag("format")
+	assert.NotNil(flag)
+}

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -53,6 +53,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
 	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
 	_ = cmd.Flags().BoolP("types", "t", false, "list supported resource types")
+	_ = cmd.Flags().MarkDeprecated("types", `please use "sensuctl describe-type all" instead`)
 
 	return cmd
 }


### PR DESCRIPTION
## What is this change?

It adds the `sensuctl describe-type` command, which takes 1 argument, either `all` or a comma-separated list of short names and/or fully qualified names (e.g. `namespace,checks,authentication/v2.Provider`).

The output can be formatted in either the tabular, JSON or YAML format.

I also deprecated the `sensuctl dump --types` flag so it refers to this command, but it still work for now.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3632.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I'll open a new sensu-docs issue so we document this new command and hopefully refer to this command when we list resources in our documentation (https://docs.sensu.io/sensu-go/latest/reference/rbac/#resources, https://docs.sensu.io/sensu-go/latest/sensuctl/reference/#sensuctl-edit-resource-types etc.)

## How did you verify this change?

Added rough unit tests and manually tested it on sensu-go  & sensu-enterprise-go.

## Is this change a patch?

Nope