### PR TITLE
The system's libc_type attribute is now populated on alpine containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 and sensu-agent start.
 - Keepalives can now be published via the HTTP API.
 - Token substitution templates can now express escape-quoted strings.
+- The system's libc_type attribute is now populated on alpine containers.
 
 ## [5.19.0] - 2020-03-26
 

--- a/system/system.go
+++ b/system/system.go
@@ -81,7 +81,10 @@ func Info() (types.System, error) {
 
 func getLibCType() (string, error) {
 	output, err := exec.Command("ldd", "--version").CombinedOutput()
-	if err != nil {
+	// The command above will return an exit code of 1 on alpine, but still output
+	// the relevant information. Therefore, as a workaround, we can inspect stderr
+	// and ignore the error if it contains pertinent data about the C library
+	if err != nil && !strings.Contains(strings.ToLower(string(output)), "libc") {
 		return "", err
 	}
 	text := strings.ToLower(string(output))


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This is a workaround for alpine, since `ldd --version` returns an exit code of `1` but still display the relevant information. Therefore, we inspect `stderr` to figure out whether the pertinent data is available.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3664

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?
I think there's a couple of ways to fix that problem, like we could inspect the exit code with https://golang.org/pkg/os/#ProcessState.ExitCode but that feels a lot more work for the same result.

## Were there any complications while making this change?
Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?
Nope

## How did you verify this change?
Built new docker images from sensu-enterprise-go and inspected the entity via sensuctl:

```
 $ sensuctl entity info 9be8097ecd1f --format yaml
type: Entity
api_version: core/v2
metadata:
  name: 9be8097ecd1f
  namespace: default
spec:
  [...]
  system:
    arch: amd64
    cloud_provider: ""
    hostname: 9be8097ecd1f
    libc_type: musl
    [...]
    os: linux
    platform: alpine
    platform_family: alpine
    platform_version: 3.8.5
    vm_role: guest
    vm_system: docker
  user: agent
```

## Is this change a patch?
Yep