### PR TITLE
Allow mocking of system information collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ other events within the filter namespace.
 - Log a warning when secrets cannot be sent to an agent because mTLS is not
 enabled.
 - Added the is_silenced boolean key to event.Check object.
+- System information collection on the agent can now be disabled.
 
 ### Fixed
 - Clarifies wording around a secret provider error message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ other events within the filter namespace.
 - Log a warning when secrets cannot be sent to an agent because mTLS is not
 enabled.
 - Added the is_silenced boolean key to event.Check object.
-- System information collection on the agent can now be disabled.
 
 ### Fixed
 - Clarifies wording around a secret provider error message.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -173,6 +173,10 @@ func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
 }
 
 func (a *Agent) refreshSystemInfoPeriodically(ctx context.Context) {
+	if a.config.MockSystemInfo {
+		return
+	}
+
 	defer logger.Info("shutting down system info collector")
 	ticker := time.NewTicker(time.Duration(DefaultSystemInfoRefreshInterval) * time.Second)
 	defer ticker.Stop()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -146,13 +146,16 @@ func (a *Agent) sendMessage(msg *transport.Message) {
 
 // RefreshSystemInfo refreshes system, platform, and process information.
 func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
-	if a.config.DisableSystemInfo {
-		return nil
-	}
+	var info corev2.System
+	var err error
 
-	info, err := system.Info()
-	if err != nil {
-		return err
+	if a.config.MockSystemInfo {
+		info = system.MockInfo()
+	} else {
+		info, err = system.Info()
+		if err != nil {
+			return err
+		}
 	}
 
 	if a.config.DetectCloudProvider {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -146,6 +146,10 @@ func (a *Agent) sendMessage(msg *transport.Message) {
 
 // RefreshSystemInfo refreshes system, platform, and process information.
 func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
+	if a.config.DisableSystemInfo {
+		return nil
+	}
+
 	info, err := system.Info()
 	if err != nil {
 		return err

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -69,6 +69,7 @@ const (
 	flagBackendHandshakeTimeout  = "backend-handshake-timeout"
 	flagBackendHeartbeatInterval = "backend-heartbeat-interval"
 	flagBackendHeartbeatTimeout  = "backend-heartbeat-timeout"
+	flagDisableSystemInfo        = "disable-system-info"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -76,6 +77,7 @@ const (
 	flagCertFile              = "cert-file"
 	flagKeyFile               = "key-file"
 
+	// Deprecated flags
 	deprecatedFlagAgentID          = "id"
 	deprecatedFlagKeepaliveTimeout = "keepalive-timeout"
 )
@@ -168,6 +170,7 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 
 	cfg.DisableAPI = viper.GetBool(flagDisableAPI)
 	cfg.DisableSockets = viper.GetBool(flagDisableSockets)
+	cfg.DisableSystemInfo = viper.GetBool(flagDisableSystemInfo)
 
 	return cfg, nil
 }
@@ -322,6 +325,7 @@ func handleConfig(cmd *cobra.Command) error {
 	cmd.Flags().Int(flagBackendHandshakeTimeout, viper.GetInt(flagBackendHandshakeTimeout), "number of seconds the agent should wait when negotiating a new WebSocket connection")
 	cmd.Flags().Int(flagBackendHeartbeatInterval, viper.GetInt(flagBackendHeartbeatInterval), "interval at which the agent should send heartbeats to the backend")
 	cmd.Flags().Int(flagBackendHeartbeatTimeout, viper.GetInt(flagBackendHeartbeatTimeout), "number of seconds the agent should wait for a response to a hearbeat")
+	cmd.Flags().Bool(flagDisableSystemInfo, viper.GetBool(flagDisableSystemInfo), "disable system information collection")
 
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc(logger))
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -69,7 +69,6 @@ const (
 	flagBackendHandshakeTimeout  = "backend-handshake-timeout"
 	flagBackendHeartbeatInterval = "backend-heartbeat-interval"
 	flagBackendHeartbeatTimeout  = "backend-heartbeat-timeout"
-	flagDisableSystemInfo        = "disable-system-info"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -170,7 +169,6 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 
 	cfg.DisableAPI = viper.GetBool(flagDisableAPI)
 	cfg.DisableSockets = viper.GetBool(flagDisableSockets)
-	cfg.DisableSystemInfo = viper.GetBool(flagDisableSystemInfo)
 
 	return cfg, nil
 }
@@ -325,7 +323,6 @@ func handleConfig(cmd *cobra.Command) error {
 	cmd.Flags().Int(flagBackendHandshakeTimeout, viper.GetInt(flagBackendHandshakeTimeout), "number of seconds the agent should wait when negotiating a new WebSocket connection")
 	cmd.Flags().Int(flagBackendHeartbeatInterval, viper.GetInt(flagBackendHeartbeatInterval), "interval at which the agent should send heartbeats to the backend")
 	cmd.Flags().Int(flagBackendHeartbeatTimeout, viper.GetInt(flagBackendHeartbeatTimeout), "number of seconds the agent should wait for a response to a hearbeat")
-	cmd.Flags().Bool(flagDisableSystemInfo, viper.GetBool(flagDisableSystemInfo), "disable system information collection")
 
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc(logger))
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -115,6 +115,9 @@ type Config struct {
 	// in check execution.
 	DisableAssets bool
 
+	// DisableSystemInfo stops the agent from collecting system information
+	DisableSystemInfo bool
+
 	// DisableSockets disables the event sockets
 	DisableSockets bool
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -115,9 +115,6 @@ type Config struct {
 	// in check execution.
 	DisableAssets bool
 
-	// DisableSystemInfo stops the agent from collecting system information
-	DisableSystemInfo bool
-
 	// DisableSockets disables the event sockets
 	DisableSockets bool
 
@@ -190,6 +187,10 @@ type Config struct {
 	// will close the existing connection with the backend and attempt to
 	// reconnect with exponential backoff
 	BackendHeartbeatTimeout int
+
+	// MockSystemInfo determines whether the system info collection should return
+	// mocked system information. This should only be used for testing.
+	MockSystemInfo bool
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -45,7 +45,6 @@ func main() {
 		cfg.Deregister = true
 		cfg.DeregistrationHandler = ""
 		cfg.DisableAPI = true
-		cfg.DisableSystemInfo = true
 		cfg.DisableSockets = true
 		cfg.StatsdServer = &agent.StatsdServerConfig{
 			Disable:       true,
@@ -61,6 +60,7 @@ func main() {
 		cfg.Subscriptions = subscriptions
 		cfg.AgentName = name
 		cfg.BackendURLs = backends
+		cfg.MockSystemInfo = true
 
 		agent, err := agent.NewAgent(cfg)
 		if err != nil {

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -45,6 +45,7 @@ func main() {
 		cfg.Deregister = true
 		cfg.DeregistrationHandler = ""
 		cfg.DisableAPI = true
+		cfg.DisableSystemInfo = true
 		cfg.DisableSockets = true
 		cfg.StatsdServer = &agent.StatsdServerConfig{
 			Disable:       true,

--- a/system/system.go
+++ b/system/system.go
@@ -17,6 +17,7 @@ import (
 
 	_ "unsafe"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 	"github.com/shirou/gopsutil/host"
 	shirounet "github.com/shirou/gopsutil/net"
@@ -77,6 +78,27 @@ func Info() (types.System, error) {
 	}
 
 	return system, nil
+}
+
+func MockInfo() corev2.System {
+	return corev2.System{
+		Hostname:        "localhost.localdomain",
+		OS:              "linux",
+		Platform:        "centos",
+		PlatformFamily:  "rhel",
+		PlatformVersion: "7.8.2003",
+		Network: corev2.Network{
+			Interfaces: []corev2.NetworkInterface{
+				{Name: "lo", MAC: "", Addresses: []string{"127.0.0.1/8", "::1/128"}},
+				{Name: "eth0", MAC: "52:54:00:8a:fe:e6", Addresses: []string{"10.0.2.15/24", "fe80::5054:ff:fe8a:fee6/64"}},
+				{Name: "eth1", MAC: "08:00:27:2b:88:65", Addresses: []string{"192.168.1.17/24", "fe80::a00:27ff:fe2b:8865/64"}},
+			},
+		},
+		Arch:     "amd64",
+		LibCType: "glibc",
+		VMSystem: "vbox",
+		VMRole:   "guest",
+	}
 }
 
 func getLibCType() (string, error) {


### PR DESCRIPTION
## What is this change?

It permits an agent to optionally disable collection of system information. This is particularly relevant in case of the _loadit_ benchmarking tool.

## Why is this change necessary?

For performance testing.

## Does your change need a Changelog entry?

Added, although we don't need to ship this in 6.0

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs will be required, just depends on whether we include that change within 6.0.

## How did you verify this change?

Manually tested.

## Is this change a patch?

Nope