### PR TITLE
Add trusted ca file for backend and sensuctl assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ using the Prometheus Exposition Text Format.
 maximum API request body size, in bytes.
 
 ### Changed
-- The trusted CA file is now used for agent-side asset retrieval.
+- The trusted CA file is now used for agent and backend asset retrieval.
 
 ### Fixed
 - The backend will no longer start when the dashboard TLS configuration is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ using the Prometheus Exposition Text Format.
 maximum API request body size, in bytes.
 
 ### Changed
-- The trusted CA file is now used for agent and backend asset retrieval.
+- The trusted CA file is now used for agent, backend and sensuctl asset retrieval.
 
 ### Fixed
 - The backend will no longer start when the dashboard TLS configuration is not

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -236,7 +236,11 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Initialize asset manager
 	backendEntity := b.getBackendEntity(config)
 	logger.WithField("entity", backendEntity).Info("backend entity information")
-	assetManager := asset.NewManager(config.CacheDir, "", backendEntity, &sync.WaitGroup{})
+	var trustedCAFile string
+	if config.TLS != nil {
+		trustedCAFile = config.TLS.TrustedCAFile
+	}
+	assetManager := asset.NewManager(config.CacheDir, trustedCAFile, backendEntity, &sync.WaitGroup{})
 	limit := b.cfg.AssetsRateLimit
 	if limit == 0 {
 		limit = rate.Limit(asset.DefaultAssetsRateLimit)

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -108,7 +108,11 @@ func NewCommandManager(cli *cli.SensuCli) (*CommandManager, error) {
 	// start the asset manager
 	ctx := context.TODO()
 	wg := sync.WaitGroup{}
-	m.assetManager = asset.NewManager(cacheDir, "", entity, &wg)
+	var trustedCAFile string
+	if !cli.Config.InsecureSkipTLSVerify() {
+		trustedCAFile = cli.Config.TrustedCAFile()
+	}
+	m.assetManager = asset.NewManager(cacheDir, trustedCAFile, entity, &wg)
 	m.assetGetter, err = m.assetManager.StartAssetManager(ctx, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

## What is this change?

Allows backend and sensuctl to provide configurable trusted CA for asset retrieval.

## Why is this change necessary?

I don't know if it is, asked this in https://github.com/sensu/sensu-go/issues/3948#issuecomment-675577475. @portertech @cwjohnston any thoughts on supporting this for backend and sensuctl assets as well?

Enhances https://github.com/sensu/sensu-go/pull/3975.

## Does your change need a Changelog entry?

Yas.

## Do you need clarification on anything?

Nah.

## Were there any complications while making this change?

Nah.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We good.

## How did you verify this change?

Full QA crucible.

## Is this change a patch?

Nah, targeting master.