### PR TITLE
Add GoVersion to version.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ supported yet.
 displayed inline.
 - [Web] Added additional modes for those with colour blindness.
 - Added `Edition` field to version information.
+- Addded `GoVersion` field to version information.
 
 ### Changed
 - Warning messages from Resty library are now suppressed in sensuctl.

--- a/version/version.go
+++ b/version/version.go
@@ -44,7 +44,10 @@ func Semver() string {
 		}
 	}
 
-	// Append the edition suffix to the version
+	return version
+}
+
+func SemverWithEditionSuffix() string {
 	var editionSuffix string
 	switch Edition {
 	case "community":
@@ -54,9 +57,7 @@ func Semver() string {
 	default:
 		editionSuffix = InvalidEditionSuffix
 	}
-	version = fmt.Sprintf("%s+%s", version, editionSuffix)
-
-	return version
+	return fmt.Sprintf("%s+%s", Semver(), editionSuffix)
 }
 
 func SemverWithEditionSuffix() string {

--- a/version/version.go
+++ b/version/version.go
@@ -65,19 +65,6 @@ func SemverWithEditionSuffix() string {
 	return fmt.Sprintf("%s+%s", Semver(), editionSuffix)
 }
 
-func SemverWithEditionSuffix() string {
-	var editionSuffix string
-	switch Edition {
-	case "community":
-		editionSuffix = CommunityEditionSuffix
-	case "enterprise":
-		editionSuffix = EnterpriseEditionSuffix
-	default:
-		editionSuffix = InvalidEditionSuffix
-	}
-	return fmt.Sprintf("%s+%s", Semver(), editionSuffix)
-}
-
 func EditionOutput() string {
 	if Edition == "community" || Edition == "enterprise" {
 		return fmt.Sprintf("%s edition", Edition)

--- a/version/version.go
+++ b/version/version.go
@@ -44,6 +44,18 @@ func Semver() string {
 		}
 	}
 
+	// Append the edition suffix to the version
+	var editionSuffix string
+	switch Edition {
+	case "community":
+		editionSuffix = CommunityEditionSuffix
+	case "enterprise":
+		editionSuffix = EnterpriseEditionSuffix
+	default:
+		editionSuffix = InvalidEditionSuffix
+	}
+	version = fmt.Sprintf("%s+%s", version, editionSuffix)
+
 	return version
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"runtime/debug"
+	"runtime"
 )
 
 const (
@@ -28,6 +29,10 @@ var (
 	// Edition stores the edition of the build
 	// (e.g. community or enterprise)
 	Edition string = "community"
+
+	// GoVersion stores the version of Go used to build the binary
+	// (e.g. go1.14.2)
+	GoVersion string = runtime.Version()
 )
 
 // Semver returns full semantic versioning compatible identifier.
@@ -93,6 +98,7 @@ func FormattedOutput(component string) string {
 	if BuildDate != "" {
 		output += fmt.Sprintf(", built %s", BuildDate)
 	}
+	output += fmt.Sprintf(", built with %s", GoVersion)
 	return output
 }
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -52,9 +52,11 @@ func TestPrintln(t *testing.T) {
 			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag",
 		},
 		{
+			name: "component, version, and invalid edition specified",
 			component: "testing",
 			version:   "1.2.3",
-			edition:   "commercial",
+			edition:   "fake",
+			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag",
 		},
 	}
 	for _, tt := range tests {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestPrintln(t *testing.T) {
+	goVersion := "go1.14.2"
 	tests := []struct {
 		name      string
 		component string
@@ -14,20 +15,23 @@ func TestPrintln(t *testing.T) {
 		edition   string
 		buildDate string
 		buildSHA  string
+		goVersion string
 		want      string
 	}{
 		{
 			name: "component & version specified",
 			component: "testing",
 			version:   "1.2.3",
-			want: "testing version 1.2.3+ce, community edition",
+			goVersion: goVersion,
+			want: "testing version 1.2.3+ce, community edition, built with go1.14.2",
 		},
 		{
 			name: "component, version & buildSHA specified, nil edition",
 			component: "testing",
 			version:   "1.2.3",
 			buildSHA:  "387c20615518f1325528705e0ef09e4d30d80378",
-			want: "testing version 1.2.3+ce, community edition, build 387c20615518f1325528705e0ef09e4d30d80378",
+			goVersion: goVersion,
+			want: "testing version 1.2.3+ce, community edition, build 387c20615518f1325528705e0ef09e4d30d80378, built with go1.14.2",
 		},
 		{
 			name: "component, version, buildDate, & buildSHA specified",
@@ -35,21 +39,24 @@ func TestPrintln(t *testing.T) {
 			version:   "1.2.3",
 			buildDate: "2019-10-09",
 			buildSHA:  "387c20615518f1325528705e0ef09e4d30d80378",
-			want: "testing version 1.2.3+ce, community edition, build 387c20615518f1325528705e0ef09e4d30d80378, built 2019-10-09",
+			goVersion: goVersion,
+			want: "testing version 1.2.3+ce, community edition, build 387c20615518f1325528705e0ef09e4d30d80378, built 2019-10-09, built with go1.14.2",
 		},
 		{
 			name: "component, version, and enterprise edition specified",
 			component: "testing",
 			version:   "1.2.3",
 			edition:   "enterprise",
-			want: "testing version 1.2.3+ee, enterprise edition",
+			goVersion: goVersion,
+			want: "testing version 1.2.3+ee, enterprise edition, built with go1.14.2",
 		},
 		{
 			name: "component, version, and invalid edition specified",
 			component: "testing",
 			version:   "1.2.3",
 			edition:   "fake",
-			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag",
+			goVersion: goVersion,
+			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag, built with go1.14.2",
 		},
 		{
 			name: "component, version, and invalid edition specified",
@@ -67,6 +74,7 @@ func TestPrintln(t *testing.T) {
 			}
 			BuildDate = tt.buildDate
 			BuildSHA = tt.buildSHA
+			GoVersion = tt.goVersion
 			assert.EqualValues(t, tt.want, FormattedOutput(tt.component))
 		})
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -51,6 +51,11 @@ func TestPrintln(t *testing.T) {
 			edition:   "fake",
 			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag",
 		},
+		{
+			component: "testing",
+			version:   "1.2.3",
+			edition:   "commercial",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -63,6 +63,7 @@ func TestPrintln(t *testing.T) {
 			component: "testing",
 			version:   "1.2.3",
 			edition:   "fake",
+			goVersion: goVersion,
 			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag, built with go1.14.2",
 		},
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -63,7 +63,7 @@ func TestPrintln(t *testing.T) {
 			component: "testing",
 			version:   "1.2.3",
 			edition:   "fake",
-			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag",
+			want: "testing version 1.2.3+invalid, built with an invalid \"edition\" ldflag, built with go1.14.2",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What is this change?

Adds a new `GoVersion` field to `version.go` that records the version of Go used to build each binary.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-enterprise-go/issues/976.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new docs required.

## How did you verify this change?

Updated tests and also tested manually.

## Is this change a patch?

No.