### PR TITLE
Add the entity config watcher to agentd

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -259,6 +259,11 @@ func (s *Session) sender() {
 				continue
 			}
 
+			// Enforce the entity class to agent
+			if watchEvent.Entity.EntityClass != corev2.EntityAgentClass {
+				watchEvent.Entity.EntityClass = corev2.EntityAgentClass
+			}
+
 			bytes, err := s.marshal(watchEvent.Entity)
 			if err != nil {
 				logger.WithError(err).Error("session failed to serialize entity config")

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -63,7 +63,6 @@ type Session struct {
 	handler      *handler.MessageHandler
 	wg           *sync.WaitGroup
 	stopWG       sync.WaitGroup
-	sendq        chan *transport.Message
 	checkChannel chan interface{}
 	bus          messaging.MessageBus
 	ringPool     *ringv2.Pool
@@ -231,7 +230,6 @@ func (s *Session) sender() {
 	for {
 		var msg *transport.Message
 		select {
-		// case msg = <-s.sendq:
 		case c := <-s.entityConfig.updatesChannel:
 			cfg, ok := c.(*corev3.EntityConfig)
 			if !ok {

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -11,6 +11,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/testing/mocktransport"
 	"github.com/sensu/sensu-go/transport"
@@ -220,7 +221,11 @@ func TestSessionEntityUpdates(t *testing.T) {
 	}
 
 	// Mock an entity update from the entity watcher
-	if err := bus.Publish(messaging.EntityConfigTopic("acme", "testing"), corev3.FixtureEntityConfig("testing")); err != nil {
+	watchEvent := store.WatchEventEntityConfig{
+		Action: store.WatchUpdate,
+		Entity: corev3.FixtureEntityConfig("testing"),
+	}
+	if err := bus.Publish(messaging.EntityConfigTopic("acme", "testing"), &watchEvent); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/agentd/watcher.go
+++ b/backend/agentd/watcher.go
@@ -1,0 +1,75 @@
+package agentd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gogo/protobuf/proto"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/store"
+	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	etcdstorev2 "github.com/sensu/sensu-go/backend/store/v2/etcdstore"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+)
+
+// EntityConfigWatcher watches changes to EntityConfig in etcd and publish them
+// over the bus as store.WatchEventEntityConfig
+func EntityConfigWatcher(ctx context.Context, client *clientv3.Client, bus messaging.MessageBus) {
+	key := etcdstorev2.StoreKey(storev2.ResourceRequest{
+		Context:   ctx,
+		StoreName: new(corev3.EntityConfig).StoreName(),
+	})
+	w := etcdstore.Watch(ctx, client, key, true)
+
+	go handleResults(w, bus)
+}
+
+// handleResults handles the results from the etcd watcher. It uses the
+// store.Watcher interface to allow easier testing
+func handleResults(w store.Watcher, bus messaging.MessageBus) {
+	for response := range w.Result() {
+		if response.Type == store.WatchError {
+			logger.
+				WithError(errors.New(string(response.Object))).
+				Error("unexpected error while watching for entity config updates")
+			continue
+		}
+
+		var (
+			configWrapper wrap.Wrapper
+			entityConfig  corev3.EntityConfig
+		)
+
+		// Decode and unwrap the entity config
+		if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
+			fmt.Println(err)
+			logger.WithField("key", response.Key).WithError(err).
+				Error("unable to unmarshal entity config from key")
+			continue
+		}
+		if err := configWrapper.UnwrapInto(&entityConfig); err != nil {
+			logger.WithField("key", response.Key).WithError(err).
+				Error("unable to unwrap entity config from key")
+			continue
+		}
+
+		event := store.WatchEventEntityConfig{
+			Action: response.Type,
+			Entity: &entityConfig,
+		}
+
+		topic := messaging.EntityConfigTopic(entityConfig.Metadata.Namespace, entityConfig.Metadata.Name)
+		if err := bus.Publish(topic, &event); err != nil {
+			logger.WithField("topic", topic).WithError(err).
+				Error("unable to publish an entity config update to the bus")
+			continue
+		}
+
+		logger.WithField("topic", topic).
+			Debug("successfully published an entity config update to the bus")
+	}
+}

--- a/backend/agentd/watcher_test.go
+++ b/backend/agentd/watcher_test.go
@@ -1,0 +1,107 @@
+package agentd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+	"github.com/sensu/sensu-go/testing/mockbus"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockWatcher struct {
+	resultChan chan store.WatchEvent
+}
+
+func (w *mockWatcher) Result() <-chan store.WatchEvent {
+	return w.resultChan
+}
+
+func (w *mockWatcher) Stop() {
+	close(w.resultChan)
+}
+
+func Test_handleResults(t *testing.T) {
+	type busFunc func(*mockbus.MockBus)
+
+	// The state bytes are used to mock an invalid struct
+	state, _ := wrap.Resource(corev3.FixtureEntityState("foo"))
+	stateBytes, _ := proto.Marshal(state)
+
+	cfg, _ := wrap.Resource(corev3.FixtureEntityConfig("bar"))
+	cfgBytes, _ := proto.Marshal(cfg)
+
+	tests := []struct {
+		name       string
+		busFunc    busFunc
+		watchEvent store.WatchEvent
+	}{
+		{
+			name:       "watch error",
+			watchEvent: store.WatchEvent{Type: store.WatchError},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "invalid proto message",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: []byte("foo"),
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "invalid struct",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: stateBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "bus error",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: cfgBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(errors.New("error"))
+			},
+		},
+		{
+			name: "watch events are successfully published to the bus",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: cfgBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock a watcher
+			watcher := &mockWatcher{resultChan: make(chan store.WatchEvent)}
+			defer watcher.Stop()
+
+			// Mock the bus
+			bus := &mockbus.MockBus{}
+			if tt.busFunc != nil {
+				tt.busFunc(bus)
+			}
+
+			go handleResults(watcher, bus)
+
+			watcher.resultChan <- tt.watchEvent
+		})
+	}
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -318,6 +318,9 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	}
 	b.Daemons = append(b.Daemons, agent)
 
+	// Start the entity config watcher, so agentd sessions are notified of updates
+	agentd.EntityConfigWatcher(b.ctx, b.Client, bus)
+
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// TopicEntityConfig is the topic for the entity configuration sent by agentd
+	// to agents
+	TopicEntityConfig = "sensu:entity-config"
+
 	// TopicEvent is the topic for events that have been written to Etcd and
 	// normalized by eventd.
 	TopicEvent = "sensu:event"
@@ -81,6 +85,12 @@ type MessageBus interface {
 
 	// Publish sends a message to a topic.
 	Publish(topic string, message interface{}) error
+}
+
+// EntityConfigTopic is a helper to determine the proper topic name for an
+// entity
+func EntityConfigTopic(namespace, name string) string {
+	return fmt.Sprintf("%s:%s:%s", TopicEntityConfig, namespace, name)
 }
 
 // SubscriptionTopic is a helper to determine the proper topic name for a

--- a/backend/messaging/message_bus_test.go
+++ b/backend/messaging/message_bus_test.go
@@ -12,3 +12,9 @@ func TestSubscriptionTopic(t *testing.T) {
 	topic := SubscriptionTopic("acme", "foo")
 	assert.Equal(t, expectedTopic, topic)
 }
+
+func TestEntityConfigTopic(t *testing.T) {
+	expectedTopic := fmt.Sprintf("%s:dev:foo", TopicEntityConfig)
+	topic := EntityConfigTopic("dev", "foo")
+	assert.Equal(t, expectedTopic, topic)
+}

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -95,21 +96,22 @@ type SelectionPredicate struct {
 	Subcollection string
 }
 
-// A WatchEventCheckConfig contains the modified store object and the action that occured
-// during the modification.
+// A WatchEventCheckConfig contains the modified store object and the action
+// that occured during the modification.
 type WatchEventCheckConfig struct {
 	CheckConfig *types.CheckConfig
 	Action      WatchActionType
 }
 
-// A WatchEventHookConfig contains the modified asset object and the action that occurred
-// during the modification.
+// A WatchEventHookConfig contains the modified asset object and the action that
+// occurred during the modification.
 type WatchEventHookConfig struct {
 	HookConfig *types.HookConfig
 	Action     WatchActionType
 }
 
-// WatchEventTessenConfig is a notification that the tessen config store has been updated.
+// WatchEventTessenConfig is a notification that the tessen config store has
+// been updated.
 type WatchEventTessenConfig struct {
 	TessenConfig *corev2.TessenConfig
 	Action       WatchActionType
@@ -119,6 +121,13 @@ type WatchEventTessenConfig struct {
 type WatchEventResource struct {
 	Resource corev2.Resource
 	Action   WatchActionType
+}
+
+// WatchEventEntityConfig contains an updated entity config and the action that
+// occurred during this modification.
+type WatchEventEntityConfig struct {
+	Entity *corev3.EntityConfig
+	Action WatchActionType
 }
 
 // Store is used to abstract the durable storage used by the Sensu backend

--- a/go.sum
+++ b/go.sum
@@ -273,7 +273,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=
 github.com/sensu/lasr v1.2.1/go.mod h1:VIMtIK67Bcef6dTfctRCBg8EY9M9TtCY9NEFT6Zw5xQ=
-github.com/sensu/sensu-go/api/core v0.0.0-20200702162057-266601324835 h1:idjCMi0f5lg7GtLx6Vis4GwNhYwmIMf0I1KU3UpPQ5A=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada h1:WokF3GuxBeL+n4Lk4Fa8v9mbdjlrl7bHuneF4N1bk2I=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=
 github.com/sensu/lasr v1.2.1/go.mod h1:VIMtIK67Bcef6dTfctRCBg8EY9M9TtCY9NEFT6Zw5xQ=
+github.com/sensu/sensu-go/api/core v0.0.0-20200702162057-266601324835 h1:idjCMi0f5lg7GtLx6Vis4GwNhYwmIMf0I1KU3UpPQ5A=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada h1:WokF3GuxBeL+n4Lk4Fa8v9mbdjlrl7bHuneF4N1bk2I=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -30,6 +30,9 @@ const (
 	// MessageTypeEvent is the message type string for events.
 	MessageTypeEvent = "event"
 
+	// MessageTypeEntityConfig is the message type sent for entity config updates
+	MessageTypeEntityConfig = "entity_config"
+
 	// HeaderKeyAgentName is the HTTP request header specifying the Agent name
 	HeaderKeyAgentName = "Sensu-AgentName"
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into master after merging this patch!

If not, this feature work can go directly into the master branch.
-->