### PR TITLE
Don't block proxy check requests scheduling on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Errors while publishing proxy check requests do not block scheduling for other
+entities.
+
 ## [5.20.2] - 2020-05-26
 
 ### Added


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It prevents the scheduler from stopping the scheduling of proxy check requests if token substitution or execution of a proxy check fails for a proxy entity, and continues with the next entity instead.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3784

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?
Nope

## Were there any complications while making this change?
Nope


## Have you reviewed and updated the documentation for this change? Is new documentation required?
Nope

## How did you verify this change?

Added a unit test & manually verified.

## Is this change a patch?

Yep