### PR TITLE
Support generic query params in sensuctl dump

### DIFF
--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -161,7 +161,8 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 
 			val := reflect.New(reflect.SliceOf(reflect.TypeOf(req)))
 			err = cli.Client.List(
-				req.URIPath(), val.Interface(), &client.ListOptions{
+				fmt.Sprintf("%s?types=%s", req.URIPath(), types.WrapResource(req).Type),
+				val.Interface(), &client.ListOptions{
 					ChunkSize: ChunkSize,
 				}, nil)
 			if err != nil {

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"reflect"
 
@@ -161,7 +162,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 
 			val := reflect.New(reflect.SliceOf(reflect.TypeOf(req)))
 			err = cli.Client.List(
-				fmt.Sprintf("%s?types=%s", req.URIPath(), types.WrapResource(req).Type),
+				fmt.Sprintf("%s?types=%s", req.URIPath(), url.QueryEscape(types.WrapResource(req).Type)),
 				val.Interface(), &client.ListOptions{
 					ChunkSize: ChunkSize,
 				}, nil)


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Adds backwards compatible support for a `types` query parameter to be added to the URI to list resources.

## Why is this change necessary?

Required by https://github.com/sensu/sensu-enterprise-go/issues/1216

## Does your change need a Changelog entry?

No, purely internal. Changelog entry will be noted in enterprise.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

See enterprise RP.

## Is this change a patch?

No, it supports a minor feature.