### PR TITLE
Add ResourceTemplate, and enterprise migration system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## Added
+- Added ResourceTemplate resource. ResourceTemplate will be used to populate
+namespaces with initial resources.
+
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.
 - Initialize labels & annotations for v3 resources when fields are nil.

--- a/api/core/v3/go.sum
+++ b/api/core/v3/go.sum
@@ -122,6 +122,7 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/sensu/sensu-go/api/core/v3 v3.0.1/go.mod h1:ILvOXnuBvwssCXEFOgolETLrJnoEHOuGbFWwMluGl6g=
+github.com/sensu/sensu-go/api/core/v3 v3.1.0/go.mod h1:OWGb7stbn1Eo4j6HGkz3CPb3jpdeiOCTGmSVnDe8mNA=
 github.com/sensu/sensu-go/types v0.1.0 h1:1xB7nsPM6H0j+sDV6MTJTRrUqCZK1DN4zsn8tQNVhIA=
 github.com/sensu/sensu-go/types v0.1.0/go.mod h1:o3tBPy2BUWb3jPvMQ+pBs0CgCyN1vC1/loN4anURxvs=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/api/core/v3/resource_generated_test.go
+++ b/api/core/v3/resource_generated_test.go
@@ -321,6 +321,161 @@ func TestEntityStateGetTypeMeta(t *testing.T) {
 	}
 }
 
+func TestResourceTemplateSetMetadata(t *testing.T) {
+	value := new(ResourceTemplate)
+	var iface interface{} = value
+	metaer, ok := iface.(getMetadataer)
+	if !ok {
+		return
+	}
+	meta := &corev2.ObjectMeta{
+		Name:        "snoopdogg",
+		Namespace:   "lbc",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	value.SetMetadata(meta)
+	if got, want := metaer.GetMetadata(), meta; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad metadata: got %v, want %v", got, want)
+	}
+}
+
+func TestResourceTemplateStoreName(t *testing.T) {
+	var value ResourceTemplate
+	got := value.StoreName()
+	if len(got) == 0 {
+		t.Error("undefined store suffix")
+	}
+	var iface interface{} = value
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
+			t.Errorf("bad store suffix: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestResourceTemplateRBACName(t *testing.T) {
+	var value ResourceTemplate
+	got := value.RBACName()
+	if len(got) == 0 {
+		t.Error("undefined rbac name")
+	}
+	var iface interface{} = value
+	if namer, ok := iface.(rbacNamer); ok {
+		if got, want := value.RBACName(), namer.rbacName(); got != want {
+			t.Errorf("bad rbac name: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestResourceTemplateURIPath(t *testing.T) {
+	var value ResourceTemplate
+	value.Metadata = &corev2.ObjectMeta{
+		Namespace: "default",
+		Name:      "foo",
+	}
+	got := value.URIPath()
+	if _, err := url.Parse(got); err != nil {
+		t.Error(err)
+	}
+	var iface interface{} = value
+	if pather, ok := iface.(uriPather); ok {
+		if got, want := value.URIPath(), pather.uriPath(); got != want {
+			t.Errorf("bad uri path: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestResourceTemplateValidate(t *testing.T) {
+	var value ResourceTemplate
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for nil metadata")
+	}
+	value.Metadata = &corev2.ObjectMeta{
+		Name:        "#@$@#%@#%@#%",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for invalid metadata name")
+	}
+	value.Metadata.Name = "foo"
+	var iface interface{} = &value
+	if validator, ok := iface.(validator); ok {
+		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
+			t.Errorf("validator error: got %s, want %s", got, want)
+		}
+		return
+	}
+	if err := value.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestResourceTemplateUnmarshalJSON(t *testing.T) {
+	msg := []byte(`{"metadata": {"namespace": "default", "name": "foo"}}`)
+	var value ResourceTemplate
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+	var iface interface{} = &value
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if got, want := meta.Namespace, "default"; got != want {
+			t.Errorf("bad namespace: got %s, want %s", got, want)
+		}
+		if got, want := meta.Name, "foo"; got != want {
+			t.Errorf("bad name: got %s, want %s", got, want)
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+	}
+
+	// make sure labels are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "labels": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Labels), 1; got != want {
+			t.Error("expected one label")
+		}
+	}
+
+	// make sure annotations are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "annotations": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Annotations), 1; got != want {
+			t.Error("expected one annotation")
+		}
+	}
+}
+
+func TestResourceTemplateGetTypeMeta(t *testing.T) {
+	var value ResourceTemplate
+	meta := value.GetTypeMeta()
+	if got, want := meta.APIVersion, "core/v3"; got != want {
+		t.Errorf("bad api version: got %s, want %s", got, want)
+	}
+	if got, want := meta.Type, "ResourceTemplate"; got != want {
+		t.Errorf("bad type: got %s, want %s", got, want)
+	}
+}
+
 func TestResourceUniqueness(t *testing.T) {
 	types := make(map[reflect.Type]GeneratedType)
 	for _, v := range typeMap {

--- a/api/core/v3/resource_template.go
+++ b/api/core/v3/resource_template.go
@@ -37,7 +37,8 @@ func (r *ResourceTemplate) Execute(meta *corev2.ObjectMeta) (Resource, error) {
 	}
 	t, err := types.ResolveRaw(r.APIVersion, r.Type)
 	if err != nil {
-		return nil, fmt.Errorf("error expanding resource template: unknown type: %s", err)
+		// do not wrap this error
+		return nil, err
 	}
 	resource, ok := t.(Resource)
 	if !ok {

--- a/api/core/v3/resource_template.go
+++ b/api/core/v3/resource_template.go
@@ -1,0 +1,15 @@
+package v3
+
+import corev2 "github.com/sensu/sensu-go/api/core/v2"
+
+type ResourceTemplate struct {
+	Metadata   *corev2.ObjectMeta `json:"metadata"`
+	APIVersion string             `json:"api_version"`
+	Type       string             `json:"type"`
+	Template   string             `json:"template"`
+	Path       string             `json:"path"`
+}
+
+func (r *ResourceTemplate) GetMetadata() *corev2.ObjectMeta {
+	return r.Metadata
+}

--- a/api/core/v3/resource_template.go
+++ b/api/core/v3/resource_template.go
@@ -1,15 +1,53 @@
 package v3
 
-import corev2 "github.com/sensu/sensu-go/api/core/v2"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	types "github.com/sensu/sensu-go/types"
+)
+
+// ResourceTemplate is a template for core/v3 resources.
 type ResourceTemplate struct {
 	Metadata   *corev2.ObjectMeta `json:"metadata"`
 	APIVersion string             `json:"api_version"`
 	Type       string             `json:"type"`
 	Template   string             `json:"template"`
-	Path       string             `json:"path"`
 }
 
 func (r *ResourceTemplate) GetMetadata() *corev2.ObjectMeta {
 	return r.Metadata
+}
+
+// Execute executes the Template in the ResourceTemplate. It's given a metadata
+// object to draw variables from. Typically, templating will be done with a
+// variable namespace or name, but could also be done with labels and annotations
+// from the metadata, depending on the nature of the template.
+func (r *ResourceTemplate) Execute(meta *corev2.ObjectMeta) (Resource, error) {
+	tmpl, err := template.New("resource").Parse(r.Template)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing resource template: %s", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, meta); err != nil {
+		return nil, fmt.Errorf("error executing resource template: %s", err)
+	}
+	t, err := types.ResolveRaw(r.APIVersion, r.Type)
+	if err != nil {
+		return nil, fmt.Errorf("error expanding resource template: unknown type: %s", err)
+	}
+	resource, ok := t.(Resource)
+	if !ok {
+		return nil, fmt.Errorf("error expanding resource template: %T is not a core/v3 resource", t)
+	}
+	if err := json.Unmarshal(buf.Bytes(), &resource); err != nil {
+		return nil, fmt.Errorf("error expanding resource template: invalid json: %s", err)
+	}
+	if err := resource.Validate(); err != nil {
+		return nil, fmt.Errorf("error expanding resource template: resource not valid: %s", err)
+	}
+	return resource, nil
 }

--- a/api/core/v3/resource_template.go
+++ b/api/core/v3/resource_template.go
@@ -52,3 +52,13 @@ func (r *ResourceTemplate) Execute(meta *corev2.ObjectMeta) (Resource, error) {
 	}
 	return resource, nil
 }
+
+func (r *ResourceTemplate) validate() error {
+	if _, err := template.New("validate").Parse(r.Template); err != nil {
+		return err
+	}
+	if _, err := types.ResolveRaw(r.APIVersion, r.Type); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/core/v3/resource_template_test.go
+++ b/api/core/v3/resource_template_test.go
@@ -1,0 +1,100 @@
+package v3_test
+
+import (
+	"reflect"
+	testing "testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	v3 "github.com/sensu/sensu-go/api/core/v3"
+)
+
+func TestResourceTemplateExecute(t *testing.T) {
+	template := &v3.ResourceTemplate{
+		Metadata: &corev2.ObjectMeta{
+			Name: "template",
+		},
+		APIVersion: "core/v3",
+		Type:       "EntityConfig",
+		Template: `
+		{
+			"metadata": {
+				"namespace": "{{ .Namespace }}",
+				"name": "entity1"
+			},
+			"entity_class": "agent",
+			"user": "agent",
+			"subscriptions": ["a", "b", "c"]
+		}
+		`,
+	}
+
+	metadata := &corev2.ObjectMeta{
+		Namespace: "myns",
+	}
+
+	got, err := template.Execute(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &v3.EntityConfig{
+		Metadata: &corev2.ObjectMeta{
+			Name:        "entity1",
+			Namespace:   "myns",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		EntityClass:   "agent",
+		User:          "agent",
+		Subscriptions: []string{"a", "b", "c"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bad resource: got %#v, want %#v", got, want)
+	}
+
+	// Causes entityconfig validation to fail
+	metadata.Namespace = ""
+	if _, err := template.Execute(metadata); err == nil {
+		t.Error("expected non-nil error")
+	}
+	metadata.Namespace = "myns"
+
+	// causes type lookup to fail
+	template.APIVersion = "notexists"
+	if _, err := template.Execute(metadata); err == nil {
+		t.Error("expected non-nil error")
+	}
+	template.APIVersion = "core/v3"
+
+	// causes json unmarshaling to fail
+	template.Template = `{sdlfkjsdlfkj}`
+	if _, err := template.Execute(metadata); err == nil {
+		t.Error("expected non-nil error")
+	}
+}
+
+func TestResourceTemplateValidate(t *testing.T) {
+	tmpl := &v3.ResourceTemplate{
+		Metadata: &corev2.ObjectMeta{
+			Name:        "foobar",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		APIVersion: "core/v3",
+		Type:       "EntityConfig",
+		Template:   "{{ .Foobar }}",
+	}
+	if err := tmpl.Validate(); err != nil {
+		t.Error(err)
+	}
+	tmpl.Template = "{{"
+	if err := tmpl.Validate(); err == nil {
+		t.Error("expected non-nil error")
+	}
+	tmpl.Template = "{{ .Foobar }}"
+	tmpl.APIVersion = "fake/v2"
+	if err := tmpl.Validate(); err == nil {
+		t.Error("expected non-nil error")
+	}
+}

--- a/api/core/v3/typemap.go
+++ b/api/core/v3/typemap.go
@@ -25,10 +25,12 @@ func init() {
 
 // typeMap is used to dynamically look up data types from strings.
 var typeMap = map[string]interface{}{
-	"EntityConfig":  &EntityConfig{},
-	"entity_config": &EntityConfig{},
-	"EntityState":   &EntityState{},
-	"entity_state":  &EntityState{},
+	"EntityConfig":      &EntityConfig{},
+	"entity_config":     &EntityConfig{},
+	"EntityState":       &EntityState{},
+	"entity_state":      &EntityState{},
+	"ResourceTemplate":  &ResourceTemplate{},
+	"resource_template": &ResourceTemplate{},
 }
 
 // rbacMap is like typemap, but its keys are RBAC names, and its values are

--- a/api/core/v3/typemap_test.go
+++ b/api/core/v3/typemap_test.go
@@ -191,6 +191,98 @@ func TestResolveV2ResourceEntityState(t *testing.T) {
 	}
 }
 
+func TestResolveResourceTemplate(t *testing.T) {
+	var value interface{} = new(ResourceTemplate)
+	if _, ok := value.(Resource); ok {
+		resource, err := ResolveResource("ResourceTemplate")
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil metadata")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+		return
+	}
+	_, err := ResolveResource("ResourceTemplate")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if got, want := err.Error(), `"ResourceTemplate" is not a Resource`; got != want {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestResolveResourceTemplateByRBACName(t *testing.T) {
+	value := new(ResourceTemplate)
+	var iface interface{} = value
+	resource, err := ResolveResourceByRBACName(value.RBACName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveResourceTemplateByStoreName(t *testing.T) {
+	value := new(ResourceTemplate)
+	var iface interface{} = value
+	resource, err := ResolveResourceByStoreName(value.StoreName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveV2ResourceResourceTemplate(t *testing.T) {
+	v2Resource, err := ResolveV2Resource("ResourceTemplate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3Resource, err := ResolveResource("ResourceTemplate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := v2Resource.(*V2ResourceProxy).Resource, v3Resource; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad resource: got %v, want %v", got, want)
+	}
+}
+
 func TestResolveNotExists(t *testing.T) {
 	_, err := ResolveResource("!#$@$%@#$")
 	if err == nil {

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -130,6 +130,11 @@ func UpgradeCommand() *cobra.Command {
 			if err := etcdstore.MigrateDB(context.Background(), client, etcdstore.Migrations); err != nil {
 				return err
 			}
+			if len(etcdstore.EnterpriseMigrations) > 0 {
+				if err := etcdstore.MigrateEnterpriseDB(context.Background(), client, etcdstore.EnterpriseMigrations); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -101,6 +101,12 @@ func SeedCluster(ctx context.Context, store store.Store, client *clientv3.Client
 				logger.WithError(err).Error("error bringing the database to the latest version")
 				return
 			}
+			if len(etcd.EnterpriseMigrations) > 0 {
+				if err = etcd.MigrateEnterpriseDB(ctx, client, etcd.EnterpriseMigrations); err != nil {
+					logger.WithError(err).Error("error bringing the enterprise database to the latest version")
+					return
+				}
+			}
 		}
 
 		// Set initialized flag

--- a/backend/store/etcd/migrations.go
+++ b/backend/store/etcd/migrations.go
@@ -24,7 +24,7 @@ var Migrations = []Migration{
 
 // EnterpriseMigrations is like Migrations, but is appended to by enterprise
 // Sensu.
-var EnterpriseMigrations = []Migration{}
+var EnterpriseMigrations = []Migration{Base}
 
 // Base is the base version of the database. It is never executed.
 func Base(ctx context.Context, client *clientv3.Client) error {

--- a/backend/store/etcd/version.go
+++ b/backend/store/etcd/version.go
@@ -10,11 +10,24 @@ import (
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 )
 
-const DatabaseVersionKey = "sensu_database_version"
+const (
+	DatabaseVersionKey           = "sensu_database_version"
+	EnterpriseDatabaseVersionKey = "sensu_enterprise_database_version"
+)
 
 // GetDatabaseVersion gets the current database version.
 func GetDatabaseVersion(ctx context.Context, client *clientv3.Client) (int, error) {
 	versionPath := path.Join(EtcdRoot, DatabaseVersionKey)
+	return getIntegerAtPath(ctx, versionPath, client)
+}
+
+// GetEnterpriseDatabaseVersion gets the current enterprise database version.
+func GetEnterpriseDatabaseVersion(ctx context.Context, client *clientv3.Client) (int, error) {
+	versionPath := path.Join(EtcdRoot, EnterpriseDatabaseVersionKey)
+	return getIntegerAtPath(ctx, versionPath, client)
+}
+
+func getIntegerAtPath(ctx context.Context, versionPath string, client *clientv3.Client) (int, error) {
 	var resp *clientv3.GetResponse
 	err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
 		resp, err = client.Get(ctx, versionPath)
@@ -33,8 +46,18 @@ func GetDatabaseVersion(ctx context.Context, client *clientv3.Client) (int, erro
 	return version, nil
 }
 
+// SetDatabaseVersion sets the database version.
 func SetDatabaseVersion(ctx context.Context, client *clientv3.Client, version int) error {
 	versionPath := path.Join(EtcdRoot, DatabaseVersionKey)
+	return kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		_, err = client.Put(ctx, versionPath, fmt.Sprintf("%d", version))
+		return kvc.RetryRequest(n, err)
+	})
+}
+
+// SetEnterpriseDatabaseVersion sets the enterprise database version.
+func SetEnterpriseDatabaseVersion(ctx context.Context, client *clientv3.Client, version int) error {
+	versionPath := path.Join(EtcdRoot, EnterpriseDatabaseVersionKey)
 	return kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
 		_, err = client.Put(ctx, versionPath, fmt.Sprintf("%d", version))
 		return kvc.RetryRequest(n, err)

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"reflect"
@@ -11,6 +12,8 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
+
+var ErrAPINotFound = errors.New("api not found")
 
 // compatibility shim - can't import core/v3
 type corev3Resource interface {
@@ -313,7 +316,7 @@ func ResolveRaw(apiVersion string, typename string) (interface{}, error) {
 	defer packageMapMu.RUnlock()
 	resolver, ok := packageMap[apiVersion]
 	if !ok {
-		return nil, fmt.Errorf("invalid API version: %s", apiVersion)
+		return nil, ErrAPINotFound
 	}
 	switch resolver := resolver.(type) {
 	case func(string) (Resource, error):


### PR DESCRIPTION
## What is this change?

This change adds ResourceTemplate, a basic facility for populating newly created namespaces with pre-fabbed data structures.

## Why is this change necessary?

We'll be using this to populate namespaces with resources from the enterprise product. The facility might be of further use in OSS Sensu as well.

Closes #4202.

## Does your change need a Changelog entry?

Yes

## Is this change a patch?

No