### PR TITLE
Use code gen "scripts" from internal packages

### DIFF
--- a/api/core/v2/internal/codegen/check_protoc/LICENSE
+++ b/api/core/v2/internal/codegen/check_protoc/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/core/v2/internal/codegen/check_protoc/main.go
+++ b/api/core/v2/internal/codegen/check_protoc/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"os/exec"
+	"regexp"
+)
+
+var libprotoRe = regexp.MustCompile(`^libprotoc 3.9.1\s$`)
+
+func main() {
+	out, err := exec.Command("protoc", "--version").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !libprotoRe.Match(out) {
+		log.Fatalf("bad protoc version: want %q, got %q", libprotoRe.String(), string(out))
+	}
+}

--- a/api/core/v2/internal/codegen/generate_type/LICENSE
+++ b/api/core/v2/internal/codegen/generate_type/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/core/v2/internal/codegen/generate_type/generate_type.go
+++ b/api/core/v2/internal/codegen/generate_type/generate_type.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"text/template"
+	"unicode"
+	"unicode/utf8"
+)
+
+var (
+	tmplPath = flag.String("t", "", "Path to template file")
+	output   = flag.String("o", "", "Path to output file")
+	typeRe   = regexp.MustCompile(`^type ([A-Z].+) struct \{`)
+)
+
+type tmplData struct {
+	TypeNames []string
+	Comment   string
+}
+
+// kebabCase is like snakeCase, but underscores are converted to dashes
+func kebabCase(camelCase string) string {
+	return strings.ReplaceAll(snakeCase(camelCase), "_", "-")
+}
+
+func snakeCase(camelCase string) string {
+	result := make([]rune, 0)
+	for i, s := range camelCase {
+		tl := strings.ToLower(string(s))
+
+		// Treat acronyms as single-word, e.g. LDAP -> ldap
+		var nextCharCaseChanges bool
+		if i+1 < len(camelCase) {
+			nextChar, _ := utf8.DecodeRune([]byte{camelCase[i+1]})
+			// Check if the next character case differs from the current character
+			if (unicode.IsLower(s) && unicode.IsUpper(nextChar)) || (unicode.IsUpper(s) && unicode.IsLower(nextChar)) {
+				nextCharCaseChanges = true
+			}
+		}
+
+		// Add an underscore before the previous character only if it's not the
+		// first character, the next character case changes and we don't already
+		// have an underscore in the result rune
+		if i > 0 && nextCharCaseChanges && result[len(result)-1] != '_' {
+			// Prepend the underscore if the next character is lowercase, otherwise
+			// append it
+			if unicode.IsUpper(s) {
+				result = append(result, '_')
+				result = append(result, []rune(tl)...)
+			} else if unicode.IsLower(s) {
+				result = append(result, []rune(tl)...)
+				result = append(result, '_')
+			}
+		} else {
+			result = append(result, []rune(tl)...)
+		}
+	}
+	return string(result)
+}
+
+func receiver(name string) string {
+	if name == "" {
+		panic("can't resolve receiver name")
+	}
+	letter := strings.ToLower(name[:1])
+	return fmt.Sprintf("%s *%s", letter, name)
+}
+
+func rvar(name string) string {
+	if name == "" {
+		panic("can't resolve receiver name")
+	}
+	return strings.ToLower(name[:1])
+}
+
+func storeSuffix(name string) string {
+	return fmt.Sprintf("%ss", snakeCase(name))
+}
+
+func rbacName(name string) string {
+	return fmt.Sprintf("%ss", snakeCase(name))
+}
+
+func main() {
+	flag.Parse()
+	tmpl, err := template.New(*tmplPath).Funcs(template.FuncMap{
+		"snakeCase":   snakeCase,
+		"receiver":    receiver,
+		"rvar":        rvar,
+		"storeSuffix": storeSuffix,
+		"rbacName":    rbacName,
+		"kebabCase":   kebabCase,
+	}).ParseFiles(*tmplPath)
+
+	if err != nil {
+		log.Fatalf("fatal error parsing %s: %s", *tmplPath, err)
+	}
+	typeNames, err := discoverTypeNames()
+	if err != nil {
+		log.Fatalf("fatal error discovering types: %s", err)
+	}
+	tmplData := tmplData{
+		TypeNames: typeNames,
+		Comment:   "automatically generated file, do not edit!",
+	}
+	out, err := os.Create(*output)
+	if err != nil {
+		log.Fatalf("fatal error creating typemap.go: %s", err)
+	}
+	if err := tmpl.Execute(out, tmplData); err != nil {
+		log.Fatalf("fatal error generating typemap.go: %s", err)
+	}
+}
+
+func discoverTypeNames() ([]string, error) {
+	var typeNames []string
+	doc, err := exec.Command("go", "doc", "-all", ".").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", string(doc), err)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(doc))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		matches := typeRe.FindSubmatch(line)
+		if len(matches) > 1 {
+			// capturing group match in matches[1]
+			typeNames = append(typeNames, string(matches[1]))
+		}
+	}
+	return typeNames, scanner.Err()
+}

--- a/api/core/v2/internal/codegen/generate_type/generate_type_test.go
+++ b/api/core/v2/internal/codegen/generate_type/generate_type_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "testing"
+
+func TestSnakeCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single uppercase character",
+			input: "A",
+			want:  "a",
+		},
+		{
+			name:  "single-word with some uppercases",
+			input: "FooBar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "all uppercase word",
+			input: "FOO",
+			want:  "foo",
+		},
+		{
+			name:  "lowercase with underscore",
+			input: "foo_bar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "some uppercases with underscore",
+			input: "Foo_Bar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "acronym",
+			input: "TLSOptions",
+			want:  "tls_options",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := snakeCase(tt.input); got != tt.want {
+				t.Errorf("snakeCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v2/types_gen.go
+++ b/api/core/v2/types_gen.go
@@ -5,11 +5,11 @@ package v2
 // protoc-gen-gofast used in this generator. We could not find a way of doing
 // this at the time of this writing.
 
-//go:generate go run ../../../scripts/check_protoc/main.go
+//go:generate go run ./internal/codegen/check_protoc
 //go:generate go build -o $GOPATH/bin/protoc-gen-gofast github.com/gogo/protobuf/protoc-gen-gofast
 //go:generate -command protoc protoc --plugin $GOPATH/bin/protoc-gen-gofast --gofast_out=plugins:$GOPATH/src -I=$GOPATH/pkg/mod -I=$GOPATH/src -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.3.1/protobuf
 //go:generate protoc github.com/sensu/sensu-go/api/core/v2/adhoc.proto github.com/sensu/sensu-go/api/core/v2/any.proto github.com/sensu/sensu-go/api/core/v2/apikey.proto github.com/sensu/sensu-go/api/core/v2/asset.proto github.com/sensu/sensu-go/api/core/v2/authentication.proto github.com/sensu/sensu-go/api/core/v2/check.proto github.com/sensu/sensu-go/api/core/v2/entity.proto github.com/sensu/sensu-go/api/core/v2/event.proto github.com/sensu/sensu-go/api/core/v2/extension.proto github.com/sensu/sensu-go/api/core/v2/filter.proto github.com/sensu/sensu-go/api/core/v2/handler.proto github.com/sensu/sensu-go/api/core/v2/hook.proto github.com/sensu/sensu-go/api/core/v2/keepalive.proto github.com/sensu/sensu-go/api/core/v2/meta.proto github.com/sensu/sensu-go/api/core/v2/metrics.proto github.com/sensu/sensu-go/api/core/v2/mutator.proto github.com/sensu/sensu-go/api/core/v2/namespace.proto github.com/sensu/sensu-go/api/core/v2/rbac.proto github.com/sensu/sensu-go/api/core/v2/secret.proto github.com/sensu/sensu-go/api/core/v2/silenced.proto github.com/sensu/sensu-go/api/core/v2/tessen.proto github.com/sensu/sensu-go/api/core/v2/time_window.proto github.com/sensu/sensu-go/api/core/v2/tls.proto github.com/sensu/sensu-go/api/core/v2/user.proto
-//go:generate go run ../../../scripts/generate_type -t typemap.tmpl -o typemap.go
+//go:generate go run ./internal/codegen/generate_type -t typemap.tmpl -o typemap.go
 //go:generate go fmt typemap.go
-//go:generate go run ../../../scripts/generate_type -t typemap_test.tmpl -o typemap_test.go
+//go:generate go run ./internal/codegen/generate_type -t typemap_test.tmpl -o typemap_test.go
 //go:generate go fmt typemap_test.go

--- a/api/core/v3/internal/codegen/check_protoc/LICENSE
+++ b/api/core/v3/internal/codegen/check_protoc/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/core/v3/internal/codegen/check_protoc/main.go
+++ b/api/core/v3/internal/codegen/check_protoc/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+	"os/exec"
+	"regexp"
+)
+
+var libprotoRe = regexp.MustCompile(`^libprotoc 3.9.1\s$`)
+
+func main() {
+	out, err := exec.Command("protoc", "--version").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !libprotoRe.Match(out) {
+		log.Fatalf("bad protoc version: want %q, got %q", libprotoRe.String(), string(out))
+	}
+}

--- a/api/core/v3/internal/codegen/generate_type/LICENSE
+++ b/api/core/v3/internal/codegen/generate_type/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/api/core/v3/internal/codegen/generate_type/generate_type.go
+++ b/api/core/v3/internal/codegen/generate_type/generate_type.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"text/template"
+	"unicode"
+	"unicode/utf8"
+)
+
+var (
+	tmplPath = flag.String("t", "", "Path to template file")
+	output   = flag.String("o", "", "Path to output file")
+	typeRe   = regexp.MustCompile(`^type ([A-Z].+) struct \{`)
+)
+
+type tmplData struct {
+	TypeNames []string
+	Comment   string
+}
+
+// kebabCase is like snakeCase, but underscores are converted to dashes
+func kebabCase(camelCase string) string {
+	return strings.ReplaceAll(snakeCase(camelCase), "_", "-")
+}
+
+func snakeCase(camelCase string) string {
+	result := make([]rune, 0)
+	for i, s := range camelCase {
+		tl := strings.ToLower(string(s))
+
+		// Treat acronyms as single-word, e.g. LDAP -> ldap
+		var nextCharCaseChanges bool
+		if i+1 < len(camelCase) {
+			nextChar, _ := utf8.DecodeRune([]byte{camelCase[i+1]})
+			// Check if the next character case differs from the current character
+			if (unicode.IsLower(s) && unicode.IsUpper(nextChar)) || (unicode.IsUpper(s) && unicode.IsLower(nextChar)) {
+				nextCharCaseChanges = true
+			}
+		}
+
+		// Add an underscore before the previous character only if it's not the
+		// first character, the next character case changes and we don't already
+		// have an underscore in the result rune
+		if i > 0 && nextCharCaseChanges && result[len(result)-1] != '_' {
+			// Prepend the underscore if the next character is lowercase, otherwise
+			// append it
+			if unicode.IsUpper(s) {
+				result = append(result, '_')
+				result = append(result, []rune(tl)...)
+			} else if unicode.IsLower(s) {
+				result = append(result, []rune(tl)...)
+				result = append(result, '_')
+			}
+		} else {
+			result = append(result, []rune(tl)...)
+		}
+	}
+	return string(result)
+}
+
+func receiver(name string) string {
+	if name == "" {
+		panic("can't resolve receiver name")
+	}
+	letter := strings.ToLower(name[:1])
+	return fmt.Sprintf("%s *%s", letter, name)
+}
+
+func rvar(name string) string {
+	if name == "" {
+		panic("can't resolve receiver name")
+	}
+	return strings.ToLower(name[:1])
+}
+
+func storeSuffix(name string) string {
+	return fmt.Sprintf("%ss", snakeCase(name))
+}
+
+func rbacName(name string) string {
+	return fmt.Sprintf("%ss", snakeCase(name))
+}
+
+func main() {
+	flag.Parse()
+	tmpl, err := template.New(*tmplPath).Funcs(template.FuncMap{
+		"snakeCase":   snakeCase,
+		"receiver":    receiver,
+		"rvar":        rvar,
+		"storeSuffix": storeSuffix,
+		"rbacName":    rbacName,
+		"kebabCase":   kebabCase,
+	}).ParseFiles(*tmplPath)
+
+	if err != nil {
+		log.Fatalf("fatal error parsing %s: %s", *tmplPath, err)
+	}
+	typeNames, err := discoverTypeNames()
+	if err != nil {
+		log.Fatalf("fatal error discovering types: %s", err)
+	}
+	tmplData := tmplData{
+		TypeNames: typeNames,
+		Comment:   "automatically generated file, do not edit!",
+	}
+	out, err := os.Create(*output)
+	if err != nil {
+		log.Fatalf("fatal error creating typemap.go: %s", err)
+	}
+	if err := tmpl.Execute(out, tmplData); err != nil {
+		log.Fatalf("fatal error generating typemap.go: %s", err)
+	}
+}
+
+func discoverTypeNames() ([]string, error) {
+	var typeNames []string
+	doc, err := exec.Command("go", "doc", "-all", ".").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s", string(doc), err)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(doc))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		matches := typeRe.FindSubmatch(line)
+		if len(matches) > 1 {
+			// capturing group match in matches[1]
+			typeNames = append(typeNames, string(matches[1]))
+		}
+	}
+	return typeNames, scanner.Err()
+}

--- a/api/core/v3/internal/codegen/generate_type/generate_type_test.go
+++ b/api/core/v3/internal/codegen/generate_type/generate_type_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "testing"
+
+func TestSnakeCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single uppercase character",
+			input: "A",
+			want:  "a",
+		},
+		{
+			name:  "single-word with some uppercases",
+			input: "FooBar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "all uppercase word",
+			input: "FOO",
+			want:  "foo",
+		},
+		{
+			name:  "lowercase with underscore",
+			input: "foo_bar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "some uppercases with underscore",
+			input: "Foo_Bar",
+			want:  "foo_bar",
+		},
+		{
+			name:  "acronym",
+			input: "TLSOptions",
+			want:  "tls_options",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := snakeCase(tt.input); got != tt.want {
+				t.Errorf("snakeCase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v3/types_gen.go
+++ b/api/core/v3/types_gen.go
@@ -5,15 +5,15 @@ package v3
 // protoc-gen-gofast used in this generator. We could not find a way of doing
 // this at the time of this writing.
 
-//go:generate go run ../../../scripts/check_protoc/main.go
+//go:generate go run ./internal/codegen/check_protoc
 //go:generate go build -o $GOPATH/bin/protoc-gen-gofast github.com/gogo/protobuf/protoc-gen-gofast
 //go:generate -command protoc protoc --plugin $GOPATH/bin/protoc-gen-gofast --gofast_out=plugins:$GOPATH/src -I=$GOPATH/pkg/mod -I=$GOPATH/pkg/mod/github.com/gogo/protobuf@v1.3.1/protobuf -I=$GOPATH/src
 //go:generate protoc github.com/sensu/sensu-go/api/core/v3/entity_state.proto github.com/sensu/sensu-go/api/core/v3/entity_config.proto
-//go:generate go run ../../../scripts/generate_type -t typemap.tmpl -o typemap.go
+//go:generate go run ./internal/codegen/generate_type -t typemap.tmpl -o typemap.go
 //go:generate go fmt typemap.go
-//go:generate go run ../../../scripts/generate_type -t typemap_test.tmpl -o typemap_test.go
+//go:generate go run ./internal/codegen/generate_type -t typemap_test.tmpl -o typemap_test.go
 //go:generate go fmt typemap_test.go
-//go:generate go run ../../../scripts/generate_type -t resource_generated.tmpl -o resource_generated.go
+//go:generate go run ./internal/codegen/generate_type -t resource_generated.tmpl -o resource_generated.go
 //go:generate go fmt resource_generated.go
-//go:generate go run ../../../scripts/generate_type -t resource_generated_test.tmpl -o resource_generated_test.go
+//go:generate go run ./internal/codegen/generate_type -t resource_generated_test.tmpl -o resource_generated_test.go
 //go:generate go fmt resource_generated_test.go


### PR DESCRIPTION
This commit moves some programs needed for code generation to
internal packages. This is done to prevent 'go generate' from
breaking when used within a module.

Fixes 'go generate' for core/v2, and for core/v3, when we publish
its module.