### PR TITLE
Change the OoO for processing resource input

### DIFF
--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -44,10 +44,8 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
-		for _, input := range inputs {
-			if err := resource.Process(cli, client, input, recurse, processor); err != nil {
-				return err
-			}
+		if err := resource.Process(cli, client, inputs, recurse, processor); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/cli/resource/process.go
+++ b/cli/resource/process.go
@@ -84,10 +84,11 @@ func ProcessFile(input string, recurse bool) ([]*types.Wrapper, error) {
 		if err != nil {
 			return err
 		}
-		resources, err = Parse(f)
+		res, err := Parse(f)
 		if err != nil {
 			return fmt.Errorf("in %s: %s", input, err)
 		}
+		resources = append(resources, res...)
 		return nil
 	})
 	return resources, err
@@ -129,11 +130,10 @@ func ProcessURL(client *http.Client, urly *url.URL, input string, recurse bool) 
 			resources = append(resources, res...)
 		}
 	} else {
-		res, err := Parse(resp.Body)
+		resources, err := Parse(resp.Body)
 		if err != nil {
 			return resources, fmt.Errorf("in %s: %s", input, err)
 		}
-		resources = append(resources, res...)
 	}
 	return resources, nil
 }

--- a/cli/resource/process.go
+++ b/cli/resource/process.go
@@ -130,7 +130,7 @@ func ProcessURL(client *http.Client, urly *url.URL, input string, recurse bool) 
 			resources = append(resources, res...)
 		}
 	} else {
-		resources, err := Parse(resp.Body)
+		resources, err = Parse(resp.Body)
 		if err != nil {
 			return resources, fmt.Errorf("in %s: %s", input, err)
 		}

--- a/cli/resource/process_test.go
+++ b/cli/resource/process_test.go
@@ -11,22 +11,10 @@ import (
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/cli"
-	"github.com/sensu/sensu-go/cli/client"
-	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-type mockProcessor struct {
-	mock.Mock
-}
-
-func (m *mockProcessor) Process(client client.GenericClient, resources []*types.Wrapper) error {
-	return m.Called(client, resources).Error(0)
-}
 
 func TestProcessURL(t *testing.T) {
 	bytes, err := json.Marshal(types.WrapResource(corev2.FixtureCheck("check")))
@@ -38,14 +26,10 @@ func TestProcessURL(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	processor := &mockProcessor{}
-	processor.On("Process", mock.Anything, mock.Anything).Return(nil)
-	config := &config.MockConfig{}
-	config.On("Namespace").Return("")
-
 	urly, err := url.Parse(ts.URL)
 	assert.NoError(t, err)
-	assert.NoError(t, ProcessURL(&cli.SensuCli{Config: config}, ts.Client(), urly, ts.URL, false, processor))
+	_, err = ProcessURL(ts.Client(), urly, ts.URL, false)
+	assert.NoError(t, err)
 }
 
 func TestProcessFile(t *testing.T) {
@@ -57,9 +41,6 @@ func TestProcessFile(t *testing.T) {
 	err = ioutil.WriteFile(fp, []byte(`{"type": "Namespace", "spec": {"name": "foo"}}`), 0644)
 	assert.NoError(t, err)
 
-	processor := &mockProcessor{}
-	processor.On("Process", mock.Anything, mock.Anything).Return(nil)
-	config := &config.MockConfig{}
-	config.On("Namespace").Return("")
-	assert.NoError(t, ProcessFile(&cli.SensuCli{Config: config}, fp, false, processor))
+	_, err = ProcessFile(fp, false)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Changes the order of operations for processing resource input. When provided multiple files, urls, or directories, all resources should be read first before the processing command (`create` or `prune`) take place.

Required by https://github.com/sensu/sensu-enterprise-go/pull/1284

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3702

## Does your change need a Changelog entry?

Yes, in enterprise.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

```
$ sensuctl create -f check1.yaml -f check2.yaml -f check3.yaml 
$ sensuctl check list
   Name    Command    Interval   Cron   Timeout   TTL   Subscriptions   Handlers   Assets   Hooks   Publish?   Stdin?   Metric Format   Metric Handlers  
 ──────── ────────── ────────── ────── ───────── ───── ─────────────── ────────── ──────── ─────── ────────── ──────── ─────────────── ───────────────── 
  check1   echo foo         10                0     0   metrics                                     false      false                                     
  check2   echo foo         10                0     0   metrics                                     false      false                                     
  check3   echo foo         10                0     0   metrics                                     false      false                                     
$ sensuctl prune checks -f check1.yaml -f check2.yaml
[
  {
    "type": "CheckConfig",
    "api_version": "core/v2",
    "name": "check3",
    "namespace": "default",
    "labels": {
      "sensu.io/managed_by": "sensuctl"
    },
    "created_by": "admin"
  }
]

$ sensuctl check list
   Name    Command    Interval   Cron   Timeout   TTL   Subscriptions   Handlers   Assets   Hooks   Publish?   Stdin?   Metric Format   Metric Handlers  
 ──────── ────────── ────────── ────── ───────── ───── ─────────────── ────────── ──────── ─────── ────────── ──────── ─────────────── ───────────────── 
  check1   echo foo         10                0     0   metrics                                     false      false                                     
  check2   echo foo         10                0     0   metrics                                     false      false                                     
```

## Is this change a patch?

It's a bugfix but it somewhat reworks things so I'm targeting master!