### PR TITLE
Changes to agent logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ hash, in place of the cleartext password
 - Added the beginnings of the core/v3 API.
 - Added automatically generated tests for the core/v2 API.
 
+### Changed
+- `sensu-agent`'s default log level is now `info` instead of `warn`.
+
 ### Fixed
 - The password verification logic when running `sensuctl user change-password`
 has been moved from sensuctl to the backend API.
-### Fixed
 - Errors while publishing proxy check requests do not block scheduling for other
 entities.
 - Listing namespaces in sensuctl with `--chunk-size` now works properly.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,7 +38,7 @@ import (
 func GetDefaultAgentName() string {
 	defaultAgentName, err := os.Hostname()
 	if err != nil {
-		logger.WithError(err).Error("error getting hostname")
+		logger.WithError(err).Warn("failed to get hostname, generating unique ID instead")
 		defaultAgentName = uuid.New().String()
 	}
 	return defaultAgentName
@@ -163,7 +163,7 @@ func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
 }
 
 func (a *Agent) refreshSystemInfoPeriodically(ctx context.Context) {
-	defer logger.Debug("shutting down system info collector")
+	defer logger.Info("shutting down system info collector")
 	ticker := time.NewTicker(time.Duration(DefaultSystemInfoRefreshInterval) * time.Second)
 	defer ticker.Stop()
 
@@ -288,7 +288,7 @@ func (a *Agent) Run(ctx context.Context) error {
 }
 
 func (a *Agent) connectionManager(ctx context.Context, cancel context.CancelFunc) {
-	defer logger.Debug("shutting down connection manager")
+	defer logger.Info("shutting down connection manager")
 	for {
 		a.connectedMu.Lock()
 		a.connected = false

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -276,7 +276,7 @@ func handleConfig(cmd *cobra.Command) error {
 	viper.SetDefault(flagUser, agent.DefaultUser)
 	viper.SetDefault(flagTrustedCAFile, "")
 	viper.SetDefault(flagInsecureSkipTLSVerify, false)
-	viper.SetDefault(flagLogLevel, "warn")
+	viper.SetDefault(flagLogLevel, "info")
 	viper.SetDefault(flagBackendHandshakeTimeout, 15)
 	viper.SetDefault(flagBackendHeartbeatInterval, 30)
 	viper.SetDefault(flagBackendHeartbeatTimeout, 45)


### PR DESCRIPTION
## What is this change?

- default logging level set to `info` instead of `warn`
- change level of a few messages

Small concern that `sensu-agent` has a default log level of `info` while `sensu-backend` and `sensuctl` have a a default of `warn`.

## Why is this change necessary?

Closes #3704.

## Does your change need a Changelog entry?

Yes, added.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes, small change to example `--help` output for `sensu-agent`.
PR: 

## How did you verify this change?


## Is this change a patch?

No.