### PR TITLE
Add trusted ca file for agent assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added Prometheus transformer for extracting metrics from check output
 using the Prometheus Exposition Text Format.
 
+### Changed
+- The trusted CA file is now used for agent-side asset retrieval.
+
 ## [6.0.0] - 2020-08-04
 
 ### Added

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -271,7 +271,11 @@ func (a *Agent) Run(ctx context.Context) error {
 	logger.Info("configuration successfully validated")
 
 	if !a.config.DisableAssets {
-		assetManager := asset.NewManager(a.config.CacheDir, a.getAgentEntity(), &a.wg)
+		var trustedCAFile string
+		if a.config.TLS != nil {
+			trustedCAFile = a.config.TLS.TrustedCAFile
+		}
+		assetManager := asset.NewManager(a.config.CacheDir, trustedCAFile, a.getAgentEntity(), &a.wg)
 		limit := a.config.AssetsRateLimit
 		if limit == 0 {
 			limit = rate.Limit(asset.DefaultAssetsRateLimit)

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -19,6 +19,7 @@ var (
 // expander are nil, the getter will use the built-in components.
 func NewBoltDBGetter(db *bolt.DB,
 	localStorage string,
+	trustedCAFile string,
 	fetcher Fetcher,
 	verifier Verifier,
 	expander Expander,
@@ -26,7 +27,8 @@ func NewBoltDBGetter(db *bolt.DB,
 
 	if fetcher == nil {
 		fetcher = &httpFetcher{
-			Limiter: limiter,
+			Limiter:       limiter,
+			trustedCAFile: trustedCAFile,
 		}
 	}
 

--- a/asset/fetcher_test.go
+++ b/asset/fetcher_test.go
@@ -38,7 +38,7 @@ func TestFetchExistingAsset(t *testing.T) {
 	var headers map[string]string
 
 	fetcher := &httpFetcher{
-		URLGetter: func(ctx context.Context, path string, header map[string]string) (io.ReadCloser, error) {
+		URLGetter: func(ctx context.Context, path, trustedCAFile string, header map[string]string) (io.ReadCloser, error) {
 			return os.Open(path)
 		},
 	}
@@ -67,7 +67,7 @@ func TestHTTPGet(t *testing.T) {
 	defer ts.Close()
 
 	headers := map[string]string{"foo": "bar", "hi": "hello, sup"}
-	closer, err := httpGet(context.Background(), ts.URL, headers)
+	closer, err := httpGet(context.Background(), ts.URL, "", headers)
 	assert.NotNil(t, closer)
 	assert.NoError(t, err)
 }
@@ -81,7 +81,7 @@ func TestHTTPGetNon200(t *testing.T) {
 	defer ts.Close()
 
 	headers := map[string]string{"foo": "bar", "hi": "hello, sup"}
-	closer, err := httpGet(context.Background(), ts.URL, headers)
+	closer, err := httpGet(context.Background(), ts.URL, "", headers)
 	assert.Nil(t, closer)
 	assert.EqualError(t, err, "error fetching asset: Response Code 404")
 }

--- a/asset/integration_test.go
+++ b/asset/integration_test.go
@@ -81,6 +81,7 @@ func TestBoltDBManager(t *testing.T) {
 	getter := asset.NewBoltDBGetter(
 		db,
 		tmpAssetDir,
+		"",
 		&localFetcher{},
 		nil,
 		nil,

--- a/asset/manager.go
+++ b/asset/manager.go
@@ -18,17 +18,19 @@ const (
 
 // Manager ...
 type Manager struct {
-	cacheDir string
-	entity   *types.Entity
-	wg       *sync.WaitGroup
+	cacheDir      string
+	entity        *types.Entity
+	wg            *sync.WaitGroup
+	trustedCAFile string
 }
 
 // NewManager ...
-func NewManager(cacheDir string, entity *types.Entity, wg *sync.WaitGroup) *Manager {
+func NewManager(cacheDir, trustedCAFile string, entity *types.Entity, wg *sync.WaitGroup) *Manager {
 	return &Manager{
-		cacheDir: cacheDir,
-		entity:   entity,
-		wg:       wg,
+		cacheDir:      cacheDir,
+		entity:        entity,
+		wg:            wg,
+		trustedCAFile: trustedCAFile,
 	}
 }
 
@@ -55,7 +57,7 @@ func (m *Manager) StartAssetManager(ctx context.Context, limiter *rate.Limiter) 
 		}
 	}()
 	boltDBGetter := NewBoltDBGetter(
-		db, m.cacheDir, nil, nil, nil, limiter)
+		db, m.cacheDir, m.trustedCAFile, nil, nil, nil, limiter)
 
 	return NewFilteredManager(boltDBGetter, m.entity), nil
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -236,7 +236,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Initialize asset manager
 	backendEntity := b.getBackendEntity(config)
 	logger.WithField("entity", backendEntity).Info("backend entity information")
-	assetManager := asset.NewManager(config.CacheDir, backendEntity, &sync.WaitGroup{})
+	assetManager := asset.NewManager(config.CacheDir, "", backendEntity, &sync.WaitGroup{})
 	limit := b.cfg.AssetsRateLimit
 	if limit == 0 {
 		limit = rate.Limit(asset.DefaultAssetsRateLimit)

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -108,7 +108,7 @@ func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 	// start the asset manager
 	ctx := context.TODO()
 	wg := sync.WaitGroup{}
-	m.assetManager = asset.NewManager(cacheDir, entity, &wg)
+	m.assetManager = asset.NewManager(cacheDir, "", entity, &wg)
 	m.assetGetter, err = m.assetManager.StartAssetManager(ctx, nil)
 	if err != nil {
 		return nil, err

--- a/cli/cmdmanager/manager_test.go
+++ b/cli/cmdmanager/manager_test.go
@@ -605,7 +605,7 @@ func TestCommandManager_ExecCommand(t *testing.T) {
 	}
 
 	callbackFn := func(m *CommandManager, cacheDir string) {
-		m.assetManager = asset.NewManager(cacheDir, entity, &wg)
+		m.assetManager = asset.NewManager(cacheDir, "", entity, &wg)
 		m.assetGetter = &mockassetgetter.MockAssetGetter{}
 	}
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Allows agent to provide configurable trusted CA for asset retrieval.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3948

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

I'm unsure why we wouldn't want this for backend-side assets (ex. handlers, mutators) as well: https://github.com/sensu/sensu-go/issues/3948#issuecomment-675577475

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nah.

## How did you verify this change?

Tested asset retrieval with and without `--trusted-ca-file` configured on the agent.

## Is this change a patch?

Change in functionality, I wouldn't consider this a patch, therefore targeting master.