### PR TITLE
Replace uuid with event id in logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ sensu-backend (`SENSU_BACKEND_CONFIG_FILE`) & sensu-agent (`SENSU_CONFIG_FILE`).
 ### Changed
 - Adjust the date and duration formats used when listing and displaying silenced
 entries in sensuctl.
-- Use event ID in logging instead of UUID.
+- Make `event_id` usage in logging consistent.
 
 ### Fixed
 - The config-file flag is no longer order dependant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ sensu-backend (`SENSU_BACKEND_CONFIG_FILE`) & sensu-agent (`SENSU_CONFIG_FILE`).
 ### Changed
 - Adjust the date and duration formats used when listing and displaying silenced
 entries in sensuctl.
+- Use event ID in logging instead of UUID.
 
 ### Fixed
 - The config-file flag is no longer order dependant.

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -185,11 +185,8 @@ func (e *Eventd) Start() error {
 func withEventFields(e interface{}, logger *logrus.Entry) *logrus.Entry {
 	event, _ := e.(*corev2.Event)
 	if event != nil {
-		logger = logger.WithField("entity", event.Entity.Name)
-		logger = logger.WithField("event_id", event.ID)
-		if event.Check != nil {
-			logger = logger.WithField("check", event.Check.Name)
-		}
+		fields := utillogging.EventFields(event, false)
+		logger = logger.WithFields(fields)
 	}
 	return logger
 }

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -212,17 +212,9 @@ func (p *Pipeline) expandHandlers(ctx context.Context, handlers []string, level 
 func (p *Pipeline) pipeHandler(handler *corev2.Handler, event *corev2.Event, eventData []byte) (*command.ExecutionResponse, error) {
 	ctx := corev2.SetContextFromResource(context.Background(), handler)
 	// Prepare log entry
-	fields := logrus.Fields{
-		"namespace":  handler.Namespace,
-		"handler":    handler.Name,
-		"assets":     handler.RuntimeAssets,
-		"event_uuid": event.GetUUID().String(),
-		"entity":     event.Entity.Name,
-	}
-
-	if event.HasCheck() {
-		fields["check"] = event.Check.Name
-	}
+	fields := utillogging.EventFields(event, false)
+	fields["handler_name"] = handler.Name
+	fields["handler_namespace"] = handler.Namespace
 
 	if p.licenseGetter != nil {
 		if license := p.licenseGetter.Get(); license != "" {
@@ -316,17 +308,10 @@ func (p *Pipeline) socketHandler(handler *corev2.Handler, event *corev2.Event, e
 	timeout := handler.Timeout
 
 	// Prepare log entry
-	fields := logrus.Fields{
-		"namespace":  handler.Namespace,
-		"handler":    handler.Name,
-		"protocol":   protocol,
-		"event_uuid": event.GetUUID().String(),
-		"entity":     event.Entity.Name,
-	}
-
-	if event.HasCheck() {
-		fields["check"] = event.Check.Name
-	}
+	fields := utillogging.EventFields(event, false)
+	fields["handler_name"] = handler.Name
+	fields["handler_namespace"] = handler.Namespace
+	fields["handler_protocol"] = protocol
 
 	// If Timeout is not specified, use the default.
 	if timeout == 0 {

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -14,7 +14,7 @@ func EventFields(event *types.Event, debug bool) map[string]interface{} {
 	}
 
 	fields := logrus.Fields{
-		"event_id":         event.ID,
+		"event_id":         event.GetUUID().String(),
 		"entity_name":      event.Entity.Name,
 		"entity_namespace": event.Entity.Namespace,
 	}

--- a/util/logging/logging.go
+++ b/util/logging/logging.go
@@ -14,9 +14,9 @@ func EventFields(event *types.Event, debug bool) map[string]interface{} {
 	}
 
 	fields := logrus.Fields{
+		"event_id":         event.ID,
 		"entity_name":      event.Entity.Name,
 		"entity_namespace": event.Entity.Namespace,
-		"uuid":             event.GetUUID().String(),
 	}
 
 	if event.HasCheck() {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Replaces all instances where `event_uuid` was logged with `event_id`.

## Why is this change necessary?

Closes #4093.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Nope!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Just unit/integration tests.

## Is this change a patch?

No.
