### PR TITLE
Print renamed asset in help message

### DIFF
--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -99,7 +99,11 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
-		fmt.Printf("%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
+		if rename != "" {
+			fmt.Printf("%s [\"%s\"].\n", help, rename)
+		} else {
+			fmt.Printf("%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
+		}
 		return nil
 	}
 }

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -85,15 +85,14 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		if err := resource.Validate(resources, cli.Config.Namespace()); err != nil {
 			return err
 		}
-		var assetName string
+		assetPath := path.Join(bAsset.Namespace, bAsset.Name)
 		for i := range resources {
 			meta := resources[i].Value.GetObjectMeta()
 			if rename != "" {
 				meta.Name = rename
 			} else {
-				meta.Name = path.Join(bAsset.Namespace, bAsset.Name)
+				meta.Name = assetPath
 			}
-			assetName = meta.Name
 			resources[i].Value.SetObjectMeta(meta)
 		}
 		processor := resource.NewPutter()
@@ -101,8 +100,12 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			return err
 		}
 
-		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
-		fmt.Printf("%s [\"%s\"].\n", help, assetName)
+		fmt.Printf("added asset: %s:%s\n", assetPath, bonsaiVersion.Original())
+		if rename != "" {
+			fmt.Printf("%s [\"%s\"].\n", help, rename)
+		} else {
+			fmt.Printf("%s [\"%s\"].\n", help, assetPath)
+		}
 		return nil
 	}
 }

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -101,11 +101,11 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		fmt.Printf("added asset: %s:%s\n", assetPath, bonsaiVersion.Original())
-		if rename != "" {
-			fmt.Printf("%s [\"%s\"].\n", help, rename)
-		} else {
-			fmt.Printf("%s [\"%s\"].\n", help, assetPath)
+		assetName := rename
+		if assetName == "" {
+			assetName = assetPath
 		}
+		fmt.Printf("%s [\"%s\"].\n", help, assetName)
 		return nil
 	}
 }

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path"
 
 	"github.com/sensu/sensu-go/bonsai"
 	"github.com/sensu/sensu-go/cli"
@@ -90,7 +91,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			if rename != "" {
 				meta.Name = rename
 			} else {
-				meta.Name = fmt.Sprintf("%s/%s", bAsset.Namespace, bAsset.Name)
+				meta.Name = path.Join(bAsset.Namespace, bAsset.Name)
 			}
 			assetName = meta.Name
 			resources[i].Value.SetObjectMeta(meta)

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -84,6 +84,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		if err := resource.Validate(resources, cli.Config.Namespace()); err != nil {
 			return err
 		}
+		var assetName string
 		for i := range resources {
 			meta := resources[i].Value.GetObjectMeta()
 			if rename != "" {
@@ -91,6 +92,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			} else {
 				meta.Name = fmt.Sprintf("%s/%s", bAsset.Namespace, bAsset.Name)
 			}
+			assetName = meta.Name
 			resources[i].Value.SetObjectMeta(meta)
 		}
 		processor := resource.NewPutter()
@@ -99,11 +101,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 		}
 
 		fmt.Printf("added asset: %s/%s:%s\n", bAsset.Namespace, bAsset.Name, bonsaiVersion.Original())
-		if rename != "" {
-			fmt.Printf("%s [\"%s\"].\n", help, rename)
-		} else {
-			fmt.Printf("%s [\"%s/%s\"].\n", help, bAsset.Namespace, bAsset.Name)
-		}
+		fmt.Printf("%s [\"%s\"].\n", help, assetName)
 		return nil
 	}
 }

--- a/graphql/generator/common.go
+++ b/graphql/generator/common.go
@@ -135,15 +135,15 @@ func isEnum(tt ast.Type, i info) bool {
 func mustExtractSuffix(obj *ast.ObjectDefinition) string {
 	namedDir := findDirectiveNamed(obj.Directives, "named")
 	if namedDir == nil {
-		logger.Fatal(MissingNamedDirectiveErr)
+		panic(MissingNamedDirectiveErr)
 	}
 	suffixArg := findArgumentNamed(namedDir.Arguments, "suffix")
 	if suffixArg == nil {
-		logger.Fatal(MissingNamedDirectiveErr)
+		panic(MissingNamedDirectiveErr)
 	}
 	suffix, ok := suffixArg.Value.GetValue().(string)
 	if !ok {
-		logger.Fatal(MissingNamedDirectiveErr)
+		panic(MissingNamedDirectiveErr)
 	}
 	return suffix
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

@hillaryfraley found this bug when documenting https://github.com/sensu/sensu-docs/issues/2599. We should print the correct runtime asset name if it is renamed with `--rename`.

```
$ sensuctl asset add sensu/sensu-slack-handler --rename slack-handler
no version specified, using latest: 1.3.2
fetching bonsai asset: sensu/sensu-slack-handler:1.3.2
added asset: sensu/sensu-slack-handler:1.3.2

You have successfully added the Sensu asset resource, but the asset will not get downloaded until
it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
resource, populate the "runtime_assets" field with ["slack-handler"].

$ sensuctl asset add sensu/sensu-slack-handler
no version specified, using latest: 1.3.2
fetching bonsai asset: sensu/sensu-slack-handler:1.3.2
added asset: sensu/sensu-slack-handler:1.3.2

You have successfully added the Sensu asset resource, but the asset will not get downloaded until
it's invoked by another Sensu resource (ex. check). To add this runtime asset to the appropriate
resource, populate the "runtime_assets" field with ["sensu/sensu-slack-handler"].
```