### PR TITLE
Add ResourceV3 watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Added
 - Added ResourceTemplate resource. ResourceTemplate will be used to populate
 namespaces with initial resources.
+- Added `GetResourceV3Watcher()` to the `store/etcd` package.
 
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.

--- a/backend/store/etcd/watchers.go
+++ b/backend/store/etcd/watchers.go
@@ -134,6 +134,7 @@ func GetResourceV3Watcher(ctx context.Context, client *clientv3.Client, key stri
 	c := make(chan store.WatchEventResourceV3, 1)
 
 	go func() {
+		defer logger.Info("closed ResourceV3 watcher")
 		defer close(c)
 
 		for {
@@ -163,7 +164,14 @@ func GetResourceV3Watcher(ctx context.Context, client *clientv3.Client, key stri
 						Resource: component,
 					}
 
-				case action == store.WatchError, action == store.WatchUnknown:
+				case action == store.WatchError:
+					logger.Error("error from underlying etcd watcher")
+					c <- store.WatchEventResourceV3{
+						Action: action,
+					}
+
+				case action == store.WatchUnknown:
+					logger.Warn("unknown message from underlying etcd watcher")
 					c <- store.WatchEventResourceV3{
 						Action: action,
 					}

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -133,6 +133,17 @@ type WatchEventResource struct {
 	Action   WatchActionType
 }
 
+// WatchEventResourceV3 is a notification that a corev3.Resource has been
+// created, deleted or updated.
+type WatchEventResourceV3 struct {
+	// Resource is the resource associated with the event. It is nil when Action
+	// is WatchError or WatchUnknown.
+	Resource corev3.Resource
+
+	// Action is the type of action that affected the resource.
+	Action WatchActionType
+}
+
 // WatchEventEntityConfig contains an updated entity config and the action that
 // occurred during this modification.
 type WatchEventEntityConfig struct {


### PR DESCRIPTION
-------

## What is this change?

This adds `GetResourceV3Watcher()` to the `store/etcd` package. Similarly to the
other `GetXWatcher()` functions, it returns a channel with events related to the
given key, representing a store path to any type of `corev3.Resource`.

## Why is this change necessary?

This function and the associated `WatchEventResourceV3` type were written for
more specific work in the enterprise code, but they are useful in general and
should be moved here.

## Does your change need a Changelog entry?

Yes, added.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes required.

## How did you verify this change?

Used in enterprise feature. Unit tests for the various `GetXWatcher()` functions
would be nice, although a bit of refactoring might be necessary.

## Is this change a patch?

No.