### PR TITLE
Enrich output of sensuctl asset add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ data access patterns.
 `EntityState` respectively.
 - Improves logging around the agent websocket connection.
 - sensu-agent configuration can now be managed via the HTTP API.
+- Enriches output of `sensuctl asset add` with help usage for how to use the runtime asset.
 
 ## [5.21.0] - 2020-06-10
 

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -14,6 +14,10 @@ import (
 )
 
 var rename string
+var help string = `
+You have successfully added the Sensu asset resource, but the asset will not get downloaded until
+it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
+resource, populate the "runtime_assets" field with`
 
 // AddCommand adds command that allows user to add assets from Bonsai.
 func AddCommand(cli *cli.SensuCli) *cobra.Command {
@@ -95,6 +99,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
+		fmt.Printf("help usage:\n%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
 		return nil
 	}
 }

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -99,7 +99,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
-		fmt.Printf("help usage:\n%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
+		fmt.Printf("%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
 		return nil
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Enriches output of `sensuctl asset add` with help usage for how to use the runtime asset.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3885

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Filed https://github.com/sensu/sensu-docs/issues/2599

## How did you verify this change?

```
$ sensuctl asset add sensu/monitoring-plugins
no version specified, using latest: 2.5.2
fetching bonsai asset: sensu/monitoring-plugins:2.5.2
added asset: sensu/monitoring-plugins:2.5.2

You have successfully added the Sensu asset resource, but the asset will not get downloaded until
it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
resource, populate the "runtime_assets" field with ["sensu/monitoring-plugins"].
```

## Is this change a patch?

No, but targeting master for the next release.