### PR TITLE
Nil check pointer fields in some watchers before using them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ round robin checks.
 in OSS builds.
 - Fixed a potential crash in tessend.
 - Fixed a potential deadlock in agentd.
+- Fixed a bug where some Etcd watchers could try to process watch events holding
+invalid pointers.
 
 ## [6.2.2] - 2021-01-14
 

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -3,6 +3,7 @@ package agentd
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -246,6 +247,10 @@ func (a *Agentd) runWatcher() {
 }
 
 func (a *Agentd) handleEvent(event store.WatchEventEntityConfig) error {
+	if event.Entity == nil {
+		return errors.New("nil entity received from entity config watcher")
+	}
+
 	topic := messaging.EntityConfigTopic(event.Entity.Metadata.Namespace, event.Entity.Metadata.Name)
 	if err := a.bus.Publish(topic, &event); err != nil {
 		logger.WithField("topic", topic).WithError(err).

--- a/backend/schedulerd/check_watcher.go
+++ b/backend/schedulerd/check_watcher.go
@@ -129,6 +129,12 @@ func (c *CheckWatcher) startWatcher() {
 
 func (c *CheckWatcher) handleWatchEvent(watchEvent store.WatchEventCheckConfig) {
 	check := watchEvent.CheckConfig
+
+	if check == nil {
+		logger.Error("nil check config received from check config watcher")
+		return
+	}
+
 	key := concatUniqueKey(check.Name, check.Namespace)
 
 	c.mu.Lock()

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -319,6 +319,11 @@ func (t *Tessend) startWatcher() {
 func (t *Tessend) handleWatchEvent(watchEvent store.WatchEventTessenConfig) {
 	tessen := watchEvent.TessenConfig
 
+	if tessen == nil {
+		logger.Error("nil config received from tessen config watcher")
+		return
+	}
+
 	switch watchEvent.Action {
 	case store.WatchCreate:
 		logger.WithField("opt-out", tessen.OptOut).Debug("tessen configuration created")


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
