### PR TITLE
[backend/api] fill created_by field

### DIFF
--- a/backend/api/check.go
+++ b/backend/api/check.go
@@ -34,6 +34,7 @@ func (c *CheckClient) CreateCheck(ctx context.Context, check *corev2.CheckConfig
 	if err := authorize(ctx, c.auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, check)
 	return c.store.UpdateCheckConfig(ctx, check)
 }
 
@@ -43,6 +44,7 @@ func (c *CheckClient) UpdateCheck(ctx context.Context, check *corev2.CheckConfig
 	if err := authorize(ctx, c.auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, check)
 	return c.store.UpdateCheckConfig(ctx, check)
 }
 

--- a/backend/api/entity.go
+++ b/backend/api/entity.go
@@ -74,6 +74,7 @@ func (e *EntityClient) CreateEntity(ctx context.Context, entity *corev2.Entity) 
 	if err := authorize(ctx, e.auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, entity)
 	if err := e.entityStore.UpdateEntity(ctx, entity); err != nil {
 		return err
 	}
@@ -86,6 +87,7 @@ func (e *EntityClient) UpdateEntity(ctx context.Context, entity *corev2.Entity) 
 	if err := authorize(ctx, e.auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, entity)
 
 	// We have 2 code paths here: one for proxy entities and another for all
 	// other types of entities. We had to make that distinction because Entity

--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
@@ -40,6 +41,11 @@ func (e *EventClient) UpdateEvent(ctx context.Context, event *corev2.Event) erro
 	attrs := eventUpdateAttributes(ctx)
 	if err := authorize(ctx, e.auth, attrs); err != nil {
 		return err
+	}
+	if claims := jwt.GetClaimsFromContext(ctx); claims != nil {
+		event.CreatedBy = claims.StandardClaims.Subject
+		event.Check.CreatedBy = claims.StandardClaims.Subject
+		event.Entity.CreatedBy = claims.StandardClaims.Subject
 	}
 	// Update the event through eventd
 	return e.bus.Publish(messaging.TopicEventRaw, event)

--- a/backend/api/generic.go
+++ b/backend/api/generic.go
@@ -56,6 +56,7 @@ func (g *GenericClient) Create(ctx context.Context, value corev2.Resource) error
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, value)
 	return g.Store.CreateResource(ctx, value)
 }
 
@@ -95,6 +96,7 @@ func (g *GenericClient) Update(ctx context.Context, value corev2.Resource) error
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, value)
 	return g.Store.CreateOrUpdateResource(ctx, value)
 }
 

--- a/backend/api/meta.go
+++ b/backend/api/meta.go
@@ -8,10 +8,10 @@ import (
 )
 
 // Fills given resource's created-by field using given authorization details.
-func setCreatedBy(ctx context.Context, res corev2.Resource) {
-	meta := res.GetObjectMeta()
+func setCreatedBy(ctx context.Context, resource corev2.Resource) {
+	meta := resource.GetObjectMeta()
 	if claims := jwt.GetClaimsFromContext(ctx); claims != nil {
 		meta.CreatedBy = claims.StandardClaims.Subject
-		res.SetObjectMeta(meta)
+		resource.SetObjectMeta(meta)
 	}
 }

--- a/backend/api/meta.go
+++ b/backend/api/meta.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"context"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
+)
+
+// Fills given resource's created-by field using given authorization details.
+func setCreatedBy(ctx context.Context, res corev2.Resource) {
+	meta := res.GetObjectMeta()
+	if claims := jwt.GetClaimsFromContext(ctx); claims != nil {
+		meta.CreatedBy = claims.StandardClaims.Subject
+		res.SetObjectMeta(meta)
+	}
+}

--- a/backend/api/namespace_test.go
+++ b/backend/api/namespace_test.go
@@ -835,6 +835,7 @@ func TestNamespaceCRUDSideEffects(t *testing.T) {
 		ObjectMeta: corev2.ObjectMeta{
 			Namespace: "test_namespace",
 			Name:      pipelineRoleName,
+			CreatedBy: "cluster-admin",
 		},
 		Rules: []corev2.Rule{
 			{
@@ -857,6 +858,7 @@ func TestNamespaceCRUDSideEffects(t *testing.T) {
 		ObjectMeta: corev2.ObjectMeta{
 			Name:      pipelineRoleName,
 			Namespace: "test_namespace",
+			CreatedBy: "cluster-admin",
 		},
 	}
 	s.AssertNumberOfCalls(t, "CreateResource", 1)

--- a/backend/api/silenced.go
+++ b/backend/api/silenced.go
@@ -33,6 +33,7 @@ func (s *SilencedClient) UpdateSilenced(ctx context.Context, silenced *corev2.Si
 	if err := authorize(ctx, s.auth, attrs); err != nil {
 		return err
 	}
+	setCreatedBy(ctx, silenced)
 	if err := s.store.UpdateSilencedEntry(ctx, silenced); err != nil {
 		return fmt.Errorf("couldn't update silenced entry: %s", err)
 	}


### PR DESCRIPTION
Updates the `backend/api` package so that the `ObjectMeta`'s `CreatedBy` field is filled on create & update. 

Fixes sensu/sensu-enterprise-go#1318.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>