### PR TITLE
Add wait flag to sensu-backend init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 appear in sensuctl dump output. The bug only applied to users who had access to
 the other namespaces.
 
+### Added
+- Added wait flag to the sensu-backend init command which toggles waiting
+indefinitely for etcd to become available.
+
 ## [6.2.1] - 2021-01-08
 
 ### Fixed

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -26,6 +26,7 @@ const (
 	flagInitAdminPassword = "cluster-admin-password"
 	flagInteractive       = "interactive"
 	flagTimeout           = "timeout"
+	flagWait              = "wait"
 )
 
 type seedConfig struct {
@@ -172,22 +173,31 @@ func InitCommand() *cobra.Command {
 			// required to debug TLS errors because the seeding below will not print
 			// the latest connection error (see
 			// https://github.com/sensu/sensu-go/issues/3663)
-			for _, url := range clientURLs {
-				tctx, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
-				defer cancel()
-				_, err = client.Status(tctx, url)
-				if err != nil {
-					// We do not need to log the error, etcd's client interceptor will log
-					// the actual underlying error
-					continue
-				}
-				// The endpoint did not return any error, therefore we can proceed
-				goto seed
-			}
-			// All endpoints returned an error, return the latest one
-			return err
+			wait := viper.GetBool(flagWait)
+			connected := false
+			for !connected {
+				for _, url := range clientURLs {
+					logger.Infof("attempting to connect to etcd server: %s", url)
 
-		seed:
+					tctx, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
+					defer cancel()
+
+					_, err = client.Status(tctx, url)
+					if err != nil {
+						// We do not need to log the error, etcd's client interceptor will log
+						// the actual underlying error
+						continue
+					}
+					// The endpoint did not return any error, therefore we can proceed
+					connected = true
+					break
+				}
+				if !wait {
+					// All endpoints returned an error, return the latest one
+					return err
+				}
+			}
+
 			return seedCluster(client, seedConfig)
 		},
 	}
@@ -196,6 +206,7 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
 	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
+	cmd.Flags().Bool(flagWait, false, "wait indefinitely to establish a connection to etcd (takes precedence over timeout)")
 
 	setupErr = handleConfig(cmd, os.Args[1:], false)
 


### PR DESCRIPTION
## What is this change?

Adds a new `wait` flag to the `sensu-backend init` command to allow users to wait indefinitely for etcd to become available instead of requiring a timeout.

## Why is this change necessary?

This will allow us to remove a the retry logic from the Docker entrypoint.sh file which will resolve some of the issues we've seen.

Partially fixes https://github.com/sensu/sensu-go/issues/4147.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation will be required. See https://github.com/sensu/sensu-docs/issues/2942.

## How did you verify this change?

1. Stop sensu-backend.
2. Run `sensu-backend init --wait`.
3. Watch it continuously attempt connecting to the etcd servers defined.
4. Start sensu-backend.
5. The init command executes.

## Is this change a patch?

No.
