### PR TITLE
Make SIGHUP a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ defined.
 round robin checks.
 - Fixed a bug where build information would get calculated for every keepalive
 in OSS builds.
+- Don't trigger internal restart on SIGHUP.
 
 ## [6.2.3] - 2021-01-21
 


### PR DESCRIPTION
## What is this change?

This commit removes the functionality that causes sensu-go's internal
daemons to restart on SIGHUP. Instead, SIGHUP is now a no-op.

In the enterprise product, SIGHUP is used to rotate the special event
log file, so the restarting behaviour was undesirable.

We don't anticipate anyone should ever want to force an internal daemon
restart, users should instead restart the whole sensu-backend process if
that's what they want to do. So, support for doing this is now removed.

## Why is this change necessary?

Fixes #4217 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

I ran sensu-backend and sent SIGHUP to it manually several times. It had no effect, as expected.

## Is this change a patch?

No.
