### PR TITLE
[GraphQL] Fix bug with hook config field resolver

### DIFF
--- a/backend/apid/graphql/hook.go
+++ b/backend/apid/graphql/hook.go
@@ -20,6 +20,12 @@ type hookImpl struct {
 	schema.HookAliases
 }
 
+// Config implements response to request for 'config' field.
+func (*hookImpl) Config(p graphql.ResolveParams) (interface{}, error) {
+	hook := p.Source.(*corev2.Hook)
+	return &hook.HookConfig, nil
+}
+
 // IsTypeOf is used to determine if a given value is associated with the type
 func (*hookImpl) IsTypeOf(s interface{}, p graphql.IsTypeOfParams) bool {
 	_, ok := s.(*corev2.Hook)


### PR DESCRIPTION
## What is this change?

By default field resolvers will use reflection to resolve a specific field, however, the default resolver has issues traversing embedded types. As such when it was trying to resolve the hook config field it was leading to a panic.

## Why is this change necessary?

Required for sensu/web#305

## Does your change need a Changelog entry?

Unlikely, the GraphQL service isn't publicly supported at this time.

## How did you verify this change?

Manual.