### PR TITLE
Move sensuctl dump for all namespaces to 6.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added wait flag to the sensu-backend init command which toggles waiting
+indefinitely for etcd to become available.
+
+## [6.2.3] - 2021-01-21
+
 ### Fixed
 - Fixed the `agent-managed-entity` agent config attribute when no labels are
 defined.
@@ -14,13 +20,7 @@ defined.
 appear in sensuctl dump output. The bug only applied to users who had access to
 the other namespaces.
 
-## [6.2.2] - 2021-01-14
-
-### Added
-- Added wait flag to the sensu-backend init command which toggles waiting
-indefinitely for etcd to become available.
-
-## [6.2.1] - 2021-01-08
+## [6.2.1, 6.2.2] - 2021-01-08
 
 ### Fixed
 - The expire field of silenced entries represents the configured expiration, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed the `agent-managed-entity` agent config attribute when no labels are
 defined.
-
-## [6.2.2] - 2021-01-14
-
-### Fixed
 - Fixed a bug where events from namespaces other than the one requested could
 appear in sensuctl dump output. The bug only applied to users who had access to
 the other namespaces.
+
+## [6.2.2] - 2021-01-14
 
 ### Added
 - Added wait flag to the sensu-backend init command which toggles waiting


### PR DESCRIPTION
## What is this change?

Moves "...events from namespaces other than the one requested could appear in sensuctl dump output..." item from 6.2.2 release to 6.2.3


## Why is this change necessary?

This change actually happened in 6.2.3 rather than 6.2.2

## Does your change need a Changelog entry?

Yes :)

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/pull/2946

## How did you verify this change?

Confirmed w/ @portertech 

## Is this change a patch?

No
