### PR TITLE
Added password confirmation for interactive commands (#3848)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Added
+- Sensuctl and sensu-backend ask for password retype when a new password is
+created when in interactive mode.
 - Build info is now exposed as a prometheus metric via the /metrics endpoint.
 
 ### Fixed

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,8 +34,9 @@ type seedConfig struct {
 }
 
 type initOpts struct {
-	AdminUsername string `survey:"cluster-admin-username"`
-	AdminPassword string `survey:"cluster-admin-password"`
+	AdminUsername             string `survey:"cluster-admin-username"`
+	AdminPassword             string `survey:"cluster-admin-password"`
+	AdminPasswordConfirmation string `survey:"cluster-admin-password-confirmation"`
 }
 
 func (i *initOpts) administerQuestionnaire() error {
@@ -50,6 +52,13 @@ func (i *initOpts) administerQuestionnaire() error {
 			Name: "cluster-admin-password",
 			Prompt: &survey.Password{
 				Message: "Cluster Admin Password:",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "cluster-admin-password-confirmation",
+			Prompt: &survey.Password{
+				Message: "Retype Cluster Admin Password:",
 			},
 			Validate: survey.Required,
 		},
@@ -137,6 +146,9 @@ func InitCommand() *cobra.Command {
 				var opts initOpts
 				if err := opts.administerQuestionnaire(); err != nil {
 					return err
+				}
+				if opts.AdminPassword != opts.AdminPasswordConfirmation {
+					return errors.New("Password confirmation doesn't match the password")
 				}
 				uname = opts.AdminUsername
 				pword = opts.AdminPassword

--- a/cli/commands/user/create.go
+++ b/cli/commands/user/create.go
@@ -14,9 +14,10 @@ import (
 )
 
 type createOpts struct {
-	Username string `survey:"username"`
-	Password string `survey:"password"`
-	Groups   string `survey:"group"`
+	Username             string `survey:"username"`
+	Password             string `survey:"password"`
+	PasswordConfirmation string `survey:"passwordConfirmation"`
+	Groups               string `survey:"group"`
 }
 
 // CreateCommand adds command that allows user to create new users
@@ -53,6 +54,9 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 				opts.withFlags(cmd.Flags())
 			}
 
+			if isInteractive && opts.Password != opts.PasswordConfirmation {
+				return errors.New("Password confirmation doesn't match the password")
+			}
 			user := opts.toUser()
 			if err := user.Validate(); err != nil {
 				if !isInteractive {
@@ -97,6 +101,13 @@ func (opts *createOpts) administerQuestionnaire() error {
 			Name: "password",
 			Prompt: &survey.Password{
 				Message: "Password:",
+			},
+			Validate: survey.Required,
+		},
+		{
+			Name: "passwordConfirmation",
+			Prompt: &survey.Password{
+				Message: "Retype password:",
 			},
 			Validate: survey.Required,
 		},


### PR DESCRIPTION
## What is this change?

This change added a password confirmation for sensuctl and sensu-backend when a password creation is requested in interactive mode.

## Why is this change necessary?

This change implements the feature request #3848 

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

I'm not sure about the messages the commands should display, but for now i did the following:

Success cases:

```bash
./bin/sensuctl user create --interactive
? Username: ausername
? Password: ****
? Retype password: ****
? Groups:

./bin/sensu-backend init --interactive
? Cluster Admin Username: admin
? Cluster Admin Password: ********
? Retype Cluster Admin Password: ********
```

Unsuccessful cases:

```bash
./bin/sensuctl user create --interactive
? Username: ausername
? Password: *****
? Retype password: *****
? Groups: 
Error: Password confirmation doesn't match the password

./bin/sensu-backend init --interactive
? Cluster Admin Username: admin
? Cluster Admin Password: *****
? Retype Cluster Admin Password: *****
{"component":"backend","error":"password confirmation didn't match","level":"fatal","msg":"error executing sensu-backend","time":"2020-10-14T23:21:42-03:00"}
```

## Were there any complications while making this change?

I couldn't find examples of tests with interactive commands so I tried to use [go-expect](https://github.com/Netflix/go-expect) but without success. I dint go further, but I think the problem may be related to trying to write in a closed stdin in `github.com/!alec!aivazis/survey@v1.4.1/input.go`

```golang
	// start reading runes from the standard in
	rr := terminal.NewRuneReader(os.Stdin)
	rr.SetTermMode()
	defer rr.RestoreTermMode()
```

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No

## How did you verify this change?

First I ran `./buid.sh` to ensure no test was breaking. After that, I built both sensuctl and sensu-backend and tried to run cases where the password and the confirmation matched and cases where didn't match as follows:

Success cases:

```bash
./bin/sensuctl user create --interactive
? Username: ausername
? Password: ****
? Retype password: ****
? Groups:

./bin/sensu-backend init --interactive
? Cluster Admin Username: admin
? Cluster Admin Password: ********
? Retype Cluster Admin Password: ********
```

Unsuccessful cases:

```bash
./bin/sensuctl user create --interactive
? Username: ausername
? Password: *****
? Retype password: *****
? Groups: 
Error: Password confirmation doesn't match the password

./bin/sensu-backend init --interactive
? Cluster Admin Username: admin
? Cluster Admin Password: *****
? Retype Cluster Admin Password: *****
{"component":"backend","error":"password confirmation didn't match","level":"fatal","msg":"error executing sensu-backend","time":"2020-10-14T23:21:42-03:00"}
```

## Is this change a patch?

No
