### PR TITLE
Initialize Labels & Annotations for v3 resources when fields are nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.
+- Initialize labels & annotations for v3 resources when fields are nil.
 
 ## [6.2.3] - 2021-01-21
 

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.6.0
-	github.com/sensu/sensu-go/api/core/v3 v3.0.1
+	github.com/sensu/sensu-go/api/core/v3 v3.1.0
 	github.com/sensu/sensu-go/types v0.3.0
 	github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada
 	github.com/sirupsen/logrus v1.6.0

--- a/types/go.mod
+++ b/types/go.mod
@@ -11,5 +11,6 @@ require (
 	github.com/json-iterator/go v1.1.9
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff
 	github.com/sensu/sensu-go/api/core/v2 v2.6.0
+	github.com/sensu/sensu-go/api/core/v3 v3.1.0
 	github.com/stretchr/testify v1.6.0
 )

--- a/types/go.sum
+++ b/types/go.sum
@@ -41,6 +41,10 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1
 github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
+github.com/sensu/sensu-go/api/core v0.0.0-20210202231754-0ddd51d87fa3 h1:cVvbMDddlTagAGWrEYr26HgSWH1EP5GIOIPw3MWKnuU=
+github.com/sensu/sensu-go/api/core/v3 v3.1.0 h1:VdNadrqM/bIvRCaeONL+RwNb21hA0d103iANHwHUo1g=
+github.com/sensu/sensu-go/api/core/v3 v3.1.0/go.mod h1:OWGb7stbn1Eo4j6HGkz3CPb3jpdeiOCTGmSVnDe8mNA=
+github.com/sensu/sensu-go/types v0.3.0/go.mod h1:TyeO3h/82XE1KppZRFg+jKB4QYwY2hE5hbCzjnnGdRo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Initializes the Labels & Annotations metadata fields in core/v3-compatible resources when the fields are nil when unmarshaling a wrapped resource.

## Why is this change necessary?

V3 resources will not validate when the labels & annotations fields aren't set within the metadata of a wrapped resource.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required.

## How did you verify this change?

I created a new test case with @echlebek as well as testing that the BSM Rule Template resource can be created without specifying labels or annotations.

## Is this change a patch?

No.
