### PR TITLE
[GraphQL] Avoid unnecessary fetch in adhoc check mutation

### DIFF
--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -154,17 +154,15 @@ func (r *mutationsImpl) ExecuteCheck(p schema.MutationExecuteCheckFieldResolverP
 	ctx := setContextFromComponents(p.Context, components)
 
 	client := r.svc.CheckClient
-	check, err := client.FetchCheck(ctx, components.UniqueComponent())
-	if err != nil {
-		return nil, err
-	}
-
 	adhocReq := corev2.AdhocRequest{
-		ObjectMeta:    check.ObjectMeta,
+		ObjectMeta: corev2.NewObjectMeta(
+			components.UniqueComponent(),
+			components.Namespace(),
+		),
 		Subscriptions: p.Args.Input.Subscriptions,
 		Reason:        p.Args.Input.Reason,
 	}
-	err = client.ExecuteCheck(ctx, check.Name, &adhocReq)
+	err := client.ExecuteCheck(ctx, components.UniqueComponent(), &adhocReq)
 	return map[string]interface{}{
 		"clientMutationId": p.Args.Input.ClientMutationID,
 		"errors":           wrapInputErrors("id", err),

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -99,9 +99,7 @@ func TestMutationTypeExecuteCheck(t *testing.T) {
 	params := schema.MutationExecuteCheckFieldResolverParams{}
 	params.Args.Input = &inputs
 
-	check := corev2.FixtureCheckConfig("test")
 	client := new(MockCheckClient)
-	client.On("FetchCheck", mock.Anything, mock.Anything).Return(check, nil)
 	client.On("ExecuteCheck", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	cfg := ServiceConfig{CheckClient: client}
 	impl := mutationsImpl{svc: cfg}


### PR DESCRIPTION
## What is this change?

By not unnecessary fetching the check when we queue an adhoc check, we avoid a potential panic in the case where the check is not available.

## Why is this change necessary?

Sidesteps chance of a panic. See https://github.com/sensu/web/issues/141.

## Does your change need a Changelog entry?

Unlikely, the GraphQL service is not publicly supported. 

## Do you need clarification on anything?

I suspect we do not need to ensure that users have _both_ read & write access to checks, but it might be worth double checking.
## How did you verify this change?

Reviewed unit test & ran it manually.