### PR TITLE
Fix libc implementation for ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- The proper libc implementation is now displayed for Ubuntu entities.
+
 ## [5.20.1] - 2020-05-15
 *No changelog for this release.*
 

--- a/system/system.go
+++ b/system/system.go
@@ -88,7 +88,7 @@ func getLibCType() (string, error) {
 		return "", err
 	}
 	text := strings.ToLower(string(output))
-	if strings.Contains(text, "gnu") {
+	if strings.Contains(text, "gnu") || strings.Contains(text, "glibc") {
 		return "glibc", nil
 	}
 	if strings.Contains(text, "musl") {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Checks `ldd --version` output for `glibc` per ubuntu:
```
$ sudo ldd --version
ldd (Ubuntu GLIBC 2.23-0ubuntu10) 2.23
```

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3762

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Tested in staging against https://github.com/sensu/sensu-enterprise-go/tree/bugfix/ubuntu-libc with https://github.com/sensu/sensu-go-qa-crucible/pull/124.

## Is this change a patch?

Yup, targeting release/5.20 branch.