### PR TITLE
Add check state to event fields

### DIFF
--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -71,6 +71,7 @@ func FixtureCheck(id string) *Check {
 	c.Executed = t + 1
 	c.Duration = 1.0
 	c.History = history
+	c.State = EventPassingState
 
 	return c
 }

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -433,6 +433,7 @@ func EventFields(r Resource) map[string]string {
 		"event.check.publish":        strconv.FormatBool(resource.Check.Publish),
 		"event.check.round_robin":    strconv.FormatBool(resource.Check.RoundRobin),
 		"event.check.runtime_assets": strings.Join(resource.Check.RuntimeAssets, ","),
+		"event.check.state":          resource.Check.State,
 		"event.check.status":         strconv.Itoa(int(resource.Check.Status)),
 		"event.check.subscriptions":  strings.Join(resource.Check.Subscriptions, ","),
 		"event.entity.deregister":    strconv.FormatBool(resource.Entity.Deregister),

--- a/api/core/v2/event_test.go
+++ b/api/core/v2/event_test.go
@@ -904,6 +904,12 @@ func TestEventFields(t *testing.T) {
 			want:    "reynolds",
 		},
 		{
+			name:    "exposes check.state",
+			args:    FixtureEvent("frank", "reynolds"),
+			wantKey: "event.check.state",
+			want:    "passing",
+		},
+		{
 			name: "exposes check labels",
 			args: &Event{
 				Check:  &Check{ObjectMeta: ObjectMeta{Labels: map[string]string{"src": "bonsai"}}},


### PR DESCRIPTION
## What is this change?

Add check state to event fields allowing events to be filtered by their state.

## Why is this change necessary?

Required for sensu/sensu-enterprise-go#1083