### PR TITLE
Fix potential crash in tessend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ defined.
 round robin checks.
 - Fixed a bug where build information would get calculated for every keepalive
 in OSS builds.
+- Fix a potential crash in tessend
 
 ## [6.2.2] - 2021-01-14
 

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -393,7 +393,7 @@ func (t *Tessend) handleEvents(ctx context.Context, tessen *corev2.TessenConfig,
 			case ringv2.EventTrigger:
 				logger.WithField("values", event.Values).Debug("tessen ring trigger")
 				// only trigger tessen if the next backend in the ring is this backend
-				if event.Values[0] == t.backendID {
+				if len(event.Values) > 0 && event.Values[0] == t.backendID {
 					if t.enabled() {
 						go t.collectAndSend()
 					}


### PR DESCRIPTION
## What is this change?

This change adds a length check on the `ringv2.Event.Value` before accessing it
since it is possible, though unlikely, that it has a zero length, leading to a
bad memory access and a crash.

## Why is this change necessary?

Prevent potential but rare crash of `tessend`.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

I'm still a bit unclear about how the ring is even able to emit such
`ringv2.EventTrigger` events with a zero-length `Value`.

The length check is warranted in `tessend` in any case.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes needed.

## Is this change a patch?

I believe that the conditions under which this crash can happen are so rare that
it doesn't warrant making this change a patch and that it's OK to just include
it in our next minor release.