### PR TITLE
Enable namespace creation side effects for updates

### DIFF
--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -364,6 +364,9 @@ func (a *NamespaceClient) UpdateNamespace(ctx context.Context, namespace *corev2
 	if err := a.client.Update(ctx, namespace); err != nil {
 		return err
 	}
+	if err := a.createResourceTemplates(ctx, namespace.Name); err != nil {
+		return err
+	}
 	return a.createRoleAndBinding(ctx, namespace.Name)
 }
 


### PR DESCRIPTION
## What is this change?

This commit changes the namespace CRUD API to implement the same side
effects for create-or-update as currently exist for create. The
namespace POST API has also been updated to make use of the
functionality.

## Why is this change necessary?

It fixes an unreleased defect that largely applies to an upcoming enterprise feature.

## Does your change need a Changelog entry?

No.

## How did you verify this change?

The change is covered by unit tests and also by automated QA.

## Is this change a patch?

No.