### PR TITLE
Log and return an error if a mutator cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Clarifies wording around a secret provider error message.
+- Logs and returns an error if a mutator cannot be found.
 
 ### Changed
 - Improves logging around the agent websocket connection.

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -76,7 +76,7 @@ func (p *Pipeline) HandleEvent(ctx context.Context, event *corev2.Event) error {
 
 		eventData, err := p.mutateEvent(handler, event)
 		if err != nil {
-			logger.WithError(err).Warn("error mutating event")
+			logger.WithFields(fields).WithError(err).Warn("error mutating event")
 			if _, ok := err.(*store.ErrInternal); ok {
 				// Fatal error
 				return err

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -76,7 +76,7 @@ func (p *Pipeline) HandleEvent(ctx context.Context, event *corev2.Event) error {
 
 		eventData, err := p.mutateEvent(handler, event)
 		if err != nil {
-			logger.WithFields(fields).WithError(err).Warn("error mutating event")
+			logger.WithFields(fields).WithError(err).Error("error mutating event")
 			if _, ok := err.(*store.ErrInternal); ok {
 				// Fatal error
 				return err

--- a/backend/pipeline/mutator.go
+++ b/backend/pipeline/mutator.go
@@ -60,7 +60,7 @@ func (p *Pipeline) mutateEvent(handler *corev2.Handler, event *corev2.Event) ([]
 		extension, err := p.store.GetExtension(tctx, handler.Mutator)
 		if err != nil {
 			if err == store.ErrNoExtension {
-				return nil, fmt.Errorf("mutator '%s' does not exist", handler.Mutator)
+				return nil, fmt.Errorf("mutator %q does not exist", handler.Mutator)
 			}
 			// Warning: do not wrap this error
 			return nil, err

--- a/backend/pipeline/mutator.go
+++ b/backend/pipeline/mutator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -59,7 +60,7 @@ func (p *Pipeline) mutateEvent(handler *corev2.Handler, event *corev2.Event) ([]
 		extension, err := p.store.GetExtension(tctx, handler.Mutator)
 		if err != nil {
 			if err == store.ErrNoExtension {
-				return nil, nil
+				return nil, fmt.Errorf("mutator '%s' does not exist", handler.Mutator)
 			}
 			// Warning: do not wrap this error
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Logs and returns an error if a mutator cannot be found.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/2784

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

- Added a unit test that fails without the suggested changes.
- Verified e2e with the steps to reproduce from the original issue.

New enriched log with error:
```
{"check_name":"foo","check_namespace":"default","component":"pipelined","entity_name":"nikkictl","entity_namespace":"default","error":"mutator \"nope\" does not exist","handler":"cat","level":"error","msg":"error mutating event","time":"2020-06-29T12:43:11-04:00","uuid":"5192efe0-8645-4b2d-a55a-1e05ec3d1f20"}
```

## Is this change a patch?

Yes, but TBH I'm not sure what our branch strategy is right now with a few potential upcoming releases. Targeting master for now.