### PR TITLE
Initialize backend entity management in keepalived

### DIFF
--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -612,10 +612,19 @@ func parseKey(key string) (namespace, name string, err error) {
 // handleUpdate sets the entity's last seen time and publishes an OK check event
 // to the message bus.
 func (k *Keepalived) handleUpdate(e *corev2.Event) error {
+	ctx := corev2.SetContextFromResource(context.Background(), e.Entity)
+	fetchedEntity, err := k.store.GetEntityByName(ctx, e.Entity.Name)
+	if err != nil {
+		logger.WithError(err).Error("error getting entity")
+		return err
+	}
+
+	if fetchedEntity != nil {
+		e.Entity = fetchedEntity
+	}
 	entity := e.Entity
 
-	ctx := corev2.SetContextFromResource(context.Background(), entity)
-	if err := k.store.DeleteFailingKeepalive(ctx, e.Entity); err != nil {
+	if err := k.store.DeleteFailingKeepalive(ctx, entity); err != nil {
 		// Warning: do not wrap this error
 		return err
 	}

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -612,19 +612,10 @@ func parseKey(key string) (namespace, name string, err error) {
 // handleUpdate sets the entity's last seen time and publishes an OK check event
 // to the message bus.
 func (k *Keepalived) handleUpdate(e *corev2.Event) error {
-	ctx := corev2.SetContextFromResource(context.Background(), e.Entity)
-	fetchedEntity, err := k.store.GetEntityByName(ctx, e.Entity.Name)
-	if err != nil {
-		logger.WithError(err).Error("error getting entity")
-		return err
-	}
-
-	if fetchedEntity != nil {
-		e.Entity = fetchedEntity
-	}
 	entity := e.Entity
 
-	if err := k.store.DeleteFailingKeepalive(ctx, entity); err != nil {
+	ctx := corev2.SetContextFromResource(context.Background(), entity)
+	if err := k.store.DeleteFailingKeepalive(ctx, e.Entity); err != nil {
 		// Warning: do not wrap this error
 		return err
 	}

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -168,6 +168,7 @@ func TestStartStop(t *testing.T) {
 			k := test.Keepalived
 
 			test.Store.On("GetFailingKeepalives", mock.Anything).Return(tc.records, nil)
+			test.Store.On("GetEntityByName", mock.Anything, mock.Anything).Return(corev2.FixtureEntity("foo"), nil)
 			for _, event := range tc.events {
 				test.Store.On("GetEventByEntityCheck", mock.Anything, event.Entity.Name, "keepalive").Return(event, nil)
 				if event.Check.Status != 0 {
@@ -196,6 +197,7 @@ func TestEventProcessing(t *testing.T) {
 	event := corev2.FixtureEvent("entity", "keepalive")
 	event.Check.Status = 1
 
+	test.Store.On("GetEntityByName", mock.Anything, mock.Anything).Return(event.Entity, nil)
 	test.StoreV2.On("CreateOrUpdate", mock.MatchedBy(func(req storv2.ResourceRequest) bool {
 		return req.StoreName == new(corev3.EntityState).StoreName()
 	}), mock.Anything).Return(nil)

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -168,7 +168,6 @@ func TestStartStop(t *testing.T) {
 			k := test.Keepalived
 
 			test.Store.On("GetFailingKeepalives", mock.Anything).Return(tc.records, nil)
-			test.Store.On("GetEntityByName", mock.Anything, mock.Anything).Return(corev2.FixtureEntity("foo"), nil)
 			for _, event := range tc.events {
 				test.Store.On("GetEventByEntityCheck", mock.Anything, event.Entity.Name, "keepalive").Return(event, nil)
 				if event.Check.Status != 0 {
@@ -197,7 +196,6 @@ func TestEventProcessing(t *testing.T) {
 	event := corev2.FixtureEvent("entity", "keepalive")
 	event.Check.Status = 1
 
-	test.Store.On("GetEntityByName", mock.Anything, mock.Anything).Return(event.Entity, nil)
 	test.StoreV2.On("CreateOrUpdate", mock.MatchedBy(func(req storv2.ResourceRequest) bool {
 		return req.StoreName == new(corev3.EntityState).StoreName()
 	}), mock.Anything).Return(nil)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Initializes backend entity management in keepalived.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3872

## Does your change need a Changelog entry?

Already covered in https://github.com/sensu/sensu-go/blob/master/CHANGELOG.md#breaking.

## Do you need clarification on anything?

I did, but @echlebek clarified all of my questions in the original issue.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Filed https://github.com/sensu/sensu-docs/issues/2597

## How did you verify this change?

Unit test. Some e2e testing. I was able to verify that entity config does not get overwritten by new flag options, however the entity within a keepalive event does get overwritten. Is this out of scope @echlebek?

_Edit:_ Event's entity is in scope, added logic to account for this use case in `handleUpdate`.

_Edit:_ Reverted the change to `handleUpdate`, as Eric believes this perhaps is handled by other in progress work.

## Is this change a patch?

Nope, supports a breaking change!