### PR TITLE
Log TLS failures when initializing the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added a `timeout` flag to `sensu-backend init`.
+
+### Fixed
+- `sensu-backend init` now logs any TLS failures encountered.
+
 ## [5.19.1] - 2020-04-13
 
 ### Fixed

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -238,8 +238,8 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize pipelined
 	pipeline, err := pipelined.New(pipelined.Config{
-		Store: stor,
-		Bus:   bus,
+		Store:                   stor,
+		Bus:                     bus,
 		ExtensionExecutorGetter: rpc.NewGRPCExtensionExecutor,
 		AssetGetter:             assetGetter,
 		BufferSize:              viper.GetInt(FlagPipelinedBufferSize),
@@ -313,14 +313,14 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:             bus,
-		Store:           stor,
-		EventStore:      eventStoreProxy,
-		LivenessFactory: liveness.EtcdFactory(b.runCtx, b.Client),
-		RingPool:        ringPool,
-		BufferSize:      viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:     viper.GetInt(FlagKeepalivedWorkers),
-		StoreTimeout:    2 * time.Minute,
+		Bus:                   bus,
+		Store:                 stor,
+		EventStore:            eventStoreProxy,
+		LivenessFactory:       liveness.EtcdFactory(b.runCtx, b.Client),
+		RingPool:              ringPool,
+		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
+		StoreTimeout:          2 * time.Minute,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -29,7 +29,7 @@ const (
 type seedConfig struct {
 	backend.Config
 	SeedConfig seeds.Config
-	Timeout    uint
+	Timeout    time.Duration
 }
 
 type initOpts struct {
@@ -118,11 +118,11 @@ func InitCommand() *cobra.Command {
 				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
 			}
 
-			timeout := viper.GetUint(flagTimeout)
+			timeout := viper.GetDuration(flagTimeout)
 
 			client, err := clientv3.New(clientv3.Config{
 				Endpoints:   clientURLs,
-				DialTimeout: time.Duration(timeout) * time.Second,
+				DialTimeout: timeout * time.Second,
 				TLS:         tlsConfig,
 			})
 
@@ -160,7 +160,7 @@ func InitCommand() *cobra.Command {
 			// the latest connection error (see
 			// https://github.com/sensu/sensu-go/issues/3663)
 			for _, url := range clientURLs {
-				tctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+				tctx, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
 				defer cancel()
 				_, err = client.Status(tctx, url)
 				if err != nil {
@@ -191,7 +191,7 @@ func InitCommand() *cobra.Command {
 
 func seedCluster(client *clientv3.Client, config seedConfig) error {
 	store := etcdstore.NewStore(client, "")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Timeout)*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout*time.Second)
 	defer cancel()
 	if err := seeds.SeedCluster(ctx, store, config.SeedConfig); err != nil {
 		return err

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultTimeout = 5
+	defaultTimeout = "5"
 
 	flagInitAdminUsername = "cluster-admin-username"
 	flagInitAdminPassword = "cluster-admin-password"
@@ -182,7 +182,7 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().String(flagInitAdminUsername, "", "cluster admin username")
 	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
-	cmd.Flags().Uint(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
+	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
 
 	setupErr = handleConfig(cmd, false)
 

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -15,18 +15,21 @@ import (
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 )
 
 const (
+	defaultTimeout = 5
+
 	flagInitAdminUsername = "cluster-admin-username"
 	flagInitAdminPassword = "cluster-admin-password"
 	flagInteractive       = "interactive"
+	flagTimeout           = "timeout"
 )
 
 type seedConfig struct {
 	backend.Config
 	SeedConfig seeds.Config
+	Timeout    uint
 }
 
 type initOpts struct {
@@ -115,13 +118,12 @@ func InitCommand() *cobra.Command {
 				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
 			}
 
+			timeout := viper.GetUint(flagTimeout)
+
 			client, err := clientv3.New(clientv3.Config{
 				Endpoints:   clientURLs,
-				DialTimeout: 5 * time.Second,
+				DialTimeout: time.Duration(timeout) * time.Second,
 				TLS:         tlsConfig,
-				DialOptions: []grpc.DialOption{
-					grpc.WithBlock(),
-				},
 			})
 
 			if err != nil {
@@ -150,8 +152,29 @@ func InitCommand() *cobra.Command {
 					AdminUsername: uname,
 					AdminPassword: pword,
 				},
+				Timeout: timeout,
 			}
 
+			// Make sure at least one of the provided endpoints is reachable. This is
+			// required to debug TLS errors because the seeding below will not print
+			// the latest connection error (see
+			// https://github.com/sensu/sensu-go/issues/3663)
+			for _, url := range clientURLs {
+				tctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+				defer cancel()
+				_, err = client.Status(tctx, url)
+				if err != nil {
+					// We do not need to log the error, etcd's client interceptor will log
+					// the actual underlying error
+					continue
+				}
+				// The endpoint did not return any error, therefore we can proceed
+				goto seed
+			}
+			// All endpoints returned an error, return the latest one
+			return err
+
+		seed:
 			return seedCluster(client, seedConfig)
 		},
 	}
@@ -159,6 +182,7 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().String(flagInitAdminUsername, "", "cluster admin username")
 	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
+	cmd.Flags().Uint(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
 
 	setupErr = handleConfig(cmd, false)
 
@@ -167,7 +191,7 @@ func InitCommand() *cobra.Command {
 
 func seedCluster(client *clientv3.Client, config seedConfig) error {
 	store := etcdstore.NewStore(client, "")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.Timeout)*time.Second)
 	defer cancel()
 	if err := seeds.SeedCluster(ctx, store, config.SeedConfig); err != nil {
 		return err

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -250,7 +250,6 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 					log.Println(http.ListenAndServe("127.0.0.1:6060", nil))
 				}()
 			}
-
 			return sensuBackend.RunWithInitializer(initialize)
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It removes the use of a blocking client when attempting to initialize the backend, in order to have etcd log any TLS error encountered.

See https://github.com/sensu/sensu-go/issues/3663#issuecomment-613656403 for more context.

It also adds a `--timeout` flag to the `sensu-backend init` command.

## Why is this change necessary?

This is a workaround for https://github.com/sensu/sensu-go/issues/3663. We can probably implement a better solution with a blocking client once [this PR](https://github.com/grpc/grpc-go/pull/3430) is released and etcd is updated to use it.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

go-grpc is not easy 😅 

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested.

## Is this change a patch?

I'd say so