### PR TITLE
Instantiate ResourceTemplates on namespace create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added ResourceTemplate resource. ResourceTemplate will be used to populate
 namespaces with initial resources.
 - Add `EntityServiceClass` constant to the `corev2` package, representing BSM Services.
+- Added ResourceTemplate instantiation on namespace creation.
 
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -181,7 +181,7 @@ func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		routers.NewHandlersRouter(cfg.Store),
 		routers.NewHooksRouter(cfg.Store),
 		routers.NewMutatorsRouter(cfg.Store),
-		routers.NewNamespacesRouter(cfg.Store, cfg.Store, &rbac.Authorizer{Store: cfg.Store}),
+		routers.NewNamespacesRouter(cfg.Store, cfg.Store, &rbac.Authorizer{Store: cfg.Store}, cfg.Storev2),
 		routers.NewRolesRouter(cfg.Store),
 		routers.NewRoleBindingsRouter(cfg.Store),
 		routers.NewSilencedRouter(cfg.Store),

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -399,7 +399,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		HealthController:  actions.NewHealthController(stor, b.Client.Cluster, etcdClientTLSConfig),
 		MutatorClient:     api.NewMutatorClient(stor, auth),
 		SilencedClient:    api.NewSilencedClient(stor, auth),
-		NamespaceClient:   api.NewNamespaceClient(stor, stor, auth),
+		NamespaceClient:   api.NewNamespaceClient(stor, stor, auth, storv2),
 		HookClient:        api.NewHookConfigClient(stor, auth),
 		UserClient:        api.NewUserClient(stor, auth),
 		RBACClient:        api.NewRBACClient(stor, auth),


### PR DESCRIPTION
## What is this change?

This commit causes sensu-go to implicitly create resources in newly
created namespaces when they are defined. So far, there are no
ResourceTemplates defined, so no new resources will be created for OSS.

## Why is this change necessary?

This is supported work for the BSM enterprise feature. We may leverage it in the future and expose it to users, but for now it is internal only.

## Does your change need a Changelog entry?

Yes.

## How did you verify this change?

Unit tests only.

## Is this change a patch?

No.
