### PR TITLE
sensuctl logout resets the TLS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ instance of the event.
 filters matched.
 - Return underlying errors when fetching an asset.
 - Fixed a bug where the etcd event store would return prefixed matches rather than exact matches when getting events by entity.
+- `sensuctl logout` now resets the TLS configuration.
 
 ## [5.19.1] - 2020-04-13
 

--- a/cli/commands/logout/logout.go
+++ b/cli/commands/logout/logout.go
@@ -31,6 +31,22 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 				return err
 			}
 
+			// Reset to the default configuration values
+			if err := cli.Config.SaveInsecureSkipTLSVerify(false); err != nil {
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
+			if err := cli.Config.SaveTrustedCAFile(""); err != nil {
+				fmt.Fprintln(cmd.OutOrStderr())
+				return fmt.Errorf(
+					"unable to write new configuration file with error: %s",
+					err,
+				)
+			}
+
 			fmt.Fprintln(cmd.OutOrStdout(), "You have been logged out")
 			return nil
 		},

--- a/cli/commands/logout/logout_test.go
+++ b/cli/commands/logout/logout_test.go
@@ -22,6 +22,8 @@ func TestLogout(t *testing.T) {
 	config.On("SaveTokens", mock.Anything).Return(nil)
 	tokens := types.FixtureTokens("foo", "bar")
 	config.On("Tokens").Return(tokens)
+	config.On("SaveInsecureSkipTLSVerify", false).Return(nil)
+	config.On("SaveTrustedCAFile", "").Return(nil)
 
 	out, err := test.RunCmd(cmd, []string{})
 	assert.Regexp(t, "logged out", out)
@@ -38,6 +40,8 @@ func TestLogoutServerError(t *testing.T) {
 	config := cli.Config.(*clienttest.MockConfig)
 	tokens := types.FixtureTokens("foo", "bar")
 	config.On("Tokens").Return(tokens)
+	config.On("SaveInsecureSkipTLSVerify", false).Return(nil)
+	config.On("SaveTrustedCAFile", "").Return(nil)
 
 	out, err := test.RunCmd(cmd, []string{"bar"})
 	// No error, print help usage
@@ -56,6 +60,8 @@ func TestLogoutServerConfigFile(t *testing.T) {
 	tokens := types.FixtureTokens("foo", "bar")
 	config.On("SaveTokens", mock.Anything).Return(fmt.Errorf("error"))
 	config.On("Tokens").Return(tokens)
+	config.On("SaveInsecureSkipTLSVerify", false).Return(nil)
+	config.On("SaveTrustedCAFile", "").Return(nil)
 
 	out, err := test.RunCmd(cmd, []string{"bar"})
 	// Print usage


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR modifies `sensuctl logout` so it resets the `trusted-ca-file` & `insecure-skip-tls-verify` values.

There's currently an underlying bug which configure the CLI client with these two TLS values before the flags are even evaluated: https://github.com/sensu/sensu-go/blob/de25272fc85857fcab003eab874acef1bd791808/cli/cli.go#L40-L49

Here's a demo of the current behavior:

```
# We expect a TLS error here
$ sensuctl configure -n --username admin --password P@ssw0rd! --url https://52.36.245.15:8080

Error: unable to authenticate with error: Get https://52.36.245.15:8080/auth: x509: certificate signed by unknown authority
exit status 1

# Using the --insecure-skip-tls-verify flag should make it possible to authenticate, which it does
$ sensuctl configure -n --username admin --password P@ssw0rd! --url https://52.36.245.15:8080 --insecure-skip-tls-verify
$

# Removing the --insecure-skip-tls-verify flag should make it fail again, but it does not! Running this command a second time will make the error come back.
$ sensuctl configure -n --username admin --password P@ssw0rd! --url https://52.36.245.15:8080
$ 
```

## Why is this change necessary?

Required by https://github.com/sensu/sensu-go-qa-crucible/pull/115, so the agents specs can be run multiple times without failing.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope. I think fixing the underlying cause might be a bit too complex for now.

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested + unit tests.

## Is this change a patch?

Yep