### PR TITLE
Fixed a potential crash in the scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed the `agent-managed-entity` agent config attribute when no labels are
 defined.
+- Fixed a bug where the scheduler could crash in rare circumstances, when using
+round robin checks.
 
 ## [6.2.2] - 2021-01-14
 

--- a/backend/schedulerd/roundrobin_cron.go
+++ b/backend/schedulerd/roundrobin_cron.go
@@ -80,7 +80,13 @@ func (s *RoundRobinCronScheduler) handleEvent(executor *CheckExecutor, event rin
 			"removing entity from round-robin")
 
 	case ringv2.EventTrigger:
-		s.logger.Info("scheduling check")
+		if len(event.Values) == 0 {
+			s.logger.Error("round robin check scheduled, but no available entities")
+			return
+		}
+		// The ring has produced a trigger for the entity, and a check should
+		// be executed.
+		s.logger.WithFields(logrus.Fields{"agents": event.Values}).Info("executing round robin check on agents")
 		s.mu.Lock()
 		s.schedule(executor, s.proxyEntities, event.Values)
 		s.mu.Unlock()

--- a/backend/schedulerd/roundrobin_interval.go
+++ b/backend/schedulerd/roundrobin_interval.go
@@ -157,6 +157,10 @@ func (s *RoundRobinIntervalScheduler) handleEvent(executor *CheckExecutor, event
 		}).Info("removing entity from round-robin")
 
 	case ringv2.EventTrigger:
+		if len(event.Values) == 0 {
+			s.logger.Error("round robin check scheduled, but no available entities")
+			return
+		}
 		// The ring has produced a trigger for the entity, and a check should
 		// be executed.
 		s.logger.WithFields(logrus.Fields{"agents": event.Values}).Info("executing round robin check on agents")


### PR DESCRIPTION
## What is this change?

This commit fixes a potential crash in the scheduler when using round
robin checks. The crash only occurs when using postgres with the
"enable_round_robin: true" configuration option.

## Why is this change necessary?

It fixes a latent bug exposed by the enterprise product. OSS users are unaffected.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Manually. To trigger the bug, I created a round robin interval check using proxy_requests and splay.

## Is this change a patch?

Yes.