### PR TITLE
Add validation for subjects in role bindings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - The proper libc implementation is now displayed for Ubuntu entities.
 - Add validation for subjects in RBAC RoleBinding and ClusterRoleBinding.
+- Fixed a bug where single-letter subscriptions were not allowed, even though
+they were intended to be.
 
 ## [5.20.1] - 2020-05-15
 *No changelog for this release.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - The proper libc implementation is now displayed for Ubuntu entities.
+- Add validation for subjects in RBAC RoleBinding and ClusterRoleBinding.
 
 ## [5.20.1] - 2020-05-15
 *No changelog for this release.*

--- a/api/core/v2/rbac_test.go
+++ b/api/core/v2/rbac_test.go
@@ -56,9 +56,9 @@ func TestRuleResourceNameMatches(t *testing.T) {
 		want                  bool
 	}{
 		{
-			name:                  "rule allows all names",
+			name: "rule allows all names",
 			requestedResourceName: "checks",
-			want:                  true,
+			want: true,
 		},
 		{
 			name:          "rule only allows a specific name none specified in req",
@@ -69,13 +69,13 @@ func TestRuleResourceNameMatches(t *testing.T) {
 			name:                  "does not match",
 			resourceNames:         []string{"foo"},
 			requestedResourceName: "bar",
-			want:                  false,
+			want: false,
 		},
 		{
 			name:                  "matches",
 			resourceNames:         []string{"foo", "bar"},
 			requestedResourceName: "bar",
-			want:                  true,
+			want: true,
 		},
 	}
 	for _, tc := range tests {
@@ -190,6 +190,90 @@ func Test_split(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := split(tt.list); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("splitVerbs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateSubjects(t *testing.T) {
+	tests := []struct {
+		Name     string
+		ExpErr   bool
+		Subjects []Subject
+	}{
+		{
+			Name: "valid",
+			Subjects: []Subject{
+				{
+					Type: "user",
+					Name: "eric",
+				},
+			},
+		},
+		{
+			Name: "missing type",
+			Subjects: []Subject{
+				{
+					Name: "eric",
+				},
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "missing name",
+			Subjects: []Subject{
+				{
+					Type: "user",
+				},
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "invalid name",
+			Subjects: []Subject{
+				{
+					Name: "^*^*#$^&#^",
+					Type: "user",
+				},
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "invalid type",
+			Subjects: []Subject{
+				{
+					Name: "eric",
+					Type: "#$*@$*@^#$*",
+				},
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "one valid, one invalid",
+			Subjects: []Subject{
+				{
+					Type: "user",
+					Name: "eric",
+				},
+				{
+					Type: "user",
+				},
+			},
+			ExpErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := ValidateSubjects(test.Subjects)
+			if test.ExpErr {
+				if err == nil {
+					t.Fatal("expected non-nil error")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		})
 	}

--- a/api/core/v2/rbac_test.go
+++ b/api/core/v2/rbac_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -264,7 +265,7 @@ func TestValidateSubjects(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
+		t.Run(test.Name+"_ValidateSubjects", func(t *testing.T) {
 			err := ValidateSubjects(test.Subjects)
 			if test.ExpErr {
 				if err == nil {
@@ -276,5 +277,45 @@ func TestValidateSubjects(t *testing.T) {
 				}
 			}
 		})
+
+		t.Run(test.Name+"_RoleBinding", func(t *testing.T) {
+			crb := FixtureClusterRoleBinding("b")
+			fmt.Println("CRB NAME", crb.Name)
+			crb.Subjects = test.Subjects
+			err := crb.Validate()
+			if test.ExpErr {
+				if err == nil {
+					t.Fatal("expected non-nil error")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+		})
+
+		t.Run(test.Name+"_ClusterRoleBinding", func(t *testing.T) {
+			rb := FixtureRoleBinding("a", "b")
+			rb.Subjects = test.Subjects
+			err := rb.Validate()
+			if test.ExpErr {
+				if err == nil {
+					t.Fatal("expected non-nil error")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+		})
+	}
+}
+
+func TestClusterRoleBindingValidateSub(t *testing.T) {
+	crb := FixtureClusterRoleBinding("a")
+	if err := crb.Validate(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/api/core/v2/rbac_test.go
+++ b/api/core/v2/rbac_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -280,7 +279,6 @@ func TestValidateSubjects(t *testing.T) {
 
 		t.Run(test.Name+"_RoleBinding", func(t *testing.T) {
 			crb := FixtureClusterRoleBinding("b")
-			fmt.Println("CRB NAME", crb.Name)
 			crb.Subjects = test.Subjects
 			err := crb.Validate()
 			if test.ExpErr {

--- a/api/core/v2/validators.go
+++ b/api/core/v2/validators.go
@@ -20,7 +20,7 @@ var StrictNameRegex = regexp.MustCompile(`\A[a-z0-9\_\.\-]+\z`)
 // SubscriptionNameRegex is used to validate the name of a subscription, which
 // can contain a single ":" character in case of an entity subscription (e.g.
 // entity:foo)
-var SubscriptionNameRegex = regexp.MustCompile(`\A[\w\.\-]+\:?[\w\.\-]+\z`)
+var SubscriptionNameRegex = regexp.MustCompile(`\A[\w\.\-]+(\:?[\w\.\-]+)?\z`)
 
 // ValidateName validates the name of an element so it's not empty and it does
 // not contains specical characters. Compatible with Sensu 1.0.


### PR DESCRIPTION
## What is this change?

This commit adds validation for subjects in RBAC role bindings and
cluster role bindings. Previously, users could create bindings with
invalid subjects, leading to confusion.

## Why is this change necessary?

Fixes #3770 

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes are not required.

## How did you verify this change?

Unit testing should suffice.

## Is this change a patch?

Yes.