### PR TITLE
[GraphQL] Expose registered middleware

### DIFF
--- a/graphql/service.go
+++ b/graphql/service.go
@@ -151,6 +151,11 @@ func (service *Service) Regenerate() error {
 	return err
 }
 
+// Middleware returns all middleware registered with the service.
+func (service *Service) Middleware() []Middleware {
+	return service.mware
+}
+
 // QueryParams describe parameters of a GraphQL query.
 type QueryParams struct {
 	OperationName  string


### PR DESCRIPTION
Expose registered middleware so that upstream implementations may invoke middleware chain. Will contribute to closing issue https://github.com/sensu/sensu-enterprise-go/issues/1294.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>