### PR TITLE
Ensure keepalive entities are consistent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -313,6 +313,8 @@ func (a *Agent) connectionManager(ctx context.Context, cancel context.CancelFunc
 		a.connected = false
 		a.connectedMu.Unlock()
 
+		a.clearAgentEntity()
+
 		conn, err := a.connectWithBackoff(ctx)
 		if err != nil {
 			if err == ctx.Err() {
@@ -412,7 +414,7 @@ func (a *Agent) newKeepalive() *transport.Message {
 
 	// We want to send the entity from the local configuration, in case we need to
 	// register this agent, which should use the local entity configuration
-	entity := a.getLocalEntity()
+	entity := a.getAgentEntity()
 	uid, _ := uuid.NewRandom()
 
 	keepalive := &corev2.Event{

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -24,12 +24,6 @@ func (a *Agent) clearAgentEntity() {
 	a.entityConfig = nil
 }
 
-func (a *Agent) getLocalEntity() *corev2.Entity {
-	a.entityMu.Lock()
-	defer a.entityMu.Unlock()
-	return v3EntityToV2(a.getLocalEntityConfig(), a.getEntityState())
-}
-
 func (a *Agent) getLocalEntityConfig() *corev3.EntityConfig {
 	if a.localEntityConfig != nil {
 		return a.localEntityConfig

--- a/agent/entity.go
+++ b/agent/entity.go
@@ -18,6 +18,12 @@ func (a *Agent) getAgentEntity() *corev2.Entity {
 	return v3EntityToV2(a.entityConfig, a.getEntityState())
 }
 
+func (a *Agent) clearAgentEntity() {
+	a.entityMu.Lock()
+	defer a.entityMu.Unlock()
+	a.entityConfig = nil
+}
+
 func (a *Agent) getLocalEntity() *corev2.Entity {
 	a.entityMu.Lock()
 	defer a.entityMu.Unlock()

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -295,7 +295,7 @@ func TestProcessRegistration(t *testing.T) {
 
 			storev2.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(tc.storev2Err)
 			storev2.On("Get", mock.Anything).Return(tc.storeEntity, nil)
-			err = keepalived.handleEntityRegistration(tc.entity)
+			err = keepalived.handleEntityRegistration(tc.entity, new(corev2.Event))
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedEventLen, len(tsubEvent.ch))


### PR DESCRIPTION
This commit fixes a bug where entity information in keepalive events
was not correct. To achieve this, the following things were done:

* Use a.getAgentEntity() when creating keepalives
* Clear the agent's cached entity on session restart
* Update keepalived to only send an entity notification if the
entity config is out of sync.
* Update keepalived to update keepalive events with the latest
entity config.