### PR TITLE
[GraphQL] Fixes crash when selecting entity metadata

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -37,8 +37,7 @@ func (*entityImpl) ID(p graphql.ResolveParams) (string, error) {
 func (*entityImpl) Metadata(p graphql.ResolveParams) (interface{}, error) {
 	entity := p.Source.(*corev2.Entity)
 	entity = entity.GetRedactedEntity()
-	meta := entity.GetObjectMeta()
-	return &meta, nil
+	return entity.GetObjectMeta(), nil
 }
 
 // LastSeen implements response to request for 'executed' field.

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -21,7 +21,7 @@ func TestEntityTypeMetadataField(t *testing.T) {
 	res, err := impl.Metadata(graphql.ResolveParams{Source: src})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
-	assert.IsType(t, &v2.ObjectMeta{}, res)
+	assert.IsType(t, v2.ObjectMeta{}, res)
 }
 
 func TestEntityTypeRelatedField(t *testing.T) {

--- a/backend/apid/graphql/meta.go
+++ b/backend/apid/graphql/meta.go
@@ -3,7 +3,7 @@ package graphql
 import (
 	"sort"
 
-	v2 "github.com/sensu/sensu-go/api/core/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/graphql"
 )
@@ -26,14 +26,22 @@ type KVPairString struct {
 
 // Labels implements response to request for 'labels' field.
 func (r *objectMetaImpl) Labels(p graphql.ResolveParams) (interface{}, error) {
-	src := p.Source.(v2.ObjectMeta)
-	return makeKVPairString(src.Labels), nil
+	return makeKVPairString(toObjMeta(p.Source).Labels), nil
 }
 
 // Annotations implements response to request for 'annotations' field.
 func (r *objectMetaImpl) Annotations(p graphql.ResolveParams) (interface{}, error) {
-	src := p.Source.(v2.ObjectMeta)
-	return makeKVPairString(src.Annotations), nil
+	return makeKVPairString(toObjMeta(p.Source).Annotations), nil
+}
+
+func toObjMeta(m interface{}) corev2.ObjectMeta {
+	switch m := m.(type) {
+	case corev2.ObjectMeta:
+		return m
+	case *corev2.ObjectMeta:
+		return *m
+	}
+	return corev2.ObjectMeta{}
 }
 
 func makeKVPairString(m map[string]string) []KVPairString {

--- a/backend/apid/graphql/meta_test.go
+++ b/backend/apid/graphql/meta_test.go
@@ -28,7 +28,7 @@ func TestObjectMetaTypeLabelsField(t *testing.T) {
 }
 
 func TestObjectMetaTypeAnnotationsField(t *testing.T) {
-	meta := v2.ObjectMeta{
+	meta := &v2.ObjectMeta{
 		Annotations: map[string]string{
 			"jeff": "gertsman",
 			"brad": "shoemaker",


### PR DESCRIPTION
`ObjectMeta` type previous expected that argument was a value and not a pointer.

Regression introduced in #4128.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>