### PR TITLE
Clarify secrets error message, add BrokenProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Clarifies wording around a secret provider error message.
 
 ## [5.21.0] - 2020-06-10
 

--- a/backend/secrets/broken_provider.go
+++ b/backend/secrets/broken_provider.go
@@ -1,0 +1,56 @@
+package secrets
+
+import (
+	"fmt"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// BrokenProvider is a sentinel provider that can be used in place of a real
+// provider, should it fail to be instantiated. Store the error from the
+// failure in BrokenProvider, so the user gets the provider creation error
+// every time the provider is queried.
+type BrokenProvider struct {
+	TypeMeta   corev2.TypeMeta
+	ObjectMeta corev2.ObjectMeta
+	Err        error
+}
+
+func (b *BrokenProvider) Get(id string) (string, error) {
+	return "", fmt.Errorf(
+		"%s/%s: %s.%s broken: cannot get secret %q: %s",
+		b.ObjectMeta.Namespace,
+		b.ObjectMeta.Name,
+		b.TypeMeta.APIVersion,
+		b.TypeMeta.Type,
+		id,
+		b.Err)
+}
+
+func (b *BrokenProvider) GetObjectMeta() corev2.ObjectMeta {
+	return b.ObjectMeta
+}
+
+func (b *BrokenProvider) SetObjectMeta(o corev2.ObjectMeta) {
+	b.ObjectMeta = o
+}
+
+func (b *BrokenProvider) SetNamespace(s string) {
+	b.ObjectMeta.Namespace = s
+}
+
+func (b *BrokenProvider) StorePrefix() string {
+	return ""
+}
+
+func (b *BrokenProvider) URIPath() string {
+	return ""
+}
+
+func (b *BrokenProvider) RBACName() string {
+	return ""
+}
+
+func (b *BrokenProvider) Validate() error {
+	return nil
+}

--- a/backend/secrets/provider.go
+++ b/backend/secrets/provider.go
@@ -108,7 +108,7 @@ func (m *ProviderManager) SubSecrets(ctx context.Context, secrets []*corev2.Secr
 		}
 		provider := providers[providerName]
 		if provider == nil {
-			err = fmt.Errorf("provider does not exist")
+			err = fmt.Errorf("provider not found, or not working: %s", providerName)
 			logger.WithFields(logrus.Fields{
 				"provider": providerName,
 				"secret":   secret.Secret,


### PR DESCRIPTION
# What is this change?

Clarifies the wording of a secret provider error message, and also adds a new type of provider, BrokenProvider. BrokenProvider can be used to add a secret provider that isn't working properly. This helps users because they will be able to see the configuration error that the provider encountered in event output, instead of in the sensu logs.

A subsequent PR for enterprise sensu will be created, making use of the BrokenProvider facility.

## Why is this change necessary?

Part of https://github.com/sensu/sensu-enterprise-go/issues/1104

## Does your change need a Changelog entry?

Yes, only for the error message clarification however.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes are not required.

## How did you verify this change?

Automated testing.

## Is this change a patch?

Yes, but the next release is 6.0, so I haven't applied it to the release branch.