### PR TITLE
Fix a bug in multi-line metric extraction that appeared in windows agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - `sensu-backend init` now logs any TLS failures encountered.
+- Fixes a bug in multi-line metric extraction that appeared in windows agents.
 
 ## [5.19.1] - 2020-04-13
 

--- a/agent/transformers/influx_db.go
+++ b/agent/transformers/influx_db.go
@@ -123,6 +123,9 @@ OUTER:
 		}
 		influxList = append(influxList, i)
 	}
+	if err := s.Err(); err != nil {
+		logger.WithFields(fields).WithError(ErrMetricExtraction).Error(err)
+	}
 
 	return influxList
 }

--- a/agent/transformers/influx_db.go
+++ b/agent/transformers/influx_db.go
@@ -1,6 +1,7 @@
 package transformers
 
 import (
+	"bufio"
 	"strconv"
 	"strings"
 	"time"
@@ -47,11 +48,14 @@ func ParseInflux(event *types.Event) InfluxList {
 	}
 
 	metric := strings.TrimSpace(event.Check.Output)
-	lines := strings.Split(metric, "\n")
+	s := bufio.NewScanner(strings.NewReader(metric))
+	l := 0
 
 OUTER:
-	for l, line := range lines {
+	for s.Scan() {
+		line := s.Text()
 		fields["line"] = l
+		l++
 		i := Influx{}
 		args := strings.Split(line, " ")
 		if len(args) != 3 && len(args) != 2 {

--- a/agent/transformers/opentsdb.go
+++ b/agent/transformers/opentsdb.go
@@ -1,6 +1,7 @@
 package transformers
 
 import (
+	"bufio"
 	"strconv"
 	"strings"
 
@@ -44,11 +45,14 @@ func ParseOpenTSDB(event *types.Event) OpenTSDBList {
 
 	// Split each line of the output into its own metric
 	output := strings.TrimSpace(event.Check.Output)
-	metrics := strings.Split(output, "\n")
+	s := bufio.NewScanner(strings.NewReader(output))
+	l := 0
 
 OUTER:
-	for l, metric := range metrics {
+	for s.Scan() {
+		metric := s.Text()
 		fields["line"] = l
+		l++
 		parts := strings.Split(metric, " ")
 
 		// Ensure we have all the required components. A single metric requires a

--- a/agent/transformers/opentsdb.go
+++ b/agent/transformers/opentsdb.go
@@ -110,6 +110,9 @@ OUTER:
 		// Add this metric to our list
 		openTSDBList = append(openTSDBList, o)
 	}
+	if err := s.Err(); err != nil {
+		logger.WithFields(fields).WithError(ErrMetricExtraction).Error(err)
+	}
 
 	return openTSDBList
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Fixes a bug in multi-line metric extraction that appeared in windows agents by using `bufio` rather than manually splitting lines separated by `\n`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3043

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Tested metrics with newline characters on a windows agent with the configuration below.

**check.yml**
```
type: CheckConfig
api_version: core/v2
metadata:
  name: extract-graphite
  namespace: default
spec:
  command: perl C:\print.pl
  interval: 10
  output_metric_format: graphite_plaintext
  output_metric_handlers:
  - ingest-graphite-metrics
  subscriptions:
  - windows
```
**print.pl**
```
print "os.SERVER.net.Ethernet.tx_bits 2562989216 1560358425\n";
```
**metric debug event**
```
$ sensuctl event info qa-automation graphite-metrics-event --format json | jq .check.output
"{\"metrics\":{\"handlers\":[\"ingest-graphite-metrics\"],\"points\":[{\"name\":\"os.SERVER.net.Ethernet.tx_bits\",\"value\":2562989216,\"timestamp\":1560358425,\"tags\":null}]}}"
```

## Is this change a patch?

Yup.