### PR TITLE
Fix several stability bugs, add SIGHUP reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - [Web] Added the ability for labels and annotations with links to images to be
 displayed inline.
 - [Web] Added additional modes for those with colour blindness.
+- Added support for restarting the backend via SIGHUP. Config reloading is not
+supported yet.
 
 ### Changed
 - Removed deprecated flags in `sensuctl silenced update` subcommand.
@@ -31,6 +33,10 @@ filters matched.
 - [Web] Fixes issue where labels with links could lead to a crash.
 - [Web] Fixed an issue where trying to use an unregistered theme could lead to a
 crash.
+- Fixed a bug that would cause the backend to crash.
+- Fixed a bug that would cause messages like "unary invoker failed" to appear
+in the logs.
+- Fixed several goroutine leaks.
 
 ## [5.19.1] - 2020-04-13
 

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -255,8 +255,14 @@ func (e *Etcd) Shutdown() error {
 	return nil
 }
 
-// NewClient returns a new etcd v3 client. Clients must be closed after use.
+// NewClient returns a new etcd v3 client.
 func (e *Etcd) NewClient() (*clientv3.Client, error) {
+	return e.NewClientContext(context.Background())
+}
+
+// NewClientContext is like NewClient, but sets the provided context on the
+// client.
+func (e *Etcd) NewClientContext(ctx context.Context) (*clientv3.Client, error) {
 	tlsConfig, err := ((transport.TLSInfo)(e.cfg.ClientTLSInfo)).ClientConfig()
 	if err != nil {
 		return nil, err
@@ -268,6 +274,7 @@ func (e *Etcd) NewClient() (*clientv3.Client, error) {
 		DialOptions: []grpc.DialOption{
 			grpc.WithBlock(),
 		},
+		Context: ctx,
 	})
 }
 

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -315,6 +315,9 @@ func (e *Eventd) alive(key string, prev liveness.State, leader bool) (bury bool)
 }
 
 func (e *Eventd) dead(key string, prev liveness.State, leader bool) (bury bool) {
+	if e.ctx.Err() != nil {
+		return false
+	}
 	lager := logger.WithFields(logrus.Fields{
 		"status":          liveness.Dead.String(),
 		"previous_status": prev.String()})

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -382,7 +382,7 @@ func TestBuryConditions(t *testing.T) {
 			if test.store != nil {
 				test.store(store)
 			}
-			eventd := &Eventd{store: store, eventStore: store}
+			eventd := &Eventd{store: store, eventStore: store, ctx: context.Background()}
 			if got, want := eventd.dead(test.key, liveness.Alive, false), test.bury; got != want {
 				t.Fatalf("bad bury result: got %v, want %v", got, want)
 			}

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -281,7 +281,10 @@ func Count(ctx context.Context, client *clientv3.Client, key string) (int64, err
 
 	resp, err := client.Get(ctx, key, opts...)
 	if err != nil {
-		return 0, &store.ErrInternal{Message: err.Error()}
+		if err != context.Canceled {
+			err = &store.ErrInternal{Message: err.Error()}
+		}
+		return 0, err
 	}
 
 	return resp.Count, nil


### PR DESCRIPTION
## What is this change?

This commit solves several issues with backend restarts.

* stopGroup and errorGroup no longer block indefinitely after the
run context is cancelled, fixing a small goroutine leak.

* The liveness package no longer caches state at the package scope,
fixing a bug where clients that were closed after a run would be
used. This was the cause of errors like "unary invoker failed",
leading to a crash.

* The backend will no longer try to restart before the previous
run has completely shut down.

* Keepalived goroutines no longer persist between restarts, fixing
a rather large goroutine leak.

* Keepalived and eventd callbacks no longer execute beyond the
scope of their contexts.

* Tessen goroutines no longer persist past the lifetime of Tessen,
which could cause spurious error messages in the logs.

* Ring notifications no longer block indefinitely, and will cease
attempting to notify when the ring's context has been cancelled.

* A small goroutine leak in Schedulerd was fixed.

* The backend ID getter no longer returns ErrInternal if its
context was cancelled.

All of these problems were discovered by implementing restart
support, by installing a signal handler for SIGHUP. With the
ability to manually trigger restarts of sensu-backend, it is much
easier to detect bugs around the backend restarting.

It's now trivial to force a backend restart, simply by issuing:

kill -s SIGHUP $(pidof sensu-backend)

In the future, this command will also cause sensu-backend to reload
its configuration.

## Why is this change necessary?

Fixes #3687 
Fixes #3722 
Potentially resolves #3613

The entire list of bugs resolved is in the description above. There are bugs resolved that do not have open issues.

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

This change is the culmination of around 12 hours of debugging.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

Each piece of this change was discovered by me running sensu-backend, issuing `kill -s SIGHUP`, and observing the results in the logs, in the goroutine profiler, and netstat. In particular, I made sure that the number of goroutines would be the same after a restart as before, and I made sure that connections were not piling up in netstat.

## Is this change a patch?

This change is a patch.