### PR TITLE
Change password survey bugfix

### DIFF
--- a/cli/commands/user/change_password.go
+++ b/cli/commands/user/change_password.go
@@ -20,7 +20,7 @@ var (
 )
 
 type passwordOpts struct {
-	Current string `survey:"current-password`
+	Current string `survey:"current-password"`
 	New     string `survey:"new-password"`
 	Confirm string `survey:"confirm-password"`
 }


### PR DESCRIPTION
## What is this change?

It fixes a typo in a survey tag for the interactive mode of `sensuctl user change-password`.

## Why is this change necessary?

It prevented users from changing a password using the interactive mode. Reported via https://github.com/sensu/sensu-docs/pull/2504#issuecomment-640714822.

## Does your change need a Changelog entry?

Nope, unreleased bug.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified.

## Is this change a patch?

Yep