### PR TITLE
Add support for core/v3.Resource to backend/api

### DIFF
--- a/backend/api/generic.go
+++ b/backend/api/generic.go
@@ -7,8 +7,11 @@ import (
 	"path"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 	"github.com/sensu/sensu-go/types"
 )
 
@@ -16,6 +19,7 @@ import (
 type GenericClient struct {
 	Kind       corev2.Resource
 	Store      store.ResourceStore
+	StoreV2    storev2.Interface
 	Auth       authorization.Authorizer
 	APIGroup   string
 	APIVersion string
@@ -25,7 +29,8 @@ func (g GenericClient) validateConfig() error {
 	if g.Kind == nil {
 		return errors.New("nil Kind")
 	}
-	if g.Store == nil {
+	_, v3Resource := g.Kind.(*corev3.V2ResourceProxy)
+	if g.Store == nil && (g.StoreV2 == nil && v3Resource) {
 		return errors.New("nil store")
 	}
 	if g.Auth == nil {
@@ -35,6 +40,20 @@ func (g GenericClient) validateConfig() error {
 		return errors.New("empty api group/version")
 	}
 	return nil
+}
+
+func (g *GenericClient) createResource(ctx context.Context, value corev2.Resource) error {
+	if value, ok := value.(*corev3.V2ResourceProxy); ok {
+		resource := value.Resource
+		req := storev2.NewResourceRequestFromResource(ctx, resource)
+		req.Namespace = corev2.ContextNamespace(ctx)
+		wrapper, err := wrap.Resource(resource)
+		if err != nil {
+			return err
+		}
+		return g.StoreV2.CreateIfNotExists(req, wrapper)
+	}
+	return g.Store.CreateResource(ctx, value)
 }
 
 // Create creates a resource, if authorized
@@ -57,7 +76,7 @@ func (g *GenericClient) Create(ctx context.Context, value corev2.Resource) error
 		return err
 	}
 	setCreatedBy(ctx, value)
-	return g.Store.CreateResource(ctx, value)
+	return g.createResource(ctx, value)
 }
 
 // SetTypeMeta sets the type of values that the client expects to be dealing
@@ -75,6 +94,20 @@ func (g *GenericClient) SetTypeMeta(meta corev2.TypeMeta) error {
 	}
 	g.Kind = kind
 	return nil
+}
+
+func (g *GenericClient) updateResource(ctx context.Context, value corev2.Resource) error {
+	if value, ok := value.(*corev3.V2ResourceProxy); ok {
+		resource := value.Resource
+		req := storev2.NewResourceRequestFromResource(ctx, resource)
+		req.Namespace = corev2.ContextNamespace(ctx)
+		wrapper, err := wrap.Resource(resource)
+		if err != nil {
+			return err
+		}
+		return g.StoreV2.CreateOrUpdate(req, wrapper)
+	}
+	return g.Store.CreateOrUpdateResource(ctx, value)
 }
 
 // Update creates or updates a resource, if authorized
@@ -97,7 +130,20 @@ func (g *GenericClient) Update(ctx context.Context, value corev2.Resource) error
 		return err
 	}
 	setCreatedBy(ctx, value)
-	return g.Store.CreateOrUpdateResource(ctx, value)
+	return g.updateResource(ctx, value)
+}
+
+func (g *GenericClient) deleteResource(ctx context.Context, name string) error {
+	if _, ok := g.Kind.(*corev3.V2ResourceProxy); ok {
+		req := storev2.ResourceRequest{
+			Namespace: corev2.ContextNamespace(ctx),
+			Name:      name,
+			StoreName: g.Kind.StorePrefix(),
+			Context:   ctx,
+		}
+		return g.StoreV2.Delete(req)
+	}
+	return g.Store.DeleteResource(ctx, g.Kind.StorePrefix(), name)
 }
 
 // Delete deletes a resource, if authorized
@@ -116,7 +162,24 @@ func (g *GenericClient) Delete(ctx context.Context, name string) error {
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err
 	}
-	return g.Store.DeleteResource(ctx, g.Kind.StorePrefix(), name)
+	return g.deleteResource(ctx, name)
+}
+
+func (g *GenericClient) getResource(ctx context.Context, name string, value corev2.Resource) error {
+	if value, ok := value.(*corev3.V2ResourceProxy); ok {
+		req := storev2.ResourceRequest{
+			Namespace: corev2.ContextNamespace(ctx),
+			Name:      name,
+			StoreName: value.StorePrefix(),
+			Context:   ctx,
+		}
+		wrapper, err := g.StoreV2.Get(req)
+		if err != nil {
+			return err
+		}
+		return wrapper.UnwrapInto(value.Resource)
+	}
+	return g.Store.GetResource(ctx, name, value)
 }
 
 // Get gets a resource, if authorized
@@ -135,7 +198,35 @@ func (g *GenericClient) Get(ctx context.Context, name string, val corev2.Resourc
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err
 	}
-	return g.Store.GetResource(ctx, name, val)
+	return g.getResource(ctx, name, val)
+}
+
+func (g *GenericClient) list(ctx context.Context, resources interface{}, pred *store.SelectionPredicate) error {
+	if _, ok := g.Kind.(*corev3.V2ResourceProxy); ok {
+		req := storev2.ResourceRequest{
+			Namespace: corev2.ContextNamespace(ctx),
+			StoreName: g.Kind.StorePrefix(),
+			Context:   ctx,
+		}
+		list, err := g.StoreV2.List(req, pred)
+		if err != nil {
+			return err
+		}
+		if resourceList, ok := resources.(*[]corev2.Resource); ok {
+			values, err := list.Unwrap()
+			if err != nil {
+				return err
+			}
+			v2values := make([]corev2.Resource, len(values))
+			for i := range values {
+				v2values[i] = corev3.V3ToV2Resource(values[i])
+			}
+			*resourceList = v2values
+			return nil
+		}
+		return list.UnwrapInto(resources)
+	}
+	return g.Store.ListResources(ctx, g.Kind.StorePrefix(), resources, pred)
 }
 
 // List lists all resources within a namespace, according to a selection
@@ -154,5 +245,5 @@ func (g *GenericClient) List(ctx context.Context, resources interface{}, pred *s
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err
 	}
-	return g.Store.ListResources(ctx, g.Kind.StorePrefix(), resources, pred)
+	return g.list(ctx, resources, pred)
 }

--- a/backend/api/generic_test.go
+++ b/backend/api/generic_test.go
@@ -3,12 +3,17 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/backend/store/v2/storetest"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/mock"
 )
@@ -21,6 +26,34 @@ func defaultTestClient(store store.ResourceStore, auth authorization.Authorizer)
 		APIGroup:   "core",
 		APIVersion: "v2",
 	}
+}
+
+func defaultV2TestClient(store storev2.Interface, auth authorization.Authorizer) *GenericClient {
+	return &GenericClient{
+		Kind:       defaultV3Resource(),
+		StoreV2:    store,
+		Auth:       auth,
+		APIGroup:   "core",
+		APIVersion: "v3",
+	}
+}
+
+func defaultV2ResourceStore() storev2.Interface {
+	store := new(storetest.Store)
+	wrappedResource, err := wrap.Resource(corev3.FixtureEntityConfig("default"))
+	if err != nil {
+		panic(err)
+	}
+	store.On("Get", mock.Anything).Return(wrappedResource, nil)
+	store.On("List", mock.Anything, mock.Anything).Return(wrap.List{wrappedResource}, nil)
+	store.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(nil)
+	store.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil)
+	store.On("Delete", mock.Anything).Return(nil)
+	return store
+}
+
+func defaultV3Resource() corev2.Resource {
+	return corev3.V3ToV2Resource(corev3.FixtureEntityConfig("default"))
 }
 
 type mockAuth struct {
@@ -40,7 +73,7 @@ func (m *mockAuth) Authorize(ctx context.Context, attrs *authorization.Attribute
 	}
 	b, ok := m.attrs[attrs.Key()]
 	if !ok {
-		return false, errors.New("no information")
+		return false, fmt.Errorf("auth missing for %v", attrs.Key())
 	}
 	return b, nil
 }
@@ -321,6 +354,195 @@ func TestGenericClient_SetTypeMeta(t *testing.T) {
 			}
 			if tt.outVersion != g.APIVersion {
 				t.Errorf("GenericClient.SetTypeMeta() version = %v, expected version = %v", g.APIVersion, tt.outVersion)
+			}
+		})
+	}
+}
+
+func TestGenericClientStoreV2(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Client    *GenericClient
+		CreateVal corev2.Resource
+		CreateErr bool
+		UpdateVal corev2.Resource
+		UpdateErr bool
+		GetName   string
+		GetVal    corev2.Resource
+		GetErr    bool
+		ListVal   []corev2.Resource
+		ListPred  *store.SelectionPredicate
+		ListErr   bool
+		DelName   string
+		DelErr    bool
+		Ctx       context.Context
+	}{
+		{
+			Name:      "authorizer rejects all",
+			Client:    defaultV2TestClient(defaultV2ResourceStore(), badAuth()),
+			CreateVal: defaultV3Resource(),
+			CreateErr: true,
+			UpdateVal: defaultV3Resource(),
+			UpdateErr: true,
+			GetName:   "toget",
+			GetVal:    defaultV3Resource(),
+			GetErr:    true,
+			DelName:   "todelete",
+			DelErr:    true,
+			ListErr:   true,
+			Ctx:       contextWithUser(defaultContext(), "tom", nil),
+		},
+		{
+			Name: "readonly access",
+			Client: defaultV2TestClient(defaultV2ResourceStore(), &mockAuth{
+				attrs: map[authorization.AttributesKey]bool{
+					authorization.AttributesKey{
+						APIGroup:     "core",
+						APIVersion:   "v3",
+						Namespace:    "default",
+						Resource:     "entity_configs",
+						ResourceName: "default",
+						UserName:     "tom",
+						Verb:         "get",
+					}: true,
+					authorization.AttributesKey{
+						APIGroup:   "core",
+						APIVersion: "v3",
+						Namespace:  "default",
+						Resource:   "entity_configs",
+						UserName:   "tom",
+						Verb:       "list",
+					}: true,
+				},
+			}),
+			CreateVal: defaultV3Resource(),
+			CreateErr: true,
+			UpdateVal: defaultV3Resource(),
+			UpdateErr: true,
+			GetName:   "default",
+			GetVal:    defaultV3Resource(),
+			GetErr:    false,
+			DelName:   "default",
+			DelErr:    true,
+			ListErr:   false,
+			Ctx:       contextWithUser(defaultContext(), "tom", nil),
+		},
+		{
+			Name: "all access",
+			Client: defaultV2TestClient(defaultV2ResourceStore(), &mockAuth{
+				attrs: map[authorization.AttributesKey]bool{
+					authorization.AttributesKey{
+						APIGroup:     "core",
+						APIVersion:   "v3",
+						Namespace:    "default",
+						Resource:     "entity_configs",
+						ResourceName: "default",
+						UserName:     "tom",
+						Verb:         "get",
+					}: true,
+					authorization.AttributesKey{
+						APIGroup:     "core",
+						APIVersion:   "v3",
+						Namespace:    "default",
+						Resource:     "entity_configs",
+						ResourceName: "default",
+						UserName:     "tom",
+						Verb:         "create",
+					}: true,
+					authorization.AttributesKey{
+						APIGroup:     "core",
+						APIVersion:   "v3",
+						Namespace:    "default",
+						Resource:     "entity_configs",
+						ResourceName: "default",
+						UserName:     "tom",
+						Verb:         "delete",
+					}: true,
+					authorization.AttributesKey{
+						APIGroup:     "core",
+						APIVersion:   "v3",
+						Namespace:    "default",
+						Resource:     "entity_configs",
+						ResourceName: "default",
+						UserName:     "tom",
+						Verb:         "update",
+					}: true,
+					authorization.AttributesKey{
+						APIGroup:   "core",
+						APIVersion: "v3",
+						Namespace:  "default",
+						Resource:   "entity_configs",
+						UserName:   "tom",
+						Verb:       "list",
+					}: true,
+				},
+			}),
+			CreateVal: defaultV3Resource(),
+			CreateErr: false,
+			UpdateVal: defaultV3Resource(),
+			UpdateErr: false,
+			GetName:   "default",
+			GetVal:    defaultV3Resource(),
+			GetErr:    false,
+			DelName:   "default",
+			DelErr:    false,
+			ListErr:   false,
+			Ctx:       contextWithUser(defaultContext(), "tom", nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name+"_create", func(t *testing.T) {
+			err := test.Client.Create(test.Ctx, test.CreateVal)
+			if err != nil && !test.CreateErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.CreateErr {
+				t.Fatal("expected non-nil error")
+			}
+		})
+		t.Run(test.Name+"_update", func(t *testing.T) {
+			err := test.Client.Update(test.Ctx, test.UpdateVal)
+			if err != nil && !test.UpdateErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.UpdateErr {
+				t.Fatal(err)
+			}
+		})
+		t.Run(test.Name+"_get", func(t *testing.T) {
+			err := test.Client.Get(test.Ctx, test.GetName, test.GetVal)
+			if err != nil && !test.GetErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.GetErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.GetVal.Validate() != nil {
+				t.Fatal(test.GetVal.Validate())
+			}
+		})
+		t.Run(test.Name+"_del", func(t *testing.T) {
+			err := test.Client.Delete(test.Ctx, test.DelName)
+			if err != nil && !test.DelErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.DelErr {
+				t.Fatal(err)
+			}
+		})
+		t.Run(test.Name+"_list", func(t *testing.T) {
+			err := test.Client.List(test.Ctx, &test.ListVal, test.ListPred)
+			if err != nil && !test.ListErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.ListErr {
+				t.Fatal(err)
+			}
+			for _, val := range test.ListVal {
+				if err == nil && val.Validate() != nil {
+					t.Fatal(val.Validate())
+				}
 			}
 		})
 	}

--- a/backend/api/generic_test.go
+++ b/backend/api/generic_test.go
@@ -547,3 +547,17 @@ func TestGenericClientStoreV2(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTypeMetaV3Resource(t *testing.T) {
+	client := &GenericClient{}
+	err := client.SetTypeMeta(corev2.TypeMeta{
+		APIVersion: "core/v3",
+		Type:       "EntityConfig",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := client.Kind.(*corev3.V2ResourceProxy); !ok {
+		t.Errorf("expected a v2 resource proxy")
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit adds support for core/v3.Resource types in the backend API
GenericClient. The support is shimmed through the
core/v3.V2ResourceProxy type.

Users are expected to set up the GenericClient with a store/v2.Interface
and a Kind that is a V2ResourceProxy, if they want to work with core/v3
resources.

## Why is this change necessary?

Supporting work for sensu-enterprise-go.

## Does your change need a Changelog entry?

No, not a user facing change.