### PR TITLE
Add managed_by label to cfg.Label

### DIFF
--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -179,10 +179,10 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 
 	// Add the ManagedByLabel label value if the agent is managed by its entity
 	if viper.GetBool(flagAgentManagedEntity) {
-		if len(labels) == 0 {
-			labels = make(map[string]string)
+		if len(cfg.Labels) == 0 {
+			cfg.Labels = make(map[string]string)
 		}
-		labels[corev2.ManagedByLabel] = "sensu-agent"
+		cfg.Labels[corev2.ManagedByLabel] = "sensu-agent"
 	}
 
 	return cfg, nil

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -60,13 +60,13 @@ func TestNewAgentConfig_AgentManagedEntityFlag(t *testing.T) {
 	}
 	_ = cmd.Flags().Set(flagAgentManagedEntity, "true")
 
-	_, err := NewAgentConfig(cmd)
+	cfg, err := NewAgentConfig(cmd)
 	if err != nil {
 		t.Fatal("unexpected error while calling handleConfig: ", err)
 	}
 
-	if !reflect.DeepEqual(labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"}) {
-		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"})
+	if !reflect.DeepEqual(cfg.Labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.Labels, map[string]string{corev2.ManagedByLabel: "sensu-agent"})
 	}
 }
 


### PR DESCRIPTION
This fixes an issue where the `managed_by` label wasn't persisted to the agent's config.