### PR TITLE
Fix bug in api package where consumer was unable to retrieve entities

### DIFF
--- a/backend/api/entity_test.go
+++ b/backend/api/entity_test.go
@@ -110,10 +110,7 @@ func TestListEntities(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("ListResources", mock.Anything, (&corev2.Entity{}).StorePrefix(), mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-					arg := args.Get(2).(*[]*corev2.Entity)
-					*arg = []*corev2.Entity{defaultEntity}
-				}).Return(nil)
+				store.On("GetEntities", mock.Anything, mock.Anything).Return([]*corev2.Entity{defaultEntity}, nil)
 				return store
 			},
 			EventStore: func() store.EventStore {
@@ -253,10 +250,7 @@ func TestGetEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("GetResource", mock.Anything, "default", mock.Anything).Run(func(args mock.Arguments) {
-					arg := args.Get(2).(*corev2.Entity)
-					*arg = *defaultEntity
-				}).Return(nil)
+				store.On("GetEntityByName", mock.Anything, "default").Return(defaultEntity, nil)
 				return store
 			},
 			EventStore: func() store.EventStore {

--- a/backend/api/entity_test.go
+++ b/backend/api/entity_test.go
@@ -390,7 +390,7 @@ func TestCreateEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("CreateResource", mock.Anything, defaultEntity).Return(nil)
+				store.On("UpdateEntity", mock.Anything, defaultEntity).Return(nil)
 				return store
 			},
 			EventStore: func() store.EventStore {
@@ -536,7 +536,7 @@ func TestUpdateEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("CreateOrUpdateResource", mock.Anything, defaultEntity).Return(nil)
+				store.On("UpdateEntity", mock.Anything, defaultEntity).Return(nil)
 				return store
 			},
 			Storev2: func() storev2.Interface {
@@ -702,7 +702,7 @@ func TestDeleteEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("DeleteResource", mock.Anything, "entities", "default").Return(nil)
+				store.On("DeleteEntityByName", mock.Anything, "default").Return(nil)
 				return store
 			},
 			EventStore: func() store.EventStore {
@@ -735,7 +735,7 @@ func TestDeleteEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("DeleteResource", mock.Anything, "entities", "default").Return(nil)
+				store.On("DeleteEntityByName", mock.Anything, "default").Return(nil)
 				return store
 			},
 			EventStore: func() store.EventStore {
@@ -769,7 +769,7 @@ func TestDeleteEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("DeleteResource", mock.Anything, "entities", "default").Return(nil)
+				store.On("DeleteEntityByName", mock.Anything, "default").Return(nil)
 				return store
 			},
 			EventStore: func() store.EventStore {
@@ -803,7 +803,7 @@ func TestDeleteEntity(t *testing.T) {
 			},
 			Store: func() store.Store {
 				store := new(mockstore.MockStore)
-				store.On("DeleteResource", mock.Anything, "entities", "default").Return(nil)
+				store.On("DeleteEntityByName", mock.Anything, "default").Return(nil)
 				return store
 			},
 			EventStore: func() store.EventStore {


### PR DESCRIPTION
## What is this change?

Previously, the `EntityClient` (api package) used the generic store methods to list/get v2 entities and now with state/config being stored separately, this no longer works in 6.X.

## Why is this change necessary?

Retain functionality.

## Does your change need a Changelog entry?

No. Regression did not exist in previous release.
 
## How did you verify this change?

Unit tests.