### PR TITLE
s/StoreSuffix/StoreName/

### DIFF
--- a/api/core/v3/internal/codegen/generate_type/generate_type.go
+++ b/api/core/v3/internal/codegen/generate_type/generate_type.go
@@ -81,7 +81,7 @@ func rvar(name string) string {
 	return strings.ToLower(name[:1])
 }
 
-func storeSuffix(name string) string {
+func storeName(name string) string {
 	return fmt.Sprintf("%ss", snakeCase(name))
 }
 
@@ -92,12 +92,12 @@ func rbacName(name string) string {
 func main() {
 	flag.Parse()
 	tmpl, err := template.New(*tmplPath).Funcs(template.FuncMap{
-		"snakeCase":   snakeCase,
-		"receiver":    receiver,
-		"rvar":        rvar,
-		"storeSuffix": storeSuffix,
-		"rbacName":    rbacName,
-		"kebabCase":   kebabCase,
+		"snakeCase": snakeCase,
+		"receiver":  receiver,
+		"rvar":      rvar,
+		"storeName": storeName,
+		"rbacName":  rbacName,
+		"kebabCase": kebabCase,
 	}).ParseFiles(*tmplPath)
 
 	if err != nil {

--- a/api/core/v3/resource.go
+++ b/api/core/v3/resource.go
@@ -18,8 +18,8 @@ type GeneratedType interface {
 	// to set. If the receiver does not have metadata to set, nothing happens.
 	SetMetadata(*corev2.ObjectMeta)
 
-	// StoreSuffix gives the path suffix to this resource type in the store.
-	StoreSuffix() string
+	// StoreName gives the name of the resource as it pertains to a store.
+	StoreName() string
 
 	// RBACName describes the name of the resource for RBAC purposes.
 	RBACName() string
@@ -65,5 +65,5 @@ func (v v2ResourceProxy) SetNamespace(ns string) {
 }
 
 func (v v2ResourceProxy) StorePrefix() string {
-	return v.StoreSuffix()
+	return v.StoreName()
 }

--- a/api/core/v3/resource_generated.go
+++ b/api/core/v3/resource_generated.go
@@ -18,9 +18,9 @@ type validator interface {
 	validate() error
 }
 
-// implement storeSuffixer to override StoreSuffix methods
-type storeSuffixer interface {
-	storeSuffix() string
+// implement storeNamer to override StoreName methods
+type storeNamer interface {
+	storeName() string
 }
 
 // implement rbacNamer to override RBACName methods
@@ -57,12 +57,12 @@ func (e *EntityConfig) SetMetadata(meta *corev2.ObjectMeta) {
 	field.Set(reflect.ValueOf(meta))
 }
 
-// StoreSuffix returns the store suffix for EntityConfig. It will be
-// overridden if there is a method for EntityConfig called "storeSuffix".
-func (e *EntityConfig) StoreSuffix() string {
+// StoreName returns the store name for EntityConfig. It will be
+// overridden if there is a method for EntityConfig called "storeName".
+func (e *EntityConfig) StoreName() string {
 	var iface interface{} = e
-	if prefixer, ok := iface.(storeSuffixer); ok {
-		return prefixer.storeSuffix()
+	if prefixer, ok := iface.(storeNamer); ok {
+		return prefixer.storeName()
 	}
 	return "entity_configs"
 }
@@ -163,12 +163,12 @@ func (e *EntityState) SetMetadata(meta *corev2.ObjectMeta) {
 	field.Set(reflect.ValueOf(meta))
 }
 
-// StoreSuffix returns the store suffix for EntityState. It will be
-// overridden if there is a method for EntityState called "storeSuffix".
-func (e *EntityState) StoreSuffix() string {
+// StoreName returns the store name for EntityState. It will be
+// overridden if there is a method for EntityState called "storeName".
+func (e *EntityState) StoreName() string {
 	var iface interface{} = e
-	if prefixer, ok := iface.(storeSuffixer); ok {
-		return prefixer.storeSuffix()
+	if prefixer, ok := iface.(storeNamer); ok {
+		return prefixer.storeName()
 	}
 	return "entity_states"
 }

--- a/api/core/v3/resource_generated.tmpl
+++ b/api/core/v3/resource_generated.tmpl
@@ -18,9 +18,9 @@ type validator interface {
 	validate() error
 }
 
-// implement storeSuffixer to override StoreSuffix methods
-type storeSuffixer interface {
-	storeSuffix() string
+// implement storeNamer to override StoreName methods
+type storeNamer interface {
+	storeName() string
 }
 
 // implement rbacNamer to override RBACName methods
@@ -58,14 +58,14 @@ func ({{ receiver $typename }}) SetMetadata(meta *corev2.ObjectMeta) {
 	field.Set(reflect.ValueOf(meta))
 }
 
-// StoreSuffix returns the store suffix for {{ $typename }}. It will be
-// overridden if there is a method for {{ $typename }} called "storeSuffix".
-func ({{ receiver $typename }}) StoreSuffix() string {
+// StoreName returns the store name for {{ $typename }}. It will be
+// overridden if there is a method for {{ $typename }} called "storeName".
+func ({{ receiver $typename }}) StoreName() string {
 	var iface interface{} = {{ rvar $typename }}
-	if prefixer, ok := iface.(storeSuffixer); ok {
-		return prefixer.storeSuffix()
+	if prefixer, ok := iface.(storeNamer); ok {
+		return prefixer.storeName()
 	}
-	return "{{ storeSuffix $typename }}"
+	return "{{ storeName $typename }}"
 }
 
 // RBACName returns the RBAC name for {{ $typename }}. It will be overridden if

--- a/api/core/v3/resource_generated_test.go
+++ b/api/core/v3/resource_generated_test.go
@@ -30,15 +30,15 @@ func TestEntityConfigSetMetadata(t *testing.T) {
 	}
 }
 
-func TestEntityConfigStoreSuffix(t *testing.T) {
+func TestEntityConfigStoreName(t *testing.T) {
 	var value EntityConfig
-	got := value.StoreSuffix()
+	got := value.StoreName()
 	if len(got) == 0 {
 		t.Error("undefined store suffix")
 	}
 	var iface interface{} = value
-	if suffixer, ok := iface.(storeSuffixer); ok {
-		if got, want := value.StoreSuffix(), suffixer.storeSuffix(); got != want {
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
 			t.Errorf("bad store suffix: got %s, want %s", got, want)
 		}
 	}
@@ -185,15 +185,15 @@ func TestEntityStateSetMetadata(t *testing.T) {
 	}
 }
 
-func TestEntityStateStoreSuffix(t *testing.T) {
+func TestEntityStateStoreName(t *testing.T) {
 	var value EntityState
-	got := value.StoreSuffix()
+	got := value.StoreName()
 	if len(got) == 0 {
 		t.Error("undefined store suffix")
 	}
 	var iface interface{} = value
-	if suffixer, ok := iface.(storeSuffixer); ok {
-		if got, want := value.StoreSuffix(), suffixer.storeSuffix(); got != want {
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
 			t.Errorf("bad store suffix: got %s, want %s", got, want)
 		}
 	}
@@ -337,12 +337,12 @@ func TestResourceUniqueness(t *testing.T) {
 			rbacNames[name] = true
 		}
 	}
-	storeSuffixes := make(map[string]bool)
+	storeNames := make(map[string]bool)
 	for _, v := range types {
-		if name := v.StoreSuffix(); storeSuffixes[name] {
+		if name := v.StoreName(); storeNames[name] {
 			t.Errorf("duplicate store suffix: %s", name)
 		} else {
-			storeSuffixes[name] = true
+			storeNames[name] = true
 		}
 	}
 }

--- a/api/core/v3/resource_generated_test.tmpl
+++ b/api/core/v3/resource_generated_test.tmpl
@@ -31,15 +31,15 @@ func Test{{ $typename }}SetMetadata(t *testing.T) {
 	}
 }
 
-func Test{{ $typename }}StoreSuffix(t *testing.T) {
+func Test{{ $typename }}StoreName(t *testing.T) {
 	var value {{ $typename }}
-	got := value.StoreSuffix()
+	got := value.StoreName()
 	if len(got) == 0 {
 		t.Error("undefined store suffix")
 	}
 	var iface interface{} = value
-	if suffixer, ok := iface.(storeSuffixer); ok {
-		if got, want := value.StoreSuffix(), suffixer.storeSuffix(); got != want {
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
 			t.Errorf("bad store suffix: got %s, want %s", got, want)
 		}
 	}
@@ -184,12 +184,12 @@ func TestResourceUniqueness(t *testing.T) {
 			rbacNames[name] = true
 		}
 	}
-	storeSuffixes := make(map[string]bool)
+	storeNames := make(map[string]bool)
 	for _, v := range types {
-		if name := v.StoreSuffix(); storeSuffixes[name] {
+		if name := v.StoreName(); storeNames[name] {
 			t.Errorf("duplicate store suffix: %s", name)
 		} else {
-			storeSuffixes[name] = true
+			storeNames[name] = true
 		}
 	}
 }

--- a/api/core/v3/resource_test.go
+++ b/api/core/v3/resource_test.go
@@ -28,7 +28,7 @@ func (t testResource) SetMetadata(meta *corev2.ObjectMeta) {
 	t.meta = meta
 }
 
-func (t testResource) StoreSuffix() string {
+func (t testResource) StoreName() string {
 	return "test"
 }
 
@@ -62,7 +62,7 @@ func TestV3ToV2Resource(t *testing.T) {
 		t.Errorf("SetNamespace had wrong effect: got Namespace %s, want %s", got, want)
 	}
 
-	if got, want := corev2Resource.StorePrefix(), resource.StoreSuffix(); got != want {
+	if got, want := corev2Resource.StorePrefix(), resource.StoreName(); got != want {
 		t.Errorf("bad StorePrefix: got %s, want %s", got, want)
 	}
 

--- a/api/core/v3/typemap.go
+++ b/api/core/v3/typemap.go
@@ -17,7 +17,7 @@ func init() {
 		}
 	}
 	for _, v := range rbacMap {
-		storeMap[v.StoreSuffix()] = v
+		storeMap[v.StoreName()] = v
 	}
 }
 
@@ -33,7 +33,7 @@ var typeMap = map[string]interface{}{
 // Resource values.
 var rbacMap = make(map[string]Resource, len(typeMap)/2)
 
-// storeMap is like rbacMap, but its keys are store suffixes.
+// storeMap is like rbacMap, but its keys are store names.
 var storeMap = make(map[string]Resource, len(typeMap)/2)
 
 // ResolveResource returns a zero-valued resource, given a name.
@@ -82,8 +82,8 @@ func ResolveResourceByRBACName(name string) (Resource, error) {
 	return newResource(resource), nil
 }
 
-// ResolveResourceByStoreSuffix resolves a resource by its store suffix.
-func ResolveResourceByStoreSuffix(name string) (Resource, error) {
+// ResolveResourceByStoreName resolves a resource by its store name.
+func ResolveResourceByStoreName(name string) (Resource, error) {
 	resource, ok := storeMap[name]
 	if !ok {
 		return nil, fmt.Errorf("resource not found: %s", name)

--- a/api/core/v3/typemap.tmpl
+++ b/api/core/v3/typemap.tmpl
@@ -17,7 +17,7 @@ func init() {
 		}
 	}
 	for _, v := range rbacMap {
-		storeMap[v.StoreSuffix()] = v
+		storeMap[v.StoreName()] = v
 	}
 }
 
@@ -31,7 +31,7 @@ var typeMap = map[string]interface{}{ {{ range $index, $typename := .TypeNames }
 // Resource values.
 var rbacMap = make(map[string]Resource, len(typeMap)/2)
 
-// storeMap is like rbacMap, but its keys are store suffixes.
+// storeMap is like rbacMap, but its keys are store names.
 var storeMap = make(map[string]Resource, len(typeMap)/2)
 
 // ResolveResource returns a zero-valued resource, given a name.
@@ -80,8 +80,8 @@ func ResolveResourceByRBACName(name string) (Resource, error) {
 	return newResource(resource), nil
 }
 
-// ResolveResourceByStoreSuffix resolves a resource by its store suffix.
-func ResolveResourceByStoreSuffix(name string) (Resource, error) {
+// ResolveResourceByStoreName resolves a resource by its store name.
+func ResolveResourceByStoreName(name string) (Resource, error) {
 	resource, ok := storeMap[name]
 	if !ok {
 		return nil, fmt.Errorf("resource not found: %s", name)

--- a/api/core/v3/typemap_test.go
+++ b/api/core/v3/typemap_test.go
@@ -59,10 +59,10 @@ func TestResolveEntityConfigByRBACName(t *testing.T) {
 	}
 }
 
-func TestResolveEntityConfigByStoreSuffix(t *testing.T) {
+func TestResolveEntityConfigByStoreName(t *testing.T) {
 	value := new(EntityConfig)
 	var iface interface{} = value
-	resource, err := ResolveResourceByStoreSuffix(value.StoreSuffix())
+	resource, err := ResolveResourceByStoreName(value.StoreName())
 	if _, ok := iface.(Resource); ok {
 		if err != nil {
 			t.Fatal(err)
@@ -137,10 +137,10 @@ func TestResolveEntityStateByRBACName(t *testing.T) {
 	}
 }
 
-func TestResolveEntityStateByStoreSuffix(t *testing.T) {
+func TestResolveEntityStateByStoreName(t *testing.T) {
 	value := new(EntityState)
 	var iface interface{} = value
-	resource, err := ResolveResourceByStoreSuffix(value.StoreSuffix())
+	resource, err := ResolveResourceByStoreName(value.StoreName())
 	if _, ok := iface.(Resource); ok {
 		if err != nil {
 			t.Fatal(err)

--- a/api/core/v3/typemap_test.tmpl
+++ b/api/core/v3/typemap_test.tmpl
@@ -60,10 +60,10 @@ func TestResolve{{ $typename }}ByRBACName(t *testing.T) {
 	}
 }
 
-func TestResolve{{ $typename }}ByStoreSuffix(t *testing.T) {
+func TestResolve{{ $typename }}ByStoreName(t *testing.T) {
 	value := new({{ $typename }})
 	var iface interface{} = value
-	resource, err := ResolveResourceByStoreSuffix(value.StoreSuffix())
+	resource, err := ResolveResourceByStoreName(value.StoreName())
 	if _, ok := iface.(Resource); ok {
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
After some consideration, I think StoreName is a better name than
StoreSuffix for core/v3 resources.

* StoreName is neither a prefix nor a suffix.
* StoreName is consistent with RBACName.
* StoreName does not imply a K/V store.

Signed-off-by: Eric Chlebek <eric@sensu.io>