### PR TITLE
sensuctl: fix shell auto-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ round robin checks.
 in OSS builds.
 - Don't trigger internal restart on SIGHUP.
 - Concatenated YAML files now support CRLF.
+- Remove extraneous auto-completion suggestions.
 
 ## [6.2.3] - 2021-01-21
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -72,6 +72,6 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 	)
 
 	for _, cmd := range rootCmd.Commands() {
-		rootCmd.ValidArgs = append(rootCmd.ValidArgs, cmd.Use)
+		rootCmd.ValidArgs = append(rootCmd.ValidArgs, cmd.Name())
 	}
 }


### PR DESCRIPTION
## What is this change?

Suggestions provided by shell auto-completion included extraneous flags and arguments (e.g. -f, FILE). This fix removes them.

## Why is this change necessary?

To only show the available auto-completion arguments.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required.

## How did you verify this change?

- Setup bash and zsh auto-completion following the instructions here.
- Rebuild sensuctl
- Restart your shell to make sure the latest auto-completion logic is loaded
- Type `sensuctl <tab><tab>`
- Observe the suggested options and make sure there only valid commands and nothing like `-f`, `[blahblah]`

## Is this change a patch?

No.