### PR TITLE
Bugfix/entity store panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### [6.1.2] - 2020-10-28
+### Fixed
+- Fixed a bug where the entity API could panic.
+
+### [6.1.2, 6.1.3] - 2020-10-28
 
 ### Fixed
 - Fixed a crash in the backend and agent related to Javascript execution.

--- a/backend/store/etcd/entity_store.go
+++ b/backend/store/etcd/entity_store.go
@@ -237,7 +237,7 @@ func entitiesFromConfigAndState(configs []corev3.EntityConfig, states []corev3.E
 	result := make([]*corev2.Entity, 0, len(states))
 	var i, j int
 	for i < len(states) && j < len(configs) {
-		switch states[i].Metadata.Cmp(configs[i].Metadata) {
+		switch states[i].Metadata.Cmp(configs[j].Metadata) {
 		case corev2.MetaLess:
 			// there is a state without a corresponding config
 			i++

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -83,3 +83,18 @@ func TestEntityIteration(t *testing.T) {
 		}
 	}
 }
+
+func TestEntityIterationNoPanicMismatched(t *testing.T) {
+	configs := []corev3.EntityConfig{
+		*corev3.FixtureEntityConfig("b"),
+		*corev3.FixtureEntityConfig("c"),
+	}
+	states := []corev3.EntityState{
+		*corev3.FixtureEntityState("a"),
+		*corev3.FixtureEntityState("b"),
+		*corev3.FixtureEntityState("c"),
+	}
+	if _, err := entitiesFromConfigAndState(configs, states); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit fixes an out of bounds slice access that causes a panic to appear in the entity API log.

## Why is this change necessary?

Fixes #4102 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

The failing unit test and subsequent fix is verification of the change.

## Is this change a patch?

Yes