### PR TITLE
Return new expiry date when renewing an auth token pair

### DIFF
--- a/backend/api/authentication.go
+++ b/backend/api/authentication.go
@@ -152,7 +152,7 @@ func (a *AuthenticationClient) RefreshAccessToken(ctx context.Context) (*corev2.
 
 	return &corev2.Tokens{
 		Access:    accessTokenString,
-		ExpiresAt: accessClaims.ExpiresAt,
+		ExpiresAt: claims.ExpiresAt,
 		Refresh:   refreshTokenString,
 	}, nil
 }


### PR DESCRIPTION
## What is this change?

Fixes bug in the `api` package where the previous expiry date was returned when renewing an auth token pair.

## Why is this change necessary?

Could lead to unintended behaviour in clients.

## How did you verify this change?

Manual.

## Is this change a patch?

Yes.