### PR TITLE
Fix retrieving command assets from bonsai

### DIFF
--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sensu/sensu-go/command"
 	"github.com/sensu/sensu-go/testing/mockassetgetter"
 	"github.com/sensu/sensu-go/testing/mockexecutor"
+	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/util/environment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -190,37 +191,6 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 			},
 		},
 		{
-			name:            "no type annotation",
-			wantErr:         true,
-			errMatch:        "requested asset does not have a type annotation set",
-			alias:           "testalias",
-			bonsaiAssetName: bAsset.fullNameWithVersion,
-			bonsaiClientFunc: func(m *MockBonsaiClient) {
-				bonsaiAsset := &bonsai.Asset{
-					Name: bAsset.fullName,
-					Versions: []*bonsai.AssetVersionGrouping{
-						{Version: bAsset.version},
-					},
-				}
-				asset := corev2.Asset{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      bAsset.name,
-						Namespace: bAsset.namespace,
-					},
-					URL:    bAsset.url,
-					Sha512: bAsset.sha512,
-				}
-				assetJSON, err := json.Marshal(asset)
-				if err != nil {
-					t.Fatal(err)
-				}
-				m.On("FetchAsset", bAsset.namespace, bAsset.name).
-					Return(bonsaiAsset, nil)
-				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
-					Return(string(assetJSON), nil)
-			},
-		},
-		{
 			name:            "invalid type annotation",
 			wantErr:         true,
 			errMatch:        "requested asset is not a sensuctl asset",
@@ -244,41 +214,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 					URL:    bAsset.url,
 					Sha512: bAsset.sha512,
 				}
-				assetJSON, err := json.Marshal(asset)
-				if err != nil {
-					t.Fatal(err)
-				}
-				m.On("FetchAsset", bAsset.namespace, bAsset.name).
-					Return(bonsaiAsset, nil)
-				m.On("FetchAssetVersion", bAsset.namespace, bAsset.name, bAsset.version).
-					Return(string(assetJSON), nil)
-			},
-		},
-		{
-			name:            "no provider annotation",
-			wantErr:         true,
-			errMatch:        "requested asset does not have a provider annotation set",
-			alias:           "testalias",
-			bonsaiAssetName: bAsset.fullNameWithVersion,
-			bonsaiClientFunc: func(m *MockBonsaiClient) {
-				bonsaiAsset := &bonsai.Asset{
-					Name: bAsset.fullName,
-					Versions: []*bonsai.AssetVersionGrouping{
-						{Version: bAsset.version},
-					},
-				}
-				asset := corev2.Asset{
-					ObjectMeta: corev2.ObjectMeta{
-						Name:      bAsset.name,
-						Namespace: bAsset.namespace,
-						Annotations: map[string]string{
-							"io.sensu.bonsai.type": "sensuctl",
-						},
-					},
-					URL:    bAsset.url,
-					Sha512: bAsset.sha512,
-				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -313,7 +249,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 					URL:    bAsset.url,
 					Sha512: bAsset.sha512,
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -347,7 +283,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 					URL:    bAsset.url,
 					Sha512: bAsset.sha512,
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -374,7 +310,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						{},
 					},
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -415,7 +351,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						},
 					},
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -452,7 +388,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						},
 					},
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -491,7 +427,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						},
 					},
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -528,7 +464,7 @@ func TestCommandManager_InstallCommandFromBonsai(t *testing.T) {
 						},
 					},
 				}
-				assetJSON, err := json.Marshal(asset)
+				assetJSON, err := json.Marshal(types.WrapResource(&asset))
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where command assets can't be retrieved
from bonsai, because it assumes they will not be provided in a
wrapper. However, bonsai does serve the asset in a wrapper.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Fixes #3768 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

I had to remove the requirement that command assets have the `io.sensu.bonsai.provider` and `io.sensu.bonsai.type` annotations. The installer will still consult these annotations, but if they are missing, installation will not be impeded.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We need developer documentation for writing bonsai assets.

## How did you verify this change?

```
[eric@cube sensu-go]$ sensuctl command install ec2-discovery portertech/sensu-ec2-discovery:0.3.0
fetching bonsai asset: portertech/sensu-ec2-discovery:0.3.0
command was installed successfully
```

## Is this change a patch?

Yes