### PR TITLE
Fix race condition in the JS VM cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a crash in the backend and agent related to Javascript execution.
+
 ## [6.1.1] - 2020-10-22
 
 ### Fixed

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -1,0 +1,23 @@
+package js
+
+import (
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types/dynamic"
+)
+
+// This is a unit test to cover the race condition found in
+// https://github.com/sensu/sensu-go/issues/4073
+func TestEvaluateRaceCondition(t *testing.T) {
+	entity := corev2.FixtureEntity("foo")
+	synth := dynamic.Synthesize(entity)
+	params := map[string]interface{}{"entity": synth}
+
+	go func() {
+		_, _ = Evaluate("true", params, nil)
+	}()
+	go func() {
+		_, _ = Evaluate("true", params, nil)
+	}()
+}

--- a/js/vm_cache.go
+++ b/js/vm_cache.go
@@ -97,5 +97,8 @@ func (c *vmCache) Dispose(key string) {
 // Init initializes the value in the cache.
 func (c *vmCache) Init(key string, vm *otto.Otto) {
 	val := &cacheValue{lastRead: time.Now().Unix(), vm: vm}
-	c.vms.Store(key, val)
+	// Do not replace the cache value if it already exists, since it's possible it
+	// was created after we determined it was missing, otherwise we might try to
+	// unlock the same mutex twice and therefore create a fatal error
+	_, _ = c.vms.LoadOrStore(key, val)
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes a race condition in the JS VM cache.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/4073

## Does your change need a Changelog entry?

Nope

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

I've added the unit test before applying the patch, which created a fatal error 100% of the time.

## Is this change a patch?

Yep
