### PR TITLE
Make the agentd health router public so it can be extended.

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -150,10 +150,10 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	// runtime, so we need this workaround
 	router := mux.NewRouter()
 
-	healthRouter := routers.NewHealthRouter(
+	HealthRouter = routers.NewHealthRouter(
 		actions.NewHealthController(a.store, a.client.Cluster, a.etcdClientTLSConfig),
 	)
-	healthRouter.Mount(router)
+	HealthRouter.Mount(router)
 
 	route := router.NewRoute().Subrouter()
 	route.HandleFunc("/", a.webSocketHandler)

--- a/backend/agentd/routers.go
+++ b/backend/agentd/routers.go
@@ -1,6 +1,0 @@
-package agentd
-
-import "github.com/sensu/sensu-go/backend/apid/routers"
-
-// HealthRouter represents the API router for the health endpoint
-var HealthRouter *routers.HealthRouter

--- a/backend/agentd/routers.go
+++ b/backend/agentd/routers.go
@@ -1,0 +1,6 @@
+package agentd
+
+import "github.com/sensu/sensu-go/backend/apid/routers"
+
+// HealthRouter represents the API router for the health endpoint
+var HealthRouter *routers.HealthRouter


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Add a function to replace the agentd's health controller to be used by sensu-enterprise-go to include Postgres health information.

## Why is this change necessary?

We need to include the Postgres health information from the agentd health endpoint accessible at http://[host]:8081. For this the default health controller needs to be replaced with an extended one that includes the Postgres health.

Fixes #4182 
Closes #4182 

## Does your change need a Changelog entry?

The releated sensu-enterprise-go change will require one but it is a transparent change in this project.

## Do you need clarification on anything?

agentd's HealthRouter needs to be accessible from sensu-enterprise-go to be able to swap the HealthControler. I'm not sure if it is the best way to make the HealthRouter accessible however it seems a similar approach was implemented for agentd's middlewares in backend/agentd/middlewares.go. If there is a better way to do it please let me know 😄 

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not required.

## How did you verify this change?

With sensu-go run the following commands and make sure the content is identical.

```
curl http://localhost:8080/health
curl http://localhost:8081/health
```

## Is this change a patch?

No.
