### PR TITLE
[GraphQL] Where possible, avoid scanning all events

### DIFF
--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -80,6 +80,20 @@ func (e *EventClient) ListEvents(ctx context.Context, pred *store.SelectionPredi
 	return events, nil
 }
 
+// ListEventsByEntity lists all events in a namespace, according to the
+// selection predicate, if authorized.
+func (e *EventClient) ListEventsByEntity(ctx context.Context, entity string, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	attrs := eventListAttributes(ctx)
+	if err := authorize(ctx, e.auth, attrs); err != nil {
+		return nil, err
+	}
+	events, err := e.store.GetEventsByEntity(ctx, entity, pred)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list events by entity: %s", err)
+	}
+	return events, nil
+}
+
 func eventUpdateAttributes(ctx context.Context) *authorization.Attributes {
 	return &authorization.Attributes{
 		APIGroup:   "core",

--- a/backend/api/event_test.go
+++ b/backend/api/event_test.go
@@ -558,3 +558,138 @@ func TestDeleteEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestListEventsByEntity(t *testing.T) {
+	tests := []struct {
+		Name       string
+		Ctx        func() context.Context
+		EventStore func() store.EventStore
+		Bus        func() messaging.MessageBus
+		Auth       func() authorization.Authorizer
+		Exp        []*corev2.Event
+		ExpErr     bool
+	}{
+		{
+			Name: "no auth",
+			Ctx:  defaultContext,
+			EventStore: func() store.EventStore {
+				store := new(mockstore.MockStore)
+				return store
+			},
+			Auth: func() authorization.Authorizer {
+				return &rbac.Authorizer{}
+			},
+			Bus: func() messaging.MessageBus {
+				return new(mockbus.MockBus)
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "wrong user",
+			Ctx: func() context.Context {
+				return contextWithUser(defaultContext(), "haxor", nil)
+			},
+			EventStore: func() store.EventStore {
+				store := new(mockstore.MockStore)
+				return store
+			},
+			Bus: func() messaging.MessageBus {
+				return new(mockbus.MockBus)
+			},
+			Auth: func() authorization.Authorizer {
+				auth := &mockAuth{
+					attrs: map[authorization.AttributesKey]bool{
+						authorization.AttributesKey{
+							APIGroup:   "core",
+							APIVersion: "v2",
+							Namespace:  "default",
+							Resource:   "events",
+							UserName:   "legit",
+							Verb:       "list",
+						}: true,
+					},
+				}
+				return auth
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "right user, wrong perms",
+			Ctx: func() context.Context {
+				return contextWithUser(defaultContext(), "haxor", nil)
+			},
+			EventStore: func() store.EventStore {
+				store := new(mockstore.MockStore)
+				return store
+			},
+			Bus: func() messaging.MessageBus {
+				return new(mockbus.MockBus)
+			},
+			Auth: func() authorization.Authorizer {
+				auth := &mockAuth{
+					attrs: map[authorization.AttributesKey]bool{
+						authorization.AttributesKey{
+							APIGroup:   "core",
+							APIVersion: "v2",
+							Namespace:  "default",
+							Resource:   "events",
+							UserName:   "legit",
+							Verb:       "create",
+						}: true,
+					},
+				}
+				return auth
+			},
+			ExpErr: true,
+		},
+		{
+			Name: "good auth",
+			Ctx: func() context.Context {
+				return contextWithUser(defaultContext(), "legit", nil)
+			},
+			EventStore: func() store.EventStore {
+				store := new(mockstore.MockStore)
+				store.On("GetEventsByEntity", mock.Anything, "ralphie", mock.Anything).Return([]*corev2.Event{defaultEvent}, nil)
+				return store
+			},
+			Bus: func() messaging.MessageBus {
+				return new(mockbus.MockBus)
+			},
+			Auth: func() authorization.Authorizer {
+				auth := &mockAuth{
+					attrs: map[authorization.AttributesKey]bool{
+						authorization.AttributesKey{
+							APIGroup:   "core",
+							APIVersion: "v2",
+							Namespace:  "default",
+							Resource:   "events",
+							UserName:   "legit",
+							Verb:       "list",
+						}: true,
+					},
+				}
+				return auth
+			},
+			Exp: []*corev2.Event{defaultEvent},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			ctx := test.Ctx()
+			eventStore := test.EventStore()
+			auth := test.Auth()
+			bus := test.Bus()
+			client := NewEventClient(eventStore, auth, bus)
+			events, err := client.ListEventsByEntity(ctx, "ralphie", &store.SelectionPredicate{})
+			if err != nil && !test.ExpErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ExpErr {
+				t.Fatal("expected non-nil error")
+			}
+			if got, want := events, test.Exp; !reflect.DeepEqual(got, want) {
+				t.Fatalf("bad events: got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -51,7 +51,7 @@ func (r *entityImpl) Events(p schema.EntityEventsFieldResolverParams) (interface
 	src := p.Source.(*corev2.Entity)
 
 	// fetch
-	results, err := loadEvents(p.Context, src.Namespace)
+	results, err := loadEvents(p.Context, src.Namespace, src.Name)
 	if err != nil {
 		return []interface{}{}, err
 	}
@@ -108,7 +108,7 @@ func (r *entityImpl) Status(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.Entity)
 
 	// fetch
-	results, err := loadEvents(p.Context, src.Namespace)
+	results, err := loadEvents(p.Context, src.Namespace, src.Name)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -52,7 +52,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 	entity.Namespace = "sensu"
 
 	client := new(MockEventClient)
-	client.On("ListEvents", mock.Anything, mock.Anything).Return([]*corev2.Event{
+	client.On("ListEventsByEntity", mock.Anything, entity.Name, mock.Anything).Return([]*corev2.Event{
 		corev2.FixtureEvent(entity.Name, "a"),
 		corev2.FixtureEvent(entity.Name, "b"),
 		corev2.FixtureEvent(entity.Name, "c"),
@@ -73,7 +73,7 @@ func TestEntityTypeStatusField(t *testing.T) {
 	// Add failing event
 	failingEv := corev2.FixtureEvent(entity.Name, "bad")
 	failingEv.Check.Status = 2
-	client.On("ListEvents", mock.Anything, mock.Anything).Return([]*corev2.Event{
+	client.On("ListEventsByEntity", mock.Anything, entity.Name, mock.Anything).Return([]*corev2.Event{
 		corev2.FixtureEvent(entity.Name, "a"),
 		failingEv,
 	}, nil).Once()
@@ -104,7 +104,7 @@ func TestEntityTypeEventsField(t *testing.T) {
 	entity := corev2.FixtureEntity("en")
 
 	client := new(MockEventClient)
-	client.On("ListEvents", mock.Anything, mock.Anything).Return([]*corev2.Event{
+	client.On("ListEventsByEntity", mock.Anything, entity.Name, mock.Anything).Return([]*corev2.Event{
 		corev2.FixtureEvent(entity.Name, "a"),
 		corev2.FixtureEvent(entity.Name, "b"),
 		corev2.FixtureEvent("no-entity", "c"),

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -37,6 +37,7 @@ type EventClient interface {
 	FetchEvent(ctx context.Context, entity, check string) (*corev2.Event, error)
 	DeleteEvent(ctx context.Context, entity, check string) error
 	ListEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error)
+	ListEventsByEntity(ctx context.Context, entity string, pred *store.SelectionPredicate) ([]*corev2.Event, error)
 }
 
 type EventFilterClient interface {

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -162,6 +162,11 @@ func (c *MockEventClient) ListEvents(ctx context.Context, pred *store.SelectionP
 	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
+func (c *MockEventClient) ListEventsByEntity(ctx context.Context, entity string, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	args := c.Called(ctx, entity, pred)
+	return args.Get(0).([]*corev2.Event), args.Error(1)
+}
+
 type MockMutatorClient struct {
 	mock.Mock
 }

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -292,7 +292,7 @@ func (r *namespaceImpl) Events(p schema.NamespaceEventsFieldResolverParams) (int
 	nsp := p.Source.(*corev2.Namespace)
 
 	// fetch
-	results, err := loadEvents(p.Context, nsp.Name)
+	results, err := loadEvents(p.Context, nsp.Name, "")
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
Previously, determining an entity's status or fetching it's relevant events would
require retrieving all events in the entity's namespace. In cluster's with a great
many events this was lead to significantly negative performance impact.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>