### PR TITLE
Don't remove entities from nonexistent rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where a small amount of extra etcd or postgres traffic was
+generated on keepalive failure.
+
 ## [6.2.0] - 2020-12-17
 
 ### Added


### PR DESCRIPTION
## What is this change?

This commit fixes a bug in keepalived, where entities are attempted to
be removed from rings that don't exist. Specifically, the entity
subscription.

On etcd this generates extra traffic, although no additional keys are
created. On postgres, this can result in many rows being inserted
needlessly.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Currently verifying on sensu-perf.

## Is this change a patch?

Yes