### PR TITLE
Include the agent entity in stdin for checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ using the Prometheus Exposition Text Format.
 
 ### Fixed
 - Failed check events now get written to the event log file.
+- Include the agent entity in data passed to the command process' STDIN.
 
 ## [6.0.0] - 2020-08-04
 

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -145,6 +145,7 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 	// Instantiate event
 	event := createEvent()
 	check := event.Check
+	event.Entity = a.getAgentEntity()
 
 	// Prepare log entry
 	fields := logrus.Fields{
@@ -245,7 +246,6 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 	event.Check.Duration = checkExec.Duration
 	event.Check.Status = uint32(checkExec.Status)
 
-	event.Entity = a.getAgentEntity()
 	event.Timestamp = time.Now().Unix()
 	id, err := uuid.NewRandom()
 	if err == nil {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It simply ensures the stdin available to checks has the agent's entity available.


## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3827

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

I manually created the following check:

```yaml
type: Check
api_version: core/v2
metadata:
  name: stdin
  namespace: default
spec:
  command: cat
  interval: 5
  publish: true
  stdin: true
  subscriptions:
  - entity:gin
```

I realized that we don't have any coverage around that in our QA crucible so I'll work on that right away.

## Is this change a patch?

Kind of, but it was marked for the 6.1 milestone so we can just cherry-pick it in case we need that.