### PR TITLE
Windows agent: fix flag issues, add log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,17 @@ sensu-backend or sensu-agent process.
 - Added token substitution for assets.
 - Added `Edition` field to version information.
 - Added `GoVersion` field to version information.
+- Windows agent now has log rotation capabilities.
 
 ### Changed
 - Warning messages from Resty library are now suppressed in sensuctl.
+
+### Fixed
+- Windows agent now accepts and remembers arguments passed to 'service run' and
+'service install'.
+- Windows agent synchronizes writes to its log file, ensuring that file size
+will update with every log line written.
+- Windows agent now logs to both console and log file when 'service run' is used.
 
 ## [5.19.3] - 2020-04-30
 

--- a/agent/cmd/service_windows.go
+++ b/agent/cmd/service_windows.go
@@ -3,77 +3,59 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
-	"sync"
-
+	"os/signal"
 	runtimedebug "runtime/debug"
+	"sync"
+	"syscall"
 
 	"github.com/sensu/sensu-go/agent"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/debug"
-	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 var (
-	_            svc.Handler = &Service{}
-	elog         debug.Log
 	AgentNewFunc = agent.NewAgentContext
 )
 
-func NewService(args []string) *Service {
-	return &Service{args: args}
+func NewService(cfg *agent.Config) *Service {
+	return &Service{cfg: cfg}
 }
 
 type Service struct {
-	args []string
-	wg   sync.WaitGroup
-	mu   sync.Mutex
+	cfg *agent.Config
+	wg  sync.WaitGroup
 }
 
-func (s *Service) start(ctx context.Context, args []string, changes chan<- svc.Status) chan error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.wg.Wait()
+func (s *Service) start(ctx context.Context, cancel context.CancelFunc, changes chan<- svc.Status) chan error {
 	s.wg.Add(1)
 	result := make(chan error, 1)
+	defer func() {
+		if e := recover(); e != nil {
+			changes <- svc.Status{State: svc.Stopped}
+			stack := runtimedebug.Stack()
+			result <- errors.New(string(stack))
+		}
+	}()
+	changes <- svc.Status{State: svc.StartPending}
+	accepts := svc.AcceptShutdown | svc.AcceptStop
+	changes <- svc.Status{State: svc.Running, Accepts: accepts}
+
+	sensuAgent, err := agent.NewAgentContext(ctx, s.cfg)
+	if err != nil {
+		result <- err
+		return result
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		defer func() {
-			if e := recover(); e != nil {
-				changes <- svc.Status{State: svc.Stopped}
-				stack := runtimedebug.Stack()
-				result <- errors.New(string(stack))
-			}
-		}()
+		defer cancel()
+		logger.Info("signal received: ", <-sigs)
+	}()
+
+	go func() {
 		defer s.wg.Done()
-		changes <- svc.Status{State: svc.StartPending}
-		// Start service here
-		binPath, err := exePath()
-		if err != nil {
-			panic(err)
-		}
-		configFile := args[0]
-		logPath := args[1]
-		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
-		if err != nil {
-			result <- fmt.Errorf("service quit: cant't open log file: %s", err)
-		}
-		defer logFile.Close()
-
-		logrus.SetFormatter(&logrus.JSONFormatter{})
-		logrus.SetOutput(logFile)
-		logger := logrus.WithFields(logrus.Fields{
-			"component": "cmd",
-		})
-
-		args = []string{binPath, "start", "-c", configFile}
-		command := StartCommand(AgentNewFunc)
-		accepts := svc.AcceptShutdown | svc.AcceptStop
-		changes <- svc.Status{State: svc.Running, Accepts: accepts}
-
-		if err := command.Execute(); err != nil {
-			logger.WithError(err).Error("sensu-agent exited with error")
+		if err := sensuAgent.Run(ctx); err != nil {
 			result <- err
 		}
 	}()
@@ -82,15 +64,14 @@ func (s *Service) start(ctx context.Context, args []string, changes chan<- svc.S
 
 func (s *Service) Execute(_ []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (bool, uint32) {
 	ctx, cancel := context.WithCancel(context.Background())
-	errs := s.start(ctx, s.args, changes)
-	elog, _ := eventlog.Open(serviceName)
-	defer elog.Close()
+	logger.Info("sensu-agent service starting")
+	errs := s.start(ctx, cancel, changes)
 	for {
 		select {
 		case req := <-r:
 			switch req.Cmd {
 			case svc.Stop, svc.Shutdown:
-				elog.Info(1, "service shutting down")
+				logger.Info("sensu-agent shutting down")
 				changes <- svc.Status{State: svc.StopPending}
 				cancel()
 				s.wg.Wait()
@@ -98,23 +79,9 @@ func (s *Service) Execute(_ []string, r <-chan svc.ChangeRequest, changes chan<-
 				return false, 0
 			}
 		case err := <-errs:
-			elog.Error(1, fmt.Sprintf("restarting due to error (%v) %s", s.args, err))
-			s.start(ctx, s.args, changes)
+			logger.WithError(err).Error("fatal error")
+			return false, 1
 		}
 	}
 	return false, 0
-}
-
-func runService(args []string) error {
-	elog, err := eventlog.Open(serviceName)
-	if err != nil {
-		return err
-	}
-	defer elog.Close()
-	elog.Info(1, fmt.Sprintf("starting %s service (%v)", serviceName, args))
-	if err := svc.Run(serviceName, NewService(args)); err != nil {
-		return err
-	}
-	elog.Info(1, fmt.Sprintf("%s service terminated", serviceName))
-	return nil
 }

--- a/agent/cmd/windows.go
+++ b/agent/cmd/windows.go
@@ -3,13 +3,20 @@
 package cmd
 
 import (
-	"errors"
+	"context"
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
+	runtimedebug "runtime/debug"
 
+	"github.com/sensu/sensu-go/util/logging"
 	"github.com/sensu/sensu-go/util/path"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/debug"
+	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 const (
@@ -18,7 +25,16 @@ const (
 	serviceDescription = "The monitoring agent for sensu-go (https://sensu.io)"
 	serviceUser        = "LocalSystem"
 
-	flagLogPath = "log-file"
+	flagLogPath              = "log-file"
+	flagLogMaxSize           = "log-max-size"
+	flagLogRetentionDuration = "log-retention-duration"
+	flagLogRetentionFiles    = "log-retention-files"
+	flagReaperInterval       = "log-reaper-interval"
+)
+
+var (
+	defaultConfigPath = fmt.Sprintf("%s\\agent.yml", path.SystemConfigDir())
+	defaultLogPath    = fmt.Sprintf("%s\\sensu-agent.log", path.SystemLogDir())
 )
 
 // NewWindowsServiceCommand creates a cobra command that offers subcommands
@@ -36,6 +52,15 @@ func NewWindowsServiceCommand() *cobra.Command {
 	return command
 }
 
+func numParents(cmd *cobra.Command) int {
+	var num int
+	for cmd.HasParent() {
+		num++
+		cmd = cmd.Parent()
+	}
+	return num
+}
+
 // NewWindowsInstallServiceCommand creates a cobra command that installs a
 // sensu-agent service in Windows.
 func NewWindowsInstallServiceCommand() *cobra.Command {
@@ -45,42 +70,27 @@ func NewWindowsInstallServiceCommand() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configFile := cmd.Flag(flagConfigFile).Value.String()
-			p, err := filepath.Abs(configFile)
-			if err != nil {
-				return fmt.Errorf("error reading config file: %s", err)
-			}
-			fi, err := os.Stat(p)
-			if err != nil {
-				return fmt.Errorf("error reading config file: %s", err)
-			}
-			if !fi.Mode().IsRegular() {
-				return errors.New("error reading config file: not a regular file")
-			}
-
-			logFile := cmd.Flag(flagLogPath).Value.String()
-			lp, err := filepath.Abs(logFile)
-			if err != nil {
-				return fmt.Errorf("error reading log file: %s", err)
-			}
-			os.OpenFile(lp, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-			lfi, err := os.Stat(lp)
-			if err != nil {
-				return fmt.Errorf("error reading log file: %s", err)
-			}
-			if !lfi.Mode().IsRegular() {
-				return errors.New("error reading log file: not a regular file")
-			}
-
-			return installService(serviceName, serviceDisplayName, serviceDescription, "service", "run", configFile, logFile)
+			installArgs := append([]string{"service", "run"}, os.Args[numParents(cmd)+1:]...)
+			return installService(serviceName, serviceDisplayName, serviceDescription, installArgs...)
 		},
 	}
 
-	defaultConfigPath := fmt.Sprintf("%s\\agent.yml", path.SystemConfigDir())
-	defaultLogPath := fmt.Sprintf("%s\\sensu-agent.log", path.SystemLogDir())
+	viper.SetDefault(flagLogPath, defaultLogPath)
+	viper.SetDefault(flagLogMaxSize, "128 MB")
+	viper.SetDefault(flagLogRetentionDuration, "168h")
+	viper.SetDefault(flagLogRetentionFiles, 10)
+	viper.SetDefault(flagReaperInterval, "1m")
 
-	cmd.Flags().StringP(flagConfigFile, "c", defaultConfigPath, "path to sensu-agent config file")
-	cmd.Flags().StringP(flagLogPath, "", defaultLogPath, "path to the sensu-agent log file")
+	cmd.Flags().String(flagLogPath, viper.GetString(flagLogPath), "path to the sensu-agent log file")
+	cmd.Flags().String(flagLogMaxSize, viper.GetString(flagLogMaxSize), "maximum size of log file")
+	cmd.Flags().String(flagLogRetentionDuration, viper.GetString(flagLogRetentionDuration), "log file retention duration (s, m, h)")
+	cmd.Flags().Int64(flagLogRetentionFiles, viper.GetInt64(flagLogRetentionFiles), "maximum number of archived files to retain")
+	cmd.Flags().String(flagReaperInterval, viper.GetString(flagReaperInterval), "frequency that the archive reaper will run at")
+
+	if err := handleConfig(cmd); err != nil {
+		// can only happen if there is developer error, so don't make any mistakes
+		panic(err)
+	}
 
 	return cmd
 }
@@ -100,14 +110,96 @@ func NewWindowsUninstallServiceCommand() *cobra.Command {
 }
 
 func NewWindowsRunServiceCommand() *cobra.Command {
-	command := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "run",
 		Short:         "run the sensu-agent service (blocking)",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return runService(args)
+		RunE: func(cmd *cobra.Command, args []string) (rerr error) {
+			logrus.SetFormatter(&logrus.JSONFormatter{})
+			isIntSession, err := svc.IsAnInteractiveSession()
+			if err != nil {
+				return fmt.Errorf("failed to determine if process is running in an interactive session: %v", err)
+			}
+			// setup logging
+			elog, err := eventlog.Open(serviceName)
+			if err != nil {
+				return fmt.Errorf("failed to open eventlog: %s", err)
+			}
+			defer elog.Close()
+			_ = viper.BindPFlags(cmd.Flags())
+			rotateFileLoggerCfg := logging.RotateFileLoggerConfig{
+				Path:              viper.GetString(flagLogPath),
+				MaxSizeBytes:      int64(viper.GetSizeInBytes(flagLogMaxSize)),
+				RetentionDuration: viper.GetDuration(flagLogRetentionDuration),
+				RetentionFiles:    viper.GetInt64(flagLogRetentionFiles),
+			}
+			fileLogger, err := logging.NewRotateFileLogger(rotateFileLoggerCfg)
+			if err != nil {
+				elog.Error(1, fmt.Sprintf("error opening log file: %s", err))
+				return err
+			}
+			var logWriter io.Writer = fileLogger
+			if isIntSession {
+				// log to the console if the session is interactive
+				logWriter = io.MultiWriter(fileLogger, os.Stderr)
+			}
+			logrus.SetOutput(logWriter)
+			logger.WithField("logger-config", rotateFileLoggerCfg).Info("logging to file")
+			defer func() {
+				if e := recover(); e != nil {
+					stack := runtimedebug.Stack()
+					msg := fmt.Sprintf("%v\n%s", e, stack)
+					logger.Error(msg)
+					rerr = fmt.Errorf("%v", e)
+				}
+			}()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			reaperErrors := fileLogger.StartReaper(ctx, viper.GetDuration(flagReaperInterval))
+			go func() {
+				for err := range reaperErrors {
+					if err != nil {
+						logger.WithError(err).Warn("error reaping archived logs")
+					}
+				}
+			}()
+			cfg, err := NewAgentConfig(cmd)
+			if err != nil {
+				if !isIntSession {
+					elog.Error(1, fmt.Sprintf("error creating agent config: %s", err))
+				}
+				logger.Error(err)
+				return err
+			}
+			run := svc.Run
+			if isIntSession {
+				run = debug.Run
+			}
+			if err := run(serviceName, NewService(cfg)); err != nil {
+				err = fmt.Errorf("error running service: %s", err)
+				elog.Error(1, err.Error())
+				return err
+			}
+			return nil
 		},
 	}
-	return command
+
+	viper.SetDefault(flagLogPath, defaultLogPath)
+	viper.SetDefault(flagLogMaxSize, "128 MB")
+	viper.SetDefault(flagLogRetentionDuration, "168h")
+	viper.SetDefault(flagLogRetentionFiles, 10)
+	viper.SetDefault(flagReaperInterval, "1m")
+
+	cmd.Flags().String(flagLogPath, viper.GetString(flagLogPath), "path to the sensu-agent log file")
+	cmd.Flags().String(flagLogMaxSize, viper.GetString(flagLogMaxSize), "maximum size of log file")
+	cmd.Flags().String(flagLogRetentionDuration, viper.GetString(flagLogRetentionDuration), "log file retention duration (s, m, h)")
+	cmd.Flags().Int64(flagLogRetentionFiles, viper.GetInt64(flagLogRetentionFiles), "maximum number of archived files to retain")
+	cmd.Flags().String(flagReaperInterval, viper.GetString(flagReaperInterval), "frequency that the archive reaper will run at")
+
+	if err := handleConfig(cmd); err != nil {
+		// can only happen if there is developer error, so don't make any mistakes
+		panic(err)
+	}
+	return cmd
 }

--- a/cmd/sensu-agent/main.go
+++ b/cmd/sensu-agent/main.go
@@ -20,7 +20,11 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmd.VersionCommand())
-	rootCmd.AddCommand(cmd.StartCommand(agent.NewAgentContext))
+	startCmd, err := cmd.StartCommandWithError(agent.NewAgentContext)
+	if err != nil {
+		logger.WithError(err).Fatal("error handling agent config")
+	}
+	rootCmd.AddCommand(startCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.WithError(err).Fatal("error executing sensu-agent")

--- a/util/logging/rotate_logger.go
+++ b/util/logging/rotate_logger.go
@@ -1,0 +1,326 @@
+package logging
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// RotateFileLoggerConfig is configuration for creating a RotateFileLogger.
+//
+// If Path is not specified, then the log will be created in the current
+// working directory, based on the binary name. (e.g. sensu-backend.log)
+//
+// If MaxSizeBytes is not specified, then each log file segment will have at
+// most 128 MB written to it.
+//
+// If RetentionDuration is not specified, then the logger will retain archived
+// log files for an unlimited duration.
+//
+// If RetentionFiles is not specified, then the logger will retain an unbounded
+// number of archived log files.
+type RotateFileLoggerConfig struct {
+	Path              string
+	MaxSizeBytes      int64
+	RetentionDuration time.Duration
+	RetentionFiles    int64
+
+	sync bool // for testing only
+}
+
+func (f *rotateFile) archive(currentName, archiveName string) (err error) {
+	defer func() {
+		e := os.Remove(archiveName)
+		if err == nil {
+			err = e
+		}
+	}()
+	reader, err := os.Open(archiveName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := reader.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+	zipFile, err := os.Create(archiveName + ".zip")
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+	zipper := zip.NewWriter(zipFile)
+	defer zipper.Close()
+	zipWriter, err := zipper.Create(archiveName)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(zipWriter, reader); err != nil {
+		return err
+	}
+	return nil
+}
+
+type rotateFile struct {
+	count     int64
+	max       int64
+	once      sync.Once
+	mu        sync.RWMutex
+	container *atomic.Value
+	file      *os.File
+	sync      bool // only for testing purposes
+}
+
+func (f *rotateFile) Rotate() (*rotateFile, error) {
+	// Ensure that all pending writes finish before starting rotation
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now().UnixNano()
+	currentName := f.file.Name()
+	archiveName := fmt.Sprintf("%s.%d", currentName, now)
+
+	replacement := &rotateFile{
+		max:       f.max,
+		container: f.container,
+		sync:      f.sync,
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(currentName, archiveName); err != nil {
+		return nil, err
+	}
+	var err error
+	replacement.file, err = os.OpenFile(currentName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return f, err
+	}
+
+	if f.sync {
+		if err := f.archive(currentName, archiveName); err != nil {
+			return nil, err
+		}
+	} else {
+		// archiver errors are silently ignored in production,
+		// as there is nothing that can be done about them.
+		go f.archive(currentName, archiveName)
+	}
+
+	return replacement, nil
+}
+
+func (f *rotateFile) Write(p []byte) (int, error) {
+	f.mu.RLock()
+	projected := atomic.AddInt64(&f.count, int64(len(p)))
+	if projected <= f.max {
+		defer f.mu.RUnlock()
+		n, err := f.file.Write(p)
+		if err == nil {
+			err = f.file.Sync()
+		}
+		return n, err
+	}
+	f.mu.RUnlock()
+
+	var err error
+	f.once.Do(func() {
+		var fr *rotateFile
+		fr, err = f.Rotate()
+		if err == nil {
+			f.container.Store(fr)
+		}
+	})
+
+	if err != nil {
+		return 0, fmt.Errorf("error rotating log: %s", err)
+	}
+	replacement := f.container.Load().(*rotateFile)
+	if replacement == f {
+		return 0, errors.New("error rotating log")
+	}
+	return replacement.Write(p)
+}
+
+func (f *rotateFile) Close() error {
+	return f.file.Close()
+}
+
+// RotateFileLogger presents a file-like interface, but dispatches writes to
+// files based on its rotation configuration. Rotated log files are compressed
+// in zip format, as this device is intended to be used for Windows.
+//
+// For information on how to configure RotateFileLogger, see RotateFileLoggerConfig.
+type RotateFileLogger struct {
+	retentionFiles    int64
+	closed            int64
+	retentionDuration time.Duration
+	container         *atomic.Value
+	path              string
+}
+
+// NewRotateFileLogger creates a new configured RotateFileLogger. It opens a
+// file for writing at the path it was configured to use. If there was an error
+// in opening the file for writing, it will be returned.
+//
+// If the logger attempts to open a file that already exists, then its size will
+// be taken into account when doing rotation.
+func NewRotateFileLogger(cfg RotateFileLoggerConfig) (*RotateFileLogger, error) {
+	if cfg.Path == "" {
+		cfg.Path = fmt.Sprintf("%s.log", os.Args[0])
+	}
+	if cfg.MaxSizeBytes == 0 {
+		// 128 MB
+		cfg.MaxSizeBytes = 1 << 27
+	}
+	w := &RotateFileLogger{
+		path:              cfg.Path,
+		retentionDuration: cfg.RetentionDuration,
+		retentionFiles:    cfg.RetentionFiles,
+		container:         new(atomic.Value),
+	}
+	var count int64
+	fi, err := os.Stat(cfg.Path)
+	if err == nil {
+		count = fi.Size()
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	// Open the log file for writing in append mode whether or not it exists
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+	fr := &rotateFile{
+		file:      f,
+		max:       cfg.MaxSizeBytes,
+		count:     count,
+		container: w.container,
+		sync:      cfg.sync,
+	}
+	w.container.Store(fr)
+	return w, nil
+}
+
+// StartReaper starts an asynchronous worker that lists the log files written
+// on an interval, and deletes ones that don't meet the retention criteria
+// configured in the RotateFileLoggerConfig.
+//
+// When the supplied context is cancelled, the reaper will stop reaping.
+//
+// Every iteration of reaping will require that the caller consume errors from
+// the provided error channel. If the caller does not consumer the reaper
+// errors, then the reaper will hang. Errors that are delivered to the error
+// channel can be nil.
+func (r *RotateFileLogger) StartReaper(ctx context.Context, interval time.Duration) <-chan error {
+	errors := make(chan error, 1)
+	go r.reapLoop(ctx, errors, interval)
+	return errors
+}
+
+func (r *RotateFileLogger) reapLoop(ctx context.Context, errors chan error, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			close(errors)
+			return
+		case <-ticker.C:
+			r.reap(errors)
+		}
+	}
+}
+
+func (r *RotateFileLogger) reap(errors chan error) {
+	dir := filepath.Dir(r.path)
+	f, err := os.Open(dir)
+	if err != nil {
+		errors <- err
+		return
+	}
+	files, err := f.Readdirnames(0)
+	if err != nil {
+		errors <- err
+		return
+	}
+	filesToReap := make([]string, 0, len(files))
+	base := filepath.Base(r.path)
+	reapRegexp := regexp.MustCompile(fmt.Sprintf(`^%s\.([0-9]+)(\.zip)?$`, regexp.QuoteMeta(base)))
+	for _, file := range files {
+		if reapRegexp.MatchString(file) {
+			filesToReap = append(filesToReap, file)
+		}
+	}
+	tooOld := make(map[string]bool, len(filesToReap))
+	if r.retentionDuration > 0 {
+		for _, file := range filesToReap {
+			matches := reapRegexp.FindStringSubmatch(file)
+			if len(matches) < 2 {
+				continue
+			}
+			var timestamp int64
+			if _, err := fmt.Sscanf(matches[1], "%d", timestamp); err != nil {
+				continue
+			}
+			archiveTime := time.Unix(0, timestamp)
+			if archiveTime.Add(r.retentionDuration).Before(time.Now()) {
+				tooOld[file] = true
+				if err := os.Remove(file); err != nil {
+					errors <- err
+				}
+			}
+		}
+	}
+	notTooOld := make([]string, 0, len(filesToReap))
+	for _, file := range filesToReap {
+		if !tooOld[file] || r.retentionDuration == 0 {
+			notTooOld = append(notTooOld, file)
+		}
+	}
+	if r.retentionFiles > 0 && int64(len(notTooOld)) > r.retentionFiles {
+		sort.Sort(sort.Reverse(sort.StringSlice(notTooOld)))
+		toRemove := notTooOld[r.retentionFiles:]
+		for _, file := range toRemove {
+			if err := os.Remove(filepath.Join(dir, file)); err != nil {
+				errors <- err
+			}
+		}
+	}
+	errors <- nil
+}
+
+// Write writes its argument to the file that is indicated by the Path field of
+// RotateFileLoggerConfig. If the write would cause the file to grow beyond the
+// bounds of its maximum size, then the call blocks until the existing log file
+// can be moved to a new location, and the path can be opened again as a new
+// file.
+func (r *RotateFileLogger) Write(p []byte) (int, error) {
+	writer := r.container.Load().(*rotateFile)
+	n, err := writer.Write(p)
+	if err == os.ErrClosed {
+		if atomic.LoadInt64(&r.closed) == 0 {
+			// The file was closed for rotation, write to the next one
+			return r.Write(p)
+		}
+	}
+	return n, err
+}
+
+// Close closes the currently opened log file. Calling Write after Close will
+// result in an error.
+func (r *RotateFileLogger) Close() error {
+	atomic.StoreInt64(&r.closed, 1)
+	return r.container.Load().(*rotateFile).Close()
+}

--- a/util/logging/rotate_logger_test.go
+++ b/util/logging/rotate_logger_test.go
@@ -1,0 +1,118 @@
+package logging
+
+import (
+	"archive/zip"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRotateFileLogger(t *testing.T) {
+	td, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(td)
+	}()
+	logPath := filepath.Join(td, "sensu.log")
+
+	var wg, writeWg sync.WaitGroup
+	writeWg.Add(100)
+	wg.Add(99)
+
+	config := RotateFileLoggerConfig{
+		Path:           logPath,
+		MaxSizeBytes:   1024,
+		RetentionFiles: 10,
+		// sync is to cause the writer to block on zipping the file, which is
+		// useful for testing, but not desirable for production use.
+		sync: true,
+	}
+
+	writer, err := NewRotateFileLogger(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := make([]byte, 512)
+	for i := range msg {
+		msg[i] = '!'
+	}
+
+	errors := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			time.Sleep(time.Duration(i) * time.Millisecond)
+			defer writeWg.Done()
+			if _, err := writer.Write(msg); err != nil {
+				errors <- err
+			}
+		}(i)
+	}
+
+	writeWg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Error(err)
+	}
+
+	dir, err := os.Open(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := dir.Readdirnames(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dir.Close()
+	if got, want := len(names), 50; got != want {
+		t.Errorf("wrong number of log files: got %d, want %d", got, want)
+	}
+	for i, name := range names {
+		if name == "sensu.log" {
+			continue
+		}
+		if !strings.HasSuffix(name, ".zip") && name != "sensu.log" {
+			t.Errorf("bad archive name: got %s but wanted something in zip", name)
+		}
+		zipfile, err := zip.OpenReader(filepath.Join(td, name))
+		if err != nil {
+			t.Errorf("file %d: %s", i, err)
+			continue
+		}
+		if got, want := len(zipfile.File), 1; got != want {
+			t.Errorf("file %d: bad number of files in zip file: got %d, want %d", i, got, want)
+		}
+		if got, want := int(zipfile.File[0].UncompressedSize), 1024; got != want {
+			t.Errorf("file %d: bad uncompressed size: got %d, want %d", i, got, want)
+		}
+		_ = zipfile.Close()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := writer.StartReaper(ctx, time.Millisecond*100)
+	if err := <-ch; err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	dir, err = os.Open(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err = dir.Readdirnames(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = dir.Close()
+	if got, want := len(names), 11; got != want {
+		// 10 zipped files plus sensu.log
+		t.Fatalf("wrong number of log files: got %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit makes signifcant fixes and improvements to the Windows
sensu-agent, including log rotation features and improvements to
the way the service installer handlers its arguments.

The service installer now supports all of the arguments that the
regular sensu-agent start command does, and will remember those
arguments when launching the application.

Log rotation is now supported, with support for configurable
log file sizes, and reaping old log files. On rotate, logs are
zipped.

## Why is this change necessary?

Closes #2937 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation updates will be required. cc @hillaryfraley

## How did you verify this change?

Extensive manual testing, including:

* Testing that `service run` works the same as `service install`.
* Testing that logs are output as expected, in both default and specified locations.
* Testing that logs rotate after the maximum log file size is reached.
* Testing that old logs are reaped according to configuration.
* Testing that arguments to `service install` are persisted and used by the service on restart.
* Testing around restarts and errors.

## Is this change a patch?

No