### PR TITLE
Return the patched resource in storev2.Patch

### DIFF
--- a/backend/store/v2/etcdstore/store.go
+++ b/backend/store/v2/etcdstore/store.go
@@ -167,10 +167,11 @@ func (s *Store) Patch(req storev2.ResourceRequest, w *storev2.Wrapper, patcher p
 	}
 
 	// Re-wrap the resource
-	w, err = wrap.Resource(resource)
+	wrappedPatch, err := wrap.Resource(resource)
 	if err != nil {
 		return &store.ErrEncode{Key: key, Err: err}
 	}
+	*w = *wrappedPatch
 
 	comparisons := []kvc.Predicate{
 		kvc.KeyIsFound(key),


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures we return the patched resource in store v2, by updating the pointer underlying value. Previously we would only return the resource definition before it was patched.

## Why is this change necessary?

Fixes a bug Hillary found while writing the docs.

## Does your change need a Changelog entry?

Nope, unreleased bug.

## Do you need clarification on anything?
Nope

## Were there any complications while making this change?

Nope
## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope
## How did you verify this change?

Manually verified, I'll add a test case in the QA crucible.
## Is this change a patch?

Yep, but for 6.1.0