### PR TITLE
Revert init wait flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ appear in sensuctl dump output. The bug only applied to users who had access to
 the other namespaces.
 
 ## [6.2.1, 6.2.2] - 2021-01-08
+## [6.2.1] - 2021-01-08
 
 ### Fixed
 - The expire field of silenced entries represents the configured expiration, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Added
-- Added wait flag to the sensu-backend init command which toggles waiting
-indefinitely for etcd to become available.
-
 ## [6.2.3] - 2021-01-21
 
 ### Fixed
@@ -21,7 +17,6 @@ appear in sensuctl dump output. The bug only applied to users who had access to
 the other namespaces.
 
 ## [6.2.1, 6.2.2] - 2021-01-08
-## [6.2.1] - 2021-01-08
 
 ### Fixed
 - The expire field of silenced entries represents the configured expiration, in


### PR DESCRIPTION
This reverts commit b3336a534c806a680e714e3b851ef2a22ad95857.

There are race conditions with this implementation and we discovered that there are issues with locking in etcd preventing a proper solution to this at the moment.