### PR TITLE
[GraphQL] Fix entity suggestions

### DIFF
--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -116,7 +116,15 @@ func (r *queryImpl) Suggest(p schema.QuerySuggestFieldResolverParams) (interface
 
 	ctx := store.NamespaceContext(p.Context, p.Args.Namespace)
 
-	err = client.List(ctx, objs.Interface(), &store.SelectionPredicate{})
+	// CRUFT: entities can no longer be retrieved through the generic API
+	// interface, to work around this we use the entity client.
+	var entities []*corev2.Entity
+	if res.Group == "core/v2" && res.Name == "entity" {
+		entities, err = r.svc.EntityClient.ListEntities(ctx)
+		objs.Elem().Set(reflect.ValueOf(entities))
+	} else {
+		err = client.List(ctx, objs.Interface(), &store.SelectionPredicate{})
+	}
 	if handleListErr(err) != nil {
 		return results, err
 	}


### PR DESCRIPTION
The suggestion service is reliant on the `backend/api` package's `GenericClient` which is no longer able to retrieve `core/v2` entities. This patch works adds a workaround to the service, allowing it to use the `EntityClient` directly.

```graphql
query MyAutoSuggestQuery {
  # Find suggestions for entity name's that include dc-01
  suggest(
    ref: "core/v2/entity/metadata/name"
    namespace: "sensu-devel"
    order: ALPHA_DESC
    q: "dc01-"
  ) {
    __typename
    values
  }
}

```

Fixes sensu/sensu-enterprise-go#1191

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>