### PR TITLE
Publish entity config updates to agentd sessions

### DIFF
--- a/backend/agentd/watcher.go
+++ b/backend/agentd/watcher.go
@@ -1,0 +1,75 @@
+package agentd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gogo/protobuf/proto"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/store"
+	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	etcdstorev2 "github.com/sensu/sensu-go/backend/store/v2/etcdstore"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+)
+
+// EntityConfigWatcher watches changes to EntityConfig in etcd and publish them
+// over the bus as store.WatchEventEntityConfig
+func EntityConfigWatcher(ctx context.Context, client *clientv3.Client, bus messaging.MessageBus) {
+	key := etcdstorev2.StoreKey(storev2.ResourceRequest{
+		Context:   ctx,
+		StoreName: new(corev3.EntityConfig).StoreName(),
+	})
+	w := etcdstore.Watch(ctx, client, key, true)
+
+	go handleResults(w, bus)
+}
+
+// handleResults handles the results from the etcd watcher. It uses the
+// store.Watcher interface to allow easier testing
+func handleResults(w store.Watcher, bus messaging.MessageBus) {
+	for response := range w.Result() {
+		if response.Type == store.WatchError {
+			logger.
+				WithError(errors.New(string(response.Object))).
+				Error("unexpected error while watching for entity config updates")
+			continue
+		}
+
+		var (
+			configWrapper wrap.Wrapper
+			entityConfig  corev3.EntityConfig
+		)
+
+		// Decode and unwrap the entity config
+		if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
+			fmt.Println(err)
+			logger.WithField("key", response.Key).WithError(err).
+				Error("unable to unmarshal entity config from key")
+			continue
+		}
+		if err := configWrapper.UnwrapInto(&entityConfig); err != nil {
+			logger.WithField("key", response.Key).WithError(err).
+				Error("unable to unwrap entity config from key")
+			continue
+		}
+
+		event := store.WatchEventEntityConfig{
+			Action: response.Type,
+			Entity: &entityConfig,
+		}
+
+		topic := messaging.EntityConfigTopic(entityConfig.Metadata.Namespace, entityConfig.Metadata.Name)
+		if err := bus.Publish(topic, &event); err != nil {
+			logger.WithField("topic", topic).WithError(err).
+				Error("unable to publish an entity config update to the bus")
+			continue
+		}
+
+		logger.WithField("topic", topic).
+			Debug("successfully published an entity config update to the bus")
+	}
+}

--- a/backend/agentd/watcher.go
+++ b/backend/agentd/watcher.go
@@ -3,7 +3,6 @@ package agentd
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
@@ -46,7 +45,6 @@ func handleResults(w store.Watcher, bus messaging.MessageBus) {
 
 		// Decode and unwrap the entity config
 		if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
-			fmt.Println(err)
 			logger.WithField("key", response.Key).WithError(err).
 				Error("unable to unmarshal entity config from key")
 			continue

--- a/backend/agentd/watcher_test.go
+++ b/backend/agentd/watcher_test.go
@@ -1,0 +1,107 @@
+package agentd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+	"github.com/sensu/sensu-go/testing/mockbus"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockWatcher struct {
+	resultChan chan store.WatchEvent
+}
+
+func (w *mockWatcher) Result() <-chan store.WatchEvent {
+	return w.resultChan
+}
+
+func (w *mockWatcher) Stop() {
+	close(w.resultChan)
+}
+
+func Test_handleResults(t *testing.T) {
+	type busFunc func(*mockbus.MockBus)
+
+	// The state bytes are used to mock an invalid struct
+	state, _ := wrap.Resource(corev3.FixtureEntityState("foo"))
+	stateBytes, _ := proto.Marshal(state)
+
+	cfg, _ := wrap.Resource(corev3.FixtureEntityConfig("bar"))
+	cfgBytes, _ := proto.Marshal(cfg)
+
+	tests := []struct {
+		name       string
+		busFunc    busFunc
+		watchEvent store.WatchEvent
+	}{
+		{
+			name:       "watch error",
+			watchEvent: store.WatchEvent{Type: store.WatchError},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "invalid proto message",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: []byte("foo"),
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "invalid struct",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: stateBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+			},
+		},
+		{
+			name: "bus error",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: cfgBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(errors.New("error"))
+			},
+		},
+		{
+			name: "watch events are successfully published to the bus",
+			watchEvent: store.WatchEvent{
+				Type:   store.WatchCreate,
+				Object: cfgBytes,
+			},
+			busFunc: func(bus *mockbus.MockBus) {
+				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock a watcher
+			watcher := &mockWatcher{resultChan: make(chan store.WatchEvent)}
+			defer watcher.Stop()
+
+			// Mock the bus
+			bus := &mockbus.MockBus{}
+			if tt.busFunc != nil {
+				tt.busFunc(bus)
+			}
+
+			go handleResults(watcher, bus)
+
+			watcher.resultChan <- tt.watchEvent
+		})
+	}
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -324,6 +324,9 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	}
 	b.Daemons = append(b.Daemons, agent)
 
+	// Start the entity config watcher, so agentd sessions are notified of updates
+	agentd.EntityConfigWatcher(b.ctx, b.Client, bus)
+
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
 		DeregistrationHandler: config.DeregistrationHandler,


### PR DESCRIPTION
## What is this change?

It adds an etcd watcher to entity configs and publish updates to the bus, so sessions can receive updates about their subscribed entities.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3881

## Does your change need a Changelog entry?

I believe this change can be considered as covered with the lines added via https://github.com/sensu/sensu-go/pull/3884.

## Do you need clarification on anything?

Nope!


## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We will need to cover the entity config update in a separate sensu-docs issue I believe.

## How did you verify this change?

Unit tests + manual testing. I'll open an issue on sensu-go-qa-crucible so we can automate some of this testing.

## Is this change a patch?

Nope