### PR TITLE
Use workaround for windows x509.SystemCertPool()

### DIFF
--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -23,6 +23,10 @@ const (
 	// DefaultAssetsBurstLimit defines the burst ceiling for a rate limited asset fetch.
 	// If 0, then the setting has no effect.
 	DefaultAssetsBurstLimit int = 100
+
+	// CRYPT_E_NOT_FOUND is an error code specific to windows cert pool.
+	// See https://github.com/golang/go/issues/16736#issuecomment-540373689.
+	CRYPT_E_NOT_FOUND = 0x80092004
 )
 
 // A Fetcher fetches a file from the specified source and returns an *os.File
@@ -55,6 +59,8 @@ func httpGet(ctx context.Context, path, trustedCAFile string, headers map[string
 		if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
 			logger.Errorf("failed to append %s to RootCAs, using system certs only", trustedCAFile)
 		}
+
+		appendCerts(rootCAs)
 
 		client = &http.Client{
 			Transport: &http.Transport{

--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -23,10 +23,6 @@ const (
 	// DefaultAssetsBurstLimit defines the burst ceiling for a rate limited asset fetch.
 	// If 0, then the setting has no effect.
 	DefaultAssetsBurstLimit int = 100
-
-	// CRYPT_E_NOT_FOUND is an error code specific to windows cert pool.
-	// See https://github.com/golang/go/issues/16736#issuecomment-540373689.
-	CRYPT_E_NOT_FOUND = 0x80092004
 )
 
 // A Fetcher fetches a file from the specified source and returns an *os.File

--- a/asset/fetcher_unix.go
+++ b/asset/fetcher_unix.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package asset
+
+import "crypto/x509"
+
+func appendCerts(rootCAs *x509.CertPool) {}

--- a/asset/fetcher_windows.go
+++ b/asset/fetcher_windows.go
@@ -1,0 +1,45 @@
+// +build windows
+
+package asset
+
+import (
+	"crypto/x509"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// CRYPT_E_NOT_FOUND is an error code specific to windows cert pool.
+	// See https://github.com/golang/go/issues/16736#issuecomment-540373689.
+	CRYPT_E_NOT_FOUND = 0x80092004
+)
+
+func appendCerts(rootCAs *x509.CertPool) {
+	storeHandle, err := syscall.CertOpenSystemStore(0, syscall.StringToUTF16Ptr("Root"))
+	if err != nil {
+		logger.WithError(err).Error(syscall.GetLastError())
+	}
+
+	var cert *syscall.CertContext
+	for {
+		cert, err = syscall.CertEnumCertificatesInStore(storeHandle, cert)
+		if err != nil {
+			if errno, ok := err.(syscall.Errno); ok {
+				if errno == CRYPT_E_NOT_FOUND {
+					break
+				}
+			}
+			logger.WithError(err).Error(syscall.GetLastError())
+		}
+		if cert == nil {
+			break
+		}
+		// Copy the buf, since ParseCertificate does not create its own copy.
+		buf := (*[1 << 20]byte)(unsafe.Pointer(cert.EncodedCert))[:]
+		buf2 := make([]byte, cert.Length)
+		copy(buf2, buf)
+		if c, err := x509.ParseCertificate(buf2); err == nil {
+			rootCAs.AddCert(c)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Implements the workaround detailed in https://github.com/golang/go/issues/16736#issuecomment-540373689 to fix asset trusted ca file on windows agents.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/4016

## Does your change need a Changelog entry?

No, not a regression, fixes bug introduced in unreleased https://github.com/sensu/sensu-go/pull/3975 `The trusted CA file is now used for agent-side asset retrieval.`

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

![giphy](https://user-images.githubusercontent.com/10634078/93922223-a5ee8400-fcdf-11ea-9943-7b6fcbfd60ea.gif)

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

I deployed a whole windows golang env to test this 🙃 Verifying in a build with crucible now.

## Is this change a patch?

Yes, but targeting master for the next release.