### PR TITLE
Don't restart sensu-backend on etcdserver: too many requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ crash.
 - Fixed a bug that would cause messages like "unary invoker failed" to appear
 in the logs.
 - Fixed several goroutine leaks.
+- Fixed a bug that would cause the backend to crash when the etcd client got an
+error saying "etcdserver: too many requests".
 
 ## [5.19.1] - 2020-04-13
 

--- a/backend/ringv2/ringv2.go
+++ b/backend/ringv2/ringv2.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coreos/etcd/mvcc/mvccpb"
 	cron "github.com/robfig/cron/v3"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/sensu/sensu-go/util/retry"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -171,10 +172,14 @@ func New(client *clientv3.Client, storePath string) *Ring {
 
 // IsEmpty returns true if there are no items in the ring.
 func (r *Ring) IsEmpty(ctx context.Context) (bool, error) {
-	resp, err := r.client.Get(ctx, r.itemPrefix,
-		clientv3.WithKeysOnly(),
-		clientv3.WithPrefix(),
-		clientv3.WithLimit(1))
+	var resp *clientv3.GetResponse
+	err := etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = r.client.Get(ctx, r.itemPrefix,
+			clientv3.WithKeysOnly(),
+			clientv3.WithPrefix(),
+			clientv3.WithLimit(1))
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return false, err
 	}
@@ -197,7 +202,11 @@ func (r *Ring) Add(ctx context.Context, value string, keepalive int64) (rerr err
 
 	itemKey := path.Join(r.itemPrefix, value)
 
-	getresp, err := r.client.Get(ctx, itemKey)
+	var getresp *clientv3.GetResponse
+	err := etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		getresp, err = r.client.Get(ctx, itemKey)
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return fmt.Errorf("couldn't add %q to ring: %s", value, err)
 	}
@@ -223,7 +232,11 @@ func (r *Ring) Add(ctx context.Context, value string, keepalive int64) (rerr err
 	}
 NEWLEASE:
 
-	lease, err := r.client.Grant(ctx, keepalive)
+	var lease *clientv3.LeaseGrantResponse
+	err = etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		lease, err = r.client.Grant(ctx, keepalive)
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return fmt.Errorf("couldn't add %q to ring: %s", value, err)
 	}
@@ -233,7 +246,11 @@ NEWLEASE:
 		}
 	}()
 
-	if _, err := r.client.Put(ctx, itemKey, "", clientv3.WithLease(lease.ID)); err != nil {
+	err = etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		_, err = r.client.Put(ctx, itemKey, "", clientv3.WithLease(lease.ID))
+		return etcd.RetryRequest(n, err)
+	})
+	if err != nil {
 		return fmt.Errorf("couldn't add %q to ring: %s", value, err)
 	}
 
@@ -253,8 +270,10 @@ func (r *Ring) notifyWatchers() {
 // Remove removes a value from the list. If the value does not exist, nothing
 // happens.
 func (r *Ring) Remove(ctx context.Context, value string) error {
-	_, err := r.client.Delete(ctx, path.Join(r.itemPrefix, value))
-	return err
+	return etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		_, err = r.client.Delete(ctx, path.Join(r.itemPrefix, value))
+		return etcd.RetryRequest(n, err)
+	})
 }
 
 // Watch watches the ring for events. The events are sent on the channel that
@@ -314,7 +333,11 @@ func (w *watcher) getInterval() int {
 func (w *watcher) hasTrigger(ctx context.Context) (bool, string, error) {
 	getTrigger := clientv3.OpGet(w.triggerKey())
 	getFirst := clientv3.OpGet(w.ring.itemPrefix, clientv3.WithPrefix(), clientv3.WithLimit(1))
-	resp, err := w.ring.client.Txn(ctx).Then(getTrigger, getFirst).Commit()
+	var resp *clientv3.TxnResponse
+	err := etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = w.ring.client.Txn(ctx).Then(getTrigger, getFirst).Commit()
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return false, "", err
 	}
@@ -365,8 +388,7 @@ func (w *watcher) ensureActiveTrigger(ctx context.Context) error {
 
 		resp, err := w.ring.client.Txn(ctx).If(triggerCmp).Then(triggerOp).Commit()
 		if err != nil {
-			logger.WithError(err).Error("can't write ring trigger, retrying")
-			return false, nil
+			return etcd.RetryRequest(retry, err)
 		}
 		if !resp.Succeeded {
 			_, _ = w.ring.client.Revoke(ctx, lease.ID)
@@ -458,7 +480,11 @@ func (r *Ring) nextInRing(ctx context.Context, prevKv *mvccpb.KeyValue, n int64)
 		opts = append(opts, clientv3.WithFromKey())
 		opts = append(opts, clientv3.WithRange(end))
 	}
-	resp, err := r.client.Get(ctx, key, opts...)
+	var resp *clientv3.GetResponse
+	err := etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = r.client.Get(ctx, key, opts...)
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get next item(s) in ring: %s", err)
 	}
@@ -472,7 +498,11 @@ func (r *Ring) nextInRing(ctx context.Context, prevKv *mvccpb.KeyValue, n int64)
 	}
 	if int64(len(result)) < n {
 		m := n - int64(len(result))
-		resp, err := r.client.Get(ctx, r.itemPrefix, clientv3.WithPrefix(), clientv3.WithLimit(m))
+		var resp *clientv3.GetResponse
+		err := etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+			resp, err = r.client.Get(ctx, r.itemPrefix, clientv3.WithPrefix(), clientv3.WithLimit(m))
+			return etcd.RetryRequest(n, err)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("couldn't get next item(s) in ring: %s", err)
 		}
@@ -526,7 +556,11 @@ func (w *watcher) advanceRing(ctx context.Context, prevKv *mvccpb.KeyValue) ([]*
 	triggerOp := clientv3.OpPut(w.triggerKey(), nextValue, clientv3.WithLease(lease.ID))
 	triggerCmp := clientv3.Compare(clientv3.Version(w.triggerKey()), "=", 0)
 
-	resp, err := w.ring.client.Txn(ctx).If(triggerCmp).Then(triggerOp).Commit()
+	var resp *clientv3.TxnResponse
+	err = etcd.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = w.ring.client.Txn(ctx).If(triggerCmp).Then(triggerOp).Commit()
+		return etcd.RetryRequest(n, err)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't advance ring: %s", err)
 	}

--- a/backend/store/etcd/asset_store.go
+++ b/backend/store/etcd/asset_store.go
@@ -32,7 +32,13 @@ func (s *Store) DeleteAssetByName(ctx context.Context, name string) error {
 	if name == "" {
 		return &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
-	return Delete(ctx, s.client, GetAssetsPath(ctx, name))
+	err := Delete(ctx, s.client, GetAssetsPath(ctx, name))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetAssets fetches all assets from the store
@@ -50,6 +56,9 @@ func (s *Store) GetAssetByName(ctx context.Context, name string) (*corev2.Asset,
 
 	var asset corev2.Asset
 	if err := Get(ctx, s.client, GetAssetsPath(ctx, name), &asset); err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
 		return nil, err
 	}
 	if asset.Labels == nil {

--- a/backend/store/etcd/asset_store.go
+++ b/backend/store/etcd/asset_store.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 )
 
 const (
@@ -18,13 +16,13 @@ var (
 	assetKeyBuilder = store.NewKeyBuilder(assetsPathPrefix)
 )
 
-func getAssetPath(asset *types.Asset) string {
+func getAssetPath(asset *corev2.Asset) string {
 	return assetKeyBuilder.WithResource(asset).Build(asset.Name)
 }
 
 // GetAssetsPath gets the path of the asset store.
 func GetAssetsPath(ctx context.Context, name string) string {
-	namespace := types.ContextNamespace(ctx)
+	namespace := corev2.ContextNamespace(ctx)
 
 	return assetKeyBuilder.WithNamespace(namespace).Build(name)
 }
@@ -34,38 +32,25 @@ func (s *Store) DeleteAssetByName(ctx context.Context, name string) error {
 	if name == "" {
 		return &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
-
-	if _, err := s.client.Delete(ctx, GetAssetsPath(ctx, name)); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	return nil
+	return Delete(ctx, s.client, GetAssetsPath(ctx, name))
 }
 
 // GetAssets fetches all assets from the store
-func (s *Store) GetAssets(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Asset, error) {
-	assets := []*types.Asset{}
+func (s *Store) GetAssets(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Asset, error) {
+	assets := []*corev2.Asset{}
 	err := List(ctx, s.client, GetAssetsPath, &assets, pred)
 	return assets, err
 }
 
 // GetAssetByName gets an Asset by name.
-func (s *Store) GetAssetByName(ctx context.Context, name string) (*types.Asset, error) {
+func (s *Store) GetAssetByName(ctx context.Context, name string) (*corev2.Asset, error) {
 	if name == "" {
 		return nil, &store.ErrNotValid{Err: errors.New("must specify namespace and name")}
 	}
 
-	resp, err := s.client.Get(ctx, GetAssetsPath(ctx, name))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
-	}
-	if len(resp.Kvs) == 0 {
-		return nil, nil
-	}
-
-	assetBytes := resp.Kvs[0].Value
-	asset := &types.Asset{}
-	if err := unmarshal(assetBytes, asset); err != nil {
-		return nil, &store.ErrDecode{Err: err}
+	var asset corev2.Asset
+	if err := Get(ctx, s.client, GetAssetsPath(ctx, name), &asset); err != nil {
+		return nil, err
 	}
 	if asset.Labels == nil {
 		asset.Labels = make(map[string]string)
@@ -74,29 +59,14 @@ func (s *Store) GetAssetByName(ctx context.Context, name string) (*types.Asset, 
 		asset.Annotations = make(map[string]string)
 	}
 
-	return asset, nil
+	return &asset, nil
 }
 
 // UpdateAsset updates an asset.
-func (s *Store) UpdateAsset(ctx context.Context, asset *types.Asset) error {
+func (s *Store) UpdateAsset(ctx context.Context, asset *corev2.Asset) error {
 	if err := asset.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
 
-	assetBytes, err := proto.Marshal(asset)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(asset.Namespace)), ">", 0)
-	req := clientv3.OpPut(getAssetPath(asset), string(assetBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: asset.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getAssetPath(asset), asset.Namespace, asset)
 }

--- a/backend/store/etcd/authentication.go
+++ b/backend/store/etcd/authentication.go
@@ -37,14 +37,14 @@ func (s *Store) GetJWTSecret() ([]byte, error) {
 
 	resp, err := s.client.Txn(ctx).If(cmp).Then(opPut).Else(opGet).Commit()
 	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+		return nil, err
 	}
 	if resp.Succeeded {
 		return randomBytes, nil
 	}
 	getResp := resp.Responses[0].GetResponseRange()
 	if len(getResp.Kvs) != 1 {
-		return nil, &store.ErrInternal{Message: "secret response is empty"}
+		return nil, errors.New("secret response is empty")
 	}
 	return getResp.Kvs[0].Value, nil
 }
@@ -54,7 +54,7 @@ func (s *Store) UpdateJWTSecret(secret []byte) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*5)
 	defer cancel()
 	if _, err := s.client.Put(ctx, getAuthenticationPath("secret"), string(secret)); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 	return nil
 }

--- a/backend/store/etcd/check_store.go
+++ b/backend/store/etcd/check_store.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 )
@@ -52,18 +51,9 @@ func (s *Store) GetCheckConfigByName(ctx context.Context, name string) (*types.C
 		return nil, &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
 
-	resp, err := s.client.Get(ctx, GetCheckConfigsPath(ctx, name))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
-	}
-	if len(resp.Kvs) == 0 {
-		return nil, nil
-	}
-
-	checkBytes := resp.Kvs[0].Value
-	check := &types.CheckConfig{}
-	if err := unmarshal(checkBytes, check); err != nil {
-		return nil, &store.ErrDecode{Err: err}
+	var check corev2.CheckConfig
+	if err := Get(ctx, s.client, GetCheckConfigsPath(ctx, name), &check); err != nil {
+		return nil, err
 	}
 	if check.Labels == nil {
 		check.Labels = make(map[string]string)
@@ -72,7 +62,7 @@ func (s *Store) GetCheckConfigByName(ctx context.Context, name string) (*types.C
 		check.Annotations = make(map[string]string)
 	}
 
-	return check, nil
+	return &check, nil
 }
 
 // UpdateCheckConfig updates a CheckConfig.
@@ -81,20 +71,5 @@ func (s *Store) UpdateCheckConfig(ctx context.Context, check *types.CheckConfig)
 		return &store.ErrNotValid{Err: err}
 	}
 
-	checkBytes, err := proto.Marshal(check)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(check.Namespace)), ">", 0)
-	req := clientv3.OpPut(getCheckConfigPath(check), string(checkBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: check.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getCheckConfigPath(check), check.Namespace, check)
 }

--- a/backend/store/etcd/cluster_id_store.go
+++ b/backend/store/etcd/cluster_id_store.go
@@ -37,7 +37,7 @@ func (s *Store) GetClusterID(ctx context.Context) (string, error) {
 		return RetryRequest(n, err)
 	})
 	if err != nil {
-		return "", &store.ErrInternal{Message: err.Error()}
+		return "", err
 	}
 
 	if resp.Succeeded {

--- a/backend/store/etcd/cluster_id_store.go
+++ b/backend/store/etcd/cluster_id_store.go
@@ -31,7 +31,11 @@ func (s *Store) GetClusterID(ctx context.Context) (string, error) {
 	putOp := clientv3.OpPut(key, uid)
 	cmp := clientv3.Compare(clientv3.Version(key), "=", 0)
 
-	resp, err := s.client.Txn(ctx).If(cmp).Then(putOp).Else(getOp).Commit()
+	var resp *clientv3.TxnResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Txn(ctx).If(cmp).Then(putOp).Else(getOp).Commit()
+		return RetryRequest(n, err)
+	})
 	if err != nil {
 		return "", &store.ErrInternal{Message: err.Error()}
 	}

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
@@ -61,7 +60,6 @@ func (s *Store) GetEntityByName(ctx context.Context, name string) (*corev2.Entit
 		if _, ok := err.(*store.ErrNotFound); ok {
 			return nil, nil
 		}
-		fmt.Println("hmm", err)
 		return nil, err
 	}
 	if entity.Labels == nil {

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -46,7 +46,13 @@ func (s *Store) DeleteEntityByName(ctx context.Context, name string) error {
 	}
 
 	key := GetEntitiesPath(ctx, name)
-	return Delete(ctx, s.client, key)
+	err := Delete(ctx, s.client, key)
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetEntityByName gets an Entity by its name.

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -3,9 +3,8 @@ package etcd
 import (
 	"context"
 	"errors"
+	"fmt"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 )
@@ -32,10 +31,13 @@ func (s *Store) DeleteEntity(ctx context.Context, e *corev2.Entity) error {
 	if err := e.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
-	if _, err := s.client.Delete(ctx, getEntityPath(e)); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+	err := Delete(ctx, s.client, getEntityPath(e))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
 	}
-	return nil
+	return err
 }
 
 // DeleteEntityByName deletes an Entity by its name.
@@ -45,11 +47,7 @@ func (s *Store) DeleteEntityByName(ctx context.Context, name string) error {
 	}
 
 	key := GetEntitiesPath(ctx, name)
-	if _, err := s.client.Delete(ctx, key); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-
-	return nil
+	return Delete(ctx, s.client, key)
 }
 
 // GetEntityByName gets an Entity by its name.
@@ -58,25 +56,21 @@ func (s *Store) GetEntityByName(ctx context.Context, name string) (*corev2.Entit
 		return nil, &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
 
-	resp, err := s.client.Get(ctx, GetEntitiesPath(ctx, name), clientv3.WithLimit(1))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+	var entity corev2.Entity
+	if err := Get(ctx, s.client, GetEntitiesPath(ctx, name), &entity); err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			return nil, nil
+		}
+		fmt.Println("hmm", err)
+		return nil, err
 	}
-	if len(resp.Kvs) != 1 {
-		return nil, nil
-	}
-	entity := &corev2.Entity{}
-	if err := unmarshal(resp.Kvs[0].Value, entity); err != nil {
-		return nil, &store.ErrDecode{Err: err}
-	}
-
 	if entity.Labels == nil {
 		entity.Labels = make(map[string]string)
 	}
 	if entity.Annotations == nil {
 		entity.Annotations = make(map[string]string)
 	}
-	return entity, nil
+	return &entity, nil
 }
 
 // GetEntities returns the entities for the namespace in the supplied context.
@@ -92,20 +86,5 @@ func (s *Store) UpdateEntity(ctx context.Context, e *corev2.Entity) error {
 		return &store.ErrNotValid{Err: err}
 	}
 
-	eStr, err := proto.Marshal(e)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(e.Namespace)), ">", 0)
-	req := clientv3.OpPut(getEntityPath(e), string(eStr))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: e.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getEntityPath(e), e.Namespace, e)
 }

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -65,7 +65,7 @@ func (s *Store) DeleteEventByEntityCheck(ctx context.Context, entityName, checkN
 		return &store.ErrNotValid{Err: err}
 	}
 
-	err := Delete(ctx, s.client, path)
+	err = Delete(ctx, s.client, path)
 	if err != nil {
 		if _, ok := err.(*store.ErrNotFound); ok {
 			err = nil

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -65,7 +65,13 @@ func (s *Store) DeleteEventByEntityCheck(ctx context.Context, entityName, checkN
 		return &store.ErrNotValid{Err: err}
 	}
 
-	return Delete(ctx, s.client, path)
+	err := Delete(ctx, s.client, path)
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetEvents returns the events for an (optional) namespace. If namespace is the

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -65,10 +65,7 @@ func (s *Store) DeleteEventByEntityCheck(ctx context.Context, entityName, checkN
 		return &store.ErrNotValid{Err: err}
 	}
 
-	if _, err := s.client.Delete(ctx, path); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	return err
+	return Delete(ctx, s.client, path)
 }
 
 // GetEvents returns the events for an (optional) namespace. If namespace is the
@@ -91,9 +88,13 @@ func (s *Store) GetEvents(ctx context.Context, pred *store.SelectionPredicate) (
 		}
 	}
 
-	resp, err := s.client.Get(ctx, key, opts...)
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Get(ctx, key, opts...)
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+		return nil, err
 	}
 
 	if len(resp.Kvs) == 0 {
@@ -140,9 +141,13 @@ func (s *Store) GetEventsByEntity(ctx context.Context, entityName string, pred *
 	rangeEnd := clientv3.GetPrefixRangeEnd(keyPrefix)
 	opts = append(opts, clientv3.WithRange(rangeEnd))
 
-	resp, err := s.client.Get(ctx, fmt.Sprintf("%s/", path.Join(keyPrefix, pred.Continue)), opts...)
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Get(ctx, fmt.Sprintf("%s/", path.Join(keyPrefix, pred.Continue)), opts...)
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+		return nil, err
 	}
 
 	if len(resp.Kvs) == 0 {
@@ -187,9 +192,13 @@ func (s *Store) GetEventByEntityCheck(ctx context.Context, entityName, checkName
 		return nil, &store.ErrNotValid{Err: err}
 	}
 
-	resp, err := s.client.Get(ctx, path, clientv3.WithPrefix(), clientv3.WithSerializable())
+	var resp *clientv3.GetResponse
+	err = Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Get(ctx, path, clientv3.WithPrefix(), clientv3.WithSerializable())
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+		return nil, err
 	}
 	if len(resp.Kvs) == 0 {
 		return nil, nil
@@ -293,9 +302,13 @@ func (s *Store) UpdateEvent(ctx context.Context, event *corev2.Event) (*corev2.E
 
 	cmp := namespaceExistsForResource(event.Entity)
 	req := clientv3.OpPut(getEventPath(event), string(eventBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
+	var res *clientv3.TxnResponse
+	err = Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		res, err = s.client.Txn(ctx).If(cmp).Then(req).Commit()
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return nil, nil, &store.ErrInternal{Message: err.Error()}
+		return nil, nil, err
 	}
 	if !res.Succeeded {
 		return nil, nil, &store.ErrNamespaceMissing{Namespace: event.Entity.Namespace}
@@ -351,7 +364,7 @@ func handleExpireOnResolveEntries(ctx context.Context, event *corev2.Event, st s
 
 	entries, err := st.GetSilencedEntriesByName(ctx, event.Check.Silenced...)
 	if err != nil {
-		return &store.ErrInternal{Message: fmt.Sprintf("couldn't resolve silences: %s", err)}
+		return err
 	}
 	toDelete := []string{}
 	toRetain := []string{}
@@ -364,7 +377,7 @@ func handleExpireOnResolveEntries(ctx context.Context, event *corev2.Event, st s
 	}
 
 	if err := st.DeleteSilencedEntryByName(ctx, toDelete...); err != nil {
-		return &store.ErrInternal{Message: fmt.Sprintf("couldn't resolve silences: %s", err)}
+		return err
 	}
 	event.Check.Silenced = toRetain
 

--- a/backend/store/etcd/filter_store.go
+++ b/backend/store/etcd/filter_store.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 )
 
 var (
@@ -15,7 +13,7 @@ var (
 	eventFilterKeyBuilder  = store.NewKeyBuilder(eventFiltersPathPrefix)
 )
 
-func getEventFilterPath(filter *types.EventFilter) string {
+func getEventFilterPath(filter *corev2.EventFilter) string {
 	return eventFilterKeyBuilder.WithResource(filter).Build(filter.Name)
 }
 
@@ -30,68 +28,35 @@ func (s *Store) DeleteEventFilterByName(ctx context.Context, name string) error 
 		return &store.ErrNotValid{Err: errors.New("must specify name of filter")}
 	}
 
-	resp, err := s.client.Delete(ctx, GetEventFiltersPath(ctx, name))
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-
-	if resp.Deleted != 1 {
-		return &store.ErrNotFound{Key: name}
-	}
-
-	return nil
+	return Delete(ctx, s.client, GetEventFiltersPath(ctx, name))
 }
 
 // GetEventFilters gets the list of filters for a namespace.
-func (s *Store) GetEventFilters(ctx context.Context, pred *store.SelectionPredicate) ([]*types.EventFilter, error) {
-	filters := []*types.EventFilter{}
+func (s *Store) GetEventFilters(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.EventFilter, error) {
+	filters := []*corev2.EventFilter{}
 	err := List(ctx, s.client, GetEventFiltersPath, &filters, pred)
 	return filters, err
 }
 
 // GetEventFilterByName gets an EventFilter by name.
-func (s *Store) GetEventFilterByName(ctx context.Context, name string) (*types.EventFilter, error) {
+func (s *Store) GetEventFilterByName(ctx context.Context, name string) (*corev2.EventFilter, error) {
 	if name == "" {
 		return nil, &store.ErrNotValid{Err: errors.New("must specify name of filter")}
 	}
 
-	resp, err := s.client.Get(ctx, GetEventFiltersPath(ctx, name))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
-	}
-	if len(resp.Kvs) == 0 {
-		return nil, nil
+	var filter corev2.EventFilter
+	if err := Get(ctx, s.client, GetEventFiltersPath(ctx, name), &filter); err != nil {
+		return nil, err
 	}
 
-	filterBytes := resp.Kvs[0].Value
-	filter := &types.EventFilter{}
-	if err := unmarshal(filterBytes, filter); err != nil {
-		return nil, &store.ErrDecode{Err: err}
-	}
-
-	return filter, nil
+	return &filter, nil
 }
 
 // UpdateEventFilter updates an EventFilter.
-func (s *Store) UpdateEventFilter(ctx context.Context, filter *types.EventFilter) error {
+func (s *Store) UpdateEventFilter(ctx context.Context, filter *corev2.EventFilter) error {
 	if err := filter.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
 
-	filterBytes, err := proto.Marshal(filter)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(filter.Namespace)), ">", 0)
-	req := clientv3.OpPut(getEventFilterPath(filter), string(filterBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: filter.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getEventFilterPath(filter), filter.Namespace, filter)
 }

--- a/backend/store/etcd/filter_store.go
+++ b/backend/store/etcd/filter_store.go
@@ -28,7 +28,13 @@ func (s *Store) DeleteEventFilterByName(ctx context.Context, name string) error 
 		return &store.ErrNotValid{Err: errors.New("must specify name of filter")}
 	}
 
-	return Delete(ctx, s.client, GetEventFiltersPath(ctx, name))
+	err := Delete(ctx, s.client, GetEventFiltersPath(ctx, name))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetEventFilters gets the list of filters for a namespace.
@@ -46,6 +52,9 @@ func (s *Store) GetEventFilterByName(ctx context.Context, name string) (*corev2.
 
 	var filter corev2.EventFilter
 	if err := Get(ctx, s.client, GetEventFiltersPath(ctx, name), &filter); err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
 		return nil, err
 	}
 

--- a/backend/store/etcd/handler_store.go
+++ b/backend/store/etcd/handler_store.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 )
 
 var (
@@ -15,7 +13,7 @@ var (
 	handlerKeyBuilder  = store.NewKeyBuilder(handlersPathPrefix)
 )
 
-func getHandlerPath(handler *types.Handler) string {
+func getHandlerPath(handler *corev2.Handler) string {
 	return handlerKeyBuilder.WithResource(handler).Build(handler.Name)
 }
 
@@ -30,62 +28,34 @@ func (s *Store) DeleteHandlerByName(ctx context.Context, name string) error {
 		return &store.ErrNotValid{Err: errors.New("must specify name of handler")}
 	}
 
-	if _, err := s.client.Delete(ctx, GetHandlersPath(ctx, name)); err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	return nil
+	return Delete(ctx, s.client, GetHandlersPath(ctx, name))
 }
 
 // GetHandlers gets the list of handlers for a namespace.
-func (s *Store) GetHandlers(ctx context.Context, pred *store.SelectionPredicate) ([]*types.Handler, error) {
-	handlers := []*types.Handler{}
+func (s *Store) GetHandlers(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Handler, error) {
+	handlers := []*corev2.Handler{}
 	err := List(ctx, s.client, GetHandlersPath, &handlers, pred)
 	return handlers, err
 }
 
 // GetHandlerByName gets a Handler by name.
-func (s *Store) GetHandlerByName(ctx context.Context, name string) (*types.Handler, error) {
+func (s *Store) GetHandlerByName(ctx context.Context, name string) (*corev2.Handler, error) {
 	if name == "" {
 		return nil, &store.ErrNotValid{Err: errors.New("must specify name of handler")}
 	}
 
-	resp, err := s.client.Get(ctx, GetHandlersPath(ctx, name))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+	var handler corev2.Handler
+	if err := Get(ctx, s.client, GetHandlersPath(ctx, name), &handler); err != nil {
+		return nil, err
 	}
-	if len(resp.Kvs) == 0 {
-		return nil, nil
-	}
-
-	handlerBytes := resp.Kvs[0].Value
-	handler := &types.Handler{}
-	if err := unmarshal(handlerBytes, handler); err != nil {
-		return nil, &store.ErrDecode{Err: err}
-	}
-
-	return handler, nil
+	return &handler, nil
 }
 
 // UpdateHandler updates a Handler.
-func (s *Store) UpdateHandler(ctx context.Context, handler *types.Handler) error {
+func (s *Store) UpdateHandler(ctx context.Context, handler *corev2.Handler) error {
 	if err := handler.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
 
-	handlerBytes, err := proto.Marshal(handler)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(handler.Namespace)), ">", 0)
-	req := clientv3.OpPut(getHandlerPath(handler), string(handlerBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: handler.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getHandlerPath(handler), handler.Namespace, handler)
 }

--- a/backend/store/etcd/handler_store.go
+++ b/backend/store/etcd/handler_store.go
@@ -28,7 +28,13 @@ func (s *Store) DeleteHandlerByName(ctx context.Context, name string) error {
 		return &store.ErrNotValid{Err: errors.New("must specify name of handler")}
 	}
 
-	return Delete(ctx, s.client, GetHandlersPath(ctx, name))
+	err := Delete(ctx, s.client, GetHandlersPath(ctx, name))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetHandlers gets the list of handlers for a namespace.
@@ -46,6 +52,9 @@ func (s *Store) GetHandlerByName(ctx context.Context, name string) (*corev2.Hand
 
 	var handler corev2.Handler
 	if err := Get(ctx, s.client, GetHandlersPath(ctx, name), &handler); err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
 		return nil, err
 	}
 	return &handler, nil

--- a/backend/store/etcd/handler_store_test.go
+++ b/backend/store/etcd/handler_store_test.go
@@ -37,6 +37,11 @@ func TestHandlerStorage(t *testing.T) {
 		assert.Equal(t, handler.Command, retrieved.Command)
 		assert.Equal(t, handler.Timeout, retrieved.Timeout)
 
+		dne, err := s.GetHandlerByName(ctx, "doesnotexist")
+		require.NoError(t, err)
+		require.Nil(t, dne)
+		require.NoError(t, s.DeleteHandlerByName(ctx, "doesnotexist"))
+
 		handlers, err = s.GetHandlers(ctx, pred)
 		require.NoError(t, err)
 		require.NotEmpty(t, handlers)

--- a/backend/store/etcd/hook_store.go
+++ b/backend/store/etcd/hook_store.go
@@ -31,7 +31,13 @@ func (s *Store) DeleteHookConfigByName(ctx context.Context, name string) error {
 		return errors.New("must specify name")
 	}
 
-	return Delete(ctx, s.client, GetHookConfigsPath(ctx, name))
+	err := Delete(ctx, s.client, GetHookConfigsPath(ctx, name))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
+	return err
 }
 
 // GetHookConfigs returns hook configurations for a namespace.
@@ -49,6 +55,9 @@ func (s *Store) GetHookConfigByName(ctx context.Context, name string) (*corev2.H
 
 	var hook corev2.HookConfig
 	if err := Get(ctx, s.client, GetHookConfigsPath(ctx, name), &hook); err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
 		return nil, err
 	}
 

--- a/backend/store/etcd/hook_store.go
+++ b/backend/store/etcd/hook_store.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 )
 
 const (
@@ -18,7 +16,7 @@ var (
 	hookKeyBuilder = store.NewKeyBuilder(hooksPathPrefix)
 )
 
-func getHookConfigPath(hook *types.HookConfig) string {
+func getHookConfigPath(hook *corev2.HookConfig) string {
 	return hookKeyBuilder.WithResource(hook).Build(hook.Name)
 }
 
@@ -33,60 +31,35 @@ func (s *Store) DeleteHookConfigByName(ctx context.Context, name string) error {
 		return errors.New("must specify name")
 	}
 
-	_, err := s.client.Delete(ctx, GetHookConfigsPath(ctx, name))
-	return err
+	return Delete(ctx, s.client, GetHookConfigsPath(ctx, name))
 }
 
 // GetHookConfigs returns hook configurations for a namespace.
-func (s *Store) GetHookConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*types.HookConfig, error) {
-	hooks := []*types.HookConfig{}
+func (s *Store) GetHookConfigs(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.HookConfig, error) {
+	hooks := []*corev2.HookConfig{}
 	err := List(ctx, s.client, GetHookConfigsPath, &hooks, pred)
 	return hooks, err
 }
 
 // GetHookConfigByName gets a HookConfig by name.
-func (s *Store) GetHookConfigByName(ctx context.Context, name string) (*types.HookConfig, error) {
+func (s *Store) GetHookConfigByName(ctx context.Context, name string) (*corev2.HookConfig, error) {
 	if name == "" {
 		return nil, &store.ErrNotValid{Err: errors.New("must specify name")}
 	}
 
-	resp, err := s.client.Get(ctx, GetHookConfigsPath(ctx, name))
-	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
-	}
-	if len(resp.Kvs) == 0 {
-		return nil, nil
+	var hook corev2.HookConfig
+	if err := Get(ctx, s.client, GetHookConfigsPath(ctx, name), &hook); err != nil {
+		return nil, err
 	}
 
-	hookBytes := resp.Kvs[0].Value
-	hook := &types.HookConfig{}
-	if err := unmarshal(hookBytes, hook); err != nil {
-		return nil, &store.ErrDecode{Err: err}
-	}
-
-	return hook, nil
+	return &hook, nil
 }
 
 // UpdateHookConfig updates a HookConfig.
-func (s *Store) UpdateHookConfig(ctx context.Context, hook *types.HookConfig) error {
+func (s *Store) UpdateHookConfig(ctx context.Context, hook *corev2.HookConfig) error {
 	if err := hook.Validate(); err != nil {
 		return &store.ErrNotValid{Err: err}
 	}
 
-	hookBytes, err := proto.Marshal(hook)
-	if err != nil {
-		return &store.ErrEncode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(hook.Namespace)), ">", 0)
-	req := clientv3.OpPut(getHookConfigPath(hook), string(hookBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: hook.Namespace}
-	}
-
-	return nil
+	return CreateOrUpdate(ctx, s.client, getHookConfigPath(hook), hook.Namespace, hook)
 }

--- a/backend/store/etcd/keepalive_store.go
+++ b/backend/store/etcd/keepalive_store.go
@@ -5,43 +5,46 @@ import (
 	"path"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/gogo/protobuf/proto"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/types"
 )
 
 const (
 	keepalivesPathPrefix = "keepalives"
 )
 
-func getKeepalivePath(keepalivesPath string, entity *types.Entity) string {
+func getKeepalivePath(keepalivesPath string, entity *corev2.Entity) string {
 	return path.Join(keepalivesPath, entity.Namespace, entity.Name)
 }
 
 // DeleteFailingKeepalive deletes a failing KeepaliveRecord.
-func (s *Store) DeleteFailingKeepalive(ctx context.Context, entity *types.Entity) error {
-	_, err := s.client.Delete(ctx, getKeepalivePath(s.keepalivesPath, entity))
+func (s *Store) DeleteFailingKeepalive(ctx context.Context, entity *corev2.Entity) error {
+	err := Delete(ctx, s.client, getKeepalivePath(s.keepalivesPath, entity))
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			err = nil
+		}
+	}
 	return err
 }
 
 // GetFailingKeepalives gets all of the failing KeepaliveRecords.
-func (s *Store) GetFailingKeepalives(ctx context.Context) ([]*types.KeepaliveRecord, error) {
-	resp, err := s.client.Get(ctx, s.keepalivesPath, clientv3.WithPrefix())
+func (s *Store) GetFailingKeepalives(ctx context.Context) ([]*corev2.KeepaliveRecord, error) {
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Get(ctx, s.keepalivesPath, clientv3.WithPrefix())
+		return RetryRequest(n, err)
+	})
+
 	if err != nil {
-		return nil, &store.ErrInternal{Message: err.Error()}
+		return nil, err
 	}
 
-	keepalives := []*types.KeepaliveRecord{}
+	keepalives := []*corev2.KeepaliveRecord{}
 	for _, kv := range resp.Kvs {
-		keepalive := &types.KeepaliveRecord{}
+		keepalive := &corev2.KeepaliveRecord{}
 		if err := unmarshal(kv.Value, keepalive); err != nil {
-			// if we have a problem deserializing a keepalive record, delete that record
-			// ignoring any errors we have along the way.
-			// TODO(eric): the above is questionable, consider removing this logic
-			if _, err := s.client.Delete(ctx, string(kv.Key)); err != nil {
-				logger.Debug(err)
-			}
-			continue
+			return nil, &store.ErrNotValid{Err: err}
 		}
 		keepalives = append(keepalives, keepalive)
 	}
@@ -50,22 +53,7 @@ func (s *Store) GetFailingKeepalives(ctx context.Context) ([]*types.KeepaliveRec
 }
 
 // UpdateFailingKeepalive updates a failing KeepaliveRecord.
-func (s *Store) UpdateFailingKeepalive(ctx context.Context, entity *types.Entity, expiration int64) error {
-	kr := types.NewKeepaliveRecord(entity, expiration)
-	krBytes, err := proto.Marshal(kr)
-	if err != nil {
-		return &store.ErrDecode{Err: err}
-	}
-
-	cmp := clientv3.Compare(clientv3.Version(getNamespacePath(entity.Namespace)), ">", 0)
-	req := clientv3.OpPut(getKeepalivePath(s.keepalivesPath, entity), string(krBytes))
-	res, err := s.client.Txn(ctx).If(cmp).Then(req).Commit()
-	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
-	}
-	if !res.Succeeded {
-		return &store.ErrNamespaceMissing{Namespace: entity.Namespace}
-	}
-
-	return err
+func (s *Store) UpdateFailingKeepalive(ctx context.Context, entity *corev2.Entity, expiration int64) error {
+	kr := corev2.NewKeepaliveRecord(entity, expiration)
+	return CreateOrUpdate(ctx, s.client, getKeepalivePath(s.keepalivesPath, entity), entity.Namespace, kr)
 }

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -39,8 +39,11 @@ func NewStore(client *clientv3.Client, name string) *Store {
 	return store
 }
 
+// EtcdInitialDelay is 100 ms.
 const EtcdInitialDelay = time.Millisecond * 100
 
+// Backoff delivers a pre-configured backoff object, suitable for use in making
+// etcd requests.
 func Backoff(ctx context.Context) *retry.ExponentialBackoff {
 	return &retry.ExponentialBackoff{
 		Ctx:                  ctx,
@@ -48,6 +51,11 @@ func Backoff(ctx context.Context) *retry.ExponentialBackoff {
 	}
 }
 
+// RetryRequest will return whether or not to try a request again based on the
+// error given to it, and the number of times the request has been tried.
+//
+// If RetryRequest gets "etcdserver: too many requests", then it will return
+// (false, nil). Otherwise, it will return (true, err).
 func RetryRequest(n int, err error) (bool, error) {
 	if err == nil {
 		return true, nil

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -7,11 +7,13 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/util/retry"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
@@ -37,6 +39,34 @@ func NewStore(client *clientv3.Client, name string) *Store {
 	return store
 }
 
+const EtcdInitialDelay = time.Millisecond * 100
+
+func Backoff(ctx context.Context) *retry.ExponentialBackoff {
+	return &retry.ExponentialBackoff{
+		Ctx:                  ctx,
+		InitialDelayInterval: EtcdInitialDelay,
+	}
+}
+
+func RetryRequest(n int, err error) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	if err == context.Canceled {
+		return true, err
+	}
+	if err == context.DeadlineExceeded {
+		return true, err
+	}
+	// using string comparison here because it's too difficult to tell
+	// what kind of error the client is actually delivering
+	if strings.Contains(err.Error(), "etcdserver: too many requests") {
+		logger.WithError(err).WithField("retry", n).Error("retrying")
+		return false, nil
+	}
+	return true, &store.ErrInternal{Message: err.Error()}
+}
+
 // Create the given key with the serialized object.
 func Create(ctx context.Context, client *clientv3.Client, key, namespace string, object interface{}) error {
 	bytes, err := marshal(object)
@@ -53,11 +83,15 @@ func Create(ctx context.Context, client *clientv3.Client, key, namespace string,
 	comparisons = append(comparisons, keyNotFound(key))
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Else(
-		getNamespace(namespace), getKey(key),
-	).Commit()
+	var resp *clientv3.TxnResponse
+	err = Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Txn(ctx).If(comparisons...).Then(req).Else(
+			getNamespace(namespace), getKey(key),
+		).Commit()
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
@@ -75,7 +109,6 @@ func Create(ctx context.Context, client *clientv3.Client, key, namespace string,
 			Err: fmt.Errorf("could not create the key %s", key),
 		}
 	}
-
 	return nil
 }
 
@@ -94,9 +127,13 @@ func CreateOrUpdate(ctx context.Context, client *clientv3.Client, key, namespace
 	}
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Commit()
+	var resp *clientv3.TxnResponse
+	err = Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Txn(ctx).If(comparisons...).Then(req).Commit()
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
@@ -109,29 +146,36 @@ func CreateOrUpdate(ctx context.Context, client *clientv3.Client, key, namespace
 			Err: fmt.Errorf("could not update the key %s", key),
 		}
 	}
-
 	return nil
+
 }
 
 // Delete the given key
 func Delete(ctx context.Context, client *clientv3.Client, key string) error {
-	resp, err := client.Delete(ctx, key)
+	var resp *clientv3.DeleteResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Delete(ctx, key)
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 	if resp.Deleted == 0 {
 		return &store.ErrNotFound{Key: key}
 	}
-
 	return nil
 }
 
 // Get retrieves an object with the given key
 func Get(ctx context.Context, client *clientv3.Client, key string, object interface{}) error {
 	// Fetch the key from the store
-	resp, err := client.Get(ctx, key, clientv3.WithLimit(1))
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Get(ctx, key, clientv3.WithLimit(1))
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 
 	// Ensure we only received a single item
@@ -143,7 +187,6 @@ func Get(ctx context.Context, client *clientv3.Client, key string, object interf
 	if err := unmarshal(resp.Kvs[0].Value, object); err != nil {
 		return &store.ErrDecode{Key: key, Err: err}
 	}
-
 	return nil
 }
 
@@ -182,9 +225,14 @@ func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn,
 		}
 	}
 
-	resp, err := client.Get(ctx, key, opts...)
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Get(ctx, key, opts...)
+		return RetryRequest(n, err)
+	})
+
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 
 	for _, kv := range resp.Kvs {
@@ -245,11 +293,15 @@ func Update(ctx context.Context, client *clientv3.Client, key, namespace string,
 	comparisons = append(comparisons, keyFound(key))
 
 	req := clientv3.OpPut(key, string(bytes))
-	resp, err := client.Txn(ctx).If(comparisons...).Then(req).Else(
-		getNamespace(namespace), getKey(key),
-	).Commit()
+	var resp *clientv3.TxnResponse
+	err = Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Txn(ctx).If(comparisons...).Then(req).Else(
+			getNamespace(namespace), getKey(key),
+		).Commit()
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		return &store.ErrInternal{Message: err.Error()}
+		return err
 	}
 	if !resp.Succeeded {
 		// Check if the namespace was missing
@@ -279,11 +331,12 @@ func Count(ctx context.Context, client *clientv3.Client, key string) (int64, err
 		clientv3.WithRange(clientv3.GetPrefixRangeEnd(key)),
 	}
 
-	resp, err := client.Get(ctx, key, opts...)
+	var resp *clientv3.GetResponse
+	err := Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = client.Get(ctx, key, opts...)
+		return RetryRequest(n, err)
+	})
 	if err != nil {
-		if err != context.Canceled {
-			err = &store.ErrInternal{Message: err.Error()}
-		}
 		return 0, err
 	}
 


### PR DESCRIPTION
## What is this change?

This PR causes sensu-backend to retry etcd requests if it receives an error saying "too many requests". It retries using exponential backoff.

## Why is this change necessary?

sensu-backend is too likely to crash when experiencing high load.

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs changes required.

## How did you verify this change?

Extensive performance testing.

## Is this change a patch?

Yes