### PR TITLE
Add username as field in API request logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added the username as a field to the API request logger.
+
 ## [5.20.1] - 2020-05-15
 *No changelog for this release.*
 

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -135,9 +135,9 @@ func NewRouter() *mux.Router {
 func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.NewRoute(),
+		middlewares.SimpleLogger{},
 		middlewares.RefreshToken{},
 		middlewares.LimitRequest{},
-		middlewares.SimpleLogger{},
 	)
 
 	mountRouters(subrouter,
@@ -154,11 +154,11 @@ func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
+		middlewares.SimpleLogger{},
 		middlewares.AuthorizationAttributes{},
 		middlewares.Authorization{Authorizer: &rbac.Authorizer{Store: cfg.Store}},
 		middlewares.LimitRequest{},
 		middlewares.Pagination{},
-		middlewares.SimpleLogger{},
 	)
 	mountRouters(
 		subrouter,
@@ -191,11 +191,11 @@ func EntityLimitedCoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
+		middlewares.SimpleLogger{},
 		middlewares.AuthorizationAttributes{},
 		middlewares.Authorization{Authorizer: &rbac.Authorizer{Store: cfg.Store}},
 		middlewares.LimitRequest{},
 		middlewares.Pagination{},
-		middlewares.SimpleLogger{},
 	)
 	mountRouters(
 		subrouter,
@@ -236,8 +236,8 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func PublicSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.NewRoute(),
-		middlewares.LimitRequest{},
 		middlewares.SimpleLogger{},
+		middlewares.LimitRequest{},
 	)
 
 	mountRouters(subrouter,

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -135,9 +135,9 @@ func NewRouter() *mux.Router {
 func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.NewRoute(),
-		middlewares.SimpleLogger{},
 		middlewares.RefreshToken{},
 		middlewares.LimitRequest{},
+		middlewares.SimpleLogger{},
 	)
 
 	mountRouters(subrouter,
@@ -152,13 +152,13 @@ func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
-		middlewares.SimpleLogger{},
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
 		middlewares.AuthorizationAttributes{},
 		middlewares.Authorization{Authorizer: &rbac.Authorizer{Store: cfg.Store}},
 		middlewares.LimitRequest{},
 		middlewares.Pagination{},
+		middlewares.SimpleLogger{},
 	)
 	mountRouters(
 		subrouter,
@@ -189,13 +189,13 @@ func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func EntityLimitedCoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
-		middlewares.SimpleLogger{},
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
 		middlewares.AuthorizationAttributes{},
 		middlewares.Authorization{Authorizer: &rbac.Authorizer{Store: cfg.Store}},
 		middlewares.LimitRequest{},
 		middlewares.Pagination{},
+		middlewares.SimpleLogger{},
 	)
 	mountRouters(
 		subrouter,
@@ -211,7 +211,6 @@ func EntityLimitedCoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.NewRoute(),
-		middlewares.SimpleLogger{},
 		middlewares.LimitRequest{},
 		// We permit requests that do not include an access token or API key,
 		// this allows unauthenticated clients to run introspecton queries or
@@ -221,6 +220,7 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		// https://github.com/graphql/graphiql
 		// https://graphql.org/learn/introspection/
 		middlewares.Authentication{IgnoreUnauthorized: true, Store: cfg.Store},
+		middlewares.SimpleLogger{},
 	)
 
 	mountRouters(
@@ -236,8 +236,8 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func PublicSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.NewRoute(),
-		middlewares.SimpleLogger{},
 		middlewares.LimitRequest{},
+		middlewares.SimpleLogger{},
 	)
 
 	mountRouters(subrouter,


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds the username as a field in the API request logger by extracting the jwt claims from the request context. PR required in sensu-enterprise-go to ensure the `SimpleLogger` is called _after_ authentication.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3763

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Checked the logs on requests using tokens and api keys.
```
{"component":"apid","duration":"1.272ms","level":"info","method":"GET","msg":"request completed","path":"/api/core/v2/namespaces/default/events","size":2832,"status":200,"time":"2020-05-18T12:10:14-07:00","user":"admin"}
```

## Is this change a patch?

Yas, targeting release/5.20 branch.