### PR TITLE
Continue to ignore flags parsing errors for now

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -221,15 +221,11 @@ func StartCommandWithError(initialize InitializeFunc) (*cobra.Command, error) {
 
 func handleConfig(cmd *cobra.Command, arguments []string) error {
 	configFlags := flagSet()
-	if err := configFlags.Parse(arguments); err != nil {
-		return err
-	}
+	configFlags.AddFlagSet(cmd.Flags())
+	_ = configFlags.Parse(arguments)
 
 	// Get the given config file path via flag
-	configFilePath, err := configFlags.GetString(flagConfigFile)
-	if err != nil {
-		return err
-	}
+	configFilePath, _ := configFlags.GetString(flagConfigFile)
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -303,15 +303,10 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 
 func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 	configFlags := flagSet(server)
-	if err := configFlags.Parse(arguments); err != nil {
-		return err
-	}
+	_ = configFlags.Parse(arguments)
 
 	// Get the given config file path via flag
-	configFilePath, err := configFlags.GetString(flagConfigFile)
-	if err != nil {
-		return err
-	}
+	configFilePath, _ := configFlags.GetString(flagConfigFile)
 
 	// Get the environment variable value if no config file was provided via the flag
 	if configFilePath == "" {


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>

## What is this change?

It reverts a previous change that would handle errors while parsing flags in the `handleConfig` function. Unfortunately, as we recently discovered, this is problematic because it gets called by almost all subcommands, but not all flags are usually defined.


## Why is this change necessary?

Fixes a bug found on `main`

## Does your change need a Changelog entry?

Nope, unreleased bug.

## Do you need clarification on anything?
Nope

## Were there any complications while making this change?

Viper & Cobra are hard!

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually tested

## Is this change a patch?
Nope
