### PR TITLE
[Store] Add option to sort list results

### DIFF
--- a/backend/store/v2/etcdstore/store.go
+++ b/backend/store/v2/etcdstore/store.go
@@ -298,6 +298,7 @@ func (s *Store) List(req storev2.ResourceRequest, pred *store.SelectionPredicate
 	opts := []clientv3.OpOption{
 		clientv3.WithLimit(pred.Limit),
 		clientv3.WithSerializable(),
+		clientv3.WithSort(clientv3.SortByKey, getSortOrder(req.SortOrder)),
 	}
 	rangeEnd := clientv3.GetPrefixRangeEnd(key)
 	opts = append(opts, clientv3.WithRange(rangeEnd))
@@ -354,4 +355,14 @@ func (s *Store) Exists(req storev2.ResourceRequest) (bool, error) {
 		return false, err
 	}
 	return resp.Count > 0, nil
+}
+
+func getSortOrder(order storev2.SortOrder) clientv3.SortOrder {
+	switch order {
+	case storev2.SortAscend:
+		return clientv3.SortAscend
+	case storev2.SortDescend:
+		return clientv3.SortDescend
+	}
+	return clientv3.SortNone
 }

--- a/backend/store/v2/etcdstore/store_test.go
+++ b/backend/store/v2/etcdstore/store_test.go
@@ -296,8 +296,41 @@ func TestList(t *testing.T) {
 		if pred.Continue != "" {
 			t.Error("expected empty continue token")
 		}
+		// Test listing in descending order
+		pred.Continue = ""
+		req.SortOrder = storev2.SortDescend
+		list, err = s.List(req, pred)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := len(list); got == 0 {
+			t.Fatalf("wrong number of items: got %d, want > %d", got, 0)
+		}
+		firstObj, err := list[0].Unwrap()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := firstObj.GetMetadata().Name, "foo-9"; got != want {
+			t.Errorf("unexpected first item in list: got %s, want %s", got, want)
+		}
+		// Test listing in ascending order
+		pred.Continue = ""
+		req.SortOrder = storev2.SortAscend
+		list, err = s.List(req, pred)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := len(list); got == 0 {
+			t.Fatalf("wrong number of items: got %d, want > %d", got, 0)
+		}
+		firstObj, err = list[0].Unwrap()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := firstObj.GetMetadata().Name, "foo-0"; got != want {
+			t.Errorf("unexpected first item in list: got %s, want %s", got, want)
+		}
 	})
-
 }
 
 func TestExists(t *testing.T) {

--- a/backend/store/v2/resource.go
+++ b/backend/store/v2/resource.go
@@ -8,12 +8,21 @@ import (
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 )
 
+type SortOrder int
+
+const (
+	SortNone SortOrder = iota
+	SortAscend
+	SortDescend
+)
+
 // ResourceRequest contains all the information necessary to query a store.
 type ResourceRequest struct {
 	Namespace string
 	Name      string
 	StoreName string
 	Context   context.Context
+	SortOrder SortOrder
 }
 
 // NewResourceRequestFromResource creates a ResourceRequest from a resource.


### PR DESCRIPTION
Adds option to list request, allowing results to be sorted by key in an ascending or,
descending order. While this has some obvious limitations, (case-insensitivity for one,)
it is much more efficient that pulling the entire list and sorting in memory.

Required to properly implement https://github.com/sensu/sensu-enterprise-go/pull/1418

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
