### PR TITLE
Fix CreatedBy not being carried over when converting v3 to v2 entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ code 46 when no arguments or incorrect arguments are given.
 authentication.
 - Added description to sensuctl dump command.
 - The sensuctl command descriptions now have consistent capitalization.
+- The `v3.V3EntityToV2()` API function now properly carries over the metadata's
+  `CreatedBy` field.
 
 ### [6.1.2] - 2020-10-28
 ### Fixed

--- a/api/core/v3/entity.go
+++ b/api/core/v3/entity.go
@@ -43,9 +43,6 @@ func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
 		KeepaliveHandlers: e.KeepaliveHandlers,
 		Redact:            e.Redact,
 	}
-	// We don't carry over CreatedBy, Labels and Annotations? I want to make
-	// sure this is intentional in light of the V3EntityToV2 docstring
-	// mentioning that config and state labels/annotation would be merged.
 	state := EntityState{
 		Metadata: &corev2.ObjectMeta{
 			Name:      e.ObjectMeta.Name,
@@ -60,13 +57,8 @@ func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
 
 // V3EntityToV2 converts an EntityConfig and an EntityState to a corev2.Entity.
 // Errors are returned if cfg and state's Metadata are nil or not equal in terms
-// of their namespace and name. Labels and annotations will be merged, with the
-// labels of cfg taking precedence. The resulting object will contain pointers
-// to cfg's and state's memory.
-// Labels and annotations are NOT merged? They are simply taken from cfg.
-// Whatever state might have is ignored. If this is intended, I suggest changing
-// to simply say something like "metadata from the EntityConfig is carried over
-// to the corev2.Entity".
+// of their namespace and name. The resulting object will contain pointers to
+// cfg's and state's memory, and its metadata is carried over from the config.
 func V3EntityToV2(cfg *EntityConfig, state *EntityState) (*corev2.Entity, error) {
 	if cfg.Metadata == nil {
 		return nil, errors.New("nil EntityConfig metadata")
@@ -92,8 +84,6 @@ func V3EntityToV2(cfg *EntityConfig, state *EntityState) (*corev2.Entity, error)
 	for k, v := range cfg.Metadata.Annotations {
 		meta.Annotations[k] = v
 	}
-
-	// Carry over the CreatedBy field from the config
 	meta.CreatedBy = cfg.Metadata.CreatedBy
 
 	entity := &corev2.Entity{

--- a/api/core/v3/entity.go
+++ b/api/core/v3/entity.go
@@ -93,8 +93,8 @@ func V3EntityToV2(cfg *EntityConfig, state *EntityState) (*corev2.Entity, error)
 		meta.Annotations[k] = v
 	}
 
-	// CreatedBy is also a metadata field that needs to be carried over, ie:
-	// meta.CreatedBy = cfg.Metadata.CreatedBy
+	// Carry over the CreatedBy field from the config
+	meta.CreatedBy = cfg.Metadata.CreatedBy
 
 	entity := &corev2.Entity{
 		ObjectMeta:        meta,

--- a/api/core/v3/entity.go
+++ b/api/core/v3/entity.go
@@ -43,6 +43,9 @@ func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
 		KeepaliveHandlers: e.KeepaliveHandlers,
 		Redact:            e.Redact,
 	}
+	// We don't carry over CreatedBy, Labels and Annotations? I want to make
+	// sure this is intentional in light of the V3EntityToV2 docstring
+	// mentioning that config and state labels/annotation would be merged.
 	state := EntityState{
 		Metadata: &corev2.ObjectMeta{
 			Name:      e.ObjectMeta.Name,
@@ -60,6 +63,10 @@ func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
 // of their namespace and name. Labels and annotations will be merged, with the
 // labels of cfg taking precedence. The resulting object will contain pointers
 // to cfg's and state's memory.
+// Labels and annotations are NOT merged? They are simply taken from cfg.
+// Whatever state might have is ignored. If this is intended, I suggest changing
+// to simply say something like "metadata from the EntityConfig is carried over
+// to the corev2.Entity".
 func V3EntityToV2(cfg *EntityConfig, state *EntityState) (*corev2.Entity, error) {
 	if cfg.Metadata == nil {
 		return nil, errors.New("nil EntityConfig metadata")
@@ -85,6 +92,10 @@ func V3EntityToV2(cfg *EntityConfig, state *EntityState) (*corev2.Entity, error)
 	for k, v := range cfg.Metadata.Annotations {
 		meta.Annotations[k] = v
 	}
+
+	// CreatedBy is also a metadata field that needs to be carried over, ie:
+	// meta.CreatedBy = cfg.Metadata.CreatedBy
+
 	entity := &corev2.Entity{
 		ObjectMeta:        meta,
 		EntityClass:       cfg.EntityClass,

--- a/api/core/v3/entity.go
+++ b/api/core/v3/entity.go
@@ -119,6 +119,7 @@ func FixtureEntityConfig(name string) *EntityConfig {
 			Name:        name,
 			Labels:      make(map[string]string),
 			Annotations: make(map[string]string),
+			CreatedBy:   "user123",
 		},
 		EntityClass:   corev2.EntityAgentClass,
 		User:          "agent1",

--- a/api/core/v3/entity_test.go
+++ b/api/core/v3/entity_test.go
@@ -57,7 +57,6 @@ func TestV3EntityToV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// This is not correct if we merge labels/annotations between cfg and state
 	if want, got := cfg.Metadata, entity.ObjectMeta; !proto.Equal(&got, want) {
 		t.Errorf("bad objectmeta: got %v, want %v", got, want)
 	}
@@ -81,10 +80,6 @@ func TestV3EntityToV2(t *testing.T) {
 	}
 	if want, got := cfg.Redact, entity.Redact; !reflect.DeepEqual(got, want) {
 		t.Errorf("bad Redact: got %v, want %v", got, want)
-	}
-	// This is not correct if we merge labels/annotations between cfg and state
-	if want, got := state.Metadata, entity.ObjectMeta; !proto.Equal(&got, want) {
-		t.Errorf("bad objectmeta: got %v, want %v", got, want)
 	}
 	if want, got := state.System, entity.System; !proto.Equal(&got, &want) {
 		t.Errorf("bad System: got %v, want %v", got, want)

--- a/api/core/v3/entity_test.go
+++ b/api/core/v3/entity_test.go
@@ -57,6 +57,7 @@ func TestV3EntityToV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// This is not correct if we merge labels/annotations between cfg and state
 	if want, got := cfg.Metadata, entity.ObjectMeta; !proto.Equal(&got, want) {
 		t.Errorf("bad objectmeta: got %v, want %v", got, want)
 	}
@@ -81,6 +82,7 @@ func TestV3EntityToV2(t *testing.T) {
 	if want, got := cfg.Redact, entity.Redact; !reflect.DeepEqual(got, want) {
 		t.Errorf("bad Redact: got %v, want %v", got, want)
 	}
+	// This is not correct if we merge labels/annotations between cfg and state
 	if want, got := state.Metadata, entity.ObjectMeta; !proto.Equal(&got, want) {
 		t.Errorf("bad objectmeta: got %v, want %v", got, want)
 	}


### PR DESCRIPTION
## What is this change?

With this change, when converting a (v3.EntityConfig, v3.EntityState) into a
v2.Entity, we carry over the CreatedBy metadata from the config, just like we do
for labels and annotations.

## Why is this change necessary?

Addresses a bug that @palourde came across while working on something else.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

After careful consideration, a test that asserts that, after a v3 to v2
conversion, the state's metadata ought to be the same as the resulting v2
entity's has been removed because it is not correct: metadata information is
copied from the config part. This change exposed this issue.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No change in documentation is required.

## How did you verify this change?

Unit tests only.

## Is this change a patch?

No?