### PR TITLE
Validate resources in storev2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Both V2 & V3 resources are now validated when used with storev2.
+
 ## [6.2.3] - 2021-01-21
 
 ### Fixed

--- a/api/core/v3/entity.go
+++ b/api/core/v3/entity.go
@@ -33,6 +33,12 @@ type (
 // V2EntityToV3 converts a corev2.Entity to an EntityConfig and EntityState.
 // The resulting values will contain pointers to e's memory.
 func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
+	if e.ObjectMeta.Labels == nil {
+		e.ObjectMeta.Labels = make(map[string]string)
+	}
+	if e.ObjectMeta.Annotations == nil {
+		e.ObjectMeta.Annotations = make(map[string]string)
+	}
 	cfg := EntityConfig{
 		Metadata:          &e.ObjectMeta,
 		EntityClass:       e.EntityClass,
@@ -45,8 +51,10 @@ func V2EntityToV3(e *corev2.Entity) (*EntityConfig, *EntityState) {
 	}
 	state := EntityState{
 		Metadata: &corev2.ObjectMeta{
-			Name:      e.ObjectMeta.Name,
-			Namespace: e.ObjectMeta.Namespace,
+			Name:        e.ObjectMeta.Name,
+			Namespace:   e.ObjectMeta.Namespace,
+			Labels:      e.ObjectMeta.Labels,
+			Annotations: e.ObjectMeta.Annotations,
 		},
 		System:            e.System,
 		LastSeen:          e.LastSeen,

--- a/api/core/v3/entity_test.go
+++ b/api/core/v3/entity_test.go
@@ -14,6 +14,12 @@ func TestV2EntityToV3(t *testing.T) {
 	if got, want := cfg.Metadata, entity.ObjectMeta; !proto.Equal(got, &want) {
 		t.Errorf("bad objectmeta: got %v, want %v", got, want)
 	}
+	if got, want := cfg.Metadata.Labels, make(map[string]string); !reflect.DeepEqual(got, want) {
+		t.Errorf("bad objectmeta labels: got %v, want %v", got, want)
+	}
+	if got, want := cfg.Metadata.Annotations, make(map[string]string); !reflect.DeepEqual(got, want) {
+		t.Errorf("bad objectmeta annotations: got %v, want %v", got, want)
+	}
 	if got, want := cfg.EntityClass, entity.EntityClass; got != want {
 		t.Errorf("bad EntityClass: got %v, want %v", got, want)
 	}
@@ -37,6 +43,12 @@ func TestV2EntityToV3(t *testing.T) {
 	}
 	if got, want := state.Metadata, entity.ObjectMeta; !proto.Equal(got, &want) {
 		t.Errorf("bad objectmeta: got %v, want %v", got, want)
+	}
+	if got, want := state.Metadata.Labels, make(map[string]string); !reflect.DeepEqual(got, want) {
+		t.Errorf("bad objectmeta labels: got %v, want %v", got, want)
+	}
+	if got, want := state.Metadata.Annotations, make(map[string]string); !reflect.DeepEqual(got, want) {
+		t.Errorf("bad objectmeta annotations: got %v, want %v", got, want)
 	}
 	if got, want := state.System, entity.System; !proto.Equal(&got, &want) {
 		t.Errorf("bad System: got %v, want %v", got, want)

--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -14,10 +14,10 @@ func ValidateMetadata(meta *corev2.ObjectMeta) error {
 		return err
 	}
 	if meta.Labels == nil {
-		return errors.New("nil labels")
+		meta.Labels = make(map[string]string)
 	}
 	if meta.Annotations == nil {
-		return errors.New("nil annotations")
+		meta.Annotations = make(map[string]string)
 	}
 	return nil
 }

--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -14,10 +14,10 @@ func ValidateMetadata(meta *corev2.ObjectMeta) error {
 		return err
 	}
 	if meta.Labels == nil {
-		meta.Labels = make(map[string]string)
+		return errors.New("nil labels")
 	}
 	if meta.Annotations == nil {
-		meta.Annotations = make(map[string]string)
+		return errors.New("nil annotations")
 	}
 	return nil
 }

--- a/backend/store/v2/wrap/wrapper.go
+++ b/backend/store/v2/wrap/wrapper.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -22,6 +23,10 @@ import (
 // TypeMeta - this is useful for lifters.
 type tmGetter interface {
 	GetTypeMeta() corev2.TypeMeta
+}
+
+type validatable interface {
+	Validate() error
 }
 
 func (e Encoding) Encode(v interface{}) ([]byte, error) {
@@ -131,6 +136,13 @@ func V2Resource(r corev2.Resource, opts ...Option) (*Wrapper, error) {
 }
 
 func wrap(r interface{}, opts ...Option) (*Wrapper, error) {
+	if v, ok := r.(validatable); ok {
+		if err := v.Validate(); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, errors.New("resource is missing a Validate() method")
+	}
 	if proxy, ok := r.(*corev3.V2ResourceProxy); ok {
 		r = proxy.Resource
 	}

--- a/backend/store/v2/wrap/wrapper.go
+++ b/backend/store/v2/wrap/wrapper.go
@@ -29,6 +29,8 @@ type validatable interface {
 	Validate() error
 }
 
+var ErrValidateMethodMissing = errors.New("resource is missing required Validate() method")
+
 func (e Encoding) Encode(v interface{}) ([]byte, error) {
 	switch e {
 	case Encoding_json:
@@ -141,7 +143,7 @@ func wrap(r interface{}, opts ...Option) (*Wrapper, error) {
 			return nil, err
 		}
 	} else {
-		return nil, errors.New("resource is missing a Validate() method")
+		return nil, ErrValidateMethodMissing
 	}
 	if proxy, ok := r.(*corev3.V2ResourceProxy); ok {
 		r = proxy.Resource


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Validates V2 & V3 resources before they are wrapped in the storev2 wrap package.

## Why is this change necessary?

Validation is not happening on any resources in storev2.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

I don't believe labels or annotations are mandatory so I modified the ObjectMeta Validate method to initialize as an empty map when the values are nil. I'm not sure if this is the best or correct approach; please let me know.

## How did you verify this change?

I ensured that the new BSM resources get validated with this change in place.

## Is this change a patch?

No.