### PR TITLE
[GraphQL] Sort using check state, instead of status

### DIFF
--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -213,7 +213,7 @@ func EventsByTimestamp(es []*Event, asc bool) sort.Interface {
 // last received an OK status.
 func EventsByLastOk(es []*Event) sort.Interface {
 	return &eventSorter{es, createCmpEvents(
-		cmpByIncident,
+		cmpByState,
 		cmpByLastOk,
 		cmpByUniqueComponents,
 	)}
@@ -254,10 +254,16 @@ func cmpBySeverity(a, b *Event) int {
 	return -1
 }
 
-func cmpByIncident(a, b *Event) int {
-	av, bv := a.IsIncident(), b.IsIncident()
+func cmpByState(a, b *Event) int {
+	var av, bv bool
+	if a.Check != nil {
+		av = a.Check.State != EventPassingState
+	}
+	if b.Check != nil {
+		bv = b.Check.State != EventPassingState
+	}
 
-	// Rank higher if incident
+	// Rank higher if failing/flapping
 	if av == bv {
 		return 0
 	} else if av {

--- a/api/core/v2/event_test.go
+++ b/api/core/v2/event_test.go
@@ -461,19 +461,19 @@ func TestEventsBySeverity(t *testing.T) {
 
 func TestEventsByLastOk(t *testing.T) {
 	incident := FixtureEvent("zeta", "check")
-	incident.Check.Status = 2 // crit
+	incident.Check.State = EventFailingState
 	incidentNewer := FixtureEvent("zeta", "check")
-	incidentNewer.Check.Status = 2 // crit
+	incidentNewer.Check.State = EventFlappingState
 	incidentNewer.Check.LastOK = 1
 	ok := FixtureEvent("zeta", "check")
-	ok.Check.Status = 0 // ok
+	ok.Check.State = EventPassingState
 	okNewer := FixtureEvent("zeta", "check")
-	okNewer.Check.Status = 0 // ok
+	okNewer.Check.State = EventPassingState
 	okNewer.Check.LastOK = 1
 	okDiffEntity := FixtureEvent("abba", "check")
-	okDiffEntity.Check.Status = 0 // ok
+	okDiffEntity.Check.State = EventPassingState
 	okDiffCheck := FixtureEvent("abba", "0bba")
-	okDiffCheck.Check.Status = 0 // ok
+	okDiffCheck.Check.State = EventPassingState
 
 	testCases := []struct {
 		name     string
@@ -481,17 +481,17 @@ func TestEventsByLastOk(t *testing.T) {
 		expected []*Event
 	}{
 		{
-			name:     "Sorts by lastOK",
+			name:     "sort by lastOK",
 			input:    []*Event{ok, okNewer, incidentNewer, incident},
 			expected: []*Event{incidentNewer, incident, okNewer, ok},
 		},
 		{
-			name:     "incidents are sorted to the top",
+			name:     "non-passing are sorted to the top",
 			input:    []*Event{okNewer, incidentNewer, ok, incident},
 			expected: []*Event{incidentNewer, incident, okNewer, ok},
 		},
 		{
-			name:     "Fallback to entity & check name when severity is same",
+			name:     "fallback to entity & check name when severity is same",
 			input:    []*Event{ok, okNewer, okDiffCheck, okDiffEntity},
 			expected: []*Event{okNewer, okDiffCheck, okDiffEntity, ok},
 		},


### PR DESCRIPTION
When sorting events by the value of their `last ok` property, use the event's state instead of status. In this way events that are in the flapping state but currently have a status of zero are not "shifting" between the top and bottom of the list.

Closes https://github.com/sensu/sensu-enterprise-go/issues/1218

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
