### PR TITLE
Document web UI separate from backend as of 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ to get started is with the official Docker image, sensu/sensu.
 
 See the [installation documentation](https://docs.sensu.io/sensu-go/latest/installation/install-sensu/) to get started.
 
+**NOTE**: Starting with Sensu Go version 6.0, for instances built from source, the web UI is now a [standalone product](https://github.com/sensu/web) — it is no longer included with the Sensu backend. To build the web UI from source, use the [installation instructions](https://github.com/sensu/web/blob/master/INSTALL.md) in the Sensu Go Web repository.
+
 ### Building from source
 
 The various components of Sensu Go can be manually built from this repository.


### PR DESCRIPTION
## What is this change?

Update the readme to explain that for users who will build from source, the web UI is separate from the backend as of 6.0 and add link to web UI-specific installation instructions.

## Why is this change necessary?

Document separate web UI repo for OSS and point users to web UI installation instructions.

## Does your change need a Changelog entry?

I don't think so. I think this change would have been properly entered on the changelog for 6.0 and this readme update does not need a separate entry.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

This is already documented in the 6.0 release notes as a breaking change.

## How did you verify this change?

I confirmed w/James that we should point users to the web UI-specific instructions.

## Is this change a patch?

No