### PR TITLE
Remove validation for partial V3 resources in PATCH API

### DIFF
--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"errors"
+	fmt "fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
@@ -11,7 +12,7 @@ func ValidateMetadata(meta *corev2.ObjectMeta) error {
 		return errors.New("nil metadata")
 	}
 	if err := corev2.ValidateName(meta.Name); err != nil {
-		return err
+		return fmt.Errorf("name %s", err)
 	}
 	if meta.Labels == nil {
 		return errors.New("nil labels")

--- a/backend/apid/handlers/patch.go
+++ b/backend/apid/handlers/patch.go
@@ -130,7 +130,7 @@ func (h Handlers) patchV3Resource(ctx context.Context, body []byte, name, namesp
 	}
 
 	req := storev2.NewResourceRequest(ctx, namespace, name, resource.StoreName())
-	w, err := wrap.Resource(resource)
+	w, err := wrap.ResourceWithoutValidation(resource)
 	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}

--- a/backend/apid/handlers/patch_integration_test.go
+++ b/backend/apid/handlers/patch_integration_test.go
@@ -1,0 +1,151 @@
+// +build integration
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sensu/sensu-go/backend/seeds"
+	"github.com/sensu/sensu-go/backend/store"
+	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	etcdstorev2 "github.com/sensu/sensu-go/backend/store/v2/etcdstore"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+	"github.com/sirupsen/logrus"
+)
+
+type comparable interface {
+	Equal(interface{}) bool
+}
+
+func testWithEtcdStores(t *testing.T, f func(*etcdstore.Store, *etcdstorev2.Store)) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	e, cleanup := etcd.NewTestEtcd(t)
+	defer cleanup()
+
+	client := e.NewEmbeddedClient()
+
+	s1 := etcdstore.NewStore(client, e.Name())
+	s2 := etcdstorev2.NewStore(client)
+
+	if err := seeds.SeedInitialData(s1); err != nil {
+		t.Fatalf("failed to seed initial etcd data: %v", err)
+	}
+
+	f(s1, s2)
+}
+
+func patchRequest(target, namespace, id, body string) *http.Request {
+	r := httptest.NewRequest("PATCH", target, strings.NewReader(body))
+
+	// some of our code reads the namespace from the request context and other
+	// code reads it from mux.Vars(), so we must set both.
+	r = r.WithContext(store.NamespaceContext(r.Context(), namespace))
+	vars := map[string]string{
+		"namespace": namespace,
+		"id":        id,
+	}
+	return mux.SetURLVars(r, vars)
+}
+
+func TestHandlers_PatchResource(t *testing.T) {
+	type fields struct {
+		Resource   corev2.Resource
+		V3Resource corev3.Resource
+	}
+	type args struct {
+		r *http.Request
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		storeInit func(*testing.T, *etcdstore.Store, *etcdstorev2.Store)
+		want      interface{}
+		wantErr   bool
+	}{
+		{
+			name: "V2 resources can be patched",
+			fields: fields{
+				Resource: &corev2.CheckConfig{},
+			},
+			args: args{
+				r: patchRequest("/", "default", "testcheck", `{"subscriptions": ["windows"]}`),
+			},
+			storeInit: func(t *testing.T, s1 *etcdstore.Store, s2 *etcdstorev2.Store) {
+				ctx := store.NamespaceContext(context.Background(), "default")
+				check := corev2.FixtureCheckConfig("testcheck")
+				if err := s1.UpdateCheckConfig(ctx, check); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: func() interface{} {
+				check := corev2.FixtureCheckConfig("testcheck")
+				check.Subscriptions = []string{"windows"}
+				return check
+			}(),
+		},
+		{
+			name: "V3 resources can be patched",
+			fields: fields{
+				V3Resource: &corev3.EntityConfig{},
+			},
+			args: args{
+				r: patchRequest("/", "default", "testentity", `{"subscriptions":["windows"]}`),
+			},
+			storeInit: func(t *testing.T, s1 *etcdstore.Store, s2 *etcdstorev2.Store) {
+				ctx := store.NamespaceContext(context.Background(), "default")
+				entity := corev3.FixtureEntityConfig("testentity")
+				req := storev2.NewResourceRequestFromResource(ctx, entity)
+				wrapper, err := wrap.Resource(entity)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := s2.CreateOrUpdate(req, wrapper); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: func() interface{} {
+				entity := corev3.FixtureEntityConfig("testentity")
+				entity.Subscriptions = []string{"windows", "entity:testentity"}
+				return entity
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testWithEtcdStores(t, func(s1 *etcdstore.Store, s2 *etcdstorev2.Store) {
+				if tt.storeInit != nil {
+					tt.storeInit(t, s1, s2)
+				}
+				h := Handlers{
+					Resource:   tt.fields.Resource,
+					V3Resource: tt.fields.V3Resource,
+					Store:      s1,
+					StoreV2:    s2,
+				}
+				got, err := h.PatchResource(tt.args.r)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("Handlers.PatchResource() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				wantComparable, ok := tt.want.(comparable)
+				if !ok {
+					t.Fatal("want cannot be type asserted as comparable")
+				}
+				if !wantComparable.Equal(got) {
+					t.Errorf("Handlers.PatchResource() = %v, want %v", got, tt.want)
+				}
+			})
+		})
+	}
+}

--- a/backend/apid/handlers/patch_test.go
+++ b/backend/apid/handlers/patch_test.go
@@ -1,0 +1,63 @@
+package handlers
+
+import "testing"
+
+func TestValidatePatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       []byte
+		vars       map[string]string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "errors when metadata name & resource id do not match",
+			data: []byte(`{"metadata":{"name":"foo"}}`),
+			vars: map[string]string{
+				"id": "bar",
+			},
+			wantErr:    true,
+			wantErrMsg: "the name of the resource (foo) does not match the name in the URI (bar)",
+		},
+		{
+			name: "errors when metadata namespace & resource namespace do not match",
+			data: []byte(`{"metadata":{"namespace":"foo"}}`),
+			vars: map[string]string{
+				"namespace": "bar",
+			},
+			wantErr:    true,
+			wantErrMsg: "the namespace of the resource (foo) does not match the namespace in the URI (bar)",
+		},
+		{
+			name: "succeeds when resource name & namespace are empty",
+			data: []byte(`{}`),
+			vars: map[string]string{
+				"id":        "foo",
+				"namespace": "bar",
+			},
+			wantErr: false,
+		},
+		{
+			name: "succeeds when name & metadata match resource name & namespace",
+			data: []byte(`{"metadata":{"name":"foo","namespace":"bar"}}`),
+			vars: map[string]string{
+				"id":        "foo",
+				"namespace": "bar",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePatch(tt.data, tt.vars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && err.Error() != tt.wantErrMsg {
+				t.Errorf("validatePatch() errorMsg = %v, wantErrMsg %v", err, tt.wantErrMsg)
+				return
+			}
+		})
+	}
+}

--- a/backend/store/v2/wrap/wrapper.go
+++ b/backend/store/v2/wrap/wrapper.go
@@ -132,19 +132,20 @@ func Resource(r corev3.Resource, opts ...Option) (*Wrapper, error) {
 	return wrap(r, opts...)
 }
 
+func ResourceWithoutValidation(r corev3.Resource, opts ...Option) (*Wrapper, error) {
+	return wrapWithoutValidation(r, opts...)
+}
+
 // V2Resource is like Resource, but works on older core v2 resources.
 func V2Resource(r corev2.Resource, opts ...Option) (*Wrapper, error) {
 	return wrap(r, opts...)
 }
 
-func wrap(r interface{}, opts ...Option) (*Wrapper, error) {
-	if v, ok := r.(validatable); ok {
-		if err := v.Validate(); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, ErrValidateMethodMissing
-	}
+func V2ResourceWithoutValidation(r corev2.Resource, opts ...Option) (*Wrapper, error) {
+	return wrapWithoutValidation(r, opts...)
+}
+
+func wrapWithoutValidation(r interface{}, opts ...Option) (*Wrapper, error) {
 	if proxy, ok := r.(*corev3.V2ResourceProxy); ok {
 		r = proxy.Resource
 	}
@@ -176,6 +177,17 @@ func wrap(r interface{}, opts ...Option) (*Wrapper, error) {
 	w.Value = w.Compression.Compress(message)
 
 	return &w, nil
+}
+
+func wrap(r interface{}, opts ...Option) (*Wrapper, error) {
+	if v, ok := r.(validatable); ok {
+		if err := v.Validate(); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, ErrValidateMethodMissing
+	}
+	return wrapWithoutValidation(r, opts...)
 }
 
 // Unwrap unmarshals the wrapper's value into a resource, according to the


### PR DESCRIPTION
## What is this change?

Removes the validation that was happening for V3 resources in the PATCH API.

## Why is this change necessary?

The initial validation of V3 resources in the PATCH API would always fail as it was trying to validate incomplete resources.

Closes #4241.

## Does your change need a Changelog entry?

No as this is fixing a regression for code that has not yet been released.

## Do you need clarification on anything?

Attempting to patch a resource using a non-existent field will succeed & the non-existent field will be ignored.  I'm not sure if there's some way we can validate that the fields are correct. Errors are still returned if the data type of a field does not match the resource field's data type.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I added specs to reproduce the issue and then implemented a fix.

## Is this change a patch?

No.
