### PR TITLE
Add support for entities managed by agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ created when in interactive mode.
 - Add support for environment variables to define configuration file paths of
 sensu-backend (`SENSU_BACKEND_CONFIG_FILE`) & sensu-agent (`SENSU_CONFIG_FILE`).
 - Added event sequence numbers.
+- Entities may now be managed exclusively by their agents when sensu-agent is
+started with the new `agent-managed-entity` configuration attribute.
 
 ### Changed
 - Adjust the date and duration formats used when listing and displaying silenced

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -491,6 +491,10 @@ func (a *Agent) newKeepalive() *transport.Message {
 	entity := a.getAgentEntity()
 	uid, _ := uuid.NewRandom()
 
+	if a.config.AgentManagedEntity {
+		entity.CreatedBy = a.config.User
+	}
+
 	keepalive := &corev2.Event{
 		ObjectMeta: corev2.NewObjectMeta("", entity.Namespace),
 		ID:         uid[:],

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -101,11 +101,9 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	logrus.SetLevel(level)
 
 	labels := viper.GetStringMapString(flagLabels)
-	fmt.Println(viper.GetBool(flagAgentManagedEntity))
 	if viper.GetBool(flagAgentManagedEntity) {
 		labels[corev2.ManagedByLabel] = "sensu-agent"
 	}
-	fmt.Printf("labels = %#v\n", labels)
 
 	cfg := agent.NewConfig()
 	cfg.AgentManagedEntity = viper.GetBool(flagAgentManagedEntity)

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -72,6 +72,7 @@ const (
 	flagBackendHandshakeTimeout  = "backend-handshake-timeout"
 	flagBackendHeartbeatInterval = "backend-heartbeat-interval"
 	flagBackendHeartbeatTimeout  = "backend-heartbeat-timeout"
+	flagAgentManagedEntity       = "agent-managed-entity"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -99,7 +100,13 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	}
 	logrus.SetLevel(level)
 
+	labels := viper.GetStringMapString(flagLabels)
+	if viper.GetBool(flagAgentManagedEntity) {
+		labels[corev2.ManagedByLabel] = "sensu-agent"
+	}
+
 	cfg := agent.NewConfig()
+	cfg.AgentManagedEntity = viper.GetBool(flagAgentManagedEntity)
 	cfg.API.Host = viper.GetString(flagAPIHost)
 	cfg.API.Port = viper.GetInt(flagAPIPort)
 	cfg.AssetsRateLimit = rate.Limit(viper.GetFloat64(flagAssetsRateLimit))
@@ -124,7 +131,7 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.StatsdServer.Host = viper.GetString(flagStatsdMetricsHost)
 	cfg.StatsdServer.Port = viper.GetInt(flagStatsdMetricsPort)
 	cfg.StatsdServer.Handlers = viper.GetStringSlice(flagStatsdEventHandlers)
-	cfg.Labels = viper.GetStringMapString(flagLabels)
+	cfg.Labels = labels
 	cfg.Annotations = viper.GetStringMapString(flagAnnotations)
 	cfg.User = viper.GetString(flagUser)
 	cfg.AllowList = viper.GetString(flagAllowList)
@@ -402,6 +409,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagBackendHandshakeTimeout, viper.GetInt(flagBackendHandshakeTimeout), "number of seconds the agent should wait when negotiating a new WebSocket connection")
 	flagSet.Int(flagBackendHeartbeatInterval, viper.GetInt(flagBackendHeartbeatInterval), "interval at which the agent should send heartbeats to the backend")
 	flagSet.Int(flagBackendHeartbeatTimeout, viper.GetInt(flagBackendHeartbeatTimeout), "number of seconds the agent should wait for a response to a hearbeat")
+	flagSet.Bool(flagAgentManagedEntity, viper.GetBool(flagBackendHeartbeatTimeout), "manage this entity via the agent")
 
 	flagSet.SetOutput(ioutil.Discard)
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -101,9 +101,11 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	logrus.SetLevel(level)
 
 	labels := viper.GetStringMapString(flagLabels)
+	fmt.Println(viper.GetBool(flagAgentManagedEntity))
 	if viper.GetBool(flagAgentManagedEntity) {
 		labels[corev2.ManagedByLabel] = "sensu-agent"
 	}
+	fmt.Printf("labels = %#v\n", labels)
 
 	cfg := agent.NewConfig()
 	cfg.AgentManagedEntity = viper.GetBool(flagAgentManagedEntity)
@@ -409,7 +411,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagBackendHandshakeTimeout, viper.GetInt(flagBackendHandshakeTimeout), "number of seconds the agent should wait when negotiating a new WebSocket connection")
 	flagSet.Int(flagBackendHeartbeatInterval, viper.GetInt(flagBackendHeartbeatInterval), "interval at which the agent should send heartbeats to the backend")
 	flagSet.Int(flagBackendHeartbeatTimeout, viper.GetInt(flagBackendHeartbeatTimeout), "number of seconds the agent should wait for a response to a hearbeat")
-	flagSet.Bool(flagAgentManagedEntity, viper.GetBool(flagBackendHeartbeatTimeout), "manage this entity via the agent")
+	flagSet.Bool(flagAgentManagedEntity, viper.GetBool(flagAgentManagedEntity), "manage this entity via the agent")
 
 	flagSet.SetOutput(ioutil.Discard)
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -191,6 +191,10 @@ type Config struct {
 	// MockSystemInfo determines whether the system info collection should return
 	// mocked system information. This should only be used for testing.
 	MockSystemInfo bool
+
+	// AgentManagedEntity indicates whether the agent's entity is solely managed
+	// by the agent, rather than the backend API
+	AgentManagedEntity bool
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/agent/entity_config_handler.go
+++ b/agent/entity_config_handler.go
@@ -9,6 +9,12 @@ import (
 
 func (a *Agent) handleEntityConfig(ctx context.Context, payload []byte) error {
 	var entity corev3.EntityConfig
+
+	// Ignore entity updates if this agent manages its entity
+	if a.config.AgentManagedEntity {
+		return nil
+	}
+
 	if err := a.unmarshal(payload, &entity); err != nil {
 		return err
 	}

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -360,6 +360,10 @@ func (s *Session) sender() {
 				s.unsubscribe(removed)
 			}
 
+			if watchEvent.Entity.Metadata.Labels[corev2.ManagedByLabel] == "sensu-agent" {
+				lager.Debug("not sending entity update because entity is managed by its agent")
+			}
+
 			msg = transport.NewMessage(transport.MessageTypeEntityConfig, bytes)
 		case c := <-s.checkChannel:
 			request, ok := c.(*corev2.CheckRequest)

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -481,6 +481,12 @@ func (s *Session) Start() (err error) {
 			return err
 		}
 
+		// Remove the managed_by label if the value is sensu-agent, in case the
+		// entity is no longer managed by its agent
+		if storedEntityConfig.Metadata.Labels[corev2.ManagedByLabel] == "sensu-agent" {
+			delete(storedEntityConfig.Metadata.Labels, corev2.ManagedByLabel)
+		}
+
 		// Send back this entity config to the agent so it uses that rather than
 		// its local config for its events
 		watchEvent := &store.WatchEventEntityConfig{

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -92,6 +93,10 @@ func (r *EntitiesRouter) createOrReplace(req *http.Request) (interface{}, error)
 	entity := corev2.Entity{}
 	if err := UnmarshalBody(req, &entity); err != nil {
 		return nil, err
+	}
+
+	if entity.Labels[corev2.ManagedByLabel] == "sensu-agent" {
+		return nil, actions.NewError(actions.AlreadyExistsErr, errors.New("entity is managed by its agent"))
 	}
 
 	return entity, r.controller.CreateOrReplace(req.Context(), entity)

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -371,7 +371,6 @@ func (k *Keepalived) handleEntityRegistration(entity *corev2.Entity, event *core
 	if exists {
 		// Update the entity config if the agent reconnected
 		if isFirstSequenceForAgentManagedEntity {
-			fmt.Println("updating...!")
 			if err := k.storev2.UpdateIfExists(req, wrapper); err != nil {
 				logger.WithError(err).Error("could not update entity")
 				return err

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -215,18 +215,11 @@ func (t testSubscriber) Receiver() chan<- interface{} {
 }
 
 func TestProcessRegistration(t *testing.T) {
+	type assertionFunc func(*storetest.Store)
+
 	newEntityWithClass := func(class string) *corev2.Entity {
 		entity := corev2.FixtureEntity("agent1")
 		entity.EntityClass = class
-		return entity
-	}
-
-	newAgentManagedEntity := func(class string) *corev2.Entity {
-		entity := corev2.FixtureEntity("agent1")
-		entity.EntityClass = corev2.EntityAgentClass
-		entity.Labels = map[string]string{
-			corev2.ManagedByLabel: "sensu-agent",
-		}
 		return entity
 	}
 
@@ -238,40 +231,60 @@ func TestProcessRegistration(t *testing.T) {
 		return e
 	}
 
+	newAgentManagedEntity := func(class string) *corev2.Entity {
+		entity := corev2.FixtureEntity("agent1")
+		entity.EntityClass = corev2.EntityAgentClass
+		entity.Labels = map[string]string{
+			corev2.ManagedByLabel: "sensu-agent",
+		}
+		return entity
+	}
+
+	newAgentManagedEntityConfig := func(class string) *wrap.Wrapper {
+		entity := corev3.FixtureEntityConfig("agent1")
+		entity.EntityClass = class
+		entity.Metadata.Labels = map[string]string{
+			corev2.ManagedByLabel: "sensu-agent",
+		}
+		e, err := wrap.Resource(entity)
+		require.NoError(t, err)
+		return e
+	}
+
 	firstSequenceEvent := &corev2.Event{Sequence: 1}
 
 	tt := []struct {
-		name              string
-		entity            *corev2.Entity
-		event             *corev2.Event
-		storeEntity       *wrap.Wrapper
-		expectedEventLen  int
-		storev2Err        error
-		expectedEntityLen int
+		name                   string
+		entity                 *corev2.Entity
+		event                  *corev2.Event
+		storeEntity            *wrap.Wrapper
+		expectedEventLen       int
+		storeGetErr            error
+		storeCreateOrUpdateErr error
+		expectedEntityLen      int
+		assertionFunc          assertionFunc
 	}{
 		{
-			name:             "Registered Entity",
-			entity:           newEntityWithClass("agent"),
-			storeEntity:      newEntityConfigWithClass("agent"),
-			event:            new(corev2.Event),
-			expectedEventLen: 0,
-			storev2Err:       &stor.ErrAlreadyExists{},
+			name:                   "Registered Entity",
+			entity:                 newEntityWithClass("agent"),
+			storeEntity:            newEntityConfigWithClass("agent"),
+			event:                  new(corev2.Event),
+			expectedEventLen:       0,
+			storeCreateOrUpdateErr: &stor.ErrAlreadyExists{},
 		},
 		{
 			name:             "Non-Registered Entity",
 			entity:           newEntityWithClass("agent"),
-			storeEntity:      nil,
+			storeGetErr:      &stor.ErrNotFound{},
 			event:            new(corev2.Event),
 			expectedEventLen: 1,
-			storev2Err:       nil,
 		},
 		{
 			name:             "agent-managed entity is registered",
 			entity:           newAgentManagedEntity("agent"),
-			storeEntity:      nil,
+			storeGetErr:      &stor.ErrNotFound{},
 			event:            firstSequenceEvent,
 			expectedEventLen: 1,
-			storev2Err:       nil,
 		},
 		{
 			name:             "agent-managed entity config is updated on reconnect",
@@ -279,7 +292,16 @@ func TestProcessRegistration(t *testing.T) {
 			storeEntity:      newEntityConfigWithClass("agent"),
 			event:            firstSequenceEvent,
 			expectedEventLen: 0,
-			storev2Err:       nil,
+		},
+		{
+			name:             "backend-managed entity config no longer has the managed_by label with sensu-agent",
+			entity:           newEntityWithClass("agent"),
+			storeEntity:      newAgentManagedEntityConfig("agent"),
+			event:            new(corev2.Event),
+			expectedEventLen: 0,
+			assertionFunc: func(store *storetest.Store) {
+				store.AssertCalled(t, "UpdateIfExists", mock.Anything, mock.Anything)
+			},
 		},
 	}
 
@@ -307,15 +329,18 @@ func TestProcessRegistration(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			storev2.On("Exists", mock.Anything).Return(tc.storeEntity != nil, nil)
-			storev2.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(tc.storev2Err)
-			storev2.On("UpdateIfExists", mock.Anything, mock.Anything).Return(tc.storev2Err)
-			storev2.On("Get", mock.Anything).Return(tc.storeEntity, nil)
+			storev2.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(tc.storeCreateOrUpdateErr)
+			storev2.On("UpdateIfExists", mock.Anything, mock.Anything).Return(tc.storeCreateOrUpdateErr)
+			storev2.On("Get", mock.Anything).Return(tc.storeEntity, tc.storeGetErr)
 			err = keepalived.handleEntityRegistration(tc.entity, tc.event)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedEventLen, len(tsubEvent.ch))
 			assert.NoError(t, subscriptionEvent.Cancel())
+
+			if tc.assertionFunc != nil {
+				tc.assertionFunc(storev2)
+			}
 		})
 	}
 }

--- a/cli/resource/parse.go
+++ b/cli/resource/parse.go
@@ -67,20 +67,6 @@ func Parse(in io.Reader) ([]*types.Wrapper, error) {
 				continue
 			}
 
-			// Mark the resource as managed by sensuctl in the outer labels
-			if len(w.ObjectMeta.Labels) == 0 {
-				w.ObjectMeta.Labels = map[string]string{}
-			}
-			w.ObjectMeta.Labels[corev2.ManagedByLabel] = "sensuctl"
-
-			// Mark the resource as managed by sensuctl in the inner labels
-			innerMeta := compat.GetObjectMeta(w.Value)
-			if len(innerMeta.Labels) == 0 {
-				innerMeta.Labels = map[string]string{}
-			}
-			innerMeta.Labels[corev2.ManagedByLabel] = "sensuctl"
-			compat.SetObjectMeta(w.Value, innerMeta)
-
 			resources = append(resources, &w)
 			count++
 		}

--- a/cli/resource/process.go
+++ b/cli/resource/process.go
@@ -224,15 +224,15 @@ func (p *ManagedByLabelPutter) label(resource *types.Wrapper) {
 	managedBy := p.Label
 
 	// Mark the resource as managed by `label` in the outer labels if none is
-	// alreadt set
-	if outerLabels[corev2.ManagedByLabel] == "" {
+	// already set
+	if outerLabels[corev2.ManagedByLabel] != "sensu-agent" {
 		outerLabels[corev2.ManagedByLabel] = managedBy
 	} else {
 		managedBy = outerLabels[corev2.ManagedByLabel]
 	}
 
 	// Mark the resource as managed by `label` in the inner labels
-	if innerLabels[corev2.ManagedByLabel] == "" || innerLabels[corev2.ManagedByLabel] != outerLabels[corev2.ManagedByLabel] {
+	if innerLabels[corev2.ManagedByLabel] != "sensu-agent" || innerLabels[corev2.ManagedByLabel] != outerLabels[corev2.ManagedByLabel] {
 		innerLabels[corev2.ManagedByLabel] = managedBy
 	}
 

--- a/cli/resource/process.go
+++ b/cli/resource/process.go
@@ -220,10 +220,21 @@ func (p *ManagedByLabelPutter) label(resource *types.Wrapper) {
 	}
 	innerLabels := innerMeta.Labels
 
-	// Mark the resource as managed by `label` in the outer labels
-	outerLabels[corev2.ManagedByLabel] = p.Label
+	// By default the resource should be managed by sensuctl
+	managedBy := p.Label
+
+	// Mark the resource as managed by `label` in the outer labels if none is
+	// alreadt set
+	if outerLabels[corev2.ManagedByLabel] == "" {
+		outerLabels[corev2.ManagedByLabel] = managedBy
+	} else {
+		managedBy = outerLabels[corev2.ManagedByLabel]
+	}
 
 	// Mark the resource as managed by `label` in the inner labels
-	innerLabels[corev2.ManagedByLabel] = p.Label
+	if innerLabels[corev2.ManagedByLabel] == "" || innerLabels[corev2.ManagedByLabel] != outerLabels[corev2.ManagedByLabel] {
+		innerLabels[corev2.ManagedByLabel] = managedBy
+	}
+
 	compat.SetObjectMeta(resource.Value, innerMeta)
 }

--- a/cli/resource/process_test.go
+++ b/cli/resource/process_test.go
@@ -79,7 +79,20 @@ func TestManagedByLabelPutter_label(t *testing.T) {
 			},
 		},
 		{
-			name: "the label overwrites any existing value",
+			name: "the label does not overwrites the sensu-agent value",
+			resource: types.WrapResource(&corev2.CheckConfig{
+				ObjectMeta: corev2.ObjectMeta{
+					Labels: map[string]string{
+						corev2.ManagedByLabel: "sensu-agent",
+					},
+				},
+			}),
+			want: map[string]string{
+				corev2.ManagedByLabel: "sensu-agent",
+			},
+		},
+		{
+			name: "the label overwrites any other existing value",
 			resource: types.WrapResource(&corev2.CheckConfig{
 				ObjectMeta: corev2.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
## What is this change?

It introduces support for entities that are actively managed by agents; this re-introduces the behaviour we previously had with pre-6.0 agents.

sensu-agent now has a new `agent-managed-entity` configuration flag. When used, the entity managed by this agent will use the `sensu.io/managed_by` label to indicate that sensu-agent is now the source of truth for this entity.

keepalived (via its `handleEntityRegistration` method) is now responsible for updating the entity config on startup for entities managed by their agents, by using the new `sequence` field in events and the label mentioned above. In case the agent is restarted and no longer has the `agent-managed-entity` config attribute, we will then update the stored entity config to reflect that (by removing the `sensu.io/managed_by` label).

Finally, we are preventing updates made to entities managed by their agents via the REST API in two ways:
- An entity definition uploaded with the label `sensu.io/managed_by` that equals `sensu-agent` will return HTTP 409 Conflict.
- An entity stored with the label `sensu.io/managed_by` that equals `sensu-agent` will return HTTP 409 Conflict when updated.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/4120

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Yep; the `corev3.V3EntityToV2` currently has a bug which prevents the `CreatedBy` field to be carried over to the corev2 Entity.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yep, I'll open an issue and link it here.

Update: https://github.com/sensu/sensu-docs/issues/2905

## How did you verify this change?

I've created a test cases section in https://github.com/sensu/sensu-go/issues/4120, which I've used to test this feature. Once sensu-staging is working as expected, I'll have to deploy this branch and I'll try to write some tests for our QA crucible.

Update: https://github.com/sensu/sensu-go-qa-crucible/issues/164

## Is this change a patch?

Nope
