### PR TITLE
Fix a bug in the Javascript VM cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Failed check events now get written to the event log file.
 - Per-entity subscriptions (ex. `entity:entityName`) are always available on agent entities,
 even if removed via the `/entities` API.
+- Fixed a crash in the backend and agent related to Javascript execution.
 
 ## [6.0.0] - 2020-08-04
 

--- a/js/vm_cache.go
+++ b/js/vm_cache.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"fmt"
 	"sync"
 
 	time "github.com/echlebek/timeproxy"
@@ -62,7 +63,7 @@ func (c *vmCache) reap() {
 		obj.mu.Lock()
 		defer obj.mu.Unlock()
 		valueTime := time.Unix(obj.lastRead, 0)
-		if valueTime.Before(time.Now().Add(-cacheMaxAge)) {
+		if time.Since(valueTime) > cacheMaxAge {
 			c.vms.Delete(key)
 		}
 		return true
@@ -87,7 +88,7 @@ func (c *vmCache) Acquire(key string) *otto.Otto {
 func (c *vmCache) Dispose(key string) {
 	val, ok := c.vms.Load(key)
 	if !ok {
-		return
+		panic(fmt.Sprintf("dispose called on %q, but not found", key))
 	}
 	obj := val.(*cacheValue)
 	obj.mu.Unlock()


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where the cache would behave incorrectly
if the supplied RuntimeAssets changed during the cached value's
lifetime.

## Why is this change necessary?

Fixes #3997 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

Because of the general architecture of the cache, it was very difficult to test the change for correctness. Thanks to @roganartu I was able to verify the change worked, but the test he wrote can't be added to the codebase as it depends on `time.Sleep` in library routines to work.

## How did you verify this change?

I used the verification test included in #3997 to make sure that the change works as expected. However, this test is not included in the PR, so technically it is unverified.

## Is this change a patch?

Yes