### PR TITLE
Fix the config-file flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ sensu-backend (`SENSU_BACKEND_CONFIG_FILE`) & sensu-agent (`SENSU_CONFIG_FILE`).
 - Adjust the date and duration formats used when listing and displaying silenced
 entries in sensuctl.
 
+### Fixed
+- The config-file flag is no longer order dependant.
+
 ### [6.1.2] - 2020-10-28
 ### Fixed
 - Fixed a bug where the entity API could panic.

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -322,7 +322,9 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 
 	// Use the default config path as a fallback if no config file was provided
 	// via the flag or the environment variable
+	configFilePathIsDefined := true
 	if configFilePath == "" {
+		configFilePathIsDefined = false
 		configFilePath = configFileDefaultLocation
 	}
 
@@ -490,7 +492,7 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 	_ = cmd.Flags().SetAnnotation(flagEtcdClientURLs, "categories", []string{"store"})
 
 	// Load the configuration file but only error out if flagConfigFile is used
-	if err := viper.ReadInConfig(); err != nil && configFilePath != "" {
+	if err := viper.ReadInConfig(); err != nil && configFilePathIsDefined {
 		return err
 	}
 


### PR DESCRIPTION
## What is this change?
It fixes the config-file flag so we only return an error if a file was explicitly defined and it does not exist; otherwise if the default value was used as a fallback and the file does not exist, we do not return an error, so the flag is not required.

Also, it fixes a bug where the config-file flag would need to defined first in order to be taken into account (see https://github.com/sensu/sensu-go/issues/3714).

## Why is this change necessary?

Fixes a bug introduced in https://github.com/sensu/sensu-go/commit/b092a579a36de2bf101bcbe83841da89429f4c02, which would require users to explicitly define a config-file for sensu-backend & sensu-agent.

Fixes https://github.com/sensu/sensu-go/issues/3714

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified; I'll also run this patch on staging.

## Is this change a patch?

Yes, but for an unreleased feature.
