### PR TITLE
Removed deprecated flags in 'sensuctl silenced update' #3688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Removed deprecated flags in `sensuctl silenced update` subcommand.
+
 ## [5.19.1] - 2020-04-13
 
 ### Fixed

--- a/cli/commands/silenced/update.go
+++ b/cli/commands/silenced/update.go
@@ -51,10 +51,6 @@ func UpdateCommand(cli *cli.SensuCli) *cobra.Command {
 			return nil
 		},
 	}
-	_ = cmd.Flags().StringP("subscription", "s", "", "silenced subscription")
-	_ = cmd.Flags().StringP("check", "c", "", "silenced check")
-	_ = cmd.Flags().BoolP("expire-on-resolve", "x", false, "clear silenced entry on resolution")
-	_ = cmd.Flags().StringP("expire", "e", expireDefault, "expiry in seconds")
-	_ = cmd.Flags().StringP("begin", "b", beginDefault, "silence begin in human readable time (Format: Jan 02 2006 3:04PM MST)")
+
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes deprecated flags for the `sensuctl silenced update` command; these flags were once supported about 2 years ago but at some point, the ability to update a silenced entry with flags was removed. Therefore, these flags are now misleading and should be removed.

## Why is this change necessary?

Noticed by @nixwiz in Slack!

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified.

## Is this change a patch?

Yep