### PR TITLE
Fix events by entity in etcd event store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ instance of the event.
 - Log to the warning level when an asset is not installed because none of the
 filters matched.
 - Return underlying errors when fetching an asset.
+- Fixed a bug where the etcd event store would return prefixed matches rather than exact matches when getting events by entity.
 
 ## [5.19.1] - 2020-04-13
 

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -140,7 +140,7 @@ func (s *Store) GetEventsByEntity(ctx context.Context, entityName string, pred *
 	rangeEnd := clientv3.GetPrefixRangeEnd(keyPrefix)
 	opts = append(opts, clientv3.WithRange(rangeEnd))
 
-	resp, err := s.client.Get(ctx, path.Join(keyPrefix, pred.Continue), opts...)
+	resp, err := s.client.Get(ctx, fmt.Sprintf("%s/", path.Join(keyPrefix, pred.Continue)), opts...)
 	if err != nil {
 		return nil, &store.ErrInternal{Message: err.Error()}
 	}

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -138,6 +138,10 @@ func TestEventStorage(t *testing.T) {
 			t.Errorf("bad event: got %v, want %v", got, want)
 		}
 
+		events, err = s.GetEventsByEntity(ctx, "entit", pred)
+		assert.NoError(t, err)
+		assert.Nil(t, events)
+
 		assert.NoError(t, s.DeleteEventByEntityCheck(ctx, "entity1", "check1"))
 		newEv, err = s.GetEventByEntityCheck(ctx, "entity1", "check1")
 		assert.Nil(t, newEv)


### PR DESCRIPTION
## What is this change?

Fixed a bug where the etcd event store would return prefixed matches rather than exact matches when getting events by entity.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3686

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Steps to reproduce in https://github.com/sensu/sensu-go/issues/3686, and unit test.

## Is this change a patch?

Yup.