### PR TITLE
Add Entity state update exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ data access patterns.
 - ClusterRoleBinding and RoleBinding subjects names can now contain any unicode
 characters.
 - Enriches output of `sensuctl asset add` with help usage for how to use the runtime asset.
+- Unless the entity is a proxy entity, updates to entities now ignore state
+  related fields.
 
 ## [5.21.0] - 2020-06-10
 

--- a/backend/api/entity.go
+++ b/backend/api/entity.go
@@ -80,7 +80,15 @@ func (e *EntityClient) CreateEntity(ctx context.Context, entity *corev2.Entity) 
 
 // UpdateEntity updates an entity, if authorized.
 func (e *EntityClient) UpdateEntity(ctx context.Context, entity *corev2.Entity) error {
-	// TODO(ccressent): add blurb here to explain why we make that exception.
+	// We have 2 code paths here: one for proxy entities and another for all
+	// other types of entities. We had to make that distinction because Entity
+	// is still the public API to interact with entities, even though internally
+	// we use the storev2 EntityConfig/EntityState split.
+	//
+	// The consequence was that updating an Entity could alter its state,
+	// something we don't really want unless that entity is a proxy entity.
+	//
+	// See sensu-go#3896.
 	if entity.EntityClass == corev2.EntityProxyClass {
 		if err := e.client.Update(ctx, entity); err != nil {
 			return err

--- a/backend/api/entity.go
+++ b/backend/api/entity.go
@@ -4,22 +4,27 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sirupsen/logrus"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 )
 
 // EntityClient is an API client for entities.
 type EntityClient struct {
 	client     *GenericClient
+	storev2    storev2.Interface
 	eventStore store.EventStore
 	auth       authorization.Authorizer
 }
 
 // NewEntityClient creates a new EntityClient given a store, an event store and
 // an authorizer.
-func NewEntityClient(store store.ResourceStore, eventStore store.EventStore, auth authorization.Authorizer) *EntityClient {
+func NewEntityClient(store store.ResourceStore, storev2 storev2.Interface, eventStore store.EventStore, auth authorization.Authorizer) *EntityClient {
 	return &EntityClient{
 		client: &GenericClient{
 			Auth:       auth,
@@ -28,6 +33,7 @@ func NewEntityClient(store store.ResourceStore, eventStore store.EventStore, aut
 			APIGroup:   "core",
 			APIVersion: "v2",
 		},
+		storev2:    storev2,
 		eventStore: eventStore,
 		auth:       auth,
 	}
@@ -74,9 +80,33 @@ func (e *EntityClient) CreateEntity(ctx context.Context, entity *corev2.Entity) 
 
 // UpdateEntity updates an entity, if authorized.
 func (e *EntityClient) UpdateEntity(ctx context.Context, entity *corev2.Entity) error {
-	if err := e.client.Update(ctx, entity); err != nil {
-		return err
+	// TODO(ccressent): add blurb here to explain why we make that exception.
+	if entity.EntityClass == corev2.EntityProxyClass {
+		if err := e.client.Update(ctx, entity); err != nil {
+			return err
+		}
+	} else {
+		// The generic client takes care of authorization for us, so if we
+		// bypass it as we're doing here, we must not forget to deal with
+		// authorization ourselves.
+		attrs := entityUpdateAttributes(ctx, entity.Name)
+		if err := authorize(ctx, e.auth, attrs); err != nil {
+			return err
+		}
+
+		config, _ := corev3.V2EntityToV3(entity)
+		req := storev2.NewResourceRequestFromResource(ctx, config)
+
+		wConfig, err := wrap.Resource(config)
+		if err != nil {
+			return err
+		}
+
+		if err := e.storev2.CreateOrUpdate(req, wConfig); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 
@@ -100,4 +130,15 @@ func (e *EntityClient) ListEntities(ctx context.Context) ([]*corev2.Entity, erro
 		return nil, err
 	}
 	return slice, nil
+}
+
+func entityUpdateAttributes(ctx context.Context, name string) *authorization.Attributes {
+	return &authorization.Attributes{
+		APIGroup:     "core",
+		APIVersion:   "v2",
+		Namespace:    corev2.ContextNamespace(ctx),
+		Resource:     "entities",
+		Verb:         "update",
+		ResourceName: name,
+	}
 }

--- a/backend/apid/actions/entities.go
+++ b/backend/apid/actions/entities.go
@@ -4,18 +4,23 @@ import (
 	"context"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 )
 
 // EntityController exposes actions in which a viewer can perform.
 type EntityController struct {
-	store store.EntityStore
+	store   store.EntityStore
+	storev2 storev2.Interface
 }
 
 // NewEntityController returns new EntityController
-func NewEntityController(store store.EntityStore) EntityController {
+func NewEntityController(store store.EntityStore, storev2 storev2.Interface) EntityController {
 	return EntityController{
-		store: store,
+		store:   store,
+		storev2: storev2,
 	}
 }
 
@@ -75,14 +80,27 @@ func (c EntityController) Create(ctx context.Context, entity corev2.Entity) erro
 // provided entity is invalid, the user doesn't have permissions to create or
 // update the entity, or if an internal error is returned from the store.
 func (c EntityController) CreateOrReplace(ctx context.Context, entity corev2.Entity) error {
-	// Validate
 	if err := entity.Validate(); err != nil {
 		return NewError(InvalidArgument, err)
 	}
 
-	// Persist Changes
-	if serr := c.store.UpdateEntity(ctx, &entity); serr != nil {
-		return NewError(InternalErr, serr)
+	// TODO(ccressent): add blurb here to explain why we make that exception.
+	if entity.EntityClass == corev2.EntityProxyClass {
+		if serr := c.store.UpdateEntity(ctx, &entity); serr != nil {
+			return NewError(InternalErr, serr)
+		}
+	} else {
+		config, _ := corev3.V2EntityToV3(&entity)
+		req := storev2.NewResourceRequestFromResource(ctx, config)
+
+		wConfig, err := wrap.Resource(config)
+		if err != nil {
+			return err
+		}
+
+		if err := c.storev2.CreateOrUpdate(req, wConfig); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/backend/apid/actions/entities.go
+++ b/backend/apid/actions/entities.go
@@ -84,7 +84,15 @@ func (c EntityController) CreateOrReplace(ctx context.Context, entity corev2.Ent
 		return NewError(InvalidArgument, err)
 	}
 
-	// TODO(ccressent): add blurb here to explain why we make that exception.
+	// We have 2 code paths here: one for proxy entities and another for all
+	// other types of entities. We had to make that distinction because Entity
+	// is still the public API to interact with entities, even though internally
+	// we use the storev2 EntityConfig/EntityState split.
+	//
+	// The consequence was that updating an Entity could alter its state,
+	// something we don't really want unless that entity is a proxy entity.
+	//
+	// See sensu-go#3896.
 	if entity.EntityClass == corev2.EntityProxyClass {
 		if serr := c.store.UpdateEntity(ctx, &entity); serr != nil {
 			return NewError(InternalErr, serr)

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/graphql"
 	"github.com/sensu/sensu-go/backend/apid/middlewares"
@@ -22,6 +23,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -39,6 +41,7 @@ type APId struct {
 	errChan             chan error
 	bus                 messaging.MessageBus
 	store               store.Store
+	storev2             storev2.Interface
 	eventStore          store.EventStore
 	queueGetter         types.QueueGetter
 	tls                 *types.TLSOptions
@@ -56,6 +59,7 @@ type Config struct {
 	URL                 string
 	Bus                 messaging.MessageBus
 	Store               store.Store
+	Storev2             storev2.Interface
 	EventStore          store.EventStore
 	QueueGetter         types.QueueGetter
 	TLS                 *types.TLSOptions
@@ -71,6 +75,7 @@ type Config struct {
 func New(c Config, opts ...Option) (*APId, error) {
 	a := &APId{
 		store:               c.Store,
+		storev2:             c.Storev2,
 		eventStore:          c.EventStore,
 		queueGetter:         c.QueueGetter,
 		tls:                 c.TLS,
@@ -199,7 +204,7 @@ func EntityLimitedCoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	)
 	mountRouters(
 		subrouter,
-		routers.NewEntitiesRouter(cfg.Store, cfg.EventStore),
+		routers.NewEntitiesRouter(cfg.Store, cfg.Storev2, cfg.EventStore),
 		routers.NewEventsRouter(cfg.EventStore, cfg.Bus),
 	)
 

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -9,6 +9,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
 
 // EntitiesRouter handles requests for /entities
@@ -26,9 +27,9 @@ type EntityController interface {
 }
 
 // NewEntitiesRouter instantiates new router for controlling entities resources
-func NewEntitiesRouter(store store.Store, events store.EventStore) *EntitiesRouter {
+func NewEntitiesRouter(store store.Store, storev2 storev2.Interface, events store.EventStore) *EntitiesRouter {
 	return &EntitiesRouter{
-		controller: actions.NewEntityController(store),
+		controller: actions.NewEntityController(store, storev2),
 		store:      store,
 		eventStore: events,
 	}

--- a/backend/apid/routers/entities_test.go
+++ b/backend/apid/routers/entities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/v2/storetest"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/mock"
 )
@@ -47,7 +48,8 @@ func TestEntitiesRouter(t *testing.T) {
 	s.On("DeleteEventByEntityCheck", mock.Anything, "foo", "bar").Return(nil)
 	s.On("DeleteEntityByName", mock.Anything, "foo").Return(nil)
 	s.On("GetEntityByName", mock.Anything, "foo").Return(corev2.FixtureEntity("foo"), nil)
-	router := NewEntitiesRouter(s, s)
+	s2 := new(storetest.Store)
+	router := NewEntitiesRouter(s, s2, s)
 	router.controller = controller
 	parentRouter := mux.NewRouter().PathPrefix(corev2.URLPrefix).Subrouter()
 	router.Mount(parentRouter)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,10 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/viper"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/backend/agentd"
@@ -45,9 +49,6 @@ import (
 	"github.com/sensu/sensu-go/rpc"
 	"github.com/sensu/sensu-go/system"
 	"github.com/sensu/sensu-go/util/retry"
-	"github.com/spf13/viper"
-	"golang.org/x/time/rate"
-	"google.golang.org/grpc"
 )
 
 type ErrStartup struct {
@@ -381,7 +382,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	b.GraphQLService, err = graphql.NewService(graphql.ServiceConfig{
 		AssetClient:       api.NewAssetClient(stor, auth),
 		CheckClient:       api.NewCheckClient(stor, actions.NewCheckController(stor, queueGetter), auth),
-		EntityClient:      api.NewEntityClient(stor, eventStoreProxy, auth),
+		EntityClient:      api.NewEntityClient(stor, storv2, eventStoreProxy, auth),
 		EventClient:       api.NewEventClient(eventStoreProxy, auth, bus),
 		EventFilterClient: api.NewEventFilterClient(stor, auth),
 		HandlerClient:     api.NewHandlerClient(stor, auth),


### PR DESCRIPTION
## What is this change?

Unless the entity is a proxy entity, updates to entities now ignore state related fields.

## Why is this change necessary?

Closes #3896 

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe any documentation has to change:
- nothing changes for proxy entities
- altering entity state when updating an entity was not useful since the agent would quickly override that state

## How did you verify this change?

Updated and ran all unit and integration tests.

## Is this change a patch?

No.