### PR TITLE
[GraphQL] Handle "no claims found" error 

### DIFF
--- a/backend/api/auth.go
+++ b/backend/api/auth.go
@@ -14,7 +14,7 @@ func addAuthUser(ctx context.Context, attrs *authorization.Attributes) error {
 	// Get the claims from the request context
 	claims := jwt.GetClaimsFromContext(ctx)
 	if claims == nil {
-		return authorization.ErrNoCliams
+		return authorization.ErrNoClaims
 	}
 
 	// Add the user to our request info

--- a/backend/api/auth.go
+++ b/backend/api/auth.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/authorization"
@@ -15,7 +14,7 @@ func addAuthUser(ctx context.Context, attrs *authorization.Attributes) error {
 	// Get the claims from the request context
 	claims := jwt.GetClaimsFromContext(ctx)
 	if claims == nil {
-		return errors.New("no claims found in the request context")
+		return authorization.ErrNoCliams
 	}
 
 	// Add the user to our request info

--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -353,7 +353,7 @@ func getLoader(ctx context.Context, loaderKey key) (*dataloader.Loader, error) {
 // When resolving a field, GraphQL does not consider the absence of a value an
 // error; as such we omit the error if the API client returns Permission denied.
 func handleListErr(err error) error {
-	if err == authorization.ErrUnauthorized {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
 		logger.WithError(err).Warn("couldn't access resource")
 		return nil
 	}
@@ -364,7 +364,7 @@ func handleListErr(err error) error {
 // error; as such we omit the error when the API client returns NotFound or
 // Permission denied.
 func handleFetchResult(resource interface{}, err error) (interface{}, error) {
-	if err == authorization.ErrUnauthorized {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
 		logger.WithError(err).Warn("couldn't access resource")
 		return nil, nil
 	}

--- a/backend/apid/graphql/dataloader.go
+++ b/backend/apid/graphql/dataloader.go
@@ -353,7 +353,7 @@ func getLoader(ctx context.Context, loaderKey key) (*dataloader.Loader, error) {
 // When resolving a field, GraphQL does not consider the absence of a value an
 // error; as such we omit the error if the API client returns Permission denied.
 func handleListErr(err error) error {
-	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoClaims {
 		logger.WithError(err).Warn("couldn't access resource")
 		return nil
 	}
@@ -364,7 +364,7 @@ func handleListErr(err error) error {
 // error; as such we omit the error when the API client returns NotFound or
 // Permission denied.
 func handleFetchResult(resource interface{}, err error) (interface{}, error) {
-	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoClaims {
 		logger.WithError(err).Warn("couldn't access resource")
 		return nil, nil
 	}

--- a/backend/apid/graphql/error.go
+++ b/backend/apid/graphql/error.go
@@ -22,7 +22,7 @@ func newStdErr(input string, err error) stdErr {
 		input:   input,
 		message: err.Error(),
 	}
-	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoClaims {
 		out.code = schema.ErrCodes.ERR_PERMISSION_DENIED
 	}
 	switch err.(type) {

--- a/backend/apid/graphql/error.go
+++ b/backend/apid/graphql/error.go
@@ -22,7 +22,7 @@ func newStdErr(input string, err error) stdErr {
 		input:   input,
 		message: err.Error(),
 	}
-	if err == authorization.ErrUnauthorized {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoCliams {
 		out.code = schema.ErrCodes.ERR_PERMISSION_DENIED
 	}
 	switch err.(type) {

--- a/backend/apid/graphql/fetch.go
+++ b/backend/apid/graphql/fetch.go
@@ -1,1 +1,0 @@
-package graphql

--- a/backend/apid/middlewares/authorization_attributes.go
+++ b/backend/apid/middlewares/authorization_attributes.go
@@ -122,7 +122,7 @@ func GetUser(ctx context.Context, attrs *authorization.Attributes) error {
 	// Get the claims from the request context
 	claims := jwt.GetClaimsFromContext(ctx)
 	if claims == nil {
-		return authorization.ErrNoCliams
+		return authorization.ErrNoClaims
 	}
 
 	// Add the user to our request info

--- a/backend/apid/middlewares/authorization_attributes.go
+++ b/backend/apid/middlewares/authorization_attributes.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"path"
 	"strings"
@@ -123,7 +122,7 @@ func GetUser(ctx context.Context, attrs *authorization.Attributes) error {
 	// Get the claims from the request context
 	claims := jwt.GetClaimsFromContext(ctx)
 	if claims == nil {
-		return errors.New("no claims found in the request context")
+		return authorization.ErrNoCliams
 	}
 
 	// Add the user to our request info

--- a/backend/authorization/interface.go
+++ b/backend/authorization/interface.go
@@ -8,7 +8,7 @@ import (
 )
 
 var ErrUnauthorized = errors.New("request unauthorized")
-var ErrNoCliams = errors.New("no claims found in the request context")
+var ErrNoClaims = errors.New("no claims found in the request context")
 
 // Authorizer determines whether a request is authorized using the Attributes
 // passed. It returns true if the request should be authorized, along with any

--- a/backend/authorization/interface.go
+++ b/backend/authorization/interface.go
@@ -8,6 +8,7 @@ import (
 )
 
 var ErrUnauthorized = errors.New("request unauthorized")
+var ErrNoCliams = errors.New("no claims found in the request context")
 
 // Authorizer determines whether a request is authorized using the Attributes
 // passed. It returns true if the request should be authorized, along with any


### PR DESCRIPTION
## What is this change?

Handle "no claims found" error when retrieving resources within the GraphQL service. 

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-enterprise-go/issues/1224

## How did you verify this change?

Manual