### PR TITLE
Fix the validation for env_vars to allow the equal sign in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Fixed
-- Fixed a bug where check state and last_ok were not computed until the second
-instance of the event.
 ### Added
 - Added a `timeout` flag to `sensu-backend init`.
 
@@ -18,6 +15,9 @@ instance of the event.
 
 ### Fixed
 - `sensu-backend init` now logs any TLS failures encountered.
+- Fixed a bug where check state and last_ok were not computed until the second
+instance of the event.
+- Fix the validation for env_vars to allow the equal sign in values.
 
 ## [5.19.1] - 2020-04-13
 

--- a/api/core/v2/env_vars.go
+++ b/api/core/v2/env_vars.go
@@ -6,7 +6,7 @@ import (
 )
 
 func validateVar(v string) error {
-	parts := strings.Split(v, "=")
+	parts := strings.SplitN(v, "=", 2)
 	if len(parts) != 2 {
 		return errors.New("environment variables must be of the form FOO=BAR")
 	}
@@ -31,7 +31,7 @@ func ValidateEnvVars(vars []string) error {
 func EnvVarsToMap(vars []string) map[string]string {
 	result := make(map[string]string, len(vars))
 	for _, v := range vars {
-		parts := strings.Split(v, "=")
+		parts := strings.SplitN(v, "=", 2)
 		if len(parts) == 1 {
 			continue
 		}

--- a/api/core/v2/env_vars_test.go
+++ b/api/core/v2/env_vars_test.go
@@ -23,6 +23,16 @@ func TestValidateEnvVars(t *testing.T) {
 			EnvVars:  []string{"FOO=BAR", "foo:bar"},
 			ExpError: true,
 		},
+		{
+			Name:     "it allows the equal sign in values",
+			EnvVars:  []string{"FOO=BAR=BAZ"},
+			ExpError: false,
+		},
+		{
+			Name:     "it requires a key and a value",
+			EnvVars:  []string{"FOO="},
+			ExpError: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What is this change?

It fixes the validation logic for the `env_vars` slice elements so equal signs (`=`) can be used in values.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/3252

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Successfully reproduce the use case in https://github.com/sensu/sensu-go/issues/3252, by printing the environment variable with `echo $API_TOKEN`.

```
$ s event list
   Entity      Check                                 Output                               Status   Silenced             Timestamp                             UUID
 ────────── ──────────── ─────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── ──────────────────────────────────────
  gin        check-echo   bobsyouruncle==                                                      0   false      2020-04-20 11:34:34 -0400 EDT   5408e73e-e0cc-4ef3-a4af-daa957cbebb2
```

## Is this change a patch?

Yep