### PR TITLE
Bugfixes for sensuctl dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed a bug where sensu-agent would not shut down correctly.
 - The per-entity subscription now persists with PATCH requests.
+- Allow HookConfig to be exported via `sensuctl dump`.
+- Properly log any API error in `sensuctl dump`.
 
 ## [6.1] - 2020-10-05
 

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -169,14 +169,13 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			if err != nil {
 				// We want to ignore non-nil errors that are a result of
 				// resources not existing, or features being licensed.
-				err, ok := err.(client.APIError)
-				if !ok {
-					return fmt.Errorf("API error: %s", err)
+				if err, ok := err.(client.APIError); ok {
+					switch actions.ErrCode(err.Code) {
+					case actions.PaymentRequired, actions.NotFound, actions.PermissionDenied:
+						continue
+					}
 				}
-				switch actions.ErrCode(err.Code) {
-				case actions.PaymentRequired, actions.NotFound, actions.PermissionDenied:
-					continue
-				}
+
 				return fmt.Errorf("API error: %s", err)
 			}
 

--- a/cli/resource/resolve.go
+++ b/cli/resource/resolve.go
@@ -25,7 +25,7 @@ var (
 		&corev2.Event{},
 		&corev2.EventFilter{},
 		&corev2.Handler{},
-		&corev2.Hook{},
+		&corev2.HookConfig{},
 		&corev2.Mutator{},
 		&corev2.Role{},
 		&corev2.RoleBinding{},


### PR DESCRIPTION
## What is this change?

It fixes a couple of bugs in `sensuctl dump`. First, it ensures API errors are properly logged. It also fix the type used for hooks so they can also be exported.

## Why is this change necessary?

Fixes some bugs found while writing E2E tests for `sensuctl prune`.

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified. I'll add some coverage in the PR for our QA crucible I was working on.

## Is this change a patch?

Yep
