### PR TITLE
Improve sensu-backend upgrade UX

### DIFF
--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -17,6 +17,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	flagSkipConfirm = "skip-confirm"
+)
+
 func UpgradeCommand() *cobra.Command {
 	var setupErr error
 	cmd := &cobra.Command{
@@ -88,15 +92,18 @@ func UpgradeCommand() *cobra.Command {
 				return fmt.Errorf("error connecting to cluster: %s", err)
 			}
 
-			var confirm bool
-			prompt := &survey.Confirm{
-				Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
-			}
-			if err := survey.AskOne(prompt, &confirm, nil); err != nil {
-				return err
-			}
-			if !confirm {
-				return errors.New("upgrade aborted by operator")
+			skipConfirm := viper.GetBool(flagSkipConfirm)
+			if !skipConfirm {
+				var confirm bool
+				prompt := &survey.Confirm{
+					Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
+				}
+				if err := survey.AskOne(prompt, &confirm, nil); err != nil {
+					return err
+				}
+				if !confirm {
+					return errors.New("upgrade aborted by operator")
+				}
 			}
 
 			// Make sure at least one of the provided endpoints is reachable. This is
@@ -127,6 +134,7 @@ func UpgradeCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
+	cmd.Flags().Bool(flagSkipConfirm, false, "skip interactive confirmation")
 
 	setupErr = handleConfig(cmd, false)
 

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -92,8 +92,9 @@ func UpgradeCommand() *cobra.Command {
 			prompt := &survey.Confirm{
 				Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
 			}
-			survey.AskOne(prompt, &confirm, nil)
-
+			if err := survey.AskOne(prompt, &confirm, nil); err != nil {
+				return err
+			}
 			if !confirm {
 				return errors.New("upgrade aborted by operator")
 			}

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -17,23 +17,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-type confirmOpts struct {
-	Confirm bool `survey:"confirm"`
-}
-
-func (c *confirmOpts) askConfirm() error {
-	qs := []*survey.Question{
-		{
-			Name: "confirm",
-			Prompt: &survey.Input{
-				Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
-			},
-			Validate: survey.Required,
-		},
-	}
-	return survey.Ask(qs, c)
-}
-
 func UpgradeCommand() *cobra.Command {
 	var setupErr error
 	cmd := &cobra.Command{
@@ -105,12 +88,13 @@ func UpgradeCommand() *cobra.Command {
 				return fmt.Errorf("error connecting to cluster: %s", err)
 			}
 
-			var opts confirmOpts
-
-			if err := opts.askConfirm(); err != nil {
-				return err
+			var confirm bool
+			prompt := &survey.Confirm{
+				Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
 			}
-			if !opts.Confirm {
+			survey.AskOne(prompt, &confirm, nil)
+
+			if !confirm {
 				return errors.New("upgrade aborted by operator")
 			}
 


### PR DESCRIPTION
This commit fixes the confirmation dialog, so the user doesn't have
to enter "true" or "false", and instead can enter "y" or "n".

I've tested it manually and it now produces the desired UX.

Edit: also now supports the `--skip-confirm` flag.

Fixes #3900 
Fixes #3901 