### PR TITLE
Fix entity creation via sensuctl create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - An RBAC rule with the `update` permission now properly authorizes PATCH
 requests.
 - eventd errors now include additional context for debugging.
+- Entities are now properly created using `sensuctl create`.
 
 ## [6.1] - 2020-10-05
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes entity creation when done via `sensuctl create`; only the entity_config key would be created, which would prevent entities from being queried.

Now we first try to create an entity when we have an agent entity, and if it already exists then we update the entity config.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/4062

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope, bug fix

## How did you verify this change?

Unit test + manual testing, also ran the QA crucible tests to make sure it didn't break anything.

## Is this change a patch?

Yep
