### PR TITLE
Set the User-Agent during client creation and not on each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Clarifies wording around a secret provider error message.
 - Logs and returns an error if a mutator cannot be found.
+- User-Agent header is only set on new client creation rather than on each
+request.
 
 ### Breaking
 - The database schema for entities has changed. After upgrading, users will not

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -48,11 +48,10 @@ func New(config config.Config) *RestClient {
 	// JSON
 	restyInst.SetHeader("Accept", "application/json")
 	restyInst.SetHeader("Content-Type", "application/json")
+	restyInst.SetHeader("User-Agent", "sensuctl/"+version.Semver())
 
 	// Check that Access-Token has not expired
 	restyInst.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
-		c.SetHeader("User-Agent", "sensuctl/"+version.Semver())
-
 		// Guard against requests that are not sending auth details
 		if c.Token == "" || r.UserInfo != nil {
 			return nil

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -48,6 +48,8 @@ func New(config config.Config) *RestClient {
 	// JSON
 	restyInst.SetHeader("Accept", "application/json")
 	restyInst.SetHeader("Content-Type", "application/json")
+
+	// Set the User-Agent header
 	restyInst.SetHeader("User-Agent", "sensuctl/"+version.Semver())
 
 	// Check that Access-Token has not expired


### PR DESCRIPTION

## What is this change?

Sets the User-Agent header once during client creation instead of on each request.

## Why is this change necessary?

Setting it on each request triggers a concurrent map write issue as described in #3861 

## Does your change need a Changelog entry?

I think so. I've included one.

## Do you need clarification on anything?

I don't think so.

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No doc update required.

## How did you verify this change?

In addition to the unit tests, I've tested this here (https://travis-ci.org/github/jtopjian/terraform-provider-sensu/builds/706001904) repeatedly, and has passed each time. Before this fix, the test suite would fail 9/10 times.

## Is this change a patch?

Yes, but I'm not sure which branch I should target, so I'm using master. Happy to resubmit if needed.