### PR TITLE
Update Tessen entity_count

### DIFF
--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -40,6 +40,11 @@ func GetEntitiesPath(ctx context.Context, name string) string {
 	return entityKeyBuilder.WithContext(ctx).Build(name)
 }
 
+// GetEntityConfigsPath gets the path of entity_configs in the store
+func GetEntityConfigsPath(ctx context.Context, name string) string {
+	return entityConfigKeyBuilder.WithContext(ctx).Build(name)
+}
+
 // DeleteEntity deletes an Entity.
 func (s *Store) DeleteEntity(ctx context.Context, e *corev2.Entity) error {
 	if err := e.Validate(); err != nil {

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -60,7 +60,7 @@ var (
 		"check_count":                etcd.GetCheckConfigsPath,
 		"cluster_role_count":         etcd.GetClusterRolesPath,
 		"cluster_role_binding_count": etcd.GetClusterRoleBindingsPath,
-		"entity_count":               etcd.GetEntitiesPath,
+		"entity_count":               etcd.GetEntityConfigsPath,
 		"event_count":                etcd.GetEventsPath,
 		"filter_count":               etcd.GetEventFiltersPath,
 		"handler_count":              etcd.GetHandlersPath,


### PR DESCRIPTION
## What is this change?

>With the entities now being stored as a split EntityConfig and
>EntityState in different etcd key prefixes, we can't count entities by
>looking at the old "entities" key prefix.
>
>We now consider "entity_count" to be the count of EntityConfig.
>
>Signed-off-by: Cyril Cressent <cyril@sensu.io>

## Why is this change necessary?

Make Tessen's `entity_count` non-zero in 6.0 clusters.

## Does your change need a Changelog entry?

I don't think it does, since this should have done as part of other 6.0 changes that are already mentioned in the change log.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes needed.

## How did you verify this change?

On a local test setup with entities in it, I observed that before the change, tessen would always report an `entity_count` of zero in the logs. After this change, it reports the correct count.

## Is this change a patch?

No.