### PR TITLE
Prevent crash when store watchers have an empty watch event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ namespaces with initial resources.
 defined.
 - Fixed a bug where the scheduler could crash in rare circumstances, when using
 round robin checks.
-- Fixed a bug where Etcd watchers can return a nil watch event.
+- Fixed a bug where some Etcd watchers could try to process watch events holding
+invalid pointers.
 
 ## [6.2.3] - 2021-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ namespaces with initial resources.
 defined.
 - Fixed a bug where the scheduler could crash in rare circumstances, when using
 round robin checks.
+- Fixed a bug where Etcd watchers can return a nil watch event.
 
 ## [6.2.3] - 2021-01-21
 

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -238,6 +238,10 @@ func (a *Agentd) runWatcher() {
 			if !ok {
 				return
 			}
+			if event == nil {
+				logger.Error("nil event received from entity config watcher")
+				return
+			}
 			if err := a.handleEvent(event); err != nil {
 				logger.WithError(err).Error("error handling entity config watch event")
 			}

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -238,8 +238,8 @@ func (a *Agentd) runWatcher() {
 			if !ok {
 				return
 			}
-			if event == nil {
-				logger.Error("nil event received from entity config watcher")
+			if event.Entity == nil {
+				logger.Error("nil entity received from entity config watcher")
 				return
 			}
 			if err := a.handleEvent(event); err != nil {

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -111,14 +111,9 @@ func (c *CheckWatcher) startWatcher() {
 	for {
 		select {
 		case watchEvent, ok := <-watchChan:
-			if !ok {
-				return
+			if ok {
+				c.handleWatchEvent(watchEvent)
 			}
-			if watchEvent.CheckConfig == nil {
-				logger.Error("nil check config received from check config watcher")
-				return
-			}
-			c.handleWatchEvent(watchEvent)
 		case <-c.ctx.Done():
 			c.mu.Lock()
 			defer c.mu.Unlock()
@@ -134,6 +129,12 @@ func (c *CheckWatcher) startWatcher() {
 
 func (c *CheckWatcher) handleWatchEvent(watchEvent store.WatchEventCheckConfig) {
 	check := watchEvent.CheckConfig
+
+	if check == nil {
+		logger.Error("nil check config received from check config watcher")
+		return
+	}
+
 	key := concatUniqueKey(check.Name, check.Namespace)
 
 	c.mu.Lock()

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -111,6 +111,10 @@ func (c *CheckWatcher) startWatcher() {
 	for {
 		select {
 		case watchEvent, ok := <-watchChan:
+			if watchEvent == nil {
+				logger.Error("nil watch event received from check config watcher")
+				return
+			}
 			if ok {
 				c.handleWatchEvent(watchEvent)
 			}

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -111,8 +111,8 @@ func (c *CheckWatcher) startWatcher() {
 	for {
 		select {
 		case watchEvent, ok := <-watchChan:
-			if watchEvent == nil {
-				logger.Error("nil watch event received from check config watcher")
+			if watchEvent.CheckConfig == nil {
+				logger.Error("nil check config received from check config watcher")
 				return
 			}
 			if ok {

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -111,13 +111,14 @@ func (c *CheckWatcher) startWatcher() {
 	for {
 		select {
 		case watchEvent, ok := <-watchChan:
+			if !ok {
+				return
+			}
 			if watchEvent.CheckConfig == nil {
 				logger.Error("nil check config received from check config watcher")
 				return
 			}
-			if ok {
-				c.handleWatchEvent(watchEvent)
-			}
+			c.handleWatchEvent(watchEvent)
 		case <-c.ctx.Done():
 			c.mu.Lock()
 			defer c.mu.Unlock()

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -319,6 +319,11 @@ func (t *Tessend) startWatcher() {
 func (t *Tessend) handleWatchEvent(watchEvent store.WatchEventTessenConfig) {
 	tessen := watchEvent.TessenConfig
 
+	if tessen == nil {
+		logger.Error("nil config received from tessen config watcher")
+		return
+	}
+
 	switch watchEvent.Action {
 	case store.WatchCreate:
 		logger.WithField("opt-out", tessen.OptOut).Debug("tessen configuration created")


### PR DESCRIPTION
## What is this change?

Prevents an edge case, where watcher contents can be nil, from crashing a backend.

## Why is this change necessary?

Fixes https://github.com/sensu/sensu-go/issues/4176.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I haven't seen the same 

## Is this change a patch?

No.
