### PR TITLE
Improve agent ring removal dance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and RoleBindings.
 - Log the proper CA certificate path in the error message when it can't be
 properly parsed by the agent.
 - Fix the log entry field for the check's name in schedulerd.
+- Keepalive and round robin scheduling leases are now dealt with more efficiently.
 
 ### Breaking
 - The web interface is now a standalone product and no longer distributed

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -656,9 +656,7 @@ func (s *Session) unsubscribe(subscriptions []string) {
 			defer ringWG.Done()
 			ring := s.ringPool.Get(ringv2.Path(s.cfg.Namespace, sub))
 			lager.Infof("removing agent from ring for subscription %q", sub)
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			if err := ring.Remove(ctx, s.cfg.AgentName); err != nil {
+			if err := ring.Remove(context.Background(), s.cfg.AgentName); err != nil {
 				lager.WithError(err).Error("unable to remove agent from ring")
 			}
 		}(sub)


### PR DESCRIPTION
## What is this change?

```
commit d2bcb52d4c9fe26948194f593a0cfd8264321a4f (HEAD -> no-ring-remove-timeout, origin/no-ring-remove-timeout)
Author: Eric Chlebek <eric@sensu.io>
Date:   Tue Aug 4 09:10:12 2020 -0700

    Revoke leases in ring Remove()
    
    This commit ensures that leases are revoked on Remove() in the
    ring Remove() method. This should be more performant than allowing
    the lease to simply expire.
    
    Signed-off-by: Eric Chlebek <eric@sensu.io>

commit b00304ef4b8d7f98cd38652bf2fca872174b3393
Author: Eric Chlebek <eric@sensu.io>
Date:   Tue Aug 4 09:04:17 2020 -0700

    Don't use a timeout for ring removal
    
    This commit removes the 1s timeout from the ring Remove() method
    called at agent deregistration. This should result in fewer leases
    hanging around.
    
    Signed-off-by: Eric Chlebek <eric@sensu.io>
```

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Only the performance aspects of Sensu have been verified after this change. We'll need to QA test it still.

## Is this change a patch?

Yes