### PR TITLE
Subscribe agentd sessions to entity config updates

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -259,6 +259,11 @@ func (s *Session) sender() {
 				continue
 			}
 
+			// Enforce the entity class to agent
+			if watchEvent.Entity.EntityClass != corev2.EntityAgentClass {
+				watchEvent.Entity.EntityClass = corev2.EntityAgentClass
+			}
+
 			bytes, err := s.marshal(watchEvent.Entity)
 			if err != nil {
 				logger.WithError(err).Error("session failed to serialize entity config")

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -63,7 +63,6 @@ type Session struct {
 	handler      *handler.MessageHandler
 	wg           *sync.WaitGroup
 	stopWG       sync.WaitGroup
-	sendq        chan *transport.Message
 	checkChannel chan interface{}
 	bus          messaging.MessageBus
 	ringPool     *ringv2.Pool
@@ -231,7 +230,6 @@ func (s *Session) sender() {
 	for {
 		var msg *transport.Message
 		select {
-		// case msg = <-s.sendq:
 		case c := <-s.entityConfig.updatesChannel:
 			cfg, ok := c.(*corev3.EntityConfig)
 			if !ok {

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -11,6 +11,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/testing/mocktransport"
 	"github.com/sensu/sensu-go/transport"
@@ -220,7 +221,11 @@ func TestSessionEntityUpdates(t *testing.T) {
 	}
 
 	// Mock an entity update from the entity watcher
-	if err := bus.Publish(messaging.EntityConfigTopic("acme", "testing"), corev3.FixtureEntityConfig("testing")); err != nil {
+	watchEvent := store.WatchEventEntityConfig{
+		Action: store.WatchUpdate,
+		Entity: corev3.FixtureEntityConfig("testing"),
+	}
+	if err := bus.Publish(messaging.EntityConfigTopic("acme", "testing"), &watchEvent); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -312,6 +312,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		TLS:          config.AgentTLSOptions,
 		RingPool:     ringPool,
 		WriteTimeout: config.AgentWriteTimeout,
+		Client:       b.Client,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", agent.Name(), err)

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// TopicEntityConfig is the topic for the entity configuration sent by agentd
+	// to agents
+	TopicEntityConfig = "sensu:entity-config"
+
 	// TopicEvent is the topic for events that have been written to Etcd and
 	// normalized by eventd.
 	TopicEvent = "sensu:event"
@@ -81,6 +85,12 @@ type MessageBus interface {
 
 	// Publish sends a message to a topic.
 	Publish(topic string, message interface{}) error
+}
+
+// EntityConfigTopic is a helper to determine the proper topic name for an
+// entity
+func EntityConfigTopic(namespace, name string) string {
+	return fmt.Sprintf("%s:%s:%s", TopicEntityConfig, namespace, name)
 }
 
 // SubscriptionTopic is a helper to determine the proper topic name for a

--- a/backend/messaging/message_bus_test.go
+++ b/backend/messaging/message_bus_test.go
@@ -12,3 +12,9 @@ func TestSubscriptionTopic(t *testing.T) {
 	topic := SubscriptionTopic("acme", "foo")
 	assert.Equal(t, expectedTopic, topic)
 }
+
+func TestEntityConfigTopic(t *testing.T) {
+	expectedTopic := fmt.Sprintf("%s:dev:foo", TopicEntityConfig)
+	topic := EntityConfigTopic("dev", "foo")
+	assert.Equal(t, expectedTopic, topic)
+}

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -95,21 +96,22 @@ type SelectionPredicate struct {
 	Subcollection string
 }
 
-// A WatchEventCheckConfig contains the modified store object and the action that occured
-// during the modification.
+// A WatchEventCheckConfig contains the modified store object and the action
+// that occured during the modification.
 type WatchEventCheckConfig struct {
 	CheckConfig *types.CheckConfig
 	Action      WatchActionType
 }
 
-// A WatchEventHookConfig contains the modified asset object and the action that occurred
-// during the modification.
+// A WatchEventHookConfig contains the modified asset object and the action that
+// occurred during the modification.
 type WatchEventHookConfig struct {
 	HookConfig *types.HookConfig
 	Action     WatchActionType
 }
 
-// WatchEventTessenConfig is a notification that the tessen config store has been updated.
+// WatchEventTessenConfig is a notification that the tessen config store has
+// been updated.
 type WatchEventTessenConfig struct {
 	TessenConfig *corev2.TessenConfig
 	Action       WatchActionType
@@ -119,6 +121,13 @@ type WatchEventTessenConfig struct {
 type WatchEventResource struct {
 	Resource corev2.Resource
 	Action   WatchActionType
+}
+
+// WatchEventEntityConfig contains an updated entity config and the action that
+// occurred during this modification.
+type WatchEventEntityConfig struct {
+	Entity *corev3.EntityConfig
+	Action WatchActionType
 }
 
 // Store is used to abstract the durable storage used by the Sensu backend

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -30,6 +30,9 @@ const (
 	// MessageTypeEvent is the message type string for events.
 	MessageTypeEvent = "event"
 
+	// MessageTypeEntityConfig is the message type sent for entity config updates
+	MessageTypeEntityConfig = "entity_config"
+
 	// HeaderKeyAgentName is the HTTP request header specifying the Agent name
 	HeaderKeyAgentName = "Sensu-AgentName"
 


### PR DESCRIPTION
## What is this change?

This PR modifies the agent sessions in agentd so receive entity config updates via the bus, encode them and send them over the relevant agents via the transport.

Additionally, I removed the `sendq` channel, which is unused.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3880

## Does your change need a Changelog entry?

There's no changes exposed to users yet.

## Do you need clarification on anything?

As discussed, I omitted the integration of the cache/watcher, which will be implemented in a subsequent PR.

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not yet.

## How did you verify this change?

Unit test + manually verified the agent received a mocked entity config update.

## Is this change a patch?

Nope