### PR TITLE
sensu-backend init fixes

### DIFF
--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -443,7 +443,7 @@ func flagSet(server bool) *pflag.FlagSet {
 	_ = flagSet.SetAnnotation(flagEtcdClientCertAuth, "categories", []string{"store"})
 	flagSet.String(flagEtcdTrustedCAFile, viper.GetString(flagEtcdTrustedCAFile), "path to the client server TLS trusted CA cert file")
 	_ = flagSet.SetAnnotation(flagEtcdTrustedCAFile, "categories", []string{"store"})
-	flagSet.String(flagEtcdClientURLs, viper.GetString(flagEtcdClientURLs), "client URLs to use when operating as an etcd client")
+	flagSet.StringSlice(flagEtcdClientURLs, viper.GetStringSlice(flagEtcdClientURLs), "client URLs to use when operating as an etcd client")
 	_ = flagSet.SetAnnotation(flagEtcdClientURLs, "categories", []string{"store"})
 
 	if server {

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"context"
+	"fmt"
 	"path"
 
 	"github.com/coreos/etcd/clientv3"
@@ -35,7 +36,7 @@ func (store *Store) NewInitializer() (store.Initializer, error) {
 		mutex:   concurrency.NewMutex(session, initializationLockKey),
 		session: session,
 		client:  client,
-		ctx:     context.TODO(),
+		ctx:     client.Ctx(),
 	}, nil
 }
 
@@ -48,14 +49,14 @@ func (s *StoreInitializer) Lock() error {
 func (s *StoreInitializer) IsInitialized() (bool, error) {
 	r, err := s.client.Get(s.ctx, path.Join(EtcdRoot, initializationKey))
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to fetch initialization key: %w", err)
 	}
 
 	// if there is no result, test the fallback and return using same logic
 	if len(r.Kvs) == 0 {
 		fallback, err := s.client.Get(s.ctx, initializationKey)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("failed to fetch fallback initialization key: %w", err)
 		} else {
 			return fallback.Count > 0, nil
 		}
@@ -67,17 +68,17 @@ func (s *StoreInitializer) IsInitialized() (bool, error) {
 // FlagAsInitialized - set .initialized key
 func (s *StoreInitializer) FlagAsInitialized() error {
 	_, err := s.client.Put(s.ctx, path.Join(EtcdRoot, initializationKey), "1")
-	return err
+	return fmt.Errorf("failed to flag database as initialized: %w", err)
 }
 
 // Close session & unlock
 func (s *StoreInitializer) Close() error {
 	if err := s.mutex.Unlock(s.ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to unlock initializer mutex: %w", err)
 	}
 
 	if err := s.session.Close(); err != nil {
-		return err
+		return fmt.Errorf("failed to close initializer session: %w", err)
 	}
 	<-s.session.Done()
 

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -68,7 +68,10 @@ func (s *StoreInitializer) IsInitialized() (bool, error) {
 // FlagAsInitialized - set .initialized key
 func (s *StoreInitializer) FlagAsInitialized() error {
 	_, err := s.client.Put(s.ctx, path.Join(EtcdRoot, initializationKey), "1")
-	return fmt.Errorf("failed to flag database as initialized: %w", err)
+	if err != nil {
+		return fmt.Errorf("failed to flag database as initialized: %w", err)
+	}
+	return nil
 }
 
 // Close session & unlock


### PR DESCRIPTION
## What is this change?

* Refactors `seeds.go`
* Removes `initializer.Lock()` when seeding etcd competing writes should be ok
* Removed seeding code from separate goroutine as it seemed unnecessary
* Improved error messages

## Why is this change necessary?

Race conditions & strange behaviour with etcd locking were causing occasional issues when running `sensu-backend init` with `--wait`.

## Does your change need a Changelog entry?

I'm not sure if this requires a changelog or not as it's technically a part of the already-merged `--wait` flag work.

## Do you need clarification on anything?

Nope!

## Were there any complications while making this change?

Many:
* etcd clientv3 doesn't show detailed error messages when used synchronously
* etcd mutex locking and/or watchers seem outright broken under certain conditions
* cannot easily alter the `CallOptions` that clientv3 uses which results in a massive dump of log messages when there's an error

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Rerunning backend-init a bunch of times with etcd being in various states.

## Is this change a patch?

Only a patch meant to fix the current state of `main`.
