### PR TITLE
Bump Go to 1.16.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 sensu_go_build_env: &sensu_go_build_env
   docker:
-    - image: cimg/go:1.16
+    - image: cimg/go:1.16.3
       auth:
         username: $DOCKER_USERNAME
         password: $DOCKER_PASSWORD

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,5 @@
 name: golangci-lint
+
 on:
   push:
     tags:
@@ -6,6 +7,13 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - *
+
+env:
+  GO_VERSION: 1.16.3
+  GOLANGCI_LINT_VERSION: v1.37.1
+
 jobs:
   lint:
     name: lint
@@ -14,11 +22,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: "${{ env.GO_VERSION }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
           args: --timeout=5m
   lint-api-core-v2-mod:
     name: lint-api-core-v2-mod
@@ -27,11 +35,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: "${{ env.GO_VERSION }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: api/core/v2
           args: --timeout=5m
   lint-api-core-v3-mod:
@@ -44,11 +52,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: "${{ env.GO_VERSION }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: api/core/v3
           args: --timeout=5m
   lint-backend-store-v2-mod:
@@ -58,11 +66,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: "${{ env.GO_VERSION }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: backend/store/v2
           args: --timeout=5m
   lint-types-mod:
@@ -72,10 +80,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: "${{ env.GO_VERSION }}"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37.1
+          version: "${{ env.GOLANGCI_LINT_VERSION }}"
           working-directory: types
           args: --timeout=5m


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Bumps Go from 1.16 to 1.16.3 which includes:
* security fixes to the archive/zip and encoding/xml packages
* fixes to cgo, the compiler, linker, the go command, and the syscall and time packages
* fixes to the compiler, linker, runtime, the go command, and the testing and time packages