### PR TITLE
Bugfix: set a storev2 in apid's config

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -407,6 +407,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		URL:                 config.APIURL,
 		Bus:                 bus,
 		Store:               stor,
+		Storev2:             storv2,
 		EventStore:          eventStoreProxy,
 		QueueGetter:         queueGetter,
 		TLS:                 config.TLS,


### PR DESCRIPTION
## What is this change?

>This is my bad; it was forgotten in a previous PR, leading to updates to
>non-proxy entities being broken in the REST API.
>
>GraphQL and backend API client were fine though!
>
>Signed-off-by: Cyril Cressent <cyril@sensu.io>

This fixes the null pointer dereference. This wasn't caught by unit tests because it's an integration issue in the backend's initialization code.

## Why is this change necessary?

Make updating non-proxy entities via the REST API (and by extension, `sensuctl`) work again.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.


## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No changes needed.

## How did you verify this change?

Re-tested updating existing entities locally, this time with combinations of proxy and non-proxy entities...

## Is this change a patch?

No.