### PR TITLE
Add a timeout for the golangci-lint github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,3 +19,4 @@ jobs:
         uses: golangci/golangci-lint-action@v1
         with:
           version: v1.27
+          args: --timeout=5m


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds a timeout for the golangci-lint github action (see https://github.com/golangci/golangci-lint-action/issues/25 and https://github.com/sensu/sensu-enterprise-go/blob/1856e77c4fe2b3bf4bf09f941d9c87751215dcc3/.github/workflows/golangci-lint.yml#L22).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3864

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

CI did.

## Is this change a patch?

Targeting master.