### PR TITLE
Don't start up with partial dashboard TLS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ using the Prometheus Exposition Text Format.
 
 ### Changed
 - The trusted CA file is now used for agent-side asset retrieval.
+
+### Fixed
+- The backend will no longer start when the dashboard TLS configuration is not
+fully specified.
+
 ## [5.21.2] - 2020-08-31
 
 ### Fixed

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -241,6 +241,13 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 					flagCertFile, flagKeyFile)
 			}
 
+			if cf, kf := len(cfg.DashboardTLSCertFile) == 0, len(cfg.DashboardTLSKeyFile) == 0; cf != kf {
+				return fmt.Errorf(
+					"dashboard tls configuration error, both flags --%s and --%s are required",
+					flagDashboardCertFile, flagDashboardKeyFile,
+				)
+			}
+
 			// Etcd TLS config
 			cfg.EtcdClientTLSInfo = etcd.TLSInfo{
 				CertFile:       viper.GetString(flagEtcdCertFile),


### PR DESCRIPTION
## What is this change?

This commit causes sensu-go to exit with failure when parsing
configuration if both dashboard TLS flags are not specified.

## Why is this change necessary?

Closes #3791 

## Does your change need a Changelog entry?

Yes, included.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes not required.

## How did you verify this change?

I started up the backend with only one dashboard TLS flag before and after the change. Before the change, the backend started up without complaint. After the change, it exited after parsing configuration, with:
```
{"component":"backend","error":"dashboard tls configuration error, both flags --dashboard-cert-file and --dashboard-key-file are required","level":"fatal","msg":"error executing sensu-backend","time":"2020-09-02T10:41:21-07:00"}
```

## Is this change a patch?

I'd say no; it's a different enough behaviour that even though it's a fix, I think it should be rolled out with the next minor release.