### PR TITLE
Improve logging around the agent websocket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Clarifies wording around a secret provider error message.
 
+### Changed
+- Improves logging around the agent websocket connection.
+
 ## [5.21.0] - 2020-06-10
 
 ### Added

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -124,9 +124,6 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 			if _, err := c.Read(msg); err != nil {
 				logger.WithError(err).Error("websocket connection error")
 			}
-			if len(msg) > 0 {
-				logger.WithField("msg", string(msg)).Debug("connection state changed")
-			}
 		},
 	}
 	for _, o := range opts {

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -119,6 +119,15 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		TLSConfig:    tlsServerConfig,
 		// Capture the log entries from agentd's HTTP server
 		ErrorLog: log.New(&logrusIOWriter{entry: logger}, "", 0),
+		ConnState: func(c net.Conn, cs http.ConnState) {
+			var msg []byte
+			if _, err := c.Read(msg); err != nil {
+				logger.WithError(err).Error("websocket connection error")
+			}
+			if len(msg) > 0 {
+				logger.WithField("msg", string(msg)).Debug("connection state changed")
+			}
+		},
 	}
 	for _, o := range opts {
 		if err := o(a); err != nil {


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a ConnState function in agentd's http server to improve logging around the agent websocket connection.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3771

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

See notes in original issue.

## Is this change a patch?

Yes, but next release is in master.