### PR TITLE
Add sensuctl completion instruction for Ubuntu and add new line at the end

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -22,6 +22,22 @@ if [ -f $(brew --prefix)/etc/bash_completion ]; then
 fi
 ```
 
+On Ubuntu, install with:
+
+```sh
+apt update && apt install bash-completion
+```
+
+Then add the following to your `~/.bash_profile`:
+
+```bash
+if [ -f /usr/share/bash-completion/bash_completion ]; then
+. /usr/share/bash-completion/bash_completion
+elif [ -f /etc/bash_completion ]; then
+. /etc/bash_completion
+fi
+```
+
 When bash-completion is available we can add the following to your `~/.bash_profile`:
 
 ```bash

--- a/cli/commands/completion/bash.go
+++ b/cli/commands/completion/bash.go
@@ -17,6 +17,16 @@ if [ -f $(brew --prefix)/etc/bash_completion ]; then
 . $(brew --prefix)/etc/bash_completion
 fi
 
+# On Ubuntu, install with:
+apt update && apt install bash-completion
+
+# Then add the following to your ~/.bash_profile
+if [ -f /usr/share/bash-completion/bash_completion ]; then
+. /usr/share/bash-completion/bash_completion
+elif [ -f /etc/bash_completion ]; then
+. /etc/bash_completion
+fi
+
 # After bash-completions are available add the following to your ~/.bash_profile
 source <(` + cli.SensuCmdName + ` completion bash)
 

--- a/cli/commands/completion/cmd.go
+++ b/cli/commands/completion/cmd.go
@@ -75,7 +75,7 @@ func (e *completionExecutor) runHelp(cmd *cobra.Command, args []string) {
 	stdErr := cmd.OutOrStderr()
 
 	if shell, err := extractShell(args, 1); err != nil {
-		fmt.Fprintf(stdErr, "%s\n\n%s", err, longUsage)
+		fmt.Fprintf(stdErr, "%s\n\n%s\n", err, longUsage)
 	} else if shell == zshShell {
 		fmt.Fprintln(stdErr, zshUsage)
 	} else if shell == bashShell {


### PR DESCRIPTION
## What is this change?

This PR adds instructions to use bash-completion on Ubuntu and adds a newline at the end of the instruction.


## Why is this change necessary?

Fixes #2478 

## Does your change need a Changelog entry?

No, my change doesn't change the behavior of sensuctl

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes, as described by the original issue I changed the file `cli/README.md`

## How did you verify this change?

To verify the newline issue, I executed `sensuctl completion -h`. To verify the lack of instruction for linux, I executed `sensuctl completion bash -h`

## Is this change a patch?

No