### PR TITLE
Persist the per-entity subscription in PATCH requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed a bug where sensu-agent would not shut down correctly.
+- The per-entity subscription now persists with PATCH requests.
 
 ## [6.1] - 2020-10-05
 

--- a/backend/store/v2/etcdstore/store.go
+++ b/backend/store/v2/etcdstore/store.go
@@ -166,6 +166,12 @@ func (s *Store) Patch(req storev2.ResourceRequest, w *storev2.Wrapper, patcher p
 		return err
 	}
 
+	// Special case for entities; we need to make sure we keep the per-entity
+	// subscription
+	if e, ok := resource.(*corev3.EntityConfig); ok {
+		e.Subscriptions = corev2.AddEntitySubscription(e.Metadata.Name, e.Subscriptions)
+	}
+
 	// Re-wrap the resource
 	wrappedPatch, err := wrap.Resource(resource)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures the per-entity subscription cannot be removed when updating the subscriptions via a PATCH request.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/4032

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested. I'll add a test case in our QA crucible and link it here.

Update: https://github.com/sensu/sensu-go-qa-crucible/pull/155

## Is this change a patch?
Yep