### PR TITLE
Support SIGUSR1 log level incrementing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - [Web] Added the ability for labels and annotations with links to images to be
 displayed inline.
 - [Web] Added additional modes for those with colour blindness.
+- Users can now increment the logging level by sending SIGUSR1 to the
+sensu-backend or sensu-agent process.
 
 ### Changed
 - Warning messages from Resty library are now suppressed in sensuctl.

--- a/agent/cmd/logger.go
+++ b/agent/cmd/logger.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/sensu/sensu-go/util/logging"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,14 +10,4 @@ var logger = logrus.WithFields(logrus.Fields{
 
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGUSR1)
-	go func() {
-		for range sigs {
-			level := logrus.GetLevel()
-			newLevel := logging.IncrementLogLevel(level)
-			logrus.Warnf("set log level to %s", newLevel)
-			logrus.SetLevel(newLevel)
-		}
-	}()
 }

--- a/agent/cmd/logger.go
+++ b/agent/cmd/logger.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/sirupsen/logrus"
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sensu/sensu-go/util/logging"
+	"github.com/sirupsen/logrus"
+)
 
 var logger = logrus.WithFields(logrus.Fields{
 	"component": "cmd",
@@ -8,4 +15,14 @@ var logger = logrus.WithFields(logrus.Fields{
 
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	go func() {
+		for range sigs {
+			level := logrus.GetLevel()
+			newLevel := logging.IncrementLogLevel(level)
+			logrus.Warnf("set log level to %s", newLevel)
+			logrus.SetLevel(newLevel)
+		}
+	}()
 }

--- a/agent/cmd/logger_unix.go
+++ b/agent/cmd/logger_unix.go
@@ -20,6 +20,11 @@ func init() {
 			newLevel := logging.IncrementLogLevel(level)
 			logrus.Warnf("set log level to %s", newLevel)
 			logrus.SetLevel(newLevel)
+			if newLevel == logrus.WarnLevel {
+				// repeat the log call, as it wouldn't have been logged at
+				// error level.
+				logrus.Warnf("set log level to %s", newLevel)
+			}
 		}
 	}()
 }

--- a/agent/cmd/logger_unix.go
+++ b/agent/cmd/logger_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sensu/sensu-go/util/logging"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	go func() {
+		for range sigs {
+			level := logrus.GetLevel()
+			newLevel := logging.IncrementLogLevel(level)
+			logrus.Warnf("set log level to %s", newLevel)
+			logrus.SetLevel(newLevel)
+		}
+	}()
+}

--- a/backend/cmd/logger.go
+++ b/backend/cmd/logger.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/sensu/sensu-go/util/logging"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,14 +10,4 @@ var logger = logrus.WithFields(logrus.Fields{
 
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGUSR1)
-	go func() {
-		for range sigs {
-			level := logrus.GetLevel()
-			newLevel := logging.IncrementLogLevel(level)
-			logrus.Warnf("set log level to %s", newLevel)
-			logrus.SetLevel(newLevel)
-		}
-	}()
 }

--- a/backend/cmd/logger.go
+++ b/backend/cmd/logger.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/sirupsen/logrus"
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sensu/sensu-go/util/logging"
+	"github.com/sirupsen/logrus"
+)
 
 var logger = logrus.WithFields(logrus.Fields{
 	"component": "cmd",
@@ -8,4 +15,14 @@ var logger = logrus.WithFields(logrus.Fields{
 
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	go func() {
+		for range sigs {
+			level := logrus.GetLevel()
+			newLevel := logging.IncrementLogLevel(level)
+			logrus.Warnf("set log level to %s", newLevel)
+			logrus.SetLevel(newLevel)
+		}
+	}()
 }

--- a/backend/cmd/logger_unix.go
+++ b/backend/cmd/logger_unix.go
@@ -20,6 +20,11 @@ func init() {
 			newLevel := logging.IncrementLogLevel(level)
 			logrus.Warnf("set log level to %s", newLevel)
 			logrus.SetLevel(newLevel)
+			if newLevel == logrus.WarnLevel {
+				// repeat the log call, as it wouldn't have been logged at
+				// error level.
+				logrus.Warnf("set log level to %s", newLevel)
+			}
 		}
 	}()
 }

--- a/backend/cmd/logger_unix.go
+++ b/backend/cmd/logger_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package cmd
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/sensu/sensu-go/util/logging"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGUSR1)
+	go func() {
+		for range sigs {
+			level := logrus.GetLevel()
+			newLevel := logging.IncrementLogLevel(level)
+			logrus.Warnf("set log level to %s", newLevel)
+			logrus.SetLevel(newLevel)
+		}
+	}()
+}

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -46,3 +46,13 @@ func EventFields(event *types.Event, debug bool) map[string]interface{} {
 
 	return fields
 }
+
+// IncrementLogLevel increments the log level, or wraps around to "error" level.
+func IncrementLogLevel(level logrus.Level) logrus.Level {
+	level++
+	if level > logrus.TraceLevel {
+		// wrap around to error level
+		level = logrus.ErrorLevel
+	}
+	return level
+}

--- a/util/logging/logging_test.go
+++ b/util/logging/logging_test.go
@@ -1,0 +1,42 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestIncrementLogLevel(t *testing.T) {
+	tests := []struct {
+		Level    logrus.Level
+		ExpLevel logrus.Level
+	}{
+		{
+			Level:    logrus.ErrorLevel,
+			ExpLevel: logrus.WarnLevel,
+		},
+		{
+			Level:    logrus.WarnLevel,
+			ExpLevel: logrus.InfoLevel,
+		},
+		{
+			Level:    logrus.InfoLevel,
+			ExpLevel: logrus.DebugLevel,
+		},
+		{
+			Level:    logrus.DebugLevel,
+			ExpLevel: logrus.TraceLevel,
+		},
+		{
+			Level:    logrus.TraceLevel,
+			ExpLevel: logrus.ErrorLevel,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Level.String(), func(t *testing.T) {
+			if got, want := IncrementLogLevel(test.Level), test.ExpLevel; got != want {
+				t.Fatalf("bad log level: got %s, want %s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit adds support to sensu-backend and sensu-agent for
incrementing the log level with SIGUSR1. When the process receives
this signal, the log level will be incremented in terms of
verbosity. When the level is at TRACE, the most verbose log level,
and the log level is incremented, it will wrap around to error
level.

## Why is this change necessary?

Closes #1742

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

It's unclear at this time how to support this for Windows.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

@hillaryfraley, we will need to document that users can now increase the log level at runtime, with the following commands for backends and agents:

```
kill -s SIGUSR1 $(pidof sensu-backend)
```
```
kill -s SIGUSR1 $(pidof sensu-agent)
```

## How did you verify this change?

I ran the above commands for the backend and agent.

## Is this change a patch?

No.