### PR TITLE
Fix sensuctl dump event output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a bug where events from namespaces other than the one requested could
+appear in sensuctl dump output. The bug only applied to users who had access to
+the other namespaces.
+
 ## [6.2.1] - 2021-01-08
 
 ### Fixed

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -40,7 +40,7 @@ func (e *Event) URIPath() string {
 		return path.Join(URLPrefix, EventsResource)
 	}
 	if !e.HasCheck() {
-		return path.Join(URLPrefix, EventsResource, url.PathEscape(e.Entity.Name))
+		return path.Join(URLPrefix, "namespaces", url.PathEscape(e.Entity.Namespace), EventsResource, url.PathEscape(e.Entity.Name))
 	}
 	return path.Join(URLPrefix, "namespaces", url.PathEscape(e.Entity.Namespace), EventsResource, url.PathEscape(e.Entity.Name), url.PathEscape(e.Check.Name))
 }
@@ -471,6 +471,13 @@ func isSilenced(e *Event) string {
 // SetNamespace sets the namespace of the resource.
 func (e *Event) SetNamespace(namespace string) {
 	e.Namespace = namespace
+	if e.Entity == nil {
+		e.Entity = new(Entity)
+	}
+	e.Entity.Namespace = namespace
+	if e.Check != nil {
+		e.Check.Namespace = namespace
+	}
 }
 
 // SetObjectMeta sets the meta of the resource.

--- a/api/core/v2/event_test.go
+++ b/api/core/v2/event_test.go
@@ -980,3 +980,45 @@ func TestEventFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSetNamespace(t *testing.T) {
+	event := new(Event)
+	event.SetNamespace("foobar")
+	if event.Entity == nil {
+		t.Fatal("nil entity")
+	}
+	if got, want := event.Namespace, "foobar"; got != want {
+		t.Errorf("bad namespace: got %q, want %q", got, want)
+	}
+	if got, want := event.Entity.Namespace, "foobar"; got != want {
+		t.Errorf("bad namespace: got %q, want %q", got, want)
+	}
+	if event.Check != nil {
+		t.Fatal("check should have been nil")
+	}
+	event.Check = new(Check)
+	event.SetNamespace("foobar")
+	if got, want := event.Check.Namespace, "foobar"; got != want {
+		t.Errorf("bad namespace: got %q, want %q", got, want)
+	}
+}
+
+func TestEventURIPath(t *testing.T) {
+	e := new(Event)
+	if got, want := e.URIPath(), "/api/core/v2/events"; got != want {
+		t.Errorf("bad URIPath; got %q, want %q", got, want)
+	}
+	e.SetNamespace("foobar")
+	if got, want := e.URIPath(), "/api/core/v2/namespaces/foobar/events"; got != want {
+		t.Errorf("bad URIPath; got %q, want %q", got, want)
+	}
+	e.Entity.Name = "baz"
+	if got, want := e.URIPath(), "/api/core/v2/namespaces/foobar/events/baz"; got != want {
+		t.Errorf("bad URIPath; got %q, want %q", got, want)
+	}
+	e.Check = new(Check)
+	e.Check.Name = "bep"
+	if got, want := e.URIPath(), "/api/core/v2/namespaces/foobar/events/baz/bep"; got != want {
+		t.Errorf("bad URIPath; got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where events from all namespaces are dumped when
sensuctl dump is invoked, even if a specific namespace is requested. The
bug was presentational in nature and does not represent a security
issue.

## Why is this change necessary?

Fixes #4166 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

I used the issue reproduction steps to verify the change and also included a unit test.

## Is this change a patch?

Yes
