### PR TITLE
Add support for entity class counts to tessen

### DIFF
--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -604,17 +604,7 @@ func (t *Tessend) getPerResourceMetrics(now int64, data *Data) error {
 	data.Metrics.Points = append(data.Metrics.Points, mp)
 
 	// loop through the entity class counts
-	for class, count := range t.EntityClassCounts() {
-		mp = &corev2.MetricPoint{
-			Name:      fmt.Sprintf("entity_class_%s_count", class),
-			Value:     float64(count),
-			Timestamp: now,
-		}
-		appendInternalTag(mp)
-		appendStoreConfig(mp, t.GetStoreConfig())
-		logMetric(mp)
-		data.Metrics.Points = append(data.Metrics.Points, mp)
-	}
+	data.Metrics.Points = append(data.Metrics.Points, t.getEntityClassMetrics(now)...)
 
 	// loop through the resource map and collect the count of each
 	// resource every 5 seconds to distribute the load on etcd
@@ -682,6 +672,22 @@ func (t *Tessend) send(data *Data) string {
 	}
 
 	return resp.Header.Get(tessenIntervalHeader)
+}
+
+func (t *Tessend) getEntityClassMetrics(now int64) []*corev2.MetricPoint {
+	var points []*corev2.MetricPoint
+	for class, count := range t.EntityClassCounts() {
+		mp := &corev2.MetricPoint{
+			Name:      fmt.Sprintf("entity_class_%s_count", class),
+			Value:     float64(count),
+			Timestamp: now,
+		}
+		appendInternalTag(mp)
+		appendStoreConfig(mp, t.GetStoreConfig())
+		logMetric(mp)
+		points = append(points, mp)
+	}
+	return points
 }
 
 // logMetric logs the metric name and value collected for transparency.


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds support for entity class counts in Tessen. Entity class counts will only be collected in commercial distributions.

Required by https://github.com/sensu/sensu-enterprise-go/pull/1041
Related https://github.com/sensu/tessen/pull/17

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3741

## Does your change need a Changelog entry?

No, entity class counts will only be collected in commercial distributions.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We log every metric for transparency, we do not have to document every metric.

## How did you verify this change?

```
SELECT
 time as "time", value, cluster_id
FROM metrics
WHERE name = 'entity_class_agent_count' AND
  $__timeFilter("time") AND tags->>'license_account_name' is not null and tags->>'license_account_name' != ''
GROUP BY time, cluster_id, value ORDER BY 1
```

## Is this change a patch?

No.