### PR TITLE
Subscribe and unsubscribe agents based on entity config updates

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -479,6 +479,14 @@ func (s *Session) subscribe(subscriptions []string) error {
 		}
 
 		topic := messaging.SubscriptionTopic(s.cfg.Namespace, sub)
+
+		// Ignore the subscription if the session is already subscribed to it
+		if _, ok := s.subscriptionsMap[topic]; ok {
+			logger.WithField("topic", topic).
+				Debug("the session is already subscribed to the topic, ignoring it")
+			continue
+		}
+
 		logger.WithField("topic", topic).Debug("subscribing to topic")
 		subscription, err := s.bus.Subscribe(topic, agent, s)
 		if err != nil {

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -480,7 +480,7 @@ func (s *Session) subscribe(subscriptions []string) error {
 	// ended
 	agent := agentUUID(s.cfg.Namespace, s.cfg.AgentName)
 
-	for _, sub := range s.cfg.Subscriptions {
+	for _, sub := range subscriptions {
 		// Ignore empty subscriptions
 		if sub == "" {
 			continue

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -321,11 +321,11 @@ func (s *Session) sender() {
 			added, removed := diff(oldSubscriptions, newSubscriptions)
 			s.cfg.Subscriptions = newSubscriptions
 			s.mu.Unlock()
-			if len(added) > 1 {
+			if len(added) > 0 {
 				lager.Debugf("found %d new subscription(s): %v", len(added), added)
 				s.subscribe(added)
 			}
-			if len(removed) > 1 {
+			if len(removed) > 0 {
 				lager.Debugf("found %d subscription(s) to unsubscribe from: %v", len(removed), removed)
 				s.unsubscribe(removed)
 			}

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -610,10 +610,24 @@ func diff(old, new []string) ([]string, []string) {
 	return added, removed
 }
 
+func removeEmptySubscriptions(subscriptions []string) []string {
+	var s []string
+	for _, subscription := range subscriptions {
+		if subscription != "" {
+			s = append(s, subscription)
+		}
+	}
+	return s
+}
+
 func sortSubscriptions(subscriptions []string) []string {
+	// Remove empty subscriptions
+	subscriptions = removeEmptySubscriptions(subscriptions)
+
 	if sort.StringsAreSorted(subscriptions) {
 		return subscriptions
 	}
+
 	sortedSubscriptions := append(subscriptions[:0:0], subscriptions...)
 	sort.Strings(sortedSubscriptions)
 	return sortedSubscriptions

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -565,4 +567,39 @@ func (s *Session) unsubscribe(subscriptions []string) {
 
 func agentUUID(namespace, name string) string {
 	return fmt.Sprintf("%s:%s-%s", namespace, name, uuid.New().String())
+}
+
+// diff compares the two given slices and returns the elements that were both
+// added and removed in the new slice, in comparison to the old slice. It relies
+// on both slices being sorted to properly work.
+func diff(old, new []string) ([]string, []string) {
+	var added, removed []string
+	i, j := 0, 0
+
+	for i < len(old) && j < len(new) {
+		c := strings.Compare(old[i], new[j])
+		if c == 0 {
+			i++
+			j++
+		} else if c < 0 {
+			removed = append(removed, old[i])
+			i++
+		} else {
+			added = append(added, new[j])
+			j++
+		}
+	}
+
+	removed = append(removed, old[i:]...)
+	added = append(added, new[j:]...)
+	return added, removed
+}
+
+func sortSubscriptions(subscriptions []string) []string {
+	if sort.StringsAreSorted(subscriptions) {
+		return subscriptions
+	}
+	sortedSubscriptions := append(subscriptions[:0:0], subscriptions...)
+	sort.Strings(sortedSubscriptions)
+	return sortedSubscriptions
 }

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -546,3 +546,78 @@ func TestSession_unsubscribe(t *testing.T) {
 		})
 	}
 }
+
+func Test_diff(t *testing.T) {
+	tests := []struct {
+		name        string
+		old         []string
+		new         []string
+		wantAdded   []string
+		wantRemoved []string
+	}{
+		{
+			name:        "simple removed and added elements",
+			old:         []string{"a", "b", "c"},
+			new:         []string{"b", "c", "d"},
+			wantAdded:   []string{"d"},
+			wantRemoved: []string{"a"},
+		},
+		{
+			name:        "simple removed and added elements but reversed",
+			old:         []string{"b", "c", "d"},
+			new:         []string{"a", "b", "c"},
+			wantAdded:   []string{"a"},
+			wantRemoved: []string{"d"},
+		},
+		{
+			name:      "duplicated elements are detected",
+			old:       []string{"a", "b", "c"},
+			new:       []string{"a", "a", "b", "c"},
+			wantAdded: []string{"a"},
+		},
+		{
+			name:        "completely different slices",
+			old:         []string{"a", "b", "c"},
+			new:         []string{"d", "e", "f"},
+			wantAdded:   []string{"d", "e", "f"},
+			wantRemoved: []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdded, gotRemoved := diff(tt.old, tt.new)
+			if !reflect.DeepEqual(gotAdded, tt.wantAdded) {
+				t.Errorf("diff() added = %#v, want %#v", gotAdded, tt.wantAdded)
+			}
+			if !reflect.DeepEqual(gotRemoved, tt.wantRemoved) {
+				t.Errorf("diff() removed = %#v, want %#v", gotRemoved, tt.wantRemoved)
+			}
+		})
+	}
+}
+
+func Test_sortSubscriptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		subscriptions []string
+		want          []string
+	}{
+		{
+			name:          "unsorted subscriptions are sorted",
+			subscriptions: []string{"b", "a", "c"},
+			want:          []string{"a", "b", "c"},
+		},
+		{
+			name:          "already sorted subscriptions are immediately returned",
+			subscriptions: []string{"a", "b", "c"},
+			want:          []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sortSubscriptions(tt.subscriptions); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortSubscriptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -569,3 +569,44 @@ func Test_sortSubscriptions(t *testing.T) {
 		})
 	}
 }
+
+func Test_removeEmptySubscriptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		subscriptions []string
+		want          []string
+	}{
+		{
+			name:          "no empty subscriptions",
+			subscriptions: []string{"foo", "bar"},
+			want:          []string{"foo", "bar"},
+		},
+		{
+			name:          "leading empty subscriptions",
+			subscriptions: []string{"", "foo", "bar"},
+			want:          []string{"foo", "bar"},
+		},
+		{
+			name:          "middle empty subscriptions",
+			subscriptions: []string{"foo", "", "bar"},
+			want:          []string{"foo", "bar"},
+		},
+		{
+			name:          "trailing empty subscriptions",
+			subscriptions: []string{"foo", "bar", ""},
+			want:          []string{"foo", "bar"},
+		},
+		{
+			name:          "multiple empty subscriptions",
+			subscriptions: []string{"", "foo", "bar", ""},
+			want:          []string{"foo", "bar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeEmptySubscriptions(tt.subscriptions); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeEmptySubscriptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is this change?

This PR adds support for automatically reflecting subscriptions changed made to entity configs in the agentd sessions.

In order to support that change, I had to refactor a bit the `Session` struct. The most notable change is the switch from a buffered channel of subscriptions (`subscriptions`) to a map of subscriptions (`subscriptionsMap`), so we don't have to deal with blocking senders and removing elements from it.

I also moved the logic around subscribing and unsubscribing from check subscriptions to their own methods, so it's re-usable and more easily testable.

Additionally, I refactored a bit the unit tests into test cases because most of these tests were sharing the same configuration logic.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3895

## Does your change need a Changelog entry?

I think it can be included in the lines around backend entity management.

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Writing tests for those changes was probably harder than the actual code.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs will be required for the entire feature.

## How did you verify this change?

Unit tests + e2e tests Nikki wrote via https://github.com/sensu/sensu-go-qa-crucible/pull/135/files. I also did a bunch of manual tests via my local cluster.

## Is this change a patch?

Nope