### PR TITLE
Stop using deterministic directories in tests.

### DIFF
--- a/asset/expander_test.go
+++ b/asset/expander_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sensu/sensu-go/testing/testutil"
 )
 
 func TestExpandValidTar(t *testing.T) {
@@ -15,12 +17,12 @@ func TestExpandValidTar(t *testing.T) {
 	}
 	defer f.Close()
 
-	tmpDir := os.TempDir()
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 	targetDirectory := filepath.Join(tmpDir, "rubby-on-rails-tar")
 	if err := os.Mkdir(targetDirectory, 0755); err != nil {
 		t.Fatalf("unable to create target directory, err: %v", err)
 	}
-	defer os.RemoveAll(targetDirectory)
 
 	expander := &archiveExpander{}
 	if err := expander.Expand(f, targetDirectory); err != nil {
@@ -50,12 +52,12 @@ func TestExpandValidTGZ(t *testing.T) {
 	}
 	defer f.Close()
 
-	tmpDir := os.TempDir()
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 	targetDirectory := filepath.Join(tmpDir, "rubby-on-rails-tgz")
 	if err := os.Mkdir(targetDirectory, 0755); err != nil {
 		t.Fatalf("unable to create target directory, err: %v", err)
 	}
-	defer os.RemoveAll(targetDirectory)
 
 	expander := &archiveExpander{}
 	if err := expander.Expand(f, targetDirectory); err != nil {
@@ -74,12 +76,12 @@ func TestExpandUnsupportedArchive(t *testing.T) {
 	}
 	defer f.Close()
 
-	tmpDir := os.TempDir()
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 	targetDirectory := filepath.Join(tmpDir, "unsupported-zip")
 	if err := os.Mkdir(targetDirectory, 0755); err != nil {
 		t.Fatalf("unable to create target directory, err: %v", err)
 	}
-	defer os.RemoveAll(targetDirectory)
 
 	expander := &archiveExpander{}
 	if err := expander.Expand(f, targetDirectory); err == nil {
@@ -98,12 +100,12 @@ func TestExpandInvalidArchive(t *testing.T) {
 	}
 	defer f.Close()
 
-	tmpDir := os.TempDir()
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 	targetDirectory := filepath.Join(tmpDir, "invalid-tar")
 	if err := os.Mkdir(targetDirectory, 0755); err != nil {
 		t.Fatalf("unable to create target directory, err: %v", err)
 	}
-	defer os.RemoveAll(targetDirectory)
 
 	expander := &archiveExpander{}
 	if err := expander.Expand(f, targetDirectory); err == nil {

--- a/asset/integration_test.go
+++ b/asset/integration_test.go
@@ -11,6 +11,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/sensu/sensu-go/asset"
+	"github.com/sensu/sensu-go/testing/testutil"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -23,7 +24,8 @@ func (f *localFetcher) Fetch(ctx context.Context, path string, headers map[strin
 func TestBoltDBManager(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := os.TempDir()
+	tmpDir, remove := testutil.TempDir(t)
+	defer remove()
 
 	path, err := filepath.Abs(".")
 	if err != nil {


### PR DESCRIPTION
Most tests already use ioutil or testutil to create one-off files/dirs.
These are the only ones left. Without this, tests tend to fail on on
multi-user machines if other users run the same tests.

Signed-off-by: Fabian Geisberger <fabi@hudson-trading.com>

## What is this change?

Instead of writing directly to TEMPDIR, use testutil.TempDir to better isolate those tests.

## Why is this change necessary?

If userA runs the test on a machine, and the directory doesn't get cleaned, userB is unable to write to that directory afterwards, breaking the tests.

## Does your change need a Changelog entry?

I don't think so. Tiny test-only chagne.

## Do you need clarification on anything?

Nope.

## Were there any complications while making this change?

Creating temp files/dirs is not standardized in the code base. Eventually all tests should probably use the testutil helper.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

n/a

## How did you verify this change?

Run the tests.

## Is this change a patch?

Nope.