### PR TITLE
Fix cmdmanager tests on Windows

### DIFF
--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -262,7 +261,7 @@ func (m *CommandManager) ExecCommand(ctx context.Context, alias string, args []s
 }
 
 func commandAbsolutePath(command *asset.RuntimeAsset) string {
-	return path.Join(command.BinDir(), commandName)
+	return filepath.Join(command.BinDir(), commandName)
 }
 
 func commandEnvironment(command *asset.RuntimeAsset, additionalEnv []string) []string {

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -716,6 +716,11 @@ func TestCommandManager_ExecCommand(t *testing.T) {
 }
 
 func TestCommandManager_commandAbsolutePath(t *testing.T) {
+	basePath, err := filepath.Abs(filepath.Join("some", "path"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name     string
 		command  *asset.RuntimeAsset
@@ -723,8 +728,8 @@ func TestCommandManager_commandAbsolutePath(t *testing.T) {
 	}{
 		{
 			name:     "",
-			command:  &asset.RuntimeAsset{Path: "/some/path"},
-			expected: "/some/path/bin/entrypoint",
+			command:  &asset.RuntimeAsset{Path: basePath},
+			expected: filepath.Join(basePath, "bin", "entrypoint"),
 		},
 	}
 
@@ -748,7 +753,6 @@ func TestCommandManager_commandEnvironment(t *testing.T) {
 			name: "additional env is passed through",
 			command: &asset.RuntimeAsset{
 				Name: "command",
-				Path: "/some/path",
 			},
 			additionalEnv: []string{"MY_VAR=value", "MY_OTHER_VAR=value"},
 		},


### PR DESCRIPTION
## What is this change?

Use `filepath` instead of `path` in tests in order to have tests that work on Windows.

## Why is this change necessary?

Fix broken test in `cmdmanager` on Windows.

## Do you need clarification on anything?

Not sure why AppVeyor didn't run on #3837 

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not needed.

## How did you verify this change?

I didn't; I'm counting on AppVeyor.

## Is this change a patch?

No.