### PR TITLE
The update verb now authorizes PATCH requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - The per-entity subscription now persists with PATCH requests.
 - Allow HookConfig to be exported via `sensuctl dump`.
 - Properly log any API error in `sensuctl dump`.
+- An RBAC rule with the `update` permission now properly authorizes PATCH
+requests.
 
 ## [6.1] - 2020-10-05
 

--- a/backend/apid/middlewares/authorization_attributes.go
+++ b/backend/apid/middlewares/authorization_attributes.go
@@ -37,13 +37,13 @@ func (a AuthorizationAttributes) Then(next http.Handler) http.Handler {
 		defer next.ServeHTTP(w, r.WithContext(ctx))
 
 		switch r.Method {
-		case "POST":
+		case http.MethodPost:
 			attrs.Verb = "create"
-		case "GET", "HEAD":
+		case http.MethodGet, http.MethodHead:
 			attrs.Verb = "get"
-		case "PUT":
+		case http.MethodPatch, http.MethodPut:
 			attrs.Verb = "update"
-		case "DELETE":
+		case http.MethodDelete:
 			attrs.Verb = "delete"
 		default:
 			attrs.Verb = ""


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

:shamecube:

## Why is this change necessary?

It fixes https://github.com/sensu/sensu-go/issues/4058

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Added unit test + manual e2e

## Is this change a patch?

Yep
