### PR TITLE
Log warning when assets are ignored because of filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Fixed
-- Fixed a bug where check state and last_ok were not computed until the second
-instance of the event.
 ### Added
 - Added a `timeout` flag to `sensu-backend init`.
 
@@ -18,6 +15,10 @@ instance of the event.
 
 ### Fixed
 - `sensu-backend init` now logs any TLS failures encountered.
+- Fixed a bug where check state and last_ok were not computed until the second
+instance of the event.
+- Log to the warning level when an asset is not installed because none of the
+filters matched.
 
 ## [5.19.1] - 2020-04-13
 

--- a/asset/filtered_manager.go
+++ b/asset/filtered_manager.go
@@ -88,7 +88,7 @@ func (f *filteredManager) Get(ctx context.Context, asset *corev2.Asset) (*Runtim
 
 	// catch case where no asset build filters pass
 	if filteredAsset == nil {
-		logger.WithFields(fields).Debug("entity not filtered from any asset builds, not installing asset")
+		logger.WithFields(fields).Warn("entity not filtered from any asset builds, not installing asset")
 		return nil, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It changes the log level for the log entry whenever an asset cannot be installed because it didn't matched any of the build filters.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3391

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified

## Is this change a patch?

Yep