### PR TITLE
Bugfix for curated namespaces

### DIFF
--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -39,12 +39,9 @@ func NewNamespaceClient(store store.ResourceStore, auth authorization.Authorizer
 // ListNamespaces fetches a list of the namespace resources that are authorized
 // by the supplied credentials. This may include implicit access via resources
 // that are in a namespace that the credentials are authorized to get.
-func (a *NamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespace, error) {
+func (a *NamespaceClient) ListNamespaces(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Namespace, error) {
 	var resources, namespaces []*corev2.Namespace
-	pred := &store.SelectionPredicate{
-		Continue: corev2.PageContinueFromContext(ctx),
-		Limit:    int64(corev2.PageSizeFromContext(ctx)),
-	}
+
 	visitor, ok := a.auth.(ruleVisitor)
 	if !ok {
 		if err := a.client.List(ctx, &namespaces, pred); err != nil {

--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -248,7 +248,7 @@ func loadNamespacesBatchFn(c NamespaceClient) dataloader.BatchFunc {
 	return func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
 		results := make([]*dataloader.Result, 0, len(keys))
 		for range keys {
-			records, err := c.ListNamespaces(ctx)
+			records, err := c.ListNamespaces(ctx, &store.SelectionPredicate{})
 			result := &dataloader.Result{Data: records, Error: handleListErr(err)}
 			results = append(results, result)
 		}

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -73,7 +73,7 @@ type SilencedClient interface {
 }
 
 type NamespaceClient interface {
-	ListNamespaces(ctx context.Context) ([]*corev2.Namespace, error)
+	ListNamespaces(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Namespace, error)
 	FetchNamespace(ctx context.Context, name string) (*corev2.Namespace, error)
 	CreateNamespace(ctx context.Context, namespace *corev2.Namespace) error
 	UpdateNamespace(ctx context.Context, namespace *corev2.Namespace) error

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -246,8 +246,8 @@ type MockNamespaceClient struct {
 	mock.Mock
 }
 
-func (c *MockNamespaceClient) ListNamespaces(ctx context.Context) ([]*corev2.Namespace, error) {
-	args := c.Called(ctx)
+func (c *MockNamespaceClient) ListNamespaces(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Namespace, error) {
+	args := c.Called(ctx, pred)
 	return args.Get(0).([]*corev2.Namespace), args.Error(1)
 }
 

--- a/backend/apid/graphql/viewer_test.go
+++ b/backend/apid/graphql/viewer_test.go
@@ -55,7 +55,7 @@ func TestViewerTypeNamespacesField(t *testing.T) {
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 
 	// Success
-	client.On("ListNamespaces", mock.Anything).Return([]*corev2.Namespace{nsp}, nil).Once()
+	client.On("ListNamespaces", mock.Anything, mock.Anything).Return([]*corev2.Namespace{nsp}, nil).Once()
 	res, err := impl.Namespaces(params)
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -46,7 +46,7 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 
 func (r *NamespacesRouter) list(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
 	client := api.NewNamespaceClient(r.store, r.auth)
-	namespaces, err := client.ListNamespaces(ctx)
+	namespaces, err := client.ListNamespaces(ctx, pred)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/apid/routers/namespaces.go
+++ b/backend/apid/routers/namespaces.go
@@ -1,8 +1,11 @@
 package routers
 
 import (
+	"context"
+
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/api"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
@@ -36,7 +39,20 @@ func (r *NamespacesRouter) Mount(parent *mux.Router) {
 
 	routes.Del(r.handlers.DeleteResource)
 	routes.Get(r.handlers.GetResource)
-	routes.List(r.handlers.ListResources, corev2.NamespaceFields)
+	routes.List(r.list, corev2.NamespaceFields)
 	routes.Post(r.handlers.CreateResource)
 	routes.Put(r.handlers.CreateOrUpdateResource)
+}
+
+func (r *NamespacesRouter) list(ctx context.Context, pred *store.SelectionPredicate) ([]corev2.Resource, error) {
+	client := api.NewNamespaceClient(r.store, r.auth)
+	namespaces, err := client.ListNamespaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]corev2.Resource, len(namespaces))
+	for i := range namespaces {
+		result[i] = namespaces[i]
+	}
+	return result, nil
 }

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -1,11 +1,14 @@
 package routers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestNamespacesRouter(t *testing.T) {
@@ -20,11 +23,60 @@ func TestNamespacesRouter(t *testing.T) {
 
 	tests := []routerTestCase{}
 	tests = append(tests, getTestCases(fixture)...)
-	tests = append(tests, listTestCases(empty)...)
 	tests = append(tests, createTestCases(empty)...)
 	tests = append(tests, updateTestCases(fixture)...)
 	tests = append(tests, deleteTestCases(fixture)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
+	}
+}
+
+func TestNamespaceRouterList(t *testing.T) {
+	namespaces := []*corev2.Namespace{
+		corev2.FixtureNamespace("default"),
+	}
+	clusterRole := corev2.ClusterRole{
+		ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+		Rules: []corev2.Rule{
+			{
+				Verbs:     []string{corev2.VerbAll},
+				Resources: []string{corev2.ResourceAll},
+			},
+		},
+	}
+	clusterRoleBinding := corev2.ClusterRoleBinding{
+		Subjects: []corev2.Subject{
+			{
+				Type: "Group",
+				Name: "cluster-admins",
+			},
+		},
+		RoleRef: corev2.RoleRef{
+			Type: "ClusterRole",
+			Name: "cluster-admin",
+		},
+		ObjectMeta: corev2.NewObjectMeta("cluster-admin", ""),
+	}
+
+	store := new(mockstore.MockStore)
+	store.On("ListClusterRoleBindings", mock.Anything, mock.Anything).Return([]*corev2.ClusterRoleBinding{&clusterRoleBinding}, nil)
+	store.On("GetClusterRole", mock.Anything, mock.Anything).Return(&clusterRole, nil)
+	store.On("ListRoleBindings", mock.Anything, mock.Anything).Return([]*corev2.RoleBinding{}, nil)
+	store.On("ListResources", mock.Anything, corev2.NamespacesResource, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		resources := args[2].(*[]*corev2.Namespace)
+		*resources = append(*resources, namespaces...)
+	}).Return(nil)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, corev2.ClaimsKey, corev2.FixtureClaims("foo", []string{"cluster-admins"}))
+
+	auth := &rbac.Authorizer{Store: store}
+	router := NewNamespacesRouter(store, auth)
+	got, err := router.list(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected namespaces to be returned")
 	}
 }

--- a/namespaces?limit=1
+++ b/namespaces?limit=1
@@ -1,0 +1,1 @@
+[{"name":"default"}]

--- a/namespaces?limit=1
+++ b/namespaces?limit=1
@@ -1,1 +1,0 @@
-[{"name":"default"}]


### PR DESCRIPTION
## What is this change?

It fixes a bug introduced in https://github.com/sensu/sensu-go/pull/3776 by reverting to the use of the API client when listing namespaces.

I modified the `ListNamespaces` method of the `NamespaceClient` so it works similarly to the generic handlers, and therefore pass the `SelectionPredicate` pointer up to the generic store.

## Why is this change necessary?

Fixes the QA crucible.

## Does your change need a Changelog entry?

Nope, it fixes unreleased stuff.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested via sensuctl & web UI, and added a unit test.

```bash
$ curl -i -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces\?limit\=1
HTTP/1.1 200 OK
Content-Type: application/json
Sensu-Continue: ZGVmYXVsdAA
Date: Thu, 04 Jun 2020 19:41:17 GMT
Content-Length: 20

[{"name":"default"}]

$ curl -i -H "Authorization: Key $SENSU_API_KEY" http://127.0.0.1:8080/api/core/v2/namespaces\?limit\=1\&continue\=ZGVmYXVsdAA
HTTP/1.1 200 OK
Content-Type: application/json
Sensu-Continue: ZGV2AA
Date: Thu, 04 Jun 2020 19:41:42 GMT
Content-Length: 16

[{"name":"dev"}]
```

## Is this change a patch?

Yep.