### PR TITLE
Do not parse the same flag set twice

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -216,15 +216,20 @@ func StartCommandWithError(initialize InitializeFunc) (*cobra.Command, error) {
 	}
 
 	cmd.RunE = NewAgentRunE(initialize, cmd)
-	return cmd, handleConfig(cmd)
+	return cmd, handleConfig(cmd, os.Args[1:])
 }
 
-func handleConfig(cmd *cobra.Command) error {
+func handleConfig(cmd *cobra.Command, arguments []string) error {
 	configFlags := flagSet()
-	_ = configFlags.Parse(os.Args[1:])
+	if err := configFlags.Parse(arguments); err != nil {
+		return err
+	}
 
 	// Get the given config file path via flag
-	configFilePath, _ := configFlags.GetString(flagConfigFile)
+	configFilePath, err := configFlags.GetString(flagConfigFile)
+	if err != nil {
+		return err
+	}
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -220,11 +220,11 @@ func StartCommandWithError(initialize InitializeFunc) (*cobra.Command, error) {
 }
 
 func handleConfig(cmd *cobra.Command) error {
-	flagSet := flagSet()
-	_ = flagSet.Parse(os.Args[1:])
+	configFlags := flagSet()
+	_ = configFlags.Parse(os.Args[1:])
 
 	// Get the given config file path via flag
-	configFilePath, _ := flagSet.GetString(flagConfigFile)
+	configFilePath, _ := configFlags.GetString(flagConfigFile)
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {
@@ -285,7 +285,8 @@ func handleConfig(cmd *cobra.Command) error {
 	viper.SetDefault(flagBackendHeartbeatTimeout, 45)
 
 	// Merge in flag set so that it appears in command usage
-	cmd.Flags().AddFlagSet(flagSet)
+	flags := flagSet()
+	cmd.Flags().AddFlagSet(flags)
 
 	cmd.Flags().SetNormalizeFunc(aliasNormalizeFunc(logger))
 

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestNewAgentConfig(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagSubscriptions, "dev,ops")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.Subscriptions, []string{"dev", "ops"}) {
+		t.Fatalf("TestNewAgentConfig() subscriptions = %v, want %v", cfg.Subscriptions, `"dev", "ops"`)
+	}
+}
+
+func tempConfig(t *testing.T, content string) *os.File {
+	t.Helper()
+
+	file, err := ioutil.TempFile(os.TempDir(), "sensu-agent-")
+	if err != nil {
+		t.Fatalf("error creating tmpFile %q: %s", file.Name(), err)
+	}
+
+	_, err = file.WriteString(content)
+	if err != nil {
+		t.Fatalf("could not write to tmpFile %q: %s", file.Name(), err)
+	}
+
+	return file
+}
+
+func Test_handleConfig_configFile(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+
+	// The default config file should be used as a fallback if no config file was
+	// defined
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	if namespace := viper.GetString(flagNamespace); namespace != "default" {
+		t.Fatalf("handleConfig() namespace = %s, want %s", namespace, "default")
+	}
+
+	// Create a temporary configuration file to be specified via the flag
+	configFileForFlag := tempConfig(t, "namespace: ops")
+	defer func() {
+		_ = configFileForFlag.Close()
+		_ = os.Remove(configFileForFlag.Name())
+	}()
+
+	// The configuration file specified via the flag should be used
+	if err := handleConfig(cmd, []string{fmt.Sprintf("--%s=%s", flagConfigFile, configFileForFlag.Name())}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	if namespace := viper.GetString(flagNamespace); namespace != "ops" {
+		t.Fatalf("handleConfig() namespace = %s, want %s", namespace, "ops")
+	}
+
+	// Create a temporary configuration file to be specified via the environment
+	// variable
+	configFileForEnv := tempConfig(t, "namespace: dev")
+	defer func() {
+		_ = configFileForEnv.Close()
+		_ = os.Remove(configFileForEnv.Name())
+	}()
+
+	// The configuration file specified via the environment variable should be
+	// used
+	os.Setenv("SENSU_CONFIG_FILE", configFileForEnv.Name())
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	if namespace := viper.GetString(flagNamespace); namespace != "dev" {
+		t.Fatalf("handleConfig() namespace = %s, want %s", namespace, "dev")
+	}
+
+	// The flag should have precedence over the environment variable
+	if err := handleConfig(cmd, []string{fmt.Sprintf("--%s=%s", flagConfigFile, configFileForFlag.Name())}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	if namespace := viper.GetString(flagNamespace); namespace != "ops" {
+		t.Fatalf("handleConfig() namespace = %s, want %s", namespace, "ops")
+	}
+}

--- a/agent/cmd/windows.go
+++ b/agent/cmd/windows.go
@@ -88,7 +88,7 @@ func NewWindowsInstallServiceCommand() *cobra.Command {
 	cmd.Flags().Int64(flagLogRetentionFiles, viper.GetInt64(flagLogRetentionFiles), "maximum number of archived files to retain")
 	cmd.Flags().String(flagReaperInterval, viper.GetString(flagReaperInterval), "frequency that the archive reaper will run at")
 
-	if err := handleConfig(cmd); err != nil {
+	if err := handleConfig(cmd, os.Args[1:]); err != nil {
 		// can only happen if there is developer error, so don't make any mistakes
 		panic(err)
 	}
@@ -198,7 +198,7 @@ func NewWindowsRunServiceCommand() *cobra.Command {
 	cmd.Flags().Int64(flagLogRetentionFiles, viper.GetInt64(flagLogRetentionFiles), "maximum number of archived files to retain")
 	cmd.Flags().String(flagReaperInterval, viper.GetString(flagReaperInterval), "frequency that the archive reaper will run at")
 
-	if err := handleConfig(cmd); err != nil {
+	if err := handleConfig(cmd, os.Args[1:]); err != nil {
 		// can only happen if there is developer error, so don't make any mistakes
 		panic(err)
 	}

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/AlecAivazis/survey"
@@ -196,7 +197,7 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
 	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
 
-	setupErr = handleConfig(cmd, false)
+	setupErr = handleConfig(cmd, os.Args[1:], false)
 
 	return cmd
 }

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -302,11 +302,11 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 }
 
 func handleConfig(cmd *cobra.Command, server bool) error {
-	flagSet := flagSet(server)
-	_ = flagSet.Parse(os.Args[1:])
+	configFlags := flagSet(server)
+	_ = configFlags.Parse(os.Args[1:])
 
 	// Get the given config file path via flag
-	configFilePath, _ := flagSet.GetString(flagConfigFile)
+	configFilePath, _ := configFlags.GetString(flagConfigFile)
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {
@@ -379,7 +379,8 @@ func handleConfig(cmd *cobra.Command, server bool) error {
 	}
 
 	// Merge in flag set so that it appears in command usage
-	cmd.Flags().AddFlagSet(flagSet)
+	flags := flagSet(server)
+	cmd.Flags().AddFlagSet(flags)
 
 	// Load the configuration file but only error out if flagConfigFile is used
 	if err := viper.ReadInConfig(); err != nil && configFilePathIsDefined {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -296,17 +296,22 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 		},
 	}
 
-	setupErr = handleConfig(cmd, true)
+	setupErr = handleConfig(cmd, os.Args[1:], true)
 
 	return cmd
 }
 
-func handleConfig(cmd *cobra.Command, server bool) error {
+func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 	configFlags := flagSet(server)
-	_ = configFlags.Parse(os.Args[1:])
+	if err := configFlags.Parse(arguments); err != nil {
+		return err
+	}
 
 	// Get the given config file path via flag
-	configFilePath, _ := configFlags.GetString(flagConfigFile)
+	configFilePath, err := configFlags.GetString(flagConfigFile)
+	if err != nil {
+		return err
+	}
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/AlecAivazis/survey"
@@ -136,7 +137,7 @@ func UpgradeCommand() *cobra.Command {
 	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
 	cmd.Flags().Bool(flagSkipConfirm, false, "skip interactive confirmation")
 
-	setupErr = handleConfig(cmd, false)
+	setupErr = handleConfig(cmd, os.Args[1:], false)
 
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It fixes a bug where configuration values for both sensu-agent & sensu-backend would be duplicated when using slices.

All flags need to be present when we first try to parse the config file attribute, otherwise it will silently fail because undefined flags were defined. However, we should use a different set of flags for the "main" command otherwise they will be parsed twice, which ends up duplicating values in configuration attributes holding a slice.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/4114

## Does your change need a Changelog entry?

Nope, unreleased bug introduced via https://github.com/sensu/sensu-go/pull/4105

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified. This is not something that's easy to test automatically.

## Is this change a patch?

Nope; it just needs to be included with the PR above.
