### PR TITLE
Limit agent transport upgrades before hitting etcd

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -157,7 +157,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 
 	route := router.NewRoute().Subrouter()
 	route.HandleFunc("/", a.webSocketHandler)
-	route.Use(authenticate, authorize, entityLimit, agentLimit)
+	route.Use(agentLimit, authenticate, authorize)
 
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -40,12 +40,6 @@ func agentLimit(next http.Handler) http.Handler {
 	return AgentLimiterMiddleware(next)
 }
 
-// entityLimit is the abstraction layer required to be able to change at
-// runtime the actual function assigned to EntityLimiterMiddleware above.
-func entityLimit(next http.Handler) http.Handler {
-	return EntityLimiterMiddleware(next)
-}
-
 // AuthStore specifies the storage requirements for authentication and
 // authorization.
 type AuthStore interface {


### PR DESCRIPTION
## What is this change?

Do less work in the hard agent limiter, by invoking less middleware.