### PR TITLE
Prevent duplicate iteration through namespace cache

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -270,7 +270,7 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	// Validate the agent namespace
 	namespace := r.Header.Get(transport.HeaderKeyNamespace)
 	var found bool
-	values := a.namespaceCache.GetAll()
+	values := a.namespaceCache.Get("")
 	for _, value := range values {
 		if namespace == value.Resource.GetObjectMeta().Name {
 			found = true

--- a/backend/store/cache/cache_test.go
+++ b/backend/store/cache/cache_test.go
@@ -2,19 +2,20 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/sensu/sensu-go/types"
 
-	"go.etcd.io/etcd/integration"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/fixture"
 	"github.com/sensu/sensu-go/types/dynamic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/integration"
 )
 
 func fixtureEntity(namespace, name string) *corev2.Entity {
@@ -172,4 +173,32 @@ func TestResourceRebuild(t *testing.T) {
 	}
 	assert.Len(t, cacher.cache["default"], 1)
 	assert.Equal(t, int64(1), cacher.Count())
+}
+
+func nonNamespacedCache(count int) Resource {
+	resources := []corev2.Resource{}
+	for i := 0; i < count; i++ {
+		resources = append(resources, &fixture.Resource{ObjectMeta: corev2.ObjectMeta{Name: fmt.Sprintf("namespace-%d", i)}})
+	}
+	return Resource{
+		cache: buildCache(resources, false),
+	}
+}
+
+func BenchmarkGetEmpty(b *testing.B) {
+	cache := nonNamespacedCache(20)
+	for n := 0; n < b.N; n++ {
+		values := cache.Get("")
+		for range values {
+		}
+	}
+}
+
+func BenchmarkGetAll(b *testing.B) {
+	cache := nonNamespacedCache(20)
+	for n := 0; n < b.N; n++ {
+		values := cache.GetAll()
+		for range values {
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

While this does not solve a large perf regression, it is a small performance win.

This change uses `cache.Get("")` rather than `cache.GetAll()` when retrieving non-namespaced resources in agentd. The benchmark tests I wrote show that it's much less efficient to iterate the cache twice. `GetAll()` iterates when consolidating resources across namespaces where `Get("")` retrieves all non-namespaced resources without iterating.

```
$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/sensu/sensu-go/backend/store/cache
BenchmarkGetEmpty-12            27691777                43.1 ns/op
BenchmarkGetAll-12               3771334               323 ns/op
PASS
ok      github.com/sensu/sensu-go/backend/store/cache   4.238s
```