### PR TITLE
Remove managed_by label creation with edit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ entries in sensuctl.
 
 ### Fixed
 - Fixed a crash in the backend and agent related to Javascript execution.
+- `sensuctl edit` no longer automatically adds the `sensu.io/managed_by` label.
 
 ## [6.1.1] - 2020-10-22
 

--- a/cli/commands/create/create.go
+++ b/cli/commands/create/create.go
@@ -36,7 +36,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		if err != nil {
 			return err
 		}
-		processor := resource.NewPutter()
+		processor := resource.NewManagedByLabelPutter("sensuctl")
 		if len(inputs) == 0 {
 			return resource.ProcessStdin(cli, client, processor)
 		}

--- a/cli/resource/parse.go
+++ b/cli/resource/parse.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 
 	"github.com/ghodss/yaml"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types"
 )
@@ -64,20 +65,6 @@ func Parse(in io.Reader) ([]*types.Wrapper, error) {
 				errCount++
 				continue
 			}
-
-			// Mark the resource as managed by sensuctl in the outer labels
-			if len(w.ObjectMeta.Labels) == 0 {
-				w.ObjectMeta.Labels = map[string]string{}
-			}
-			w.ObjectMeta.Labels[corev2.ManagedByLabel] = "sensuctl"
-
-			// Mark the resource as managed by sensuctl in the inner labels
-			innerMeta := w.Value.GetObjectMeta()
-			if len(innerMeta.Labels) == 0 {
-				innerMeta.Labels = map[string]string{}
-			}
-			innerMeta.Labels[corev2.ManagedByLabel] = "sensuctl"
-			w.Value.SetObjectMeta(innerMeta)
 
 			resources = append(resources, &w)
 			count++

--- a/cli/resource/process.go
+++ b/cli/resource/process.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/cli"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
@@ -76,7 +77,7 @@ func ProcessFile(input string, recurse bool) ([]*types.Wrapper, error) {
 		}
 
 		// Resolve symbolic link
-		if info.Mode() & os.ModeSymlink != 0 {
+		if info.Mode()&os.ModeSymlink != 0 {
 			path, err = filepath.EvalSymlinks(path)
 			if err != nil {
 				return err
@@ -182,4 +183,46 @@ func (p *Putter) Process(client client.GenericClient, resources []*types.Wrapper
 		}
 	}
 	return nil
+}
+
+// ManagedByLabelPutter is a Processor that applies a corev2.ManagedByLabel
+// label with the chosen value to resources before passing them to a Putter.
+type ManagedByLabelPutter struct {
+	putter *Putter
+	Label  string
+}
+
+func NewManagedByLabelPutter(label string) *ManagedByLabelPutter {
+	return &ManagedByLabelPutter{
+		Label:  label,
+		putter: NewPutter(),
+	}
+}
+
+func (p *ManagedByLabelPutter) Process(client client.GenericClient, resources []*types.Wrapper) error {
+	for _, resource := range resources {
+		p.label(resource)
+	}
+	return p.putter.Process(client, resources)
+}
+
+func (p *ManagedByLabelPutter) label(resource *types.Wrapper) {
+	innerMeta := resource.Value.GetObjectMeta()
+
+	if resource.ObjectMeta.Labels == nil {
+		resource.ObjectMeta.Labels = map[string]string{}
+	}
+	outerLabels := resource.ObjectMeta.Labels
+
+	if innerMeta.Labels == nil {
+		innerMeta.Labels = map[string]string{}
+	}
+	innerLabels := innerMeta.Labels
+
+	// Mark the resource as managed by `label` in the outer labels
+	outerLabels[corev2.ManagedByLabel] = p.Label
+
+	// Mark the resource as managed by `label` in the inner labels
+	innerLabels[corev2.ManagedByLabel] = p.Label
+	resource.Value.SetObjectMeta(innerMeta)
 }


### PR DESCRIPTION
## What is this change?

During a previous refactor, parts of the logic for the create, edit and
delete sub-commands were merged together. This resulted in the side
effect of having the edit and delete sub-commands automatically add a
"managed_by" label with a "sensuctl" value to resources they touched.
This is not what we want; only sensuctl create should be automatically
adding this label.

This commit removes the label creation from the code shared by the 3
sub-commands, creates a new Processor that labels resources before
submitting them to the API and uses it as part of the definition of the
create sub-command only.

## Why is this change necessary?

Closes #4087.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required.

## How did you verify this change?

Unit tests for the new labeling Processor and manual testing showing that:
- `edit` doesn't add the label to existing resources anymore
- `create` adds the label

## Is this change a patch?

Not 100% sure. I think it can go in the next minor. I can target a release
branch if that's deemed more appropriate by the reviewers.