### PR TITLE
Refactor/entity config watcher

### DIFF
--- a/backend/agentd/watcher.go
+++ b/backend/agentd/watcher.go
@@ -7,7 +7,6 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/gogo/protobuf/proto"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
-	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
@@ -15,59 +14,52 @@ import (
 	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 )
 
-// EntityConfigWatcher watches changes to EntityConfig in etcd and publish them
+// GetEntityConfigWatcher watches changes to EntityConfig in etcd and publish them
 // over the bus as store.WatchEventEntityConfig
-func EntityConfigWatcher(ctx context.Context, client *clientv3.Client, bus messaging.MessageBus) {
+func GetEntityConfigWatcher(ctx context.Context, client *clientv3.Client) <-chan store.WatchEventEntityConfig {
 	key := etcdstorev2.StoreKey(storev2.ResourceRequest{
 		Context:   ctx,
 		StoreName: new(corev3.EntityConfig).StoreName(),
 	})
 	w := etcdstore.Watch(ctx, client, key, true)
+	ch := make(chan store.WatchEventEntityConfig, 1)
 
-	go handleResults(w, bus)
-}
+	go func() {
+		defer close(ch)
+		for response := range w.Result() {
+			if response.Type == store.WatchError {
+				logger.
+					WithError(errors.New(string(response.Object))).
+					Error("unexpected error while watching for entity config updates")
+				ch <- store.WatchEventEntityConfig{
+					Action: response.Type,
+				}
+				continue
+			}
 
-// handleResults handles the results from the etcd watcher. It uses the
-// store.Watcher interface to allow easier testing
-func handleResults(w store.Watcher, bus messaging.MessageBus) {
-	for response := range w.Result() {
-		if response.Type == store.WatchError {
-			logger.
-				WithError(errors.New(string(response.Object))).
-				Error("unexpected error while watching for entity config updates")
-			continue
+			var (
+				configWrapper wrap.Wrapper
+				entityConfig  corev3.EntityConfig
+			)
+
+			// Decode and unwrap the entity config
+			if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
+				logger.WithField("key", response.Key).WithError(err).
+					Error("unable to unmarshal entity config from key")
+				continue
+			}
+			if err := configWrapper.UnwrapInto(&entityConfig); err != nil {
+				logger.WithField("key", response.Key).WithError(err).
+					Error("unable to unwrap entity config from key")
+				continue
+			}
+
+			ch <- store.WatchEventEntityConfig{
+				Action: response.Type,
+				Entity: &entityConfig,
+			}
 		}
+	}()
 
-		var (
-			configWrapper wrap.Wrapper
-			entityConfig  corev3.EntityConfig
-		)
-
-		// Decode and unwrap the entity config
-		if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
-			logger.WithField("key", response.Key).WithError(err).
-				Error("unable to unmarshal entity config from key")
-			continue
-		}
-		if err := configWrapper.UnwrapInto(&entityConfig); err != nil {
-			logger.WithField("key", response.Key).WithError(err).
-				Error("unable to unwrap entity config from key")
-			continue
-		}
-
-		event := store.WatchEventEntityConfig{
-			Action: response.Type,
-			Entity: &entityConfig,
-		}
-
-		topic := messaging.EntityConfigTopic(entityConfig.Metadata.Namespace, entityConfig.Metadata.Name)
-		if err := bus.Publish(topic, &event); err != nil {
-			logger.WithField("topic", topic).WithError(err).
-				Error("unable to publish an entity config update to the bus")
-			continue
-		}
-
-		logger.WithField("topic", topic).
-			Debug("successfully published an entity config update to the bus")
-	}
+	return ch
 }

--- a/backend/agentd/watcher_test.go
+++ b/backend/agentd/watcher_test.go
@@ -1,97 +1,19 @@
 package agentd
 
-import "github.com/sensu/sensu-go/backend/store"
+import (
+	"context"
+	"testing"
 
-type mockWatcher struct {
-	resultChan chan store.WatchEvent
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEntityConfigWatcher(t *testing.T) {
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+	client := e.NewEmbeddedClient()
+	defer client.Close()
+
+	ch := GetEntityConfigWatcher(context.Background(), client)
+	assert.NotNil(t, ch)
 }
-
-func (w *mockWatcher) Result() <-chan store.WatchEvent {
-	return w.resultChan
-}
-
-// func (w *mockWatcher) Stop() {
-// 	close(w.resultChan)
-// }
-
-// func Test_handleResults(t *testing.T) {
-// 	type busFunc func(*mockbus.MockBus)
-
-// 	// The state bytes are used to mock an invalid struct
-// 	state, _ := wrap.Resource(corev3.FixtureEntityState("foo"))
-// 	stateBytes, _ := proto.Marshal(state)
-
-// 	cfg, _ := wrap.Resource(corev3.FixtureEntityConfig("bar"))
-// 	cfgBytes, _ := proto.Marshal(cfg)
-
-// 	tests := []struct {
-// 		name       string
-// 		busFunc    busFunc
-// 		watchEvent store.WatchEvent
-// 	}{
-// 		{
-// 			name:       "watch error",
-// 			watchEvent: store.WatchEvent{Type: store.WatchError},
-// 			busFunc: func(bus *mockbus.MockBus) {
-// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-// 			},
-// 		},
-// 		{
-// 			name: "invalid proto message",
-// 			watchEvent: store.WatchEvent{
-// 				Type:   store.WatchCreate,
-// 				Object: []byte("foo"),
-// 			},
-// 			busFunc: func(bus *mockbus.MockBus) {
-// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-// 			},
-// 		},
-// 		{
-// 			name: "invalid struct",
-// 			watchEvent: store.WatchEvent{
-// 				Type:   store.WatchCreate,
-// 				Object: stateBytes,
-// 			},
-// 			busFunc: func(bus *mockbus.MockBus) {
-// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-// 			},
-// 		},
-// 		{
-// 			name: "bus error",
-// 			watchEvent: store.WatchEvent{
-// 				Type:   store.WatchCreate,
-// 				Object: cfgBytes,
-// 			},
-// 			busFunc: func(bus *mockbus.MockBus) {
-// 				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(errors.New("error"))
-// 			},
-// 		},
-// 		{
-// 			name: "watch events are successfully published to the bus",
-// 			watchEvent: store.WatchEvent{
-// 				Type:   store.WatchCreate,
-// 				Object: cfgBytes,
-// 			},
-// 			busFunc: func(bus *mockbus.MockBus) {
-// 				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(nil)
-// 			},
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			// Mock a watcher
-// 			watcher := &mockWatcher{resultChan: make(chan store.WatchEvent)}
-// 			defer watcher.Stop()
-
-// 			// Mock the bus
-// 			bus := &mockbus.MockBus{}
-// 			if tt.busFunc != nil {
-// 				tt.busFunc(bus)
-// 			}
-
-// 			go handleResults(watcher, bus)
-
-// 			watcher.resultChan <- tt.watchEvent
-// 		})
-// 	}
-// }

--- a/backend/agentd/watcher_test.go
+++ b/backend/agentd/watcher_test.go
@@ -1,16 +1,6 @@
 package agentd
 
-import (
-	"errors"
-	"testing"
-
-	"github.com/golang/protobuf/proto"
-	corev3 "github.com/sensu/sensu-go/api/core/v3"
-	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/backend/store/v2/wrap"
-	"github.com/sensu/sensu-go/testing/mockbus"
-	"github.com/stretchr/testify/mock"
-)
+import "github.com/sensu/sensu-go/backend/store"
 
 type mockWatcher struct {
 	resultChan chan store.WatchEvent
@@ -20,88 +10,88 @@ func (w *mockWatcher) Result() <-chan store.WatchEvent {
 	return w.resultChan
 }
 
-func (w *mockWatcher) Stop() {
-	close(w.resultChan)
-}
+// func (w *mockWatcher) Stop() {
+// 	close(w.resultChan)
+// }
 
-func Test_handleResults(t *testing.T) {
-	type busFunc func(*mockbus.MockBus)
+// func Test_handleResults(t *testing.T) {
+// 	type busFunc func(*mockbus.MockBus)
 
-	// The state bytes are used to mock an invalid struct
-	state, _ := wrap.Resource(corev3.FixtureEntityState("foo"))
-	stateBytes, _ := proto.Marshal(state)
+// 	// The state bytes are used to mock an invalid struct
+// 	state, _ := wrap.Resource(corev3.FixtureEntityState("foo"))
+// 	stateBytes, _ := proto.Marshal(state)
 
-	cfg, _ := wrap.Resource(corev3.FixtureEntityConfig("bar"))
-	cfgBytes, _ := proto.Marshal(cfg)
+// 	cfg, _ := wrap.Resource(corev3.FixtureEntityConfig("bar"))
+// 	cfgBytes, _ := proto.Marshal(cfg)
 
-	tests := []struct {
-		name       string
-		busFunc    busFunc
-		watchEvent store.WatchEvent
-	}{
-		{
-			name:       "watch error",
-			watchEvent: store.WatchEvent{Type: store.WatchError},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-			},
-		},
-		{
-			name: "invalid proto message",
-			watchEvent: store.WatchEvent{
-				Type:   store.WatchCreate,
-				Object: []byte("foo"),
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-			},
-		},
-		{
-			name: "invalid struct",
-			watchEvent: store.WatchEvent{
-				Type:   store.WatchCreate,
-				Object: stateBytes,
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-			},
-		},
-		{
-			name: "bus error",
-			watchEvent: store.WatchEvent{
-				Type:   store.WatchCreate,
-				Object: cfgBytes,
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(errors.New("error"))
-			},
-		},
-		{
-			name: "watch events are successfully published to the bus",
-			watchEvent: store.WatchEvent{
-				Type:   store.WatchCreate,
-				Object: cfgBytes,
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(nil)
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Mock a watcher
-			watcher := &mockWatcher{resultChan: make(chan store.WatchEvent)}
-			defer watcher.Stop()
+// 	tests := []struct {
+// 		name       string
+// 		busFunc    busFunc
+// 		watchEvent store.WatchEvent
+// 	}{
+// 		{
+// 			name:       "watch error",
+// 			watchEvent: store.WatchEvent{Type: store.WatchError},
+// 			busFunc: func(bus *mockbus.MockBus) {
+// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+// 			},
+// 		},
+// 		{
+// 			name: "invalid proto message",
+// 			watchEvent: store.WatchEvent{
+// 				Type:   store.WatchCreate,
+// 				Object: []byte("foo"),
+// 			},
+// 			busFunc: func(bus *mockbus.MockBus) {
+// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+// 			},
+// 		},
+// 		{
+// 			name: "invalid struct",
+// 			watchEvent: store.WatchEvent{
+// 				Type:   store.WatchCreate,
+// 				Object: stateBytes,
+// 			},
+// 			busFunc: func(bus *mockbus.MockBus) {
+// 				bus.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
+// 			},
+// 		},
+// 		{
+// 			name: "bus error",
+// 			watchEvent: store.WatchEvent{
+// 				Type:   store.WatchCreate,
+// 				Object: cfgBytes,
+// 			},
+// 			busFunc: func(bus *mockbus.MockBus) {
+// 				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(errors.New("error"))
+// 			},
+// 		},
+// 		{
+// 			name: "watch events are successfully published to the bus",
+// 			watchEvent: store.WatchEvent{
+// 				Type:   store.WatchCreate,
+// 				Object: cfgBytes,
+// 			},
+// 			busFunc: func(bus *mockbus.MockBus) {
+// 				bus.On("Publish", mock.Anything, mock.Anything).Once().Return(nil)
+// 			},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			// Mock a watcher
+// 			watcher := &mockWatcher{resultChan: make(chan store.WatchEvent)}
+// 			defer watcher.Stop()
 
-			// Mock the bus
-			bus := &mockbus.MockBus{}
-			if tt.busFunc != nil {
-				tt.busFunc(bus)
-			}
+// 			// Mock the bus
+// 			bus := &mockbus.MockBus{}
+// 			if tt.busFunc != nil {
+// 				tt.busFunc(bus)
+// 			}
 
-			go handleResults(watcher, bus)
+// 			go handleResults(watcher, bus)
 
-			watcher.resultChan <- tt.watchEvent
-		})
-	}
-}
+// 			watcher.resultChan <- tt.watchEvent
+// 		})
+// 	}
+// }


### PR DESCRIPTION
## What is this change?

Use channels for entity config watch events.

## Why is this change necessary?

Perf optimization.

## Does your change need a Changelog entry?

Nah.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Updated unit tests and perf run (see slack for snapshot).

## Is this change a patch?

Yup.