### PR TITLE
Add EntityServiceClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Added
 - Added ResourceTemplate resource. ResourceTemplate will be used to populate
 namespaces with initial resources.
+- Add `EntityServiceClass` constant to the `corev2` package, representing BSM Services.
 
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -26,6 +26,9 @@ const (
 	// EntityBackendClass is the name of the class given to backend entities.
 	EntityBackendClass = "backend"
 
+	// EntityServiceClass is the name of the class given to BSM service entities.
+	EntityServiceClass = "service"
+
 	// Redacted is filled in for fields that contain sensitive information
 	Redacted = "REDACTED"
 )


### PR DESCRIPTION
-------

## What is this change?

Add a constant in the `corev2` package representing an entity that is a BSM
service.

## Why is this change necessary?

The constant has been defined for BSM related work in the enterprise repository,
but it really belongs here with the other constants representing entity types.

## Does your change need a Changelog entry?

Sure, I added one...

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation about what a "service" entity class is is covered by the BSM
documentation.

## How did you verify this change?

I didn't, because it's just a new constant definition.

## Is this change a patch?

No.