### PR TITLE
Don't explicitly store liveness leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and RoleBindings.
 - Log the proper CA certificate path in the error message when it can't be
 properly parsed by the agent.
 - Fix the log entry field for the check's name in schedulerd.
+- Store fewer keys in etcd for agents.
 
 ### Breaking
 - The web interface is now a standalone product and no longer distributed


### PR DESCRIPTION
## What is this change?

Leases can be obtained from the keys they were stored with. There
is no reason to explicitly store them in etcd.

This change gets us N fewer keys stored in etcd, where N is the
number of agent entities. It also lets us do puts instead of txns,
which should be a minor efficiency win.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Verification was only done in a performance testing setting. The change will need to be put through the regular QA process to be validated.

## Is this change a patch?

Yes