### PR TITLE
Added more context when logging JavaScript filter evaluation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ namespaces with initial resources.
 - Added `GetResourceV3Watcher()` to the `store/etcd` package.
 - Add `EntityServiceClass` constant to the `corev2` package, representing BSM Services.
 - Added ResourceTemplate instantiation on namespace creation.
+- Added more context when logging JavaScript filter evaluation errors.
 
 ### Fixed
 - Both V2 & V3 resources are now validated when used with storev2.

--- a/backend/pipeline/filter.go
+++ b/backend/pipeline/filter.go
@@ -70,7 +70,7 @@ func evaluateEventFilter(ctx context.Context, event *corev2.Event, filter *corev
 	for _, expression := range filter.Expressions {
 		match, err := env.Eval(ctx, expression)
 		if err != nil {
-			logger.WithError(err).Error("error evaluating javascript event filter")
+			logger.WithFields(fields).WithError(err).Error("error evaluating javascript event filter")
 			continue
 		}
 


### PR DESCRIPTION
## What is this change?

The following information has been added to the log messages:

- check name and namespace
- entity name and namespace
- event id
- filter name


## Why is this change necessary?

Makes it easier to correlate the error with a specific filter, or event.


## Does your change need a Changelog entry?

The change includes one:
- Added more context when logging JavaScript filter evaluation errors.


## Do you need clarification on anything?

No.


## Were there any complications while making this change?

No.


## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe this require a documentation change.


## How did you verify this change?

Install the sensu-email-handler asset:
```
sensuctl asset add sensu/sensu-email-handler
```

Create an event filter with a syntax error in the expression:
```
cat << EOF | sensuctl update
---
type: EventFilter
api_version: core/v2
metadata:
  annotations: null
  labels: null
  name: state_change_only
  namespace: default
spec:
  action: allow
  expressions:
  - event.occ == 1
  runtime_assets: []
EOF
```

Create the email handler:
```
cat << EOF | sensuctl create
---
api_version: core/v2
type: Handler
metadata:
  namespace: default
  name: email
spec:
  type: pipe
  command: sensu-email-handler -f francisguimond@gmail.com -t francis@sensu.io -s smtp.google.com -u fguimond -p fake
  timeout: 10
  filters:
  - state_change_only
  runtime_assets:
  - email-handler
EOF
```

Generate an event:
```
eval $(sensuctl env)
curl -sS -X PUT \                                                                                                                                                                            ✔
-H "Authorization: Bearer $SENSU_ACCESS_TOKEN" \
-H 'Content-Type: application/json' \
-d '{
  "entity": {
    "entity_class": "proxy",
    "metadata": {
      "name": "server01",
      "namespace": "default"
    }
  },
  "check": {
    "metadata": {
      "name": "server-health"
    },
    "output": "This is a warning.",
    "status": 1,
    "interval": 60,
    "handlers": ["email"]
  }
}' \
http://localhost:8080/api/core/v2/namespaces/default/events/server01/server-health
```

Observe the backend logs. The following entry gets generated:
```
{"assets":null,"check_name":"server-health","check_namespace":"default","component":"pipelined","entity_name":"server01","entity_namespace":"default","error":"TypeError: Cannot access member 'occ' of undefined","event_id":"2c05eb62-fdaf-4794-98cb-8f886b593507","filter":"state_change_only","level":"error","msg":"error evaluating javascript event filter","time":"2021-03-10T00:12:38-05:00"}
```


## Is this change a patch?

No.
