### PR TITLE
Send a close message over the websocket when closing a session

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -3,6 +3,7 @@ package agentd
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -127,7 +128,12 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		ErrorLog: log.New(&logrusIOWriter{entry: logger}, "", 0),
 		ConnState: func(c net.Conn, cs http.ConnState) {
 			var msg []byte
+			// fmt.Println(c.Co)
 			if _, err := c.Read(msg); err != nil {
+				if err == io.EOF {
+					fmt.Println("io.EOF!")
+				}
+				fmt.Printf("%#v\n", err)
 				logger.WithError(err).Error("websocket connection error")
 			}
 		},

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -3,7 +3,6 @@ package agentd
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -128,12 +127,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		ErrorLog: log.New(&logrusIOWriter{entry: logger}, "", 0),
 		ConnState: func(c net.Conn, cs http.ConnState) {
 			var msg []byte
-			// fmt.Println(c.Co)
 			if _, err := c.Read(msg); err != nil {
-				if err == io.EOF {
-					fmt.Println("io.EOF!")
-				}
-				fmt.Printf("%#v\n", err)
 				logger.WithError(err).Error("websocket connection error")
 			}
 		},

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -434,7 +434,7 @@ func (s *Session) stop() {
 	// connection is not already closed
 	if !s.conn.Closed() {
 		if err := s.conn.SendCloseMessage(); err != nil {
-			logger.WithError(err).Warning("unexpected error while sending a close message to the agent")
+			logger.Warning("unexpected error while sending a close message to the agent")
 		}
 	}
 
@@ -451,8 +451,6 @@ func (s *Session) stop() {
 	case <-done:
 	case <-time.After(closeGracePeriod):
 	}
-
-	s.wg.Wait()
 
 	close(s.entityConfig.updatesChannel)
 	close(s.checkChannel)

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -99,7 +99,7 @@ func TestSession(t *testing.T) {
 					// Close our wait channel once we asserted the message
 					wg.Done()
 				}).Return(nil)
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {
@@ -114,6 +114,7 @@ func TestSession(t *testing.T) {
 			name: "delete watch event stops the agent session",
 			connFunc: func(conn *mocktransport.MockTransport, wg *sync.WaitGroup) {
 				conn.On("Receive").After(100*time.Millisecond).Return(&transport.Message{}, nil)
+				conn.On("Closed").Return(false)
 				conn.On("SendCloseMessage").Return(nil)
 				conn.On("Close").Return(nil)
 			},
@@ -132,7 +133,7 @@ func TestSession(t *testing.T) {
 				// The Send() method should only be called once, otherwise it means the
 				// unknown event also sent something
 				conn.On("Send", mock.Anything).Once().Return(transport.ClosedError{})
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {
@@ -156,7 +157,7 @@ func TestSession(t *testing.T) {
 			name: "invalid class entities are reset to the agent class",
 			connFunc: func(conn *mocktransport.MockTransport, wg *sync.WaitGroup) {
 				conn.On("Receive").After(100*time.Millisecond).Return(&transport.Message{}, nil)
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {
@@ -181,7 +182,7 @@ func TestSession(t *testing.T) {
 			connFunc: func(conn *mocktransport.MockTransport, wg *sync.WaitGroup) {
 				conn.On("Receive").After(100*time.Millisecond).Return(&transport.Message{}, nil)
 				conn.On("Send", mock.Anything).Return(transport.ConnectionError{Message: "some horrible network outage"})
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {
@@ -208,7 +209,7 @@ func TestSession(t *testing.T) {
 						wg.Done()
 					}
 				}).Return(nil)
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {
@@ -246,7 +247,7 @@ func TestSession(t *testing.T) {
 						t.Fatalf("did not expect to receive a message of type %s", corev2.CheckRequestType)
 					}
 				}).Return(nil)
-				conn.On("SendCloseMessage").Return(nil)
+				conn.On("Closed").Return(true)
 				conn.On("Close").Return(nil)
 			},
 			busFunc: func(bus *messaging.WizardBus, wg *sync.WaitGroup) {

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -632,7 +632,6 @@ func TestSession_receiver(t *testing.T) {
 			connFunc: func(conn *mocktransport.MockTransport, cancel context.CancelFunc) {
 				conn.On("Receive").Once().Return(&transport.Message{}, nil)
 				conn.On("Receive").Once().Run(func(args mock.Arguments) {
-					fmt.Println("cancel!")
 					cancel()
 				}).Return(&transport.Message{}, nil)
 			},
@@ -642,7 +641,6 @@ func TestSession_receiver(t *testing.T) {
 			connFunc: func(conn *mocktransport.MockTransport, cancel context.CancelFunc) {
 				conn.On("Receive").Once().Return(&transport.Message{}, errors.New("error"))
 				conn.On("Receive").Once().Run(func(args mock.Arguments) {
-					fmt.Println("cancel!")
 					cancel()
 				}).Return(&transport.Message{}, nil)
 			},
@@ -652,7 +650,6 @@ func TestSession_receiver(t *testing.T) {
 			connFunc: func(conn *mocktransport.MockTransport, cancel context.CancelFunc) {
 				conn.On("Receive").Once().Return(&transport.Message{}, transport.ConnectionError{})
 				conn.On("Receive").Once().Run(func(args mock.Arguments) {
-					fmt.Println("cancel!")
 					cancel()
 				}).Return(&transport.Message{}, nil)
 			},

--- a/testing/mocktransport/transport.go
+++ b/testing/mocktransport/transport.go
@@ -44,6 +44,13 @@ func (m *MockTransport) Send(message *transport.Message) error {
 	return args.Error(0)
 }
 
+// SendCloseMessage ...
+func (m *MockTransport) SendCloseMessage() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// Heartbeat ...
 func (m *MockTransport) Heartbeat(ctx context.Context, interval, timeout int) {
 	_ = m.Called(ctx, interval, timeout)
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -121,6 +121,11 @@ type Transport interface {
 	// sent. Send is synchronous, returning nil if the write to the underlying
 	// socket was successful and an error otherwise.
 	Send(*Message) error
+
+	// SendCloseMessage sends a close control message over the transport, and the
+	// peer should echo the message back and that message will be returned as an
+	// error from the websocket connection's read API
+	SendCloseMessage() error
 }
 
 // A WebSocketTransport is a connection between sensu Agents and Backends over
@@ -288,4 +293,9 @@ func (t *WebSocketTransport) Send(m *Message) (err error) {
 	}
 
 	return nil
+}
+
+// SendCloseMessage sends a close control message over the transport
+func (t *WebSocketTransport) SendCloseMessage() (err error) {
+	return t.Connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 }


### PR DESCRIPTION
## What is this change?

It forces the session to send a close control message over the transport (websocket) when stopping, which allows the peer (agent) to close the transport on its side too.

I also modified a bit the `stop()` logic we don't block forever when stopping the session if the peer never send back a message.

## Why is this change necessary?

It fixes a bug where the agent would always send back a last keepalive (with a possibly stale entity config) when a session would severe its connection.

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified, and also applied this patch over Eric's PR while testing.

I probably need a second pair of 👀 just to make sure I'm not missing anything.

## Is this change a patch?

Unreleased stuff.