### PR TITLE
[GraphQL] Export NodeResolver

### DIFF
--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -8,6 +8,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
 	"github.com/sensu/sensu-go/backend/apid/graphql/suggest"
 	"github.com/sensu/sensu-go/backend/store"
@@ -23,7 +24,7 @@ var _ schema.QueryFieldResolvers = (*queryImpl)(nil)
 //
 
 type queryImpl struct {
-	nodeResolver *nodeResolver
+	nodeResolver *relay.Resolver
 	svc          ServiceConfig
 }
 
@@ -218,7 +219,7 @@ func (r *queryImpl) WrappedNode(p schema.QueryWrappedNodeFieldResolverParams) (i
 //
 
 type nodeImpl struct {
-	nodeResolver *nodeResolver
+	nodeResolver *relay.Resolver
 }
 
 func (impl *nodeImpl) ResolveType(i interface{}, p graphql.ResolveTypeParams) *graphql.Type {

--- a/backend/apid/graphql/relay/node.go
+++ b/backend/apid/graphql/relay/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 // A NodeResolver describes an object that contains a globally unique ID.
-type NodeResolver struct {
+type NodeResolver struct { // TODO: rename NodeInfo?
 	ObjectType graphql.Type
 	Translator globalid.Translator
 

--- a/backend/apid/graphql/relay/resolver.go
+++ b/backend/apid/graphql/relay/resolver.go
@@ -15,6 +15,7 @@ type Resolver struct {
 	Register *NodeRegister
 }
 
+// FindType finds the GraphQL type for the given resource.
 func (r *Resolver) FindType(ctx context.Context, i interface{}) *graphql.Type {
 	translator, err := globalid.ReverseLookup(i)
 	if err != nil {
@@ -31,6 +32,7 @@ func (r *Resolver) FindType(ctx context.Context, i interface{}) *graphql.Type {
 	return &resolver.ObjectType
 }
 
+// Find lookups and retrieves the resource associated with the given GlobalID.
 func (r *Resolver) Find(ctx context.Context, id string, info graphql.ResolveInfo) (interface{}, error) {
 	// Decode given ID
 	idComponents, err := globalid.Decode(id)

--- a/backend/apid/graphql/relay/resolver.go
+++ b/backend/apid/graphql/relay/resolver.go
@@ -1,0 +1,57 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
+	"github.com/sensu/sensu-go/graphql"
+)
+
+// A Resolver retreives nodes and info using a given register.
+type Resolver struct {
+	Register *NodeRegister
+}
+
+func (r *Resolver) FindType(ctx context.Context, i interface{}) *graphql.Type {
+	translator, err := globalid.ReverseLookup(i)
+	if err != nil {
+		return nil
+	}
+
+	components := translator.Encode(ctx, i)
+	resolver := r.Register.Lookup(components)
+	if resolver == nil {
+		logger := logger.WithField("translator", fmt.Sprintf("%#v", translator))
+		logger.Error("unable to find node resolver for type")
+		return nil
+	}
+	return &resolver.ObjectType
+}
+
+func (r *Resolver) Find(ctx context.Context, id string, info graphql.ResolveInfo) (interface{}, error) {
+	// Decode given ID
+	idComponents, err := globalid.Decode(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup resolver using components of a global ID
+	resolver := r.Register.Lookup(idComponents)
+	if resolver == nil {
+		return nil, errors.New("unable to find type associated with this ID")
+	}
+
+	// Lift org & env into context
+	ctx = context.WithValue(ctx, corev2.NamespaceKey, idComponents.Namespace())
+
+	// Fetch resource from using resolver
+	params := NodeResolverParams{
+		Context:      ctx,
+		IDComponents: idComponents,
+		Info:         info,
+	}
+	return resolver.Resolve(params)
+}

--- a/backend/apid/graphql/relay/resolver_test.go
+++ b/backend/apid/graphql/relay/resolver_test.go
@@ -1,0 +1,99 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
+	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeResolverFindType(t *testing.T) {
+	register := NodeRegister{}
+	resolver := Resolver{Register: &register}
+
+	register.RegisterResolver(NodeResolver{
+		ObjectType: schema.CheckType,
+		Translator: globalid.CheckTranslator,
+	})
+
+	check := corev2.FixtureCheckConfig("http-check")
+	typeID := resolver.FindType(context.Background(), check)
+	assert.NotNil(t, typeID)
+}
+
+func TestResolver_Find(t *testing.T) {
+	tests := []struct {
+		name    string
+		resolve func(p NodeResolverParams) (interface{}, error)
+		gid     string
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name:    "bad id",
+			gid:     "sdflkasjdflkasjdfl",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "unknown id",
+			gid:     "srn:checks:cybertruck",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "missing",
+			gid:  "srn:assets:default:test",
+			resolve: func(p NodeResolverParams) (interface{}, error) {
+				return nil, nil
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "resolve err",
+			gid:  "srn:assets:default:test",
+			resolve: func(p NodeResolverParams) (interface{}, error) {
+				return nil, errors.New("test")
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "success",
+			gid:  "srn:assets:default:test",
+			resolve: func(p NodeResolverParams) (interface{}, error) {
+				return "test", nil
+			},
+			want:    "test",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			register := NodeRegister{}
+			resolver := Resolver{Register: &register}
+
+			register.RegisterResolver(NodeResolver{
+				ObjectType: schema.AssetType,
+				Translator: globalid.AssetTranslator,
+				Resolve:    tt.resolve,
+			})
+
+			got, err := resolver.Find(context.Background(), tt.gid, graphql.ResolveInfo{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolver.Find() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Resolver.Find() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Export `NodeResolver` for use by downstream products.

* moves to `relay` package
* expands test coverage

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>