### PR TITLE
Revert check/hook command to what is stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Failed check events now get written to the event log file.
 - Per-entity subscriptions (ex. `entity:entityName`) are always available on agent entities,
 even if removed via the `/entities` API.
+- Fixed a bug where stale check and hook commands could be displayed in proxy events.
 
 ## [6.0.0] - 2020-08-04
 

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -116,8 +116,6 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 	hookAssets := request.HookAssets
 	secrets := request.Secrets
 
-	// Before token subsitution we retain copy of the command
-	origCommand := checkConfig.Command
 	createEvent := func() *corev2.Event {
 		event := &corev2.Event{}
 		event.Namespace = checkConfig.Namespace
@@ -125,14 +123,10 @@ func (a *Agent) executeCheck(ctx context.Context, request *corev2.CheckRequest, 
 		event.Check.Executed = time.Now().Unix()
 		event.Check.Issued = request.Issued
 
-		// To guard against publishing sensitive/redacted client attribute values
-		// the original command value is reinstated.
-		event.Check.Command = origCommand
-
 		return event
 	}
 
-	if origCommand != undocumentedTestCheckCommand {
+	if checkConfig.Command != undocumentedTestCheckCommand {
 		// Perform token substitution on the check configuration, but only if
 		// we aren't doing load testing with the undocumented test check
 		// command.

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -345,7 +345,7 @@ func TestHandleTokenSubstitution(t *testing.T) {
 	assert.NotZero(event.Timestamp)
 	assert.EqualValues(int32(0), event.Check.Status)
 	assert.Contains(event.Check.Output, "TestTokenSubstitution defaultValue")
-	assert.Contains(event.Check.Command, checkConfig.Command) // command should not include substitutions
+	assert.NotContains(event.Check.Command, checkConfig.Command) // command should not include substitutions
 }
 
 func TestHandleTokenSubstitutionNoKey(t *testing.T) {

--- a/agent/hook.go
+++ b/agent/hook.go
@@ -31,7 +31,6 @@ func (a *Agent) ExecuteHooks(ctx context.Context, request *corev2.CheckRequest, 
 				if hookConfig == nil {
 					hookConfig = errorHookConfig(a.config.Namespace, hookName, errors.New("missing hook config"))
 				}
-				origCommand := hookConfig.Command
 				if err := a.prepareHook(hookConfig); err != nil {
 					hookConfig = errorHookConfig(hookConfig.Namespace, hookConfig.Name, err)
 				}
@@ -40,9 +39,6 @@ func (a *Agent) ExecuteHooks(ctx context.Context, request *corev2.CheckRequest, 
 				in := hookInList(hookConfig.Name, executedHooks)
 				if !in {
 					hook := a.executeHook(ctx, hookConfig, event, assets)
-					// To guard against publishing sensitive/redacted client attribute values
-					// the original command value is reinstated.
-					hook.Command = origCommand
 					executedHooks = append(executedHooks, hook)
 				}
 			}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -274,6 +274,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		eventd.Config{
 			Store:           storv2,
 			EventStore:      eventStoreProxy,
+			Storev1:         b.Store,
 			Bus:             bus,
 			LivenessFactory: liveness.EtcdFactory(b.RunContext(), b.Client),
 			Client:          b.Client,

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -61,7 +61,7 @@ func TestEventdMonitor(t *testing.T) {
 		assert.FailNow(t, err.Error())
 	}
 
-	e := newEventd(storev2, store, bus, livenessFactory)
+	e := newEventd(storev2, store, store, bus, livenessFactory)
 
 	if err := e.Start(); err != nil {
 		assert.FailNow(t, err.Error())
@@ -72,6 +72,10 @@ func TestEventdMonitor(t *testing.T) {
 	event.Check.Ttl = 5
 
 	ctx := otherTestutil.ContextWithNamespace("default")(context.Background())
+
+	if err := store.UpdateCheckConfig(ctx, corev2.FixtureCheckConfig("check1")); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := store.UpdateEntity(ctx, event.Entity); err != nil {
 		t.Fatal(err)

--- a/backend/eventd/silenced_test.go
+++ b/backend/eventd/silenced_test.go
@@ -283,6 +283,7 @@ func TestEventd_handleMessage(t *testing.T) {
 			if tt.eventStoreFunc != nil {
 				tt.eventStoreFunc(eventStore)
 			}
+			eventStore.On("GetCheckConfigByName", mock.Anything, mock.Anything).Return(corev2.FixtureCheckConfig("check"), nil)
 			store := &storetest.Store{}
 			if tt.storeFunc != nil {
 				tt.storeFunc(store)
@@ -293,6 +294,7 @@ func TestEventd_handleMessage(t *testing.T) {
 				bus:             bus,
 				store:           store,
 				eventStore:      eventStore,
+				storev1:         eventStore,
 				livenessFactory: newFakeFactory(switches),
 				workerCount:     1,
 				wg:              &sync.WaitGroup{},


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Reverts the check and hook commands within an event to what is stored for the respective check and hook (protects redacted token sub values and stale commands).

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3857

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

There were a few ways to solve this. This approach requires more calls to the store on the backend (probably not ideal). I am going to try an implementation where the backend sends the original check/hook commands in the check request.

## Were there any complications while making this change?

See answer above.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't think so!

## How did you verify this change?

```
# proxy ip = 127.0.0.1
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl event info proxy ping --format json | jq .check.command
"ping {{ .annotations.ip_address }} -c 3"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"127.0.0.1"

# proxy ip = 8.8.8.8
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl event info proxy ping --format json | jq .check.command
"ping {{ .annotations.ip_address }} -c 3"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"8.8.8.8"

# proxy ip is redacted
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl event info proxy ping --format json | jq .check.command
"ping {{ .annotations.ip_address }} -c 3"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"REDACTED"
```

## Is this change a patch?

Yup, targeting `release/6.0 branch`.