### PR TITLE
Ensure proxy entities are not stale concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Failed check events now get written to the event log file.
 - Per-entity subscriptions (ex. `entity:entityName`) are always available on agent entities,
 even if removed via the `/entities` API.
+- Proxy entities that are used in round-robin check requests are no longer stale.
 
 ## [6.0.0] - 2020-08-04
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Ensures that the interval/cron round robin schedulers do not use stale proxy entities when scheduling check requests.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3857

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Originally thought https://github.com/sensu/sensu-go/pull/3999 would be a solution. Found another related bug within round-robin proxy requests using stale proxy entities and fixed both issues here instead.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

```
# proxy ip = 127.0.0.1
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl entity info proxy --format json | jq .metadata.annotations.ip_address
"127.0.0.1"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"127.0.0.1"
$ sensuctl event info proxy ping --format json | jq .check.command
"ping 127.0.0.1 -c 3"

# proxy ip = 8.8.8.8
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl entity info proxy --format json | jq .metadata.annotations.ip_address
"8.8.8.8"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"8.8.8.8"
$ sensuctl event info proxy ping --format json | jq .check.command
"ping 8.8.8.8 -c 3"

# proxy ip is redacted
$ sensuctl edit entity proxy
Updated /api/core/v2/namespaces/default/entities/proxy
$ sensuctl entity info proxy --format json | jq .metadata.annotations.ip_address
"REDACTED"
$ sensuctl event info proxy ping --format json | jq .entity.metadata.annotations.ip_address
"REDACTED"
$ sensuctl event info proxy ping --format json | jq .check.command
"ping REDACTED -c 3"
```

## Is this change a patch?

Yup, targeting `release/6.0` branch.