### PR TITLE
Add labels and annotations as backend config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ displayed inline.
 sensu-backend or sensu-agent process.
 - Added a new `sensuctl describe-type` command to list all resource types.
 - Added a `timeout` flag to `sensu-backend init`.
+- Added `labels` and `annotations` as backend config options.
 
 ### Changed
 - Warning messages from Resty library are now suppressed in sensuctl.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -633,7 +633,11 @@ func (b *Backend) getBackendEntity(config *Config) *corev2.Entity {
 	entity := &corev2.Entity{
 		EntityClass: corev2.EntityBackendClass,
 		System:      getSystemInfo(),
-		ObjectMeta:  corev2.NewObjectMeta(getDefaultBackendID(), ""),
+		ObjectMeta: corev2.ObjectMeta{
+			Name:        getDefaultBackendID(),
+			Labels:      b.cfg.Labels,
+			Annotations: b.cfg.Annotations,
+		},
 	}
 
 	if config.DeregistrationHandler != "" {

--- a/backend/config.go
+++ b/backend/config.go
@@ -65,6 +65,12 @@ type Config struct {
 	// Pipelined Configuration
 	DeregistrationHandler string
 
+	// Labels are key-value pairs that users can provide to backend entities
+	Labels map[string]string
+
+	// Annotations are key-value pairs that users can provide to backend entities
+	Annotations map[string]string
+
 	// Etcd configuration
 	EtcdAdvertiseClientURLs      []string
 	EtcdInitialAdvertisePeerURLs []string


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds `labels` and `annotations` as backend config options.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3698

## Does your change need a Changelog entry?

Yup.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/2383

## How did you verify this change?

**Backend logs:**
```
{"component":"backend","entity":{"entity_class":"backend","metadata":{"name":"Nikkis-MacBook-Pro","labels":{"mando":"baby yoda"}}},"level":"info","msg":"backend entity information","time":"2020-04-16T14:13:32-07:00"}
```

## Is this change a patch?

Nope.