### PR TITLE
Create roles and bindings on namespace create

### DIFF
--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -12,14 +12,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const pipelineRoleName = "system:pipeline"
+
 type ruleVisitor interface {
 	VisitRulesFor(ctx context.Context, attrs *authorization.Attributes, fn rbac.RuleVisitFunc)
 }
 
 // NamespaceClient is an API client for namespaces.
 type NamespaceClient struct {
-	client GenericClient
-	auth   authorization.Authorizer
+	client        GenericClient
+	roleClient    GenericClient
+	bindingClient GenericClient
+	auth          authorization.Authorizer
 }
 
 // NewNamespaceClient creates a new NamespaceClient, given a store and authorizer.
@@ -27,6 +31,20 @@ func NewNamespaceClient(store store.ResourceStore, auth authorization.Authorizer
 	return &NamespaceClient{
 		client: GenericClient{
 			Kind:       &corev2.Namespace{},
+			Store:      store,
+			Auth:       auth,
+			APIGroup:   "core",
+			APIVersion: "v2",
+		},
+		roleClient: GenericClient{
+			Kind:       &corev2.Role{},
+			Store:      store,
+			Auth:       auth,
+			APIGroup:   "core",
+			APIVersion: "v2",
+		},
+		bindingClient: GenericClient{
+			Kind:       &corev2.RoleBinding{},
 			Store:      store,
 			Auth:       auth,
 			APIGroup:   "core",
@@ -258,12 +276,47 @@ func (a *NamespaceClient) FetchNamespace(ctx context.Context, name string) (*cor
 	return &namespace, nil
 }
 
+func (a *NamespaceClient) createRoleAndBinding(ctx context.Context, namespace string) error {
+	role := &corev2.Role{
+		ObjectMeta: corev2.ObjectMeta{
+			Namespace: namespace,
+			Name:      pipelineRoleName,
+		},
+		Rules: []corev2.Rule{
+			{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{new(corev2.Event).RBACName()},
+			},
+		},
+	}
+	binding := &corev2.RoleBinding{
+		Subjects: []corev2.Subject{
+			{
+				Type: "user",
+				Name: pipelineRoleName,
+			},
+		},
+		RoleRef: corev2.RoleRef{
+			Name: pipelineRoleName,
+			Type: "Role",
+		},
+		ObjectMeta: corev2.ObjectMeta{
+			Name:      pipelineRoleName,
+			Namespace: namespace,
+		},
+	}
+	if err := a.roleClient.Update(ctx, role); err != nil {
+		return err
+	}
+	return a.bindingClient.Update(ctx, binding)
+}
+
 // CreateNamespace creates a namespace resource, if authorized.
 func (a *NamespaceClient) CreateNamespace(ctx context.Context, namespace *corev2.Namespace) error {
 	if err := a.client.Create(ctx, namespace); err != nil {
 		return err
 	}
-	return nil
+	return a.createRoleAndBinding(ctx, namespace.Name)
 }
 
 // UpdateNamespace updates a namespace resource, if authorized.
@@ -271,5 +324,16 @@ func (a *NamespaceClient) UpdateNamespace(ctx context.Context, namespace *corev2
 	if err := a.client.Update(ctx, namespace); err != nil {
 		return err
 	}
-	return nil
+	return a.createRoleAndBinding(ctx, namespace.Name)
+}
+
+// DeleteNamespace deletes a namespace.
+func (a *NamespaceClient) DeleteNamespace(ctx context.Context, name string) error {
+	if err := a.client.Delete(ctx, name); err != nil {
+		return err
+	}
+	if err := a.bindingClient.Delete(ctx, pipelineRoleName); err != nil {
+		return err
+	}
+	return a.roleClient.Delete(ctx, pipelineRoleName)
 }

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -226,20 +226,18 @@ var createResourceInvalidMetaTestCase = func(resource corev2.Resource) routerTes
 }
 
 var createResourceAlreadyExistsTestCase = func(resource corev2.Resource) routerTestCase {
-	resource.SetNamespace("default")
-	path := resource.URIPath()
-	if ns, ok := resource.(*corev2.Namespace); ok {
-		ns.Name = "default"
-	}
-	typ := reflect.TypeOf(resource).String()
+	// Deep copy the given resource so we can modify it without affecting other
+	// test cases
+	r := reflect.New(reflect.ValueOf(resource).Elem().Type()).Interface().(corev2.Resource)
+	r.SetObjectMeta(corev2.ObjectMeta{Name: "createResourceAlreadyExistsTestCase", Namespace: "default"})
 
 	return routerTestCase{
 		name:   "it returns 409 if the resource to create already exists",
 		method: http.MethodPost,
-		path:   path,
-		body:   marshal(resource),
+		path:   resource.URIPath(),
+		body:   marshal(r),
 		storeFunc: func(s *mockstore.MockStore) {
-			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).
+			s.On("CreateResource", mock.Anything, r).
 				Return(&store.ErrAlreadyExists{}).
 				Once()
 		},
@@ -248,21 +246,19 @@ var createResourceAlreadyExistsTestCase = func(resource corev2.Resource) routerT
 }
 
 var createResourceInvalidTestCase = func(resource corev2.Resource) routerTestCase {
-	resource.SetNamespace("default")
-	path := resource.URIPath()
-	if ns, ok := resource.(*corev2.Namespace); ok {
-		ns.Name = "default"
-	}
-	typ := reflect.TypeOf(resource).String()
+	// Deep copy the given resource so we can modify it without affecting other
+	// test cases
+	r := reflect.New(reflect.ValueOf(resource).Elem().Type()).Interface().(corev2.Resource)
+	r.SetObjectMeta(corev2.ObjectMeta{Name: "createResourceInvalidTestCase", Namespace: "default"})
 
 	return routerTestCase{
 		name:   "it returns 400 if the resource to create is invalid",
 		method: http.MethodPost,
-		path:   path,
-		body:   marshal(resource),
+		path:   resource.URIPath(),
+		body:   marshal(r),
 		storeFunc: func(s *mockstore.MockStore) {
-			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).
-				Return(&store.ErrNotValid{Err: errors.New("error")}).
+			s.On("CreateResource", mock.Anything, r).
+				Return(&store.ErrNotValid{Err: errors.New("createResourceInvalidTestCase")}).
 				Once()
 		},
 		wantStatusCode: http.StatusBadRequest,
@@ -270,16 +266,18 @@ var createResourceInvalidTestCase = func(resource corev2.Resource) routerTestCas
 }
 
 var createResourceStoreErrTestCase = func(resource corev2.Resource) routerTestCase {
-	resource.SetNamespace("default")
-	typ := reflect.TypeOf(resource).String()
+	// Deep copy the given resource so we can modify it without affecting other
+	// test cases
+	r := reflect.New(reflect.ValueOf(resource).Elem().Type()).Interface().(corev2.Resource)
+	r.SetObjectMeta(corev2.ObjectMeta{Name: "createResourceStoreErrTestCase", Namespace: "default"})
 
 	return routerTestCase{
 		name:   "it returns 500 if the store returns an error while creating",
 		method: http.MethodPost,
 		path:   resource.URIPath(),
-		body:   []byte(`{"metadata": {"namespace":"default","name":"foo"}}`),
+		body:   marshal(r),
 		storeFunc: func(s *mockstore.MockStore) {
-			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).
+			s.On("CreateResource", mock.Anything, r).
 				Return(&store.ErrInternal{}).
 				Once()
 		},
@@ -288,16 +286,18 @@ var createResourceStoreErrTestCase = func(resource corev2.Resource) routerTestCa
 }
 
 var createResourceSuccessTestCase = func(resource corev2.Resource) routerTestCase {
-	resource.SetNamespace("default")
-	typ := reflect.TypeOf(resource).String()
+	// Deep copy the given resource so we can modify it without affecting other
+	// test cases
+	r := reflect.New(reflect.ValueOf(resource).Elem().Type()).Interface().(corev2.Resource)
+	r.SetObjectMeta(corev2.ObjectMeta{Name: "createResourceSuccessTestCase", Namespace: "default"})
 
 	return routerTestCase{
 		name:   "it returns 201 if the resource was created",
 		method: http.MethodPost,
 		path:   resource.URIPath(),
-		body:   marshal(resource),
+		body:   marshal(r),
 		storeFunc: func(s *mockstore.MockStore) {
-			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).
+			s.On("CreateResource", mock.Anything, r).
 				Return(nil).
 				Once()
 		},
@@ -327,10 +327,7 @@ var updateResourceInvalidPayloadTestCase = func(resource corev2.Resource) router
 }
 
 var updateResourceInvalidMetaTestCase = func(resource corev2.Resource) routerTestCase {
-	// fmt.Println(resource.URIPath())
-	// body := marshal(resource)
 	resource.SetNamespace("acme")
-	// fmt.Println(string(body))
 
 	return routerTestCase{
 		name:           "it returns 400 if the resource metadata to update does not match the request path",

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -227,12 +227,16 @@ var createResourceInvalidMetaTestCase = func(resource corev2.Resource) routerTes
 
 var createResourceAlreadyExistsTestCase = func(resource corev2.Resource) routerTestCase {
 	resource.SetNamespace("default")
+	path := resource.URIPath()
+	if ns, ok := resource.(*corev2.Namespace); ok {
+		ns.Name = "default"
+	}
 	typ := reflect.TypeOf(resource).String()
 
 	return routerTestCase{
 		name:   "it returns 409 if the resource to create already exists",
 		method: http.MethodPost,
-		path:   resource.URIPath(),
+		path:   path,
 		body:   marshal(resource),
 		storeFunc: func(s *mockstore.MockStore) {
 			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).
@@ -245,12 +249,16 @@ var createResourceAlreadyExistsTestCase = func(resource corev2.Resource) routerT
 
 var createResourceInvalidTestCase = func(resource corev2.Resource) routerTestCase {
 	resource.SetNamespace("default")
+	path := resource.URIPath()
+	if ns, ok := resource.(*corev2.Namespace); ok {
+		ns.Name = "default"
+	}
 	typ := reflect.TypeOf(resource).String()
 
 	return routerTestCase{
 		name:   "it returns 400 if the resource to create is invalid",
 		method: http.MethodPost,
-		path:   resource.URIPath(),
+		path:   path,
 		body:   marshal(resource),
 		storeFunc: func(s *mockstore.MockStore) {
 			s.On("CreateResource", mock.Anything, mock.AnythingOfType(typ)).

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -68,9 +68,6 @@ func TestNamespacesRouter(t *testing.T) {
 	tests = append(tests, getTestCases(fixture)...)
 	tests = append(tests, createTestCases(empty)...)
 	tests = append(tests, updateTestCases(fixture)...)
-	// TODO(eric): I can't figure out how to get this test to work.
-	// Need to figure out how to inject authentication so the test gets
-	// rbac claims in the context.
 	tests = append(tests, deleteTestCases(fixture)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)

--- a/backend/apid/routers/namespaces_test.go
+++ b/backend/apid/routers/namespaces_test.go
@@ -48,6 +48,10 @@ func TestNamespacesRouter(t *testing.T) {
 	s.On("CreateOrUpdateResource", mock.Anything, mock.AnythingOfType("*v2.Role")).Return(nil)
 	s.On("CreateOrUpdateResource", mock.Anything, mock.AnythingOfType("*v2.RoleBinding")).Return(nil)
 
+	// Mock role & role binding deletion, which happens upon namespace deletion
+	s.On("DeleteResource", mock.Anything, "rbac/rolebindings", "system:pipeline").Return(nil)
+	s.On("DeleteResource", mock.Anything, "rbac/roles", "system:pipeline").Return(nil)
+
 	// Mock an authorizer since the api client performs authorization on its own
 	authorizer := &mockauthorizer.Authorizer{}
 	authorizer.On("Authorize", mock.Anything, mock.Anything).Return(true, nil)
@@ -67,7 +71,7 @@ func TestNamespacesRouter(t *testing.T) {
 	// TODO(eric): I can't figure out how to get this test to work.
 	// Need to figure out how to inject authentication so the test gets
 	// rbac claims in the context.
-	//tests = append(tests, deleteTestCases(fixture)...)
+	tests = append(tests, deleteTestCases(fixture)...)
 	for _, tt := range tests {
 		run(t, tt, parentRouter, s)
 	}

--- a/testing/mockauthorizer/authorizer.go
+++ b/testing/mockauthorizer/authorizer.go
@@ -1,0 +1,19 @@
+package mockauthorizer
+
+import (
+	"context"
+
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/stretchr/testify/mock"
+)
+
+// Authorizer mocks an authorization provider
+type Authorizer struct {
+	mock.Mock
+}
+
+// Authorize ...
+func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attributes) (bool, error) {
+	args := a.Called(ctx, attrs)
+	return args.Bool(0), args.Error(1)
+}


### PR DESCRIPTION
## What is this change?

This commit modifies how namespaces are created. When namespaces
are created, a special role and role binding are now created along
with them. This role is intended to allow pipelined to access the
event store in an authorized way.

## Why is this change necessary?

Fixes #3867 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

The PR is not finished because I can't figure out how to reconcile the handler unit tests.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes not required.

## How did you verify this change?

Unverified.

## Is this change a patch?

No