### PR TITLE
Fix a bug where users could not change password

### DIFF
--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -145,6 +145,9 @@ func (r *UsersRouter) updatePassword(req *http.Request) (interface{}, error) {
 		return nil, err
 	}
 
+	// Remove any old password hash and set the new password hash. The controller
+	// will set the resulting hash in both fields before storing it.
+	user.Password = ""
 	user.PasswordHash = params["password_hash"]
 	err = r.controller.CreateOrReplace(req.Context(), user)
 	return nil, err


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

This PR fixes a bug introduced in https://github.com/sensu/sensu-go/pull/3753.

TL;DR We need to empty the `Password` field once we validated it was the proper one, otherwise the `CreateOrReplace` will refuse it because it differs from the hash.

## Why is this change necessary?

Fixes a bug found in https://github.com/sensu/sensu-go-qa-crucible/pull/122#pullrequestreview-412794184.

## Does your change need a Changelog entry?

Nope, unreleased stuff.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Deployed on staging & tested with the crucible tests.

## Is this change a patch?

Yes but it's a patch for an unreleased feature.