### PR TITLE
Warning messages from Resty library are now suppressed in sensuctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 displayed inline.
 - [Web] Added additional modes for those with colour blindness.
 
+### Changed
+- Warning messages from Resty library are now suppressed in sensuctl.
+
 ### Fixed
 - Require that pipe handlers have a command set.
 - The config file default path is now shown in the help for sensu-backend start

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -109,6 +109,11 @@ func New(config config.Config) *RestClient {
 
 	restyInst.SetLogger(logger)
 
+	// Disable warning log entries from resty when an HTTP address is used to
+	// configure sensuctl. We should remove that line whenever we decide to make
+	// sensuctl log level configurable.
+	restyInst.SetDisableWarn(true)
+
 	return client
 }
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes the following log entry whenever sensuctl is configured with an HTTP API: `WARN[0000] Using Basic Auth in HTTP mode is not secure, use HTTPS  component=cli-client`

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3678.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope. I reviewed the resty lib to make sure we weren't removing any other relevant warning messages.

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

Nope