### PR TITLE
Fix a bug where entity list could be incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Per-entity subscriptions (ex. `entity:entityName`) are always available on agent entities,
 even if removed via the `/entities` API.
 - Proxy entities that are used in round-robin check requests are no longer stale.
+- Fixed a bug where entity listing would be incorrect if agent entities were
+created via the API instead of with sensu-agent.
 
 ## [6.0.0] - 2020-08-04
 

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
@@ -54,4 +55,31 @@ func TestEntityStorage(t *testing.T) {
 		err = s.UpdateEntity(ctx, entity)
 		assert.Error(t, err)
 	})
+}
+
+func TestEntityIteration(t *testing.T) {
+	configs := []corev3.EntityConfig{
+		*corev3.FixtureEntityConfig("a"),
+		*corev3.FixtureEntityConfig("b"),
+		*corev3.FixtureEntityConfig("c"),
+		*corev3.FixtureEntityConfig("d"),
+		*corev3.FixtureEntityConfig("e"),
+	}
+	states := []corev3.EntityState{
+		*corev3.FixtureEntityState("b"),
+		*corev3.FixtureEntityState("c"),
+		*corev3.FixtureEntityState("d"),
+	}
+	entities, err := entitiesFromConfigAndState(configs, states)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(entities), len(configs); got != want {
+		t.Fatalf("bad entity count: got %d, want %d", got, want)
+	}
+	for i := range configs {
+		if got, want := configs[i].Metadata.Name, entities[i].Name; got != want {
+			t.Errorf("bad entity name: got %q, want %q", got, want)
+		}
+	}
 }


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in entity listing, when agent entities have
been created via the API, but not through sensu-agent.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Fixes #4010 

## Does your change need a Changelog entry?

Included.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs not required.

## How did you verify this change?

Unit testing.

## Is this change a patch?

Yes.