### PR TITLE
Add semgrep github action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,15 @@
+name: Semgrep
+on: [pull_request]
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    name: Check
+    steps:
+      - uses: actions/checkout@v1
+      - name: Semgrep
+        id: semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/dgryski.semgrep-go
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,5 +11,13 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           config: p/dgryski.semgrep-go
+  semgrep-sensu: # looks for .semgrep.yml due to missing config section
+    runs-on: ubuntu-latest
+    name: Check
+    steps:
+      - uses: actions/checkout@v1
+      - name: SemgrepSensu
+        id: semgrep-sensu
+        uses: returntocorp/semgrep-action@v1
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,94 @@
+rules:
+  - id: resolveparams-passed-nil-context
+    patterns:
+      - pattern: |
+          $FUNC(..., graphql.ResolveParams{...}, ...)
+      - pattern-not-inside: |
+          $FUNC(..., graphql.ResolveParams{..., Context: $X, ...,}, ...)
+    message: graphql.ResolveParams literal with nil context passed to function
+    languages: [go]
+    severity: ERROR
+  - id: resolveparams-nil-context-var
+    patterns:
+      - pattern: var $X graphql.ResolveParams
+      - pattern-not-inside: |
+            var $X graphql.ResolveParams
+            ...
+            $X.Context = $Y
+    message: graphql.ResolveParams created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: resolveparams-nil-context-var-2
+    patterns:
+      - pattern: $X := graphql.ResolveParams{}
+      - pattern-not-inside: |
+            $X := graphql.ResolveParams{}
+            ...
+            $X.Context = $Y
+    message: graphql.ResolveParams created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: params-passed-nil-context
+    patterns:
+      - pattern: |
+          $FUNC(..., graphql.Params{...}, ...)
+      - pattern-not-inside: |
+          $FUNC(..., graphql.Params{..., Context: $X, ...,}, ...)
+    message: graphql.Params literal with nil context passed to function
+    languages: [go]
+    severity: ERROR
+  - id: params-nil-context-var
+    patterns:
+      - pattern: var $X graphql.Params
+      - pattern-not-inside: |
+            var $X graphql.Params
+            ...
+            $X.Context = $Y
+    message: graphql.Params created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: params-nil-context-var-2
+    patterns:
+      - pattern: $X := graphql.Params{}
+      - pattern-not-inside: |
+            $X := graphql.Params{}
+            ...
+            $X.Context = $Y
+    message: graphql.Params created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: relay-params-passed-nil-context
+    patterns:
+      - pattern: |
+          $FUNC(..., NodeResolverParams{...}, ...)
+      - pattern-not-inside: |
+          $FUNC(..., NodeResolverParams{..., Context: $X, ...,}, ...)
+    message: NodeResolverParams literal with nil context passed to function
+    languages: [go]
+    severity: ERROR
+  - id: relay-params-nil-context-var
+    patterns:
+      - pattern: var $X NodeResolverParams
+      - pattern-not-inside: |
+            var $X NodeResolverParams
+            ...
+            $X.Context = $Y
+    message: NodeResolverParams created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: relay-params-nil-context-var-2
+    patterns:
+      - pattern: $X := NodeResolverParams{}
+      - pattern-not-inside: |
+            $X := NodeResolverParams{}
+            ...
+            $X.Context = $Y
+    message: NodeResolverParams created with nil context
+    languages: [go]
+    severity: ERROR
+  - id: generic-resolver-params-nil-context
+    patterns:
+      - pattern-regex: .*ResolverParams\{\}
+    message: ResolverParams created with nil context
+    languages: [go]
+    severity: ERROR

--- a/backend/apid/graphql/asset_test.go
+++ b/backend/apid/graphql/asset_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"testing"
 
 	v2 "github.com/sensu/sensu-go/api/core/v2"
@@ -13,7 +14,7 @@ func TestAssetTypeToJSONField(t *testing.T) {
 	src := v2.FixtureAsset("name")
 	imp := &assetImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -40,7 +40,7 @@ func TestCheckTypeHistoryFieldImpl(t *testing.T) {
 	check := corev2.FixtureCheck("test")
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("w/ argument of %d", tc.expectedLen), func(t *testing.T) {
-			params := schema.CheckHistoryFieldResolverParams{}
+			params := schema.CheckHistoryFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 			params.Source = check
 			params.Args.First = tc.firstArg
 
@@ -94,7 +94,7 @@ func TestCheckTypeIsSilencedField(t *testing.T) {
 
 	// return associated silence
 	impl := &checkImpl{}
-	res, err := impl.IsSilenced(graphql.ResolveParams{Source: check})
+	res, err := impl.IsSilenced(graphql.ResolveParams{Source: check, Context: context.Background()})
 	require.NoError(t, err)
 	assert.True(t, res)
 }
@@ -312,7 +312,7 @@ func TestCheckTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureCheck("name")
 	imp := &checkImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }
@@ -321,7 +321,7 @@ func TestCheckConfigTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureCheckConfig("name")
 	imp := &checkCfgImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }
@@ -370,7 +370,7 @@ func TestCheckTypeOutputFieldImpl(t *testing.T) {
 	check.Output = "123456789012345678901234567890"
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			params := schema.CheckOutputFieldResolverParams{}
+			params := schema.CheckOutputFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 			params.Context = context.Background()
 			params.Source = check
 			params.Args.First = tc.firstArg

--- a/backend/apid/graphql/entity_test.go
+++ b/backend/apid/graphql/entity_test.go
@@ -18,7 +18,7 @@ func TestEntityTypeMetadataField(t *testing.T) {
 	src := corev2.FixtureEntity("bug")
 	impl := entityImpl{}
 
-	res, err := impl.Metadata(graphql.ResolveParams{Source: src})
+	res, err := impl.Metadata(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 	assert.IsType(t, v2.ObjectMeta{}, res)
@@ -35,7 +35,7 @@ func TestEntityTypeRelatedField(t *testing.T) {
 	}, nil).Once()
 
 	cfg := ServiceConfig{EntityClient: client}
-	params := schema.EntityRelatedFieldResolverParams{}
+	params := schema.EntityRelatedFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Context = contextWithLoaders(context.Background(), cfg)
 	params.Source = source
 	params.Args.Limit = 10
@@ -90,7 +90,7 @@ func TestEntityTypeLastSeenField(t *testing.T) {
 
 	entity := corev2.FixtureEntity("id")
 	entity.LastSeen = now.Unix()
-	params := graphql.ResolveParams{}
+	params := graphql.ResolveParams{Context: context.Background()}
 	params.Source = entity
 
 	impl := entityImpl{}
@@ -111,7 +111,7 @@ func TestEntityTypeEventsField(t *testing.T) {
 	}, nil).Once()
 
 	// params
-	params := schema.EntityEventsFieldResolverParams{}
+	params := schema.EntityEventsFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{EventClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Args.Filters = []string{}
@@ -175,7 +175,7 @@ func TestEntityTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureEntity("name")
 	imp := &entityImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/event_filter_test.go
+++ b/backend/apid/graphql/event_filter_test.go
@@ -35,7 +35,7 @@ func TestEventFilterTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureEventFilter("my-filter")
 	imp := &eventFilterImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/event_test.go
+++ b/backend/apid/graphql/event_test.go
@@ -41,7 +41,7 @@ func TestEventTypeIsNewIncidentFieldImpl(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("event %s", tc.assertion), func(t *testing.T) {
-			params := graphql.ResolveParams{}
+			params := graphql.ResolveParams{Context: context.Background()}
 			params.Source = tc.event
 
 			impl := eventImpl{}

--- a/backend/apid/graphql/handler_test.go
+++ b/backend/apid/graphql/handler_test.go
@@ -45,13 +45,13 @@ func TestHandlerTypeMutatorField(t *testing.T) {
 
 	// Success
 	client.On("FetchMutator", mock.Anything, mutator.Name).Return(mutator, nil).Once()
-	res, err := impl.Mutator(graphql.ResolveParams{Source: handler})
+	res, err := impl.Mutator(graphql.ResolveParams{Source: handler, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 
 	// No mutator
 	handler.Mutator = ""
-	res, err = impl.Mutator(graphql.ResolveParams{Source: handler})
+	res, err = impl.Mutator(graphql.ResolveParams{Source: handler, Context: context.Background()})
 	require.NoError(t, err)
 	assert.Nil(t, res)
 }
@@ -60,7 +60,7 @@ func TestHandlerTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureHandler("name")
 	imp := &handlerImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/health_test.go
+++ b/backend/apid/graphql/health_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"reflect"
 	"strconv"
 	"testing"
@@ -28,7 +29,7 @@ func Test_clusterHealthImpl_Etcd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &clusterHealthImpl{}
-			got, err := r.Etcd(graphql.ResolveParams{Source: tt.source})
+			got, err := r.Etcd(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("clusterHealthImpl.Etcd() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -58,7 +59,7 @@ func Test_etcdClusterHealthImpl_Alarms(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &etcdClusterHealthImpl{}
-			got, err := r.Alarms(graphql.ResolveParams{Source: tt.source})
+			got, err := r.Alarms(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("etcdClusterHealthImpl.Alarms() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -88,7 +89,7 @@ func Test_etcdClusterHealthImpl_Members(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &etcdClusterHealthImpl{}
-			got, err := r.Members(graphql.ResolveParams{Source: tt.source})
+			got, err := r.Members(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("etcdClusterHealthImpl.Members() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -118,7 +119,7 @@ func Test_etcdAlarmMemberImpl_MemberID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &etcdAlarmMemberImpl{}
-			got, err := r.MemberID(graphql.ResolveParams{Source: tt.source})
+			got, err := r.MemberID(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("etcdAlarmMemberImpl.MemberID() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -148,7 +149,7 @@ func Test_etcdAlarmMemberImpl_Alarm(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &etcdAlarmMemberImpl{}
-			got, err := r.Alarm(graphql.ResolveParams{Source: tt.source})
+			got, err := r.Alarm(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("etcdAlarmMemberImpl.Alarm() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -178,7 +179,7 @@ func Test_etcdClusterMemberHealthImpl_MemberID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &etcdClusterMemberHealthImpl{}
-			got, err := r.MemberID(graphql.ResolveParams{Source: tt.source})
+			got, err := r.MemberID(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("etcdClusterMemberHealthImpl.MemberID() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/backend/apid/graphql/hook_test.go
+++ b/backend/apid/graphql/hook_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"testing"
 
 	v2 "github.com/sensu/sensu-go/api/core/v2"
@@ -13,7 +14,7 @@ func TestHookConfigTypeToJSONField(t *testing.T) {
 	src := v2.FixtureHookConfig("name")
 	imp := &hookCfgImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/metric_test.go
+++ b/backend/apid/graphql/metric_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -107,7 +108,7 @@ func Test_commonMetricImpl_Labels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &commonMetricImpl{}
-			got, err := c.Labels(graphql.ResolveParams{Source: tt.val})
+			got, err := c.Labels(graphql.ResolveParams{Source: tt.val, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("commonMetricImpl.Labels() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -144,7 +145,7 @@ func Test_commonMetricImpl_Timestamp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &commonMetricImpl{}
-			got, err := c.Timestamp(graphql.ResolveParams{Source: tt.val})
+			got, err := c.Timestamp(graphql.ResolveParams{Source: tt.val, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("commonMetricImpl.Timestamp() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -175,7 +176,7 @@ func Test_metricFamilyImpl_Type(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &metricFamilyImpl{}
-			got, err := m.Type(graphql.ResolveParams{Source: tt.val})
+			got, err := m.Type(graphql.ResolveParams{Source: tt.val, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("metricFamilyImpl.Type() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -211,7 +212,7 @@ func Test_histogramMetricImpl_Bucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &histogramMetricImpl{}
-			got, err := h.Bucket(graphql.ResolveParams{Source: tt.source})
+			got, err := h.Bucket(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("histogramMetricImpl.Bucket() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -244,7 +245,7 @@ func Test_summaryMetricImpl_SampleSum(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &summaryMetricImpl{}
-			got, err := s.SampleSum(graphql.ResolveParams{Source: tt.source})
+			got, err := s.SampleSum(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("summaryMetricImpl.SampleSum() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -284,7 +285,7 @@ func Test_histogramMetricImpl_SampleSum(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &histogramMetricImpl{}
-			got, err := h.SampleSum(graphql.ResolveParams{Source: tt.source})
+			got, err := h.SampleSum(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("histogramMetricImpl.SampleSum() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -324,7 +325,7 @@ func Test_summaryMetricImpl_SampleCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &summaryMetricImpl{}
-			got, err := s.SampleCount(graphql.ResolveParams{Source: tt.source})
+			got, err := s.SampleCount(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("summaryMetricImpl.SampleCount() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -364,7 +365,7 @@ func Test_histogramMetricImpl_SampleCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &histogramMetricImpl{}
-			got, err := h.SampleCount(graphql.ResolveParams{Source: tt.source})
+			got, err := h.SampleCount(graphql.ResolveParams{Source: tt.source, Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("histogramMetricImpl.SampleCount() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/backend/apid/graphql/mutations_test.go
+++ b/backend/apid/graphql/mutations_test.go
@@ -8,12 +8,13 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestMutationTypePutWrappedUpsertTrue(t *testing.T) {
-	params := schema.MutationPutWrappedFieldResolverParams{}
+	params := schema.MutationPutWrappedFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Raw = `
 		{
 			"type": "Silenced",
@@ -54,7 +55,7 @@ func TestMutationTypePutWrappedUpsertTrue(t *testing.T) {
 }
 
 func TestMutationTypePutWrappedUpsertFalse(t *testing.T) {
-	params := schema.MutationPutWrappedFieldResolverParams{}
+	params := schema.MutationPutWrappedFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Raw = `
 		{
 			"type": "Silenced",
@@ -96,7 +97,7 @@ func TestMutationTypePutWrappedUpsertFalse(t *testing.T) {
 
 func TestMutationTypeExecuteCheck(t *testing.T) {
 	inputs := schema.ExecuteCheckInput{}
-	params := schema.MutationExecuteCheckFieldResolverParams{}
+	params := schema.MutationExecuteCheckFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockCheckClient)
@@ -118,7 +119,7 @@ func TestMutationTypeExecuteCheck(t *testing.T) {
 
 func TestMutationTypeUpdateCheck(t *testing.T) {
 	inputs := schema.UpdateCheckInput{}
-	params := schema.MutationUpdateCheckFieldResolverParams{}
+	params := schema.MutationUpdateCheckFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 	params.ResolveParams.Args = map[string]interface{}{
 		"input": map[string]interface{}{
@@ -156,7 +157,7 @@ func TestMutationTypeUpdateCheck(t *testing.T) {
 
 func TestMutationTypeDeleteEntityField(t *testing.T) {
 	inputs := schema.DeleteRecordInput{}
-	params := schema.MutationDeleteEntityFieldResolverParams{}
+	params := schema.MutationDeleteEntityFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	entity := corev2.FixtureEntity("abc")
@@ -183,7 +184,7 @@ func TestMutationTypeDeleteEventField(t *testing.T) {
 	gid := globalid.EventTranslator.EncodeToString(context.Background(), evt)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
-	params := schema.MutationDeleteEventFieldResolverParams{}
+	params := schema.MutationDeleteEventFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockEventClient)
@@ -214,7 +215,7 @@ func TestMutationTypeDeleteHandlerField(t *testing.T) {
 	gid := globalid.HandlerTranslator.EncodeToString(context.Background(), hd)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
-	params := schema.MutationDeleteHandlerFieldResolverParams{}
+	params := schema.MutationDeleteHandlerFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockHandlerClient)
@@ -239,7 +240,7 @@ func TestMutationTypeDeleteMutatorField(t *testing.T) {
 	gid := globalid.MutatorTranslator.EncodeToString(context.Background(), mut)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
-	params := schema.MutationDeleteMutatorFieldResolverParams{}
+	params := schema.MutationDeleteMutatorFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockMutatorClient)
@@ -264,7 +265,7 @@ func TestMutationTypeDeleteEventFilterField(t *testing.T) {
 	gid := globalid.EventFilterTranslator.EncodeToString(context.Background(), flr)
 
 	inputs := schema.DeleteRecordInput{ID: gid}
-	params := schema.MutationDeleteEventFilterFieldResolverParams{}
+	params := schema.MutationDeleteEventFilterFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockEventFilterClient)
@@ -289,7 +290,7 @@ func TestMutationTypeCreateSilenceField(t *testing.T) {
 		Namespace: "a",
 		Props:     &schema.SilenceInputs{},
 	}
-	params := schema.MutationCreateSilenceFieldResolverParams{}
+	params := schema.MutationCreateSilenceFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockSilencedClient)
@@ -311,7 +312,7 @@ func TestMutationTypeCreateSilenceField(t *testing.T) {
 
 func TestMutationTypeDeleteSilenceField(t *testing.T) {
 	inputs := schema.DeleteRecordInput{}
-	params := schema.MutationDeleteSilenceFieldResolverParams{}
+	params := schema.MutationDeleteSilenceFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Input = &inputs
 
 	client := new(MockSilencedClient)

--- a/backend/apid/graphql/mutator_test.go
+++ b/backend/apid/graphql/mutator_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"testing"
 
 	v2 "github.com/sensu/sensu-go/api/core/v2"
@@ -13,7 +14,7 @@ func TestMutatorTypeToJSONField(t *testing.T) {
 	src := v2.FixtureMutator("name")
 	imp := &mutatorImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ func TestNamespaceTypeCheckConfigsField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceChecksFieldResolverParams{}
+	params := schema.NamespaceChecksFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{CheckClient: checkClient}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -48,7 +49,7 @@ func TestNamespaceTypeEntitiesField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceEntitiesFieldResolverParams{}
+	params := schema.NamespaceEntitiesFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{EntityClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -75,7 +76,7 @@ func TestNamespaceTypeEventsField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceEventsFieldResolverParams{}
+	params := schema.NamespaceEventsFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{EventClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -102,7 +103,7 @@ func TestNamespaceTypeEventFiltersField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceEventFiltersFieldResolverParams{}
+	params := schema.NamespaceEventFiltersFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{EventFilterClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -130,7 +131,7 @@ func TestNamespaceTypeHandlersField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceHandlersFieldResolverParams{}
+	params := schema.NamespaceHandlersFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{HandlerClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -162,7 +163,7 @@ func TestNamespaceTypeMutatorsField(t *testing.T) {
 	}, nil).Once()
 
 	impl := &namespaceImpl{}
-	params := schema.NamespaceMutatorsFieldResolverParams{}
+	params := schema.NamespaceMutatorsFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	cfg := ServiceConfig{MutatorClient: client}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("default")
@@ -194,7 +195,7 @@ func TestNamespaceTypeSilencesField(t *testing.T) {
 
 	impl := &namespaceImpl{}
 	cfg := ServiceConfig{SilencedClient: client}
-	params := schema.NamespaceSilencesFieldResolverParams{}
+	params := schema.NamespaceSilencesFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Context = contextWithLoadersNoCache(context.Background(), cfg)
 	params.Source = corev2.FixtureNamespace("xxx")
 

--- a/backend/apid/graphql/query_test.go
+++ b/backend/apid/graphql/query_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	"github.com/sensu/sensu-go/graphql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -20,7 +22,7 @@ func TestQueryTypeEventField(t *testing.T) {
 
 	event := corev2.FixtureEvent("a", "b")
 	args := schema.QueryEventFieldResolverArgs{Namespace: "ns", Entity: "a", Check: "b"}
-	params := schema.QueryEventFieldResolverParams{Args: args}
+	params := schema.QueryEventFieldResolverParams{Args: args, ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 
 	// Success
 	client.On("FetchEvent", mock.Anything, event.Entity.Name, event.Check.Name).Return(event, nil).Once()
@@ -36,7 +38,7 @@ func TestQueryTypeEventFilterField(t *testing.T) {
 
 	filter := corev2.FixtureEventFilter("a")
 	args := schema.QueryEventFilterFieldResolverArgs{Namespace: "ns", Name: "a"}
-	params := schema.QueryEventFilterFieldResolverParams{Args: args}
+	params := schema.QueryEventFilterFieldResolverParams{Args: args, ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 
 	// Success
 	client.On("FetchEventFilter", mock.Anything, filter.Name).Return(filter, nil).Once()
@@ -51,7 +53,7 @@ func TestQueryTypeNamespaceField(t *testing.T) {
 	impl := queryImpl{svc: cfg}
 
 	nsp := corev2.FixtureNamespace("sensu")
-	params := schema.QueryNamespaceFieldResolverParams{}
+	params := schema.QueryNamespaceFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Name = nsp.Name
 
 	// Success
@@ -67,7 +69,7 @@ func TestQueryTypeEntityField(t *testing.T) {
 	impl := queryImpl{svc: cfg}
 
 	entity := corev2.FixtureEntity("a")
-	params := schema.QueryEntityFieldResolverParams{}
+	params := schema.QueryEntityFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Namespace = entity.Namespace
 	params.Args.Name = entity.Name
 
@@ -84,7 +86,7 @@ func TestQueryTypeCheckField(t *testing.T) {
 	impl := queryImpl{svc: cfg}
 
 	check := corev2.FixtureCheckConfig("a")
-	params := schema.QueryCheckFieldResolverParams{}
+	params := schema.QueryCheckFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Namespace = check.Namespace
 	params.Args.Name = check.Name
 
@@ -101,7 +103,7 @@ func TestQueryTypeHandlerField(t *testing.T) {
 	impl := queryImpl{svc: cfg}
 
 	handler := corev2.FixtureHandler("a")
-	params := schema.QueryHandlerFieldResolverParams{}
+	params := schema.QueryHandlerFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Namespace = handler.Namespace
 	params.Args.Name = handler.Name
 
@@ -118,7 +120,7 @@ func TestQueryTypeMuatorField(t *testing.T) {
 	impl := queryImpl{svc: cfg}
 
 	mutator := corev2.FixtureMutator("a")
-	params := schema.QueryMutatorFieldResolverParams{}
+	params := schema.QueryMutatorFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Namespace = mutator.Namespace
 	params.Args.Name = mutator.Name
 
@@ -134,7 +136,7 @@ func TestQueryTypeSuggestField(t *testing.T) {
 	cfg := ServiceConfig{GenericClient: client}
 	impl := queryImpl{svc: cfg}
 
-	params := schema.QuerySuggestFieldResolverParams{}
+	params := schema.QuerySuggestFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Args.Namespace = "default"
 	params.Args.Ref = "core/v2/check_config/subscriptions"
 

--- a/backend/apid/graphql/silenced_test.go
+++ b/backend/apid/graphql/silenced_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -19,7 +20,7 @@ func TestSilencedTypeCheckField(t *testing.T) {
 
 	// Success
 	client.On("FetchCheck", mock.Anything, check.Name).Return(check, nil).Once()
-	res, err := impl.Check(graphql.ResolveParams{Source: silenced})
+	res, err := impl.Check(graphql.ResolveParams{Source: silenced, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }
@@ -29,13 +30,13 @@ func TestSilencedTypeExpiresField(t *testing.T) {
 	impl := &silencedImpl{}
 
 	// with expiry unset
-	res, err := impl.Expires(graphql.ResolveParams{Source: silenced})
+	res, err := impl.Expires(graphql.ResolveParams{Source: silenced, Context: context.Background()})
 	require.NoError(t, err)
 	assert.Nil(t, res)
 
 	// with expiry set
 	silenced.Expire = 1234
-	res, err = impl.Expires(graphql.ResolveParams{Source: silenced})
+	res, err = impl.Expires(graphql.ResolveParams{Source: silenced, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotNil(t, res)
 }
@@ -44,7 +45,7 @@ func TestSilencedTypeBeginField(t *testing.T) {
 	silenced := corev2.FixtureSilenced("unix:http-check")
 	impl := &silencedImpl{}
 
-	res, err := impl.Begin(graphql.ResolveParams{Source: silenced})
+	res, err := impl.Begin(graphql.ResolveParams{Source: silenced, Context: context.Background()})
 	require.NoError(t, err)
 	assert.Nil(t, res)
 }
@@ -53,7 +54,7 @@ func TestSilencedTypeToJSONField(t *testing.T) {
 	src := corev2.FixtureSilenced("check:subscription")
 	imp := &silencedImpl{}
 
-	res, err := imp.ToJSON(graphql.ResolveParams{Source: src})
+	res, err := imp.ToJSON(graphql.ResolveParams{Source: src, Context: context.Background()})
 	require.NoError(t, err)
 	assert.NotEmpty(t, res)
 }

--- a/backend/apid/graphql/version_test.go
+++ b/backend/apid/graphql/version_test.go
@@ -1,6 +1,7 @@
 package graphql
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ func Test_versionsImpl_Backend(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &versionsImpl{}
-			got, err := r.Backend(graphql.ResolveParams{})
+			got, err := r.Backend(graphql.ResolveParams{Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("versionsImpl.Backend() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -51,7 +52,7 @@ func Test_sensuBackendVersionImpl_Version(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &sensuBackendVersionImpl{}
-			got, err := r.Version(graphql.ResolveParams{})
+			got, err := r.Version(graphql.ResolveParams{Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sensuBackendVersionImpl.Version() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -78,7 +79,7 @@ func Test_sensuBackendVersionImpl_BuildSHA(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &sensuBackendVersionImpl{}
-			got, err := r.BuildSHA(graphql.ResolveParams{})
+			got, err := r.BuildSHA(graphql.ResolveParams{Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sensuBackendVersionImpl.BuildSHA() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -123,7 +124,7 @@ func Test_sensuBackendVersionImpl_BuildDate(t *testing.T) {
 			tt.setup()
 
 			r := &sensuBackendVersionImpl{}
-			got, err := r.BuildDate(graphql.ResolveParams{})
+			got, err := r.BuildDate(graphql.ResolveParams{Context: context.Background()})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("sensuBackendVersionImpl.BuildDate() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Adds semgrep github action. There are two separate semgrep runs performed. One that uses the `dgryski/semgrep-go` repo, and one that relies on sensu-go's `.semgrep.yml`.