### PR TITLE
Limit captured output of command execution

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -14,7 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const maxOutputLen = 1500000
+// Upper bounds of output captured during command's execution.
+const maxOutputLen = 1.5 * 1000 * 1000 // 1.5mbs
 
 const undocumentedTestCheckCommand = "!sensu_test_check!"
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/NYTimes/gziphandler v0.0.0-20180227021810-5032c8878b9d
 	github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f // indirect
+	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4 // indirect
 	github.com/atlassian/gostatsd v0.0.0-20180514010436-af796620006e
 	github.com/coreos/bbolt v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
+github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4 h1:pG7CUDQmAqAxVv4smDHWTtorVUI5B7aOcFDfgqtZuWA=
 github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4/go.mod h1:20N8GhJtHSLeRJvNhy5D1SnEHni4Xlt6p13JQMHYdDY=


### PR DESCRIPTION
## What is this change?

* Uses a ring buffer for capturing output of command.
* Sets upper bounds of output to 1.5 MB. While this value is somewhat arbitrary, etcd key size limits mean that events cannot hold more than 2MB anyways.
* Helps avoids situations where a command writes extremely large amounts of data to STDOUT / STDERR.

https://github.com/armon/circbuf/

## Why is this change necessary?

Without limits, the agents memory usage can spiral out of control, potentially leading to a crash when it is unable to allocate more memory.

An easy way to observe the negative effect of the previous implementation, is to create that runs the `yes` command and to set a timeout of say `15` seconds. Using pprof you will quickly observe the agent's `inuse_space` explode.

## Does your change need a Changelog entry?

Sure.

## Do you need clarification on anything?

1. While using pprof to investigate, I observed that when a command timed out it did not appear that the previous buffer was ever deallocated. I'm not sure if this just a case of the GC having not been run or if there is a memory leak.
2. Unclear to me how I might write a nice cross-platform unit test.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Manual.

## Is this change a patch?

Yes..?