### PR TITLE
Mock out time with timeproxy to fix flaky test

### DIFF
--- a/agent/transformers/prometheus.go
+++ b/agent/transformers/prometheus.go
@@ -3,7 +3,8 @@ package transformers
 import (
 	"math"
 	"strings"
-	"time"
+
+	time "github.com/echlebek/timeproxy"
 
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"

--- a/agent/transformers/prometheus_test.go
+++ b/agent/transformers/prometheus_test.go
@@ -3,7 +3,8 @@ package transformers
 import (
 	"math"
 	"testing"
-	"time"
+
+	time "github.com/echlebek/timeproxy"
 
 	"github.com/prometheus/common/model"
 	"github.com/sensu/sensu-go/types"

--- a/agent/transformers/timeproxy_test.go
+++ b/agent/transformers/timeproxy_test.go
@@ -1,0 +1,18 @@
+package transformers
+
+import (
+	"github.com/echlebek/crock"
+	time "github.com/echlebek/timeproxy"
+)
+
+var mockTime = crock.NewTime(time.Unix(1257894000, 0))
+
+func init() {
+	// Resolution and Multiplier make the mock time advance every `Resolution`
+	// by `Resolution * Multiplier`. That is, for the values defined here:
+	// advance the mock time by 500ms every 10ms of real time, giving us a
+	// precision of about 500ms for the mock time.
+	mockTime.Resolution = 10 * time.Millisecond
+	mockTime.Multiplier = 50
+	time.TimeProxy = mockTime
+}


### PR DESCRIPTION
## What is this change?

This commit mocks out the time package in the prometheus transformer in
order to avoid a flaky test failure.

## Why is this change necessary?

The test failed in CI with no provocation.

## Does your change need a Changelog entry?

No, this is not a user-facing change.

## How did you verify this change?

We've used timeproxy successfully in several areas of the codebase, so I'm confident this won't cause any issues.

## Is this change a patch?

Yes, but it only affects developers so I've targeted main.