### PR TITLE
Don't wait for graceful termination on agent halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where sensu-agent would not shut down correctly.
+
 ## [6.1] - 2020-10-05
 
 ### Added


### PR DESCRIPTION
## What is this change?

This commit adds a timeout to agent termination so that graceful
shutdown can't block indefinitely. It seems there is a bug in
sensu-agent that will cause an infinite loop between the backend and
agent to occur.

This only papers over the real problem, but it will at least improve the
situation somewhat until the larger issue can be addressed.

## Why is this change necessary?

Fixes #4036 

## Does your change need a Changelog entry?

Included

## Were there any complications while making this change?

The sensu-agent codebase has become a bit spaghettified. I couldn't easily fix the underlying issue.

## How did you verify this change?

To reproduce the original issue, simply start up a backend with two agents and terminate the second one. It will enter an infinite loop.

After applying the patch, the second agent will exit after 1 second, with a warning.

## Is this change a patch?

Yes