### PR TITLE
Remove k8s yaml dependency

### DIFF
--- a/cli/resource/parse.go
+++ b/cli/resource/parse.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/ghodss/yaml"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
-	"sigs.k8s.io/yaml"
 )
 
 // Parse is a rather heroic function that will parse any number of valid

--- a/go.mod
+++ b/go.mod
@@ -74,5 +74,4 @@ require (
 	gopkg.in/h2non/filetype.v1 v1.0.3
 	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools v2.2.0+incompatible // indirect
-	sigs.k8s.io/yaml v1.1.0
 )


### PR DESCRIPTION
It seems that goimports did the wrong thing here. Reverting the import to ghodss/yaml.