### PR TITLE
Use patchable AgentNewFunc

### DIFF
--- a/agent/cmd/service_windows.go
+++ b/agent/cmd/service_windows.go
@@ -40,7 +40,7 @@ func (s *Service) start(ctx context.Context, cancel context.CancelFunc, changes 
 	accepts := svc.AcceptShutdown | svc.AcceptStop
 	changes <- svc.Status{State: svc.Running, Accepts: accepts}
 
-	sensuAgent, err := agent.NewAgentContext(ctx, s.cfg)
+	sensuAgent, err := AgentNewFunc(ctx, s.cfg)
 	if err != nil {
 		result <- err
 		return result

--- a/agent/cmd/windows.go
+++ b/agent/cmd/windows.go
@@ -70,6 +70,7 @@ func NewWindowsInstallServiceCommand() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			_ = viper.BindPFlags(cmd.Flags())
 			installArgs := append([]string{"service", "run"}, os.Args[numParents(cmd)+1:]...)
 			return installService(serviceName, serviceDisplayName, serviceDescription, installArgs...)
 		},


### PR DESCRIPTION
This was missing from the previous PR. We need a way to patch the function used to create a new agent by the Windows service runner.