### PR TITLE
Set check state and last OK on first event update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a bug where check state and last_ok were not computed until the second
+instance of the event.
+
 ## [5.19.1] - 2020-04-13
 
 ### Fixed

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -6,16 +6,16 @@ import (
 	"context"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCheckConfigStorage(t *testing.T) {
 	testWithEtcd(t, func(s store.Store) {
-		check := types.FixtureCheckConfig("check1")
-		ctx := context.WithValue(context.Background(), types.NamespaceKey, check.Namespace)
+		check := corev2.FixtureCheckConfig("check1")
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, check.Namespace)
 
 		pred := &store.SelectionPredicate{}
 

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -241,6 +241,13 @@ func (s *Store) UpdateEvent(ctx context.Context, event *corev2.Event) (*corev2.E
 		}
 
 		event.Check.MergeWith(prevEvent.Check)
+	} else {
+		// If there was no previous check, we still need to set State and LastOK
+		event.Check.State = corev2.EventFailingState
+		if event.Check.Status == 0 {
+			event.Check.LastOK = event.Check.Executed
+			event.Check.State = corev2.EventPassingState
+		}
 	}
 
 	updateOccurrences(event.Check)


### PR DESCRIPTION
## What is this change?

This commit fixes two bugs where check state and last_ok properties
are not set on the first check execution. The properties are now
set before the event is written to the store.

## Why is this change necessary?

Closes #3617 
Closes #3239 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

We'll need to figure out if this bug affects the postgres event store in enterprise sensu.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes not required.

## How did you verify this change?

Integration testing seems to be good enough here.

## Is this change a patch?

Yes