### PR TITLE
Fix the agent-managed-entity config attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed the `agent-managed-entity` agent config attribute when no labels are
+defined.
+
 ## [6.2.2] - 2021-01-14
 
 ### Fixed

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -179,6 +179,9 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 
 	// Add the ManagedByLabel label value if the agent is managed by its entity
 	if viper.GetBool(flagAgentManagedEntity) {
+		if len(labels) == 0 {
+			labels = make(map[string]string)
+		}
 		labels[corev2.ManagedByLabel] = "sensu-agent"
 	}
 

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/agent"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -47,6 +48,25 @@ func TestNewAgentConfigFlags(t *testing.T) {
 
 	if !reflect.DeepEqual(cfg.Labels, map[string]string{"foo": "bar"}) {
 		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.Labels, `{"foo":"bar"}`)
+	}
+}
+
+func TestNewAgentConfig_AgentManagedEntityFlag(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagAgentManagedEntity, "true")
+
+	_, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"})
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Simon Plourde <simon@sensu.io>
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

It fixes a bug found during 6.2.2 QA, when the `agent-managed-entity` config attribute is used with sensu-agent and no labels are defined.

## Does your change need a Changelog entry?
Added

## Do you need clarification on anything?

Nope

## Were there any complications while making this change?

Nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Nope

## How did you verify this change?

Manually verified + added a unit test. Our QA crucible was also able to catch this bug.

## Is this change a patch?

Yep
