### PR TITLE
Fixes potential crash when fetching events in namespace with more than 1000 events

### DIFF
--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -9,7 +9,6 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/backend/store/etcd"
 )
 
 type key int
@@ -128,18 +127,17 @@ func loadEntities(ctx context.Context, ns string) ([]*corev2.Entity, error) {
 // events
 
 func listAllEvents(ctx context.Context, c EventClient) ([]*corev2.Event, error) {
-	cont := ""
+	pred := &store.SelectionPredicate{Continue: "", Limit: int64(loaderPageSize)}
 	results := []*corev2.Event{}
 	for {
-		r, err := c.ListEvents(ctx, &store.SelectionPredicate{Continue: cont, Limit: int64(loaderPageSize)})
+		r, err := c.ListEvents(ctx, pred)
 		if err != nil {
 			return results, err
 		}
 		results = append(results, r...)
-		if len(r) < loaderPageSize {
+		if pred.Continue == "" || len(r) < loaderPageSize {
 			break
 		}
-		cont = etcd.ComputeContinueToken(ctx, r[len(r)-1])
 	}
 	return results, nil
 }

--- a/backend/apid/graphql/dataloader_test.go
+++ b/backend/apid/graphql/dataloader_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/dataloader"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -40,7 +41,10 @@ func Test_listAllEvents(t *testing.T) {
 		{
 			name: "many pages",
 			setup: func(c *MockEventClient) {
-				c.On("ListEvents", mock.Anything, mock.Anything).Return(mkEvents(2000), nil).Once()
+				c.On("ListEvents", mock.Anything, mock.Anything).Return(mkEvents(2000), nil).Run(func(args mock.Arguments) {
+					arg := args.Get(1).(*store.SelectionPredicate)
+					arg.Continue = "test"
+				}).Once()
 				c.On("ListEvents", mock.Anything, mock.Anything).Return(mkEvents(20), nil).Once()
 			},
 			wantLen: 2020,


### PR DESCRIPTION
## What is this change?

Fixes potential error when using PostgreSQL store. If events were fetched in namespace with more than 1000 total events, GraphQL service might not have been able to retrieve all pages, resulting in an unexpected error.

## Why is this change necessary?

Can cause web application to crash / return unexpected 404.

## How did you verify this change?

Unit & manual.

## Is this change a patch?

Yes.