### PR TITLE
Reduce extra ring work further

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -700,6 +700,10 @@ func (s *Session) unsubscribe(subscriptions []string) {
 	var ringWG sync.WaitGroup
 	ringWG.Add(len(subscriptions))
 	for _, sub := range subscriptions {
+		if strings.HasPrefix(sub, "entity:") {
+			// Entity subscriptions don't get rings
+			continue
+		}
 		go func(sub string) {
 			defer ringWG.Done()
 			ring := s.ringPool.Get(ringv2.Path(s.cfg.Namespace, sub))

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -698,12 +698,12 @@ func (s *Session) unsubscribe(subscriptions []string) {
 
 	// Remove the ring for every subscription
 	var ringWG sync.WaitGroup
-	ringWG.Add(len(subscriptions))
 	for _, sub := range subscriptions {
 		if strings.HasPrefix(sub, "entity:") {
 			// Entity subscriptions don't get rings
 			continue
 		}
+		ringWG.Add(1)
 		go func(sub string) {
 			defer ringWG.Done()
 			ring := s.ringPool.Get(ringv2.Path(s.cfg.Namespace, sub))


### PR DESCRIPTION
This commit finishes the other bugfix to do with rings.

See https://github.com/sensu/sensu-go/pull/4140

This PR is necessary, as the other one did not catch all instances of `ringPool.Get`.