### PR TITLE
Do not override the expire attribute of silenced entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- The expire field of silenced entries represents the configured expiration, in
+seconds, not the remaining duration.
+
 ## [6.2.0] - 2020-12-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ code 46 when no arguments or incorrect arguments are given.
 
 ### Fixed
 - The config-file flag is no longer order dependant.
-- The agent now respects the HTTP proxy environment variables when using mTLS
-authentication.
 - Added description to sensuctl dump command.
 - The sensuctl command descriptions now have consistent capitalization.
 - The `v3.V3EntityToV2()` API function now properly carries over the metadata's

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -99,7 +99,6 @@ func (r *SilencedRouter) listr(ctx context.Context, pred *store.SelectionPredica
 	if err != nil {
 		return nil, err
 	}
-
 	result := make([]corev2.Resource, 0, len(entries))
 	for _, e := range entries {
 		result = append(result, e)

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -99,6 +99,7 @@ func (r *SilencedRouter) listr(ctx context.Context, pred *store.SelectionPredica
 	if err != nil {
 		return nil, err
 	}
+
 	result := make([]corev2.Resource, 0, len(entries))
 	for _, e := range entries {
 		result = append(result, e)

--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -216,6 +216,13 @@ func (s *Store) arraySilencedEntries(ctx context.Context, resp *clientv3.GetResp
 		leaseID := clientv3.LeaseID(kv.Lease)
 		if leaseID > 0 {
 			// legacy expiry mechanism
+			ttl, err := s.client.TimeToLive(ctx, leaseID)
+			if err != nil {
+				logger.WithError(err).Error("error setting TTL on silenced")
+				continue
+			}
+			silenced.ExpireAt = time.Now().Unix() + ttl.TTL
+
 			result = append(result, silenced)
 		} else if silenced.ExpireAt > 0 {
 			// new expiry mechanism
@@ -249,6 +256,8 @@ func (s *Store) arrayTxnSilencedEntries(ctx context.Context, resp *clientv3.TxnR
 			if err := unmarshal(kv.Value, &silenced); err != nil {
 				return nil, &store.ErrDecode{Err: fmt.Errorf("couldn't get silenced entries: %s", err)}
 			}
+
+			var expire int64
 			leaseID := clientv3.LeaseID(kv.Lease)
 			if leaseID > 0 {
 				// legacy expiry mechanism
@@ -257,18 +266,19 @@ func (s *Store) arrayTxnSilencedEntries(ctx context.Context, resp *clientv3.TxnR
 					logger.WithError(err).Error("error setting TTL on silenced")
 					continue
 				}
-				silenced.Expire = ttl.TTL
+				silenced.ExpireAt = time.Now().Unix() + ttl.TTL
+
 				results = append(results, &silenced)
 			} else if silenced.ExpireAt > 0 {
 				// new expiry mechanism
-				silenced.Expire = int64(time.Until(time.Unix(silenced.ExpireAt, 0)) / time.Second)
-				if silenced.Expire > 0 {
+				expire = int64(time.Until(time.Unix(silenced.ExpireAt, 0)) / time.Second)
+				if expire > 0 {
 					results = append(results, &silenced)
 				} else {
 					rejects = append(rejects, silenced.Name)
 				}
 			} else {
-				// no expiry
+				// the silenced entry has no expiration
 				silenced.Expire = -1
 				results = append(results, &silenced)
 			}

--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -215,6 +215,7 @@ func (s *Store) arraySilencedEntries(ctx context.Context, resp *clientv3.GetResp
 		var expire int64
 		leaseID := clientv3.LeaseID(kv.Lease)
 		if leaseID > 0 {
+			// legacy expiry mechanism
 			result = append(result, silenced)
 		} else if silenced.ExpireAt > 0 {
 			// new expiry mechanism
@@ -225,7 +226,7 @@ func (s *Store) arraySilencedEntries(ctx context.Context, resp *clientv3.GetResp
 				rejects = append(rejects, silenced.Name)
 			}
 		} else {
-			// the silenced entry has not expiry
+			// the silenced entry has no expiration
 			result = append(result, silenced)
 		}
 	}

--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -227,6 +227,7 @@ func (s *Store) arraySilencedEntries(ctx context.Context, resp *clientv3.GetResp
 			}
 		} else {
 			// the silenced entry has no expiration
+			silenced.Expire = -1
 			result = append(result, silenced)
 		}
 	}

--- a/backend/store/etcd/silenced_store_test.go
+++ b/backend/store/etcd/silenced_store_test.go
@@ -164,8 +164,9 @@ func TestSilencedStorageWithBeginAndExpire(t *testing.T) {
 		assert.False(t, entry.StartSilence(currentTime))
 		// Check that the ttl includes the expire time and delta between current
 		// and begin time
-		assert.Condition(t, func() bool {
-			return entry.Expire > 3600
-		})
+		assert.Equal(t, entry.Expire, int64(15))
+		// assert.Condition(t, func() bool {
+		// 	return entry.Expire > 3600
+		// })
 	})
 }

--- a/backend/store/etcd/silenced_store_test.go
+++ b/backend/store/etcd/silenced_store_test.go
@@ -165,8 +165,5 @@ func TestSilencedStorageWithBeginAndExpire(t *testing.T) {
 		// Check that the ttl includes the expire time and delta between current
 		// and begin time
 		assert.Equal(t, entry.Expire, int64(15))
-		// assert.Condition(t, func() bool {
-		// 	return entry.Expire > 3600
-		// })
 	})
 }

--- a/cli/commands/silenced/info.go
+++ b/cli/commands/silenced/info.go
@@ -49,6 +49,16 @@ func InfoCommand(cli *cli.SensuCli) *cobra.Command {
 
 }
 
+func expireAt(timestamp int64) string {
+	// If we have no expiration, return -1
+	if timestamp < 1 {
+		return "no expiration"
+	}
+
+	begin := time.Unix(timestamp, 0)
+	return begin.Format(timeFormat)
+}
+
 func expireTime(beginTS, expireSeconds int64) string {
 	// If we have no expiration, return -1
 	if expireSeconds == -1 {
@@ -76,8 +86,8 @@ func printToList(v interface{}, writer io.Writer) error {
 		Title: r.Name,
 		Rows: []*list.Row{
 			{
-				Label: "Expire",
-				Value: expireTime(r.Begin, r.Expire),
+				Label: "Expiration",
+				Value: expireAt(r.ExpireAt),
 			},
 			{
 				Label: "ExpireOnResolve",

--- a/cli/commands/silenced/info.go
+++ b/cli/commands/silenced/info.go
@@ -59,24 +59,6 @@ func expireAt(timestamp int64) string {
 	return begin.Format(timeFormat)
 }
 
-func expireTime(beginTS, expireSeconds int64) string {
-	// If we have no expiration, return -1
-	if expireSeconds == -1 {
-		return "-1"
-	}
-
-	begin := time.Unix(beginTS, 0)
-	if time.Now().Before(begin) {
-		// If the silenced entry is not yet in effect, because the being timestamp
-		// is in the future, display the full expiration date as RFC3339
-		expire := begin.Add(time.Duration(expireSeconds) * time.Second)
-		return expire.Format(timeFormat)
-	}
-
-	// If the silenced entry is in effect, display its configured duration
-	return (time.Duration(expireSeconds) * time.Second).String()
-}
-
 func printToList(v interface{}, writer io.Writer) error {
 	r, ok := v.(*types.Silenced)
 	if !ok {

--- a/cli/commands/silenced/info_test.go
+++ b/cli/commands/silenced/info_test.go
@@ -86,40 +86,31 @@ func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	assert.Empty(out)
 }
 
-func Test_expireTime(t *testing.T) {
+func Test_expireAt(t *testing.T) {
 	unixToInternal := int64((1969*365 + 1969/4 - 1969/100 + 1969/400) * 24 * 60 * 60)
 	future := time.Unix(1<<63-1-unixToInternal, 999999999)
 
 	tests := []struct {
-		name          string
-		beginTS       int64
-		expireSeconds int64
-		want          string
+		name     string
+		expireAt int64
+		want     string
 	}{
 		{
-			name:          "an entry without an expiration returns -1",
-			beginTS:       time.Now().Truncate(time.Duration(1) * time.Minute).Unix(),
-			expireSeconds: -1,
-			want:          "-1",
+			name:     "an entry without an expiration returns -1",
+			expireAt: -1,
+			want:     "no expiration",
 		},
 		{
-			name:          "an entry that is not yet in effect return a RFC3339 date",
-			beginTS:       future.Unix(),
-			expireSeconds: 300,
-			want:          "292277024627-12",
-		},
-		{
-			name:          "an entry that is in effect return the configured duration",
-			beginTS:       time.Now().Truncate(time.Duration(1) * time.Minute).Unix(),
-			expireSeconds: 300,
-			want:          "5m",
+			name:     "an RFC3339 date is returned",
+			expireAt: future.Unix(),
+			want:     "292277024627-12",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := expireTime(tt.beginTS, tt.expireSeconds)
+			got := expireAt(tt.expireAt)
 			if !strings.Contains(got, tt.want) {
-				t.Errorf("expireTime() = %v, want %v", got, tt.want)
+				t.Errorf("expireAt() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cli/commands/silenced/list.go
+++ b/cli/commands/silenced/list.go
@@ -129,13 +129,13 @@ func printToTable(results interface{}, writer io.Writer) {
 			},
 		},
 		{
-			Title: "Expire",
+			Title: "Expiration",
 			CellTransformer: func(data interface{}) string {
 				silenced, ok := data.(corev2.Silenced)
 				if !ok {
 					return cli.TypeError
 				}
-				return expireTime(silenced.Begin, silenced.Expire)
+				return expireAt(silenced.ExpireAt)
 			},
 		},
 		{

--- a/cli/commands/silenced/list_test.go
+++ b/cli/commands/silenced/list_test.go
@@ -86,7 +86,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 
 	assert.NotEmpty(out)
 	assert.Contains(out, "Name")            // heading
-	assert.Contains(out, "Expire")          // heading
+	assert.Contains(out, "Expiration")      // heading
 	assert.Contains(out, "ExpireOnResolve") // heading
 	assert.Contains(out, "Creator")         // heading
 	assert.Contains(out, "Check")           // heading
@@ -98,7 +98,7 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert.Contains(out, "eric")
 	assert.Contains(out, "defaultnamespace")
 	assert.Contains(out, "false")
-	assert.Contains(out, "0s")
+	assert.Contains(out, "no expiration")
 }
 
 // Test to ensure silenced command list output does not escape alphanumeric chars


### PR DESCRIPTION
## What is this change?

It fixes a breaking change introduced in 6.2.0, which would set the remaining duration of a silenced entry (it's TTL) rather than the configured duration.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/4143

## Does your change need a Changelog entry?

Added

## Do you need clarification on anything?
Nope


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
Signed-off-by: Simon Plourde <simon@sensu.io>Signed-off-by: Simon Plourde <simon@sensu.io>