### PR TITLE
Fix another bug that caused sensu-backend restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ instance of the event.
 
 ### Fixed
 - `sensu-backend init` now logs any TLS failures encountered.
+- Fixed another bug where sensu-backend would restart when agents disconnect.
 
 ## [5.19.1] - 2020-04-13
 


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->
#3614 was a partial fix for this issue, but only addressed cancellation during authorization; we shouldn't propagate context cancellation errors during authentication either.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
Fixes #3571

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

Yes.

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

It was difficult to track down the origin of the logged error since that code branch didn't log anything itself, so the only log entry was incredibly generic:

```
{"component":"backend","error":"internal error: internal error: context canceled","level":"error","msg":"backend stopped working and is restarting","time":"2020-03-27T00:55:03-04:00"}
```

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
No docs.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

Manual testing in my nonprod environment with an Ansible playbook that would previously reliably induce a restart.

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into master after merging this patch!

If not, this feature work can go directly into the master branch.
-->
Yes.