### PR TITLE
Backport js vm fixes from 6.x to 5.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Close the response body when done reading from it while downloading assets.
+- Fixed a bug where event filter or asset filter execution could cause a crash.
 
 ## [5.21.2] - 2020-08-31
 


### PR DESCRIPTION
## What is this change?

Fixes #4049 

I couldn't preserve the original commit as it was based on newer code. So instead, I simply copied the JS code from 6.0, and this is the result. The 6.0 `js` package changes perserved interfaces, so things should just work.