### PR TITLE
Return underlying errors when fetching an asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Fixed
-- Fixed a bug where check state and last_ok were not computed until the second
-instance of the event.
 ### Added
 - Added a `timeout` flag to `sensu-backend init`.
 
@@ -18,6 +15,9 @@ instance of the event.
 
 ### Fixed
 - `sensu-backend init` now logs any TLS failures encountered.
+- Fixed a bug where check state and last_ok were not computed until the second
+instance of the event.
+- Return underlying errors when fetching an asset.
 
 ## [5.19.1] - 2020-04-13
 

--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -73,12 +73,12 @@ func (h *httpFetcher) Fetch(ctx context.Context, url string, headers map[string]
 	// Write response to tmp
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "sensu-asset")
 	if err != nil {
-		return nil, fmt.Errorf("can't open tmp file for asset")
+		return nil, fmt.Errorf("can't open tmp file for asset: %s", err)
 	}
 
 	buffered := bufio.NewWriter(tmpFile)
 	if _, err = io.Copy(buffered, resp); err != nil {
-		return nil, fmt.Errorf("error downloading asset")
+		return nil, fmt.Errorf("error downloading asset: %s", err)
 	}
 	if err := buffered.Flush(); err != nil {
 		return nil, fmt.Errorf("error downloading asset: %s", err)


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds any encountered error while fetching an asset to the returned error.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3211

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

I wasn't able to reproduce the bug mentioned but while auditing the code, I found two cases where underlying errors were not returned nor logged.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

N/A

## Is this change a patch?

Yep