### PR TITLE
[GraphQL] Add argument to request truncated check output

### DIFF
--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -188,6 +188,21 @@ func (r *checkImpl) Silences(p graphql.ResolveParams) (interface{}, error) {
 	return records, err
 }
 
+// Output implements response to request for 'output' field.
+func (r *checkImpl) Output(p schema.CheckOutputFieldResolverParams) (string, error) {
+	src := p.Source.(*corev2.Check)
+	out := src.Output
+	if p.Args.First > 0 {
+		num := clampInt(p.Args.First, 0, len(out))
+		out = out[:num]
+	}
+	if p.Args.Last > 0 {
+		num := clampInt(p.Args.Last, 0, len(out))
+		out = out[len(out)-num:]
+	}
+	return out, nil
+}
+
 // OutputMetricHandlers implements response to request for 'outputMetricHandlers' field.
 func (r *checkImpl) OutputMetricHandlers(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.Check)

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -325,3 +325,61 @@ func TestCheckConfigTypeToJSONField(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }
+
+func TestCheckTypeOutputFieldImpl(t *testing.T) {
+	testCases := []struct {
+		name     string
+		result   string
+		firstArg int
+		lastArg  int
+	}{
+		{
+			name:   "no args",
+			result: "123456789012345678901234567890",
+		},
+		{
+			name:     "first 10",
+			result:   "1234567890",
+			firstArg: 10,
+		},
+		{
+			name:    "last 5",
+			result:  "67890",
+			lastArg: 5,
+		},
+		{
+			name:     "first 25 & last 10",
+			result:   "6789012345",
+			firstArg: 25,
+			lastArg:  10,
+		},
+		{
+			name:     "first out of bounds",
+			result:   "123456789012345678901234567890",
+			firstArg: 55,
+		},
+		{
+			name:     "last out of bounds",
+			result:   "12345",
+			firstArg: 5,
+			lastArg:  55,
+		},
+	}
+
+	check := corev2.FixtureCheck("test")
+	check.Output = "123456789012345678901234567890"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := schema.CheckOutputFieldResolverParams{}
+			params.Context = context.Background()
+			params.Source = check
+			params.Args.First = tc.firstArg
+			params.Args.Last = tc.lastArg
+
+			impl := checkImpl{}
+			res, err := impl.Output(params)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, res)
+		})
+	}
+}

--- a/backend/apid/graphql/schema/check.graphql
+++ b/backend/apid/graphql/schema/check.graphql
@@ -205,7 +205,7 @@ type Check implements Silenceable & Resource {
   issued: DateTime!
 
   "Output from the execution of Command"
-  output: String!
+  output(first: Int, last: Int): String!
 
   "State provides handlers with more information about the state change"
   state: String!


### PR DESCRIPTION
Allows client to request a check's output be truncated, reducing the size of the response payload.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>