### PR TITLE
Export labels for use by field selectors

### DIFF
--- a/api/core/v2/apikey.go
+++ b/api/core/v2/apikey.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/google/uuid"
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -52,10 +53,12 @@ func FixtureAPIKey(name string, username string) *APIKey {
 // APIKeyFields returns a set of fields that represent that resource.
 func APIKeyFields(r Resource) map[string]string {
 	resource := r.(*APIKey)
-	return map[string]string{
+	fields := map[string]string{
 		"api_key.name":     resource.ObjectMeta.Name,
 		"api_key.username": resource.Username,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "api_key.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/apikey_test.go
+++ b/api/core/v2/apikey_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,44 @@ func TestAPIKeyValidate(t *testing.T) {
 	assert.Equal(t, "226f9e06-9d54-45c6-a9f6-4206bfa7ccf6", a.Name)
 	assert.Equal(t, "bar", a.Username)
 	assert.Equal(t, "", a.Namespace)
+}
+
+func TestAPIKeyFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureAPIKey("circle-ci-access", "admin"),
+			wantKey: "api_key.name",
+			want:    "circle-ci-access",
+		},
+		{
+			name:    "exposes username",
+			args:    FixtureAPIKey("circle-ci-access", "admin"),
+			wantKey: "api_key.username",
+			want:    "admin",
+		},
+		{
+			name: "exposes labels",
+			args: &APIKey{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "api_key.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := APIKeyFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("APIKeyFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
 }

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/sensu/sensu-go/api/core/v2/internal/js"
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -137,11 +138,13 @@ func NewAsset(meta ObjectMeta) *Asset {
 // AssetFields returns a set of fields that represent that resource
 func AssetFields(r Resource) map[string]string {
 	resource := r.(*Asset)
-	return map[string]string{
+	fields := map[string]string{
 		"asset.name":      resource.ObjectMeta.Name,
 		"asset.namespace": resource.ObjectMeta.Namespace,
 		"asset.filters":   strings.Join(resource.Filters, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "asset.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/asset_test.go
+++ b/api/core/v2/asset_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -58,4 +59,44 @@ func TestValidateName_GH3344(t *testing.T) {
 	assert := assert.New(t)
 	asset := FixtureAsset("my-asset:1.0.2")
 	assert.NoError(asset.Validate())
+}
+
+func TestAssetFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureAsset("curl"),
+			wantKey: "asset.name",
+			want:    "curl",
+		},
+		{
+			name:    "exposes filters",
+			args:    &Asset{Filters: []string{"test"}},
+			wantKey: "asset.filters",
+			want:    "test",
+		},
+		{
+			name: "exposes labels",
+			args: &Asset{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "asset.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AssetFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("AssetFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
 }

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -12,6 +12,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	cron "github.com/robfig/cron/v3"
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 // FixtureCheckConfig returns a fixture for a CheckConfig object.
@@ -215,7 +216,7 @@ func (s *checkSorter) Less(i, j int) bool {
 // CheckConfigFields returns a set of fields that represent that resource
 func CheckConfigFields(r Resource) map[string]string {
 	resource := r.(*CheckConfig)
-	return map[string]string{
+	fields := map[string]string{
 		"check.name":           resource.ObjectMeta.Name,
 		"check.namespace":      resource.ObjectMeta.Namespace,
 		"check.handlers":       strings.Join(resource.Handlers, ","),
@@ -224,4 +225,6 @@ func CheckConfigFields(r Resource) map[string]string {
 		"check.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
 		"check.subscriptions":  strings.Join(resource.Subscriptions, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "check.labels.")
+	return fields
 }

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 	utilstrings "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
@@ -217,13 +218,15 @@ func (s *entitySorter) Less(i, j int) bool {
 // EntityFields returns a set of fields that represent that resource
 func EntityFields(r Resource) map[string]string {
 	resource := r.(*Entity)
-	return map[string]string{
+	fields := map[string]string{
 		"entity.name":          resource.ObjectMeta.Name,
 		"entity.namespace":     resource.ObjectMeta.Namespace,
 		"entity.deregister":    strconv.FormatBool(resource.Deregister),
 		"entity.entity_class":  resource.EntityClass,
 		"entity.subscriptions": strings.Join(resource.Subscriptions, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "entity.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/entity_test.go
+++ b/api/core/v2/entity_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -115,6 +116,46 @@ func TestSortEntitiesByLastSeen(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sort.Sort(SortEntitiesByLastSeen(tc.inRecords))
 			assert.EqualValues(t, tc.expected, tc.inRecords)
+		})
+	}
+}
+
+func TestEntityFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureEntity("ap-007"),
+			wantKey: "entity.name",
+			want:    "ap-007",
+		},
+		{
+			name:    "exposes deregister",
+			args:    &Entity{Deregister: true},
+			wantKey: "entity.deregister",
+			want:    "true",
+		},
+		{
+			name: "exposes labels",
+			args: &Entity{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "entity.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EntityFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("EntityFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
 		})
 	}
 }

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -423,7 +423,7 @@ func (e *Event) IsSilencedBy(entry *Silenced) bool {
 // EventFields returns a set of fields that represent that resource
 func EventFields(r Resource) map[string]string {
 	resource := r.(*Event)
-	return map[string]string{
+	fields := map[string]string{
 		"event.name":                 resource.ObjectMeta.Name,
 		"event.namespace":            resource.ObjectMeta.Namespace,
 		"event.is_silenced":          isSilenced(resource),
@@ -440,6 +440,10 @@ func EventFields(r Resource) map[string]string {
 		"event.entity.entity_class":  resource.Entity.EntityClass,
 		"event.entity.subscriptions": strings.Join(resource.Entity.Subscriptions, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "event.labels.")
+	stringsutil.MergeMapWithPrefix(fields, resource.Entity.ObjectMeta.Labels, "event.labels.")
+	stringsutil.MergeMapWithPrefix(fields, resource.Check.ObjectMeta.Labels, "event.labels.")
+	return fields
 }
 
 func isSilenced(e *Event) string {

--- a/api/core/v2/extension.go
+++ b/api/core/v2/extension.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/url"
 	"path"
+
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -51,10 +53,12 @@ func NewExtension(meta ObjectMeta) *Extension {
 // ExtensionFields returns a set of fields that represent that resource
 func ExtensionFields(r Resource) map[string]string {
 	resource := r.(*Extension)
-	return map[string]string{
+	fields := map[string]string{
 		"extension.name":      resource.ObjectMeta.Name,
 		"extension.namespace": resource.ObjectMeta.Namespace,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "extension.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/extension_test.go
+++ b/api/core/v2/extension_test.go
@@ -1,0 +1,40 @@
+package v2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtensionFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureExtension("widget"),
+			wantKey: "extension.name",
+			want:    "widget",
+		},
+		{
+			name: "exposes labels",
+			args: &Extension{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "extension.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtensionFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("ExtensionFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v2/filter.go
+++ b/api/core/v2/filter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sensu/sensu-go/api/core/v2/internal/js"
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 	utilstrings "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
@@ -166,12 +167,14 @@ func (s *eventFilterSorter) Less(i, j int) bool {
 // EventFilterFields returns a set of fields that represent that resource
 func EventFilterFields(r Resource) map[string]string {
 	resource := r.(*EventFilter)
-	return map[string]string{
+	fields := map[string]string{
 		"filter.name":           resource.ObjectMeta.Name,
 		"filter.namespace":      resource.ObjectMeta.Namespace,
 		"filter.action":         resource.Action,
 		"filter.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "filter.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/filter_test.go
+++ b/api/core/v2/filter_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,4 +44,44 @@ func TestEventFilterValidate(t *testing.T) {
 
 	// Valid filter
 	assert.NoError(t, f.Validate())
+}
+
+func TestEventFilterFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureEventFilter("allow-silenced"),
+			wantKey: "filter.name",
+			want:    "allow-silenced",
+		},
+		{
+			name:    "exposes action",
+			args:    &EventFilter{Action: "allow"},
+			wantKey: "filter.action",
+			want:    "allow",
+		},
+		{
+			name: "exposes labels",
+			args: &EventFilter{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "filter.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EventFilterFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("EventFilterFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
 }

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -184,7 +186,7 @@ func FixtureSetHandler(name string, handlers ...string) *Handler {
 // HandlerFields returns a set of fields that represent that resource
 func HandlerFields(r Resource) map[string]string {
 	resource := r.(*Handler)
-	return map[string]string{
+	fields := map[string]string{
 		"handler.name":      resource.ObjectMeta.Name,
 		"handler.namespace": resource.ObjectMeta.Namespace,
 		"handler.filters":   strings.Join(resource.Filters, ","),
@@ -192,6 +194,8 @@ func HandlerFields(r Resource) map[string]string {
 		"handler.mutator":   resource.Mutator,
 		"handler.type":      resource.Type,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "handler.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/handler_test.go
+++ b/api/core/v2/handler_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -248,6 +249,46 @@ func TestSortHandlersByName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sort.Sort(SortHandlersByName(tc.inChecks, tc.inDir))
 			assert.EqualValues(t, tc.expected, tc.inChecks)
+		})
+	}
+}
+
+func TestHandlerFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureHandler("slack"),
+			wantKey: "handler.name",
+			want:    "slack",
+		},
+		{
+			name:    "exposes type",
+			args:    &Handler{Type: "pipe"},
+			wantKey: "handler.type",
+			want:    "pipe",
+		},
+		{
+			name: "exposes labels",
+			args: &Handler{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "handler.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HandlerFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("HandlerFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
 		})
 	}
 }

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -168,10 +169,12 @@ func (h *Hook) URIPath() string {
 // HookConfigFields returns a set of fields that represent that resource
 func HookConfigFields(r Resource) map[string]string {
 	resource := r.(*HookConfig)
-	return map[string]string{
+	fields := map[string]string{
 		"hook.name":      resource.ObjectMeta.Name,
 		"hook.namespace": resource.ObjectMeta.Namespace,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "hook.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/hook_test.go
+++ b/api/core/v2/hook_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,5 +106,39 @@ func TestHookUnmarshal_GH1520(t *testing.T) {
 	}
 	if err := hc.Validate(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestHookConfigFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureHookConfig("captn"),
+			wantKey: "hook.name",
+			want:    "captn",
+		},
+		{
+			name: "exposes labels",
+			args: &HookConfig{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "hook.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HookConfigFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("HookConfigFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
 	}
 }

--- a/api/core/v2/internal/stringutil/map.go
+++ b/api/core/v2/internal/stringutil/map.go
@@ -1,0 +1,8 @@
+package stringutil
+
+// Merge contents of one map into another using a prefix.
+func MergeMapWithPrefix(a map[string]string, b map[string]string, prefix string) {
+	for k, v := range b {
+		a[prefix+k] = v
+	}
+}

--- a/api/core/v2/internal/stringutil/map_test.go
+++ b/api/core/v2/internal/stringutil/map_test.go
@@ -1,0 +1,55 @@
+package stringutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeMapWithPrefix(t *testing.T) {
+	type args struct {
+		a      map[string]string
+		b      map[string]string
+		prefix string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		expect map[string]string
+	}{
+		{
+			name: "merge empty",
+			args: args{
+				a:      map[string]string{},
+				b:      map[string]string{},
+				prefix: "prefix.",
+			},
+			expect: map[string]string{},
+		},
+		{
+			name: "empty prefix",
+			args: args{
+				a:      map[string]string{"a": "b"},
+				b:      map[string]string{"a": "c"},
+				prefix: "",
+			},
+			expect: map[string]string{"a": "c"},
+		},
+		{
+			name: "with prefix",
+			args: args{
+				a:      map[string]string{"a": "b"},
+				b:      map[string]string{"a": "b"},
+				prefix: "c.",
+			},
+			expect: map[string]string{"a": "b", "c.a": "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			MergeMapWithPrefix(tt.args.a, tt.args.b, tt.args.prefix)
+			if !reflect.DeepEqual(tt.args.a, tt.expect) {
+				t.Errorf("MergeMapWithPrefix() = %#v, want %#v", tt.args.a, tt.expect)
+			}
+		})
+	}
+}

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
 const (
@@ -122,11 +124,13 @@ func FixtureMutator(name string) *Mutator {
 // MutatorFields returns a set of fields that represent that resource
 func MutatorFields(r Resource) map[string]string {
 	resource := r.(*Mutator)
-	return map[string]string{
+	fields := map[string]string{
 		"mutator.name":           resource.ObjectMeta.Name,
 		"mutator.namespace":      resource.ObjectMeta.Namespace,
 		"mutator.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "mutator.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/mutator_test.go
+++ b/api/core/v2/mutator_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 
@@ -62,6 +63,40 @@ func TestSortMutatorsByName(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sort.Sort(SortMutatorsByName(tc.inChecks, tc.inDir))
 			assert.EqualValues(t, tc.expected, tc.inChecks)
+		})
+	}
+}
+
+func TestMutatorFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureMutator("ninja-turtle"),
+			wantKey: "mutator.name",
+			want:    "ninja-turtle",
+		},
+		{
+			name: "exposes labels",
+			args: &Mutator{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "mutator.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MutatorFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("MutatorFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
 		})
 	}
 }

--- a/api/core/v2/namespace_test.go
+++ b/api/core/v2/namespace_test.go
@@ -1,0 +1,30 @@
+package v2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNamespaceFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureNamespace("contoso"),
+			wantKey: "namespace.name",
+			want:    "contoso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NamespaceFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("NamespaceFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -374,39 +374,47 @@ func NewRoleBinding(meta ObjectMeta) *RoleBinding {
 // ClusterRoleFields returns a set of fields that represent that resource
 func ClusterRoleFields(r Resource) map[string]string {
 	resource := r.(*ClusterRole)
-	return map[string]string{
+	fields := map[string]string{
 		"clusterrole.name": resource.ObjectMeta.Name,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "clusterrole.labels.")
+	return fields
 }
 
 // ClusterRoleBindingFields returns a set of fields that represent that resource
 func ClusterRoleBindingFields(r Resource) map[string]string {
 	resource := r.(*ClusterRoleBinding)
-	return map[string]string{
+	fields := map[string]string{
 		"clusterrolebinding.name":          resource.ObjectMeta.Name,
 		"clusterrolebinding.role_ref.name": resource.RoleRef.Name,
 		"clusterrolebinding.role_ref.type": resource.RoleRef.Type,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "clusterrolebinding.labels.")
+	return fields
 }
 
 // RoleFields returns a set of fields that represent that resource
 func RoleFields(r Resource) map[string]string {
 	resource := r.(*Role)
-	return map[string]string{
+	fields := map[string]string{
 		"role.name":      resource.ObjectMeta.Name,
 		"role.namespace": resource.ObjectMeta.Namespace,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "role.labels.")
+	return fields
 }
 
 // RoleBindingFields returns a set of fields that represent that resource
 func RoleBindingFields(r Resource) map[string]string {
 	resource := r.(*RoleBinding)
-	return map[string]string{
+	fields := map[string]string{
 		"rolebinding.name":          resource.ObjectMeta.Name,
 		"rolebinding.namespace":     resource.ObjectMeta.Namespace,
 		"rolebinding.role_ref.name": resource.RoleRef.Name,
 		"rolebinding.role_ref.type": resource.RoleRef.Type,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "rolebinding.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -190,7 +190,7 @@ func (s *silenceSorter) Less(i, j int) bool {
 // SilencedFields returns a set of fields that represent that resource
 func SilencedFields(r Resource) map[string]string {
 	resource := r.(*Silenced)
-	return map[string]string{
+	fields := map[string]string{
 		"silenced.name":              resource.ObjectMeta.Name,
 		"silenced.namespace":         resource.ObjectMeta.Namespace,
 		"silenced.check":             resource.Check,
@@ -198,6 +198,8 @@ func SilencedFields(r Resource) map[string]string {
 		"silenced.expire_on_resolve": strconv.FormatBool(resource.ExpireOnResolve),
 		"silenced.subscription":      resource.Subscription,
 	}
+	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "silenced.labels.")
+	return fields
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/silenced_test.go
+++ b/api/core/v2/silenced_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"sort"
 	"testing"
 
@@ -157,6 +158,46 @@ func TestSilencedMatches(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.silenced.Matches(tc.check, tc.subscription))
+		})
+	}
+}
+
+func TestSilencedFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureSilenced("a:b"),
+			wantKey: "silenced.name",
+			want:    "a:b",
+		},
+		{
+			name:    "exposes expire_on_resolve",
+			args:    FixtureSilenced("a:b"),
+			wantKey: "silenced.expire_on_resolve",
+			want:    "false",
+		},
+		{
+			name: "exposes labels",
+			args: &Silenced{
+				ObjectMeta: ObjectMeta{
+					Labels: map[string]string{"region": "philadelphia"},
+				},
+			},
+			wantKey: "silenced.labels.region",
+			want:    "philadelphia",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SilencedFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("SilencedFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
 		})
 	}
 }

--- a/api/core/v2/user_test.go
+++ b/api/core/v2/user_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,34 @@ func TestUserValidatePassword(t *testing.T) {
 
 	u.Password = "P@ssw0rd!"
 	assert.NoError(t, u.ValidatePassword())
+}
+
+func TestUserFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Resource
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes username",
+			args:    FixtureUser("frank"),
+			wantKey: "user.username",
+			want:    "frank",
+		},
+		{
+			name:    "exposes disabled",
+			args:    FixtureUser("frank"),
+			wantKey: "user.disabled",
+			want:    "false",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UserFields(tt.args)
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("UserFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What is this change?

Excerpt from our [Search Improvements Proposal](https://docs.google.com/document/d/1R-ofH3225OuyqjAsKE75j31UODJtMDRfd8zJE9UXh0A/edit#heading=h.el864xddxh43):

> In short I will suggest that we replace our existing search with one that is entirely built upon field selectors. By focusing on selectors we can fine tune the user experience for a single path, users no longer have to learn two different forms of searching, and our own code becomes simpler.
> 
> Of course this raises the question that if we focus on field selectors, how does one query labels? I will propose that we allow querying of labels through field selectors. Otherwise, the web interface would require a second distinct search box for labels, which I feel would be less intuitive.

## Why is this change necessary?

Supports https://github.com/sensu/sensu-enterprise-go/issues/1083

## Does your change need a Changelog entry?

Probably.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Likely will require some additional documentation.

## How did you verify this change?

I added some unit tests for the [Resource]Fields functions.