### PR TITLE
Fix a bug introduced by #4034

### DIFF
--- a/backend/apid/actions/silenced.go
+++ b/backend/apid/actions/silenced.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
@@ -88,4 +89,15 @@ func (c SilencedController) CreateOrReplace(ctx context.Context, entry *corev2.S
 	}
 
 	return nil
+}
+
+func (c SilencedController) Get(ctx context.Context, name string) (*corev2.Silenced, error) {
+	entry, err := c.Store.GetSilencedEntryByName(ctx, name)
+	if err != nil {
+		return nil, NewError(InternalErr, err)
+	}
+	if entry == nil {
+		return nil, NewError(NotFound, errors.New("silenced entry not found"))
+	}
+	return entry, nil
 }


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in the silenced HTTP API where expired silenced
entries can appear, even though they should not.

## Why is this change necessary?

Fixes an issue introduced in #4034.

## Does your change need a Changelog entry?

No, at the time of this PR the bug has not been released.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not required.

## How did you verify this change?

I created a silenced entry and queried it. The regression is no longer present.

## Is this change a patch?

Nein