### PR TITLE
[GraphQL] Account for resources without embedded metadata

### DIFF
--- a/backend/apid/graphql/globalid/encoder.go
+++ b/backend/apid/graphql/globalid/encoder.go
@@ -5,7 +5,11 @@ import "context"
 type EncodeFn func(context.Context, interface{}) *StandardComponents
 
 // DefaultEncoder is the default implementation of Encode.
-func DefaultEncoder(_ context.Context, res interface{}) *StandardComponents {
+func DefaultEncoder(ctx context.Context, res interface{}) *StandardComponents {
+	if res, ok := res.(interface{ GetMetadata() string }); ok {
+		return DefaultEncoder(ctx, res.GetMetadata())
+	}
+
 	cmp := StandardComponents{}
 	if res, ok := res.(interface{ GetName() string }); ok {
 		cmp.uniqueComponent = res.GetName()

--- a/backend/apid/graphql/globalid/encoder.go
+++ b/backend/apid/graphql/globalid/encoder.go
@@ -1,12 +1,16 @@
 package globalid
 
-import "context"
+import (
+	"context"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
 
 type EncodeFn func(context.Context, interface{}) *StandardComponents
 
 // DefaultEncoder is the default implementation of Encode.
 func DefaultEncoder(ctx context.Context, res interface{}) *StandardComponents {
-	if res, ok := res.(interface{ GetMetadata() string }); ok {
+	if res, ok := res.(interface{ GetMetadata() *corev2.ObjectMeta }); ok {
 		return DefaultEncoder(ctx, res.GetMetadata())
 	}
 

--- a/backend/apid/graphql/globalid/encoder_test.go
+++ b/backend/apid/graphql/globalid/encoder_test.go
@@ -1,0 +1,53 @@
+package globalid
+
+import (
+	"context"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/testing/fixture"
+)
+
+// DefaultEncoder is the default implementation of Encode.
+func TestDefaultEncoder(t *testing.T) {
+	tc := []struct {
+		name     string
+		in       interface{}
+		expectId string
+		expectNs string
+	}{
+		{
+			name: "v2 resource",
+			in: &fixture.Resource{
+				ObjectMeta: corev2.ObjectMeta{
+					Name:      "x",
+					Namespace: "y",
+				},
+			},
+			expectId: "x",
+			expectNs: "y",
+		},
+		{
+			name: "v3 resource",
+			in: &fixture.V3Resource{
+				Metadata: &corev2.ObjectMeta{
+					Name:      "x",
+					Namespace: "y",
+				},
+			},
+			expectId: "x",
+			expectNs: "y",
+		},
+	}
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			cmp := DefaultEncoder(context.Background(), tt.in)
+			if cmp.Namespace() != tt.expectNs {
+				t.Errorf("DefaultEncoder() expect = %s, got = %s", cmp.Namespace(), tt.expectNs)
+			}
+			if cmp.UniqueComponent() != tt.expectId {
+				t.Errorf("DefaultEncoder() expect = %s, got = %s", cmp.UniqueComponent(), tt.expectId)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows globalid encoder to encode resources without embedded metadata. (Such as v3 resources.)

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>