### PR TITLE
Close event store at end of backend run

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -451,6 +451,9 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 }
 
 func (b *Backend) runOnce(sighup <-chan os.Signal) error {
+	eCloser := b.EventStore.(closer)
+	defer eCloser.Close()
+
 	var derr error
 
 	eg := errGroup{
@@ -522,9 +525,6 @@ func (b *Backend) runOnce(sighup <-chan os.Signal) error {
 	if derr == nil {
 		derr = b.RunContext().Err()
 	}
-
-	eCloser := b.EventStore.(closer)
-	_ = eCloser.Close()
 
 	return derr
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -523,7 +523,14 @@ func (b *Backend) runOnce(sighup <-chan os.Signal) error {
 		derr = b.RunContext().Err()
 	}
 
+	eCloser := b.EventStore.(closer)
+	_ = eCloser.Close()
+
 	return derr
+}
+
+type closer interface {
+	Close() error
 }
 
 // RunContext returns the context for the current run of the backend.

--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -79,3 +79,11 @@ func (e *EventStoreProxy) UpdateEventStore(to EventStore) {
 	}
 	e.gcGuard = to
 }
+
+func (e *EventStoreProxy) Close() error {
+	s := e.do()
+	if c, ok := s.(closer); ok {
+		return c.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
## What is this change?

This change ensures that after the backend restarts, the event store is closed. This fixes a bug where postgres connections can linger after the backend restarts internally.

## Why is this change necessary?

In concert with another bug, where backend restarts occur far too often, connections can leak and overwhelm the server.

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

I used the work done in https://github.com/sensu/sensu-go/pull/3723 to trigger internal restarts. It both helped me reproduce the issue and show that this patch fixes it.

## Is this change a patch?

This change is a  patch.