### PR TITLE
Prevent agentd unit test from timing out

### DIFF
--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -406,6 +406,7 @@ func (s *Session) sender() {
 // 2. Start receiver
 // 3. Start goroutine that waits for context cancellation, and shuts down service.
 func (s *Session) Start() (err error) {
+	defer close(s.entityConfig.subscriptions)
 	sessionCounter.WithLabelValues(s.cfg.Namespace).Inc()
 	s.wg = &sync.WaitGroup{}
 	s.wg.Add(2)
@@ -515,8 +516,6 @@ func (s *Session) Start() (err error) {
 		return err
 	}
 
-	close(s.entityConfig.subscriptions)
-
 	return nil
 }
 
@@ -576,7 +575,7 @@ func (s *Session) stop() {
 }
 
 // handleKeepalive is the keepalive message handler.
-func (s *Session) handleKeepalive(ctx context.Context, payload []byte) error {
+func (s *Session) handleKeepalive(_ context.Context, payload []byte) error {
 	keepalive := &corev2.Event{}
 	err := s.unmarshal(payload, keepalive)
 	if err != nil {
@@ -598,7 +597,7 @@ func (s *Session) handleKeepalive(ctx context.Context, payload []byte) error {
 }
 
 // handleEvent is the event message handler.
-func (s *Session) handleEvent(ctx context.Context, payload []byte) error {
+func (s *Session) handleEvent(_ context.Context, payload []byte) error {
 	// Decode the payload to an event
 	event := &corev2.Event{}
 	if err := s.unmarshal(payload, event); err != nil {

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -323,6 +323,8 @@ func TestSession_sender(t *testing.T) {
 }
 
 func TestSession_Start(t *testing.T) {
+	t.Skip("Disable test since it was occasionally hanging. See #4222")
+
 	type connFunc func(*mocktransport.MockTransport, *sync.WaitGroup)
 	type storeFunc func(*storetest.Store, *sync.WaitGroup)
 

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -323,8 +323,6 @@ func TestSession_sender(t *testing.T) {
 }
 
 func TestSession_Start(t *testing.T) {
-	t.Skip("Disable test since it was occasionally hanging. See #4222")
-
 	type connFunc func(*mocktransport.MockTransport, *sync.WaitGroup)
 	type storeFunc func(*storetest.Store, *sync.WaitGroup)
 


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

On a couple of occasions the `agentd/TestSession_Start` unit test timed out when executed in the build pipeline on CircleCI. 

The test goroutine is trying to stop the Session and is blocked on the `stopWG` workgroup before it can complete.

```
goroutine 241 [semacquire]:
    sync.runtime_Semacquire(0xc0005a5d90)	                                     /usr/local/go/src/runtime/sema.go:56 +0x42
    sync.(*WaitGroup).Wait(0xc0005a5d88)	                                     /usr/local/go/src/sync/waitgroup.go:130 +0xb1
    github.com/sensu/sensu-go/backend/agentd.(*Session).Stop(0xc0005a5c80)	     /home/circleci/project/backend/agentd/session.go:528 +0x95
    github.com/sensu/sensu-go/backend/agentd.TestSession_Start.func7(0xc0002c6800)   /home/circleci/project/backend/agentd/session_test.go:448 +0x970
    testing.tRunner(0xc0002c6800, 0xc0008beb20)                                      /usr/local/go/src/testing/testing.go:909 +0x19a
    created by testing.(*T).Run                                                      /usr/local/go/src/testing/testing.go:960 +0x652
```

Another function, `Session.stop()` is responsible for decrementing the workgroup and unblock waiting goroutines. However the execution of that method is iterating on a channel's content. The iteration should complete when the channel is closed. 

```
goroutine 405 [chan receive]:
    github.com/sensu/sensu-go/backend/agentd.(*Session).stop(0xc0005a5c80)        /home/circleci/project/backend/agentd/session.go:568 +0x439
    github.com/sensu/sensu-go/backend/agentd.(*Session).Start.func1(0xc0005a5c80) /home/circleci/project/backend/agentd/session.go:417 +0x88
    created by github.com/sensu/sensu-go/backend/agentd.(*Session).Start          /home/circleci/project/backend/agentd/session.go:415 +0x286
```

That channel is normally closed at the end of `Session.Start()` but if there is any error before that function completes the subscriptions channel is never closed, preventing the `Session.Stop()` from completing, and in the case of a test environment causes it to timeout.

This fix moves the close channel operation to a deferred function instead from the end of the function so if there is any error processing `Session.Start()` the channel will be closed.

## Why is this change necessary?

To prevent the backend/agentd unit test from timing out in the build pipeline.

#4222 

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not necessary.

## How did you verify this change?

I ran the test with a fake error inserted in the `Session.Start()` method and the test completes.

## Is this change a patch?

No.
