### PR TITLE
Make notepad the default Windows editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ sensu-backend or sensu-agent process.
 
 ### Changed
 - Warning messages from Resty library are now suppressed in sensuctl.
+- Notepad is now the default editor on Windows, instead of vi.
 
 ## [5.19.3] - 2020-04-30
 

--- a/cli/commands/edit/edit.go
+++ b/cli/commands/edit/edit.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"strings"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -22,8 +23,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// vi is the default editor!
-const defaultEditor = "vi"
+const (
+	// vi is the default editor!
+	defaultEditor = "vi"
+	// except on Windows
+	defaultWindowsEditor = "notepad.exe"
+)
 
 func extension(format string) string {
 	switch format {
@@ -208,6 +213,9 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 			editorEnv := os.Getenv("EDITOR")
 			if strings.TrimSpace(editorEnv) == "" {
 				editorEnv = defaultEditor
+				if runtime.GOOS == "windows" {
+					editorEnv = defaultWindowsEditor
+				}
 			}
 			editorArgs := parseCommand(editorEnv)
 			execCmd := exec.Command(editorArgs[0], append(editorArgs[1:], tf.Name())...)


### PR DESCRIPTION
## What is this change?

It makes notepad the default editor on Windows.

## Why is this change necessary?

Quality of life improvement for Windows users.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

```
wine ./sensuctl.exe edit check test
```

## Is this change a patch?

No