### PR TITLE
Add validation around resource types args in dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ### Added
 - A warning is now logged when a runtime asset was requested but does not exist.
 
 ### Fixed
 - Failed check events now get written to the event log file.
+- Added more validation around acceptable resource types in `sensuctl dump`.
 
 ## [6.0.0] - 2020-08-04
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds more validation around acceptable resource types in `sensuctl dump`. Previously, the command would try to resolve providers (ex. `secrets/v1.VaultProvider`, `authentication/v2.LDAP`) but due to the nature of these lifted resource types and our generic API design, they are not compatible.

`sensuctl dump` now only accepts resource type arguments that are displayed in `sensuctl describe-type all`. To display all secrets providers, one would run `sensuctl dump secrets/v1.Provider`.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/1216

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Yes, there were actually a few ways to solve this problem, and I discovered more bugs when attempting to resolve specific provider types such as `secrets.v1/VaultProvider`. For that reason, I thought it was best to limit the acceptable resource type arguments to those listed in `sensuctl describe-type all`. See https://github.com/sensu/sensu-go/issues/3981 for full description.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs will likely need to be modified if this approach is selected.

## How did you verify this change?

Added unit tests.

```
$ sensuctl dump secrets/v1.Env
Error: invalid resource type: secrets/v1.Env
$ sensuctl dump secrets/v1.Provider
type: Env
api_version: secrets/v1
metadata:
  name: env
spec: {}
```

## Is this change a patch?

Yup! Targeting release branch.