### PR TITLE
Use a sync.Map for WizardBus

### DIFF
--- a/backend/messaging/wizard_bus_test.go
+++ b/backend/messaging/wizard_bus_test.go
@@ -129,7 +129,8 @@ func TestBug1407(t *testing.T) {
 	require.NoError(t, subscription.Cancel())
 	subscription, err = bus.Subscribe("topic", "a", subscriber)
 	require.NoError(t, err)
-	closed := bus.topics["topic"].IsClosed()
-	assert.False(t, closed)
+	value, _ := bus.topics.Load("topic")
+	topic := value.(*wizardTopic)
+	assert.False(t, topic.IsClosed())
 
 }


### PR DESCRIPTION
## What is this change?

Use a sync.Map for the map of names to topics. This should reduce
mutex contention in WizardBus significantly.

## Why is this change necessary?

In large installations, high mutex contention can lead to the application using more CPU than necessary.

## Does your change need a Changelog entry?

No

## Is this change a patch?

Yes