### PR TITLE
Update logger field for cache version

### DIFF
--- a/backend/store/cache/logger.go
+++ b/backend/store/cache/logger.go
@@ -3,6 +3,6 @@ package cache
 import "github.com/sirupsen/logrus"
 
 var logger = logrus.WithFields(logrus.Fields{
-	"component":   "cache",
-	"api_version": "v1",
+	"component":     "cache",
+	"cache_version": "v1",
 })

--- a/backend/store/cache/v2/logger.go
+++ b/backend/store/cache/v2/logger.go
@@ -3,6 +3,6 @@ package v2
 import "github.com/sirupsen/logrus"
 
 var logger = logrus.WithFields(logrus.Fields{
-	"component":   "cache",
-	"api_version": "v2",
+	"component":     "cache",
+	"cache_version": "v2",
 })


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

This may have been an oversight from the original PR. `api_version` could be confused with the api version of a resource.

```
{"api_version":"v1","component":"cache","level":"debug","msg":"rebuilding the cache for resource type *v2.Silenced","time":"2020-07-02T11:52:03-04:00"}
{"api_version":"v2","component":"cache","level":"debug","msg":"rebuilding the cache for resource type *v3.EntityConfig","time":"2020-07-02T11:52:03-04:00"}
```
becomes
```
{"cache_version":"v1","component":"cache","level":"debug","msg":"rebuilding the cache for resource type *v2.Silenced","time":"2020-07-02T11:52:03-04:00"}
{"cache_version":"v2","component":"cache","level":"debug","msg":"rebuilding the cache for resource type *v3.EntityConfig","time":"2020-07-02T11:52:03-04:00"}
```