### PR TITLE
Prepare for the 5.21.2 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Errors produced in the agent by assets, check validation, token substitution,
 and event unmarshaling are logged once again.
 
-## [6.0.0] - 2020-08-04
-
-### Added
-- Log a warning when secrets cannot be sent to an agent because mTLS is not
-enabled.
-- Added the is_silenced boolean key to event.Check object.
-
 ## [5.21.0] - 2020-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Improved agent websocket connection logging.
+### Fixed
+- Failed check events now get written to the event log file.
+
+## [6.0.0] - 2020-08-04
+
+### Added
+- Log a warning when secrets cannot be sent to an agent because mTLS is not
+enabled.
+- Added the is_silenced boolean key to event.Check object.
 
 ### Fixed
 - Fixed potential Web UI crash when fetching events in namespace with > 1000 events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.21.2] - 2020-08-31
+
+### Fixed
+- Failed check events now get written to the event log file.
+
 ## [5.21.1] - 2020-08-05
 
 ### Changed
 - Improved agent websocket connection logging.
+
 ### Fixed
-- Failed check events now get written to the event log file.
+- Fixed potential Web UI crash when fetching events in namespace with > 1000 events.
+- Errors produced in the agent by assets, check validation, token substitution,
+and event unmarshaling are logged once again.
 
 ## [6.0.0] - 2020-08-04
 
@@ -18,11 +26,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Log a warning when secrets cannot be sent to an agent because mTLS is not
 enabled.
 - Added the is_silenced boolean key to event.Check object.
-
-### Fixed
-- Fixed potential Web UI crash when fetching events in namespace with > 1000 events.
-- Errors produced in the agent by assets, check validation, token substitution,
-and event unmarshaling are logged once again.
 
 ## [5.21.0] - 2020-06-10
 

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -442,6 +442,7 @@ func (e *Eventd) handleFailure(ctx context.Context, event *corev2.Event) error {
 		return err
 	}
 
+	e.Logger.Println(updatedEvent)
 	return e.bus.Publish(messaging.TopicEvent, updatedEvent)
 }
 


### PR DESCRIPTION
Prepare for the 5.21.2 patch release by cherry picking https://github.com/sensu/sensu-go/commit/de7058aab1aabadec2e9367377b8b56bb8184da7 and resolving the changelog manually.