### PR TITLE
Write failed check events to the event file logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Failed check events now get written to the event log file.
+
 ## [6.0.0] - 2020-08-04
 
 ### Added

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -477,6 +477,7 @@ func (e *Eventd) handleFailure(ctx context.Context, event *corev2.Event) error {
 		return err
 	}
 
+	e.Logger.Println(updatedEvent)
 	return e.bus.Publish(messaging.TopicEvent, updatedEvent)
 }
 


### PR DESCRIPTION
## What is this change?

Writes failed check events to the event file logger before publishing to the wizard bus. Previously, failed TTL check events would not get written to the event log file.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/1196

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

E2E instructions from original issue.

## Is this change a patch?

Yup, targeting `release/6.0` branch.