### PR TITLE
Add more logging context to eventd errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - The per-entity subscription now persists with PATCH requests.
 - Allow HookConfig to be exported via `sensuctl dump`.
 - Properly log any API error in `sensuctl dump`.
+- eventd errors now include additional context for debugging.
 
 ## [6.1] - 2020-10-05
 


### PR DESCRIPTION
## What is this change?

Ad-hoc improvement to eventd logging for store errors.

## Why is this change necessary?

We have a customer experiencing errors from postgres, but we aren't sure which events are causing it.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

I've only relied on automated tests but I'm feeling lucky!

## Is this change a patch?

Yep.