### PR TITLE
Support env vars for config file of agent & backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 created when in interactive mode.
 - Build info is now exposed as a prometheus metric via the /metrics endpoint.
 - Added `/health` endpoint to agentd.
+- Add support for environment variables to define configuration file paths of
+sensu-backend (`SENSU_BACKEND_CONFIG_FILE`) & sensu-agent (`SENSU_CONFIG_FILE`).
 
 ### Changed
 - Adjust the date and duration formats used when listing and displaying silenced

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -30,6 +30,8 @@ const (
 	// specified in backend urls
 	DefaultBackendPort = "8081"
 
+	environmentPrefix = "sensu"
+
 	flagAgentName                = "name"
 	flagAPIHost                  = "api-host"
 	flagAPIPort                  = "api-port"
@@ -225,12 +227,20 @@ func handleConfig(cmd *cobra.Command) error {
 	configFlagSet.SetOutput(ioutil.Discard)
 	_ = configFlagSet.Parse(os.Args[1:])
 
-	// Get the given config file path
-	configFile, _ := configFlagSet.GetString(flagConfigFile)
-	configFilePath := configFile
+	// Get the given config file path via flag
+	configFilePath, _ := configFlagSet.GetString(flagConfigFile)
 
-	// use the default config path if flagConfigFile was not used
-	if configFile == "" {
+	// Get the environment variable value if no config file was provided via the flag
+	if configFilePath == "" {
+		environmentConfigFile := fmt.Sprintf("%s_%s", environmentPrefix, flagConfigFile)
+		environmentConfigFile = strings.ToUpper(environmentConfigFile)
+		environmentConfigFile = strings.Replace(environmentConfigFile, "-", "_", -1)
+		configFilePath = os.Getenv(environmentConfigFile)
+	}
+
+	// Use the default config path as a fallback if no config file was provided
+	// via the flag or the environment variable
+	if configFilePath == "" {
 		configFilePath = filepath.Join(path.SystemConfigDir(), "agent.yml")
 	}
 
@@ -326,11 +336,11 @@ func handleConfig(cmd *cobra.Command) error {
 
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc(logger))
 
-	if err := viper.ReadInConfig(); err != nil && configFile != "" {
+	if err := viper.ReadInConfig(); err != nil && configFilePath != "" {
 		return err
 	}
 
-	viper.SetEnvPrefix("sensu")
+	viper.SetEnvPrefix(environmentPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -37,6 +37,8 @@ var (
 )
 
 const (
+	environmentPrefix = "sensu_backend"
+
 	// Flag constants
 	flagConfigFile            = "config-file"
 	flagAgentHost             = "agent-host"
@@ -305,12 +307,20 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 	configFlagSet.SetOutput(ioutil.Discard)
 	_ = configFlagSet.Parse(os.Args[1:])
 
-	// Get the given config file path
-	configFile, _ := configFlagSet.GetString(flagConfigFile)
-	configFilePath := configFile
+	// Get the given config file path via flag
+	configFilePath, _ := configFlagSet.GetString(flagConfigFile)
 
-	// use the default config path if flagConfigFile was used
-	if configFile == "" {
+	// Get the environment variable value if no config file was provided via the flag
+	if configFilePath == "" {
+		environmentConfigFile := fmt.Sprintf("%s_%s", environmentPrefix, flagConfigFile)
+		environmentConfigFile = strings.ToUpper(environmentConfigFile)
+		environmentConfigFile = strings.Replace(environmentConfigFile, "-", "_", -1)
+		configFilePath = os.Getenv(environmentConfigFile)
+	}
+
+	// Use the default config path as a fallback if no config file was provided
+	// via the flag or the environment variable
+	if configFilePath == "" {
 		configFilePath = configFileDefaultLocation
 	}
 
@@ -478,11 +488,11 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 	_ = cmd.Flags().SetAnnotation(flagEtcdClientURLs, "categories", []string{"store"})
 
 	// Load the configuration file but only error out if flagConfigFile is used
-	if err := viper.ReadInConfig(); err != nil && configFile != "" {
+	if err := viper.ReadInConfig(); err != nil && configFilePath != "" {
 		return err
 	}
 
-	viper.SetEnvPrefix("sensu_backend")
+	viper.SetEnvPrefix(environmentPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It adds support for the `SENSU_BACKEND_CONFIG_FILE` & `SENSU_CONFIG_FILE` environment variables to define the config file path for sensu-backend & sensu-agent respectively. 


## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/4069

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified; due to the nature of viper, it's impossible to inspect which configuration file was loaded, because it does not get exported by the package.

## Is this change a patch?

Nope