### PR TITLE
Always use http.ProxyFromEnvironment with assets HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Fixed a bug where the entity API could panic.
+- The agent now respects the HTTP proxy environment variables when using mTLS
+authentication.
 
 ### [6.1.2, 6.1.3] - 2020-10-28
 

--- a/asset/fetcher.go
+++ b/asset/fetcher.go
@@ -60,6 +60,7 @@ func httpGet(ctx context.Context, path, trustedCAFile string, headers map[string
 
 		client = &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					RootCAs: rootCAs,
 				},


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It ensures the HTTP client for assets retrieval follows the `HTTP_PROXY` and other similar environment variables.

Following https://github.com/sensu/sensu-go/pull/3975, we started building an HTTP client with a custom transport for agents that had a `trustedCAFile` specified, which typically happens with mTLS. However, by doing so, we no longer used `DefaultTransport` which automatically includes `ProxyFromEnvironment`. 

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/4101

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?
Nope


## Were there any complications while making this change?

Hard to test!

## Have you reviewed and updated the documentation for this change? Is new documentation required?
Nope

## How did you verify this change?

I had to manually test it. Unfortunately I don't see how we could easily test that, because of the following bit from the `ProxyFromEnvironment` docs:

> As a special case, if req.URL.Host is “localhost” (with or without a port number), then a nil URL and nil error will be returned.

Which means we can't use `127.0.0.1` or `locahost` in our unit tests.

## Is this change a patch?
Yep