### PR TITLE
Use auth for pulling all docker images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ sensu_go_build_env: &sensu_go_build_env
   docker:
     - image: cimg/go:1.13.15
       auth:
-          username: $DOCKER_USERNAME
-          password: $DOCKER_PASSWORD
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ orbs:
 sensu_go_build_env: &sensu_go_build_env
   docker:
     - image: cimg/go:1.13.15
+      auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
 
 jobs:
   test:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds authentication to Docker Hub for image pulls in CircleCI.

## Why is this change necessary?

Docker image pulls will be limited for unauthenticated users starting next Monday.

Fixes https://github.com/sensu/sensu-enterprise-go/issues/1319.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

As per CircleCI's guide, if the tests pass, after adding the auth key, it's working.

## Is this change a patch?

No but I will cherry-pick / make the appropriate changes to the other release branches afterwards.