### PR TITLE
Add health endpoint to backend websocket API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Sensuctl and sensu-backend ask for password retype when a new password is
 created when in interactive mode.
 - Build info is now exposed as a prometheus metric via the /metrics endpoint.
+- Added `/health` endpoint to agentd.
+
 ## [6.1.1] - 2020-10-22
 
 ### Fixed

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -318,17 +318,26 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	// Start the entity config watcher, so agentd sessions are notified of updates
 	entityConfigWatcher := agentd.GetEntityConfigWatcher(b.ctx, b.Client)
 
+	// Prepare the etcd client TLS config
+	etcdClientTLSInfo := (transport.TLSInfo)(config.EtcdClientTLSInfo)
+	etcdClientTLSConfig, err := etcdClientTLSInfo.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	b.EtcdClientTLSConfig = etcdClientTLSConfig
+
 	// Initialize agentd
 	agent, err := agentd.New(agentd.Config{
-		Host:         config.AgentHost,
-		Port:         config.AgentPort,
-		Bus:          bus,
-		Store:        stor,
-		TLS:          config.AgentTLSOptions,
-		RingPool:     ringPool,
-		WriteTimeout: config.AgentWriteTimeout,
-		Client:       b.Client,
-		Watcher:      entityConfigWatcher,
+		Host:                config.AgentHost,
+		Port:                config.AgentPort,
+		Bus:                 bus,
+		Store:               stor,
+		TLS:                 config.AgentTLSOptions,
+		RingPool:            ringPool,
+		WriteTimeout:        config.AgentWriteTimeout,
+		Client:              b.Client,
+		Watcher:             entityConfigWatcher,
+		EtcdClientTLSConfig: b.EtcdClientTLSConfig,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", agent.Name(), err)
@@ -352,14 +361,6 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)
 	}
 	b.Daemons = append(b.Daemons, keepalive)
-
-	// Prepare the etcd client TLS config
-	etcdClientTLSInfo := (transport.TLSInfo)(config.EtcdClientTLSInfo)
-	etcdClientTLSConfig, err := etcdClientTLSInfo.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	b.EtcdClientTLSConfig = etcdClientTLSConfig
 
 	// Prepare the authentication providers
 	authenticator := &authentication.Authenticator{}


### PR DESCRIPTION
## What is this change?

Adds an unauthenticated `/health` endpoint to the backend websocket API.

## Why is this change necessary?

See #2773 

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

I initially misunderstood how the actions controller for health worked.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes, new documentation is required.

## How did you verify this change?

I wrote a test to ensure that the `/health` endpoint on the agentd websocket port returns a 200 status.

## Is this change a patch?

No.
