### PR TITLE
Bugfix/agent panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ components are disabled.
 - Fixed an issue where a GraphQL query could fail when querying a namespace
 containing event data in excess of 2GBs.
 - Deregistration events now contain a timestamp.
+- Checks configured with missing hooks no longer cause the agent to crash.
 
 ## [5.20.2] - 2020-05-26
 

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -57,7 +57,7 @@ func TestExecuteHook(t *testing.T) {
 	assert.Equal("hello", hook.Output)
 }
 
-func TestExecuteHooks_GH3379(t *testing.T) {
+func TestExecuteHooks_GH3779(t *testing.T) {
 	cfg, cleanup := FixtureConfig()
 	defer cleanup()
 	ag, err := NewAgent(cfg)

--- a/agent/hook_test.go
+++ b/agent/hook_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	time "github.com/echlebek/timeproxy"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/command"
 	"github.com/sensu/sensu-go/testing/mockexecutor"
 
@@ -52,6 +54,35 @@ func TestExecuteHook(t *testing.T) {
 	assert.NotZero(hook.Executed)
 	assert.Equal(int32(0), hook.Status)
 	assert.Equal("hello", hook.Output)
+}
+
+func TestExecuteHooks_GH3379(t *testing.T) {
+	cfg, cleanup := FixtureConfig()
+	defer cleanup()
+	ag, err := NewAgent(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := &corev2.CheckRequest{
+		Config: corev2.FixtureCheckConfig("foo"),
+		// Deliberately set hooks to nil
+		Hooks:  nil,
+		Issued: time.Now().Unix(),
+	}
+	request.Config.CheckHooks = []corev2.HookList{
+		{
+			Hooks: []string{
+				"doesnotexist",
+			},
+			Type: "ok",
+		},
+	}
+	event := corev2.FixtureEvent("foo", "foo")
+	assets := make(map[string]*corev2.AssetList)
+	hooks := ag.ExecuteHooks(context.Background(), request, event, assets)
+	if got, want := len(hooks), 1; got != want {
+		t.Fatal("expected 1 hook")
+	}
 }
 
 func TestPrepareHook(t *testing.T) {


### PR DESCRIPTION
## What is this change?

```
    Fix a nil panic in sensu-agent
    
    This commit fixes a nil panic in sensu-agent when a hook is
    specified that does not exist. Additionally, other hook config
    errors are now surfaced properly instead of via an out-of-band
    event.
```

## Why is this change necessary?

Fixes #3779 

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

## Were there any complications while making this change?

The agent hook failure protocol required some review.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

The unit test in the first commit of this changelog proves that the fix works.

## Is this change a patch?

Yes