### PR TITLE
Add API key authentication support to sensuctl

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,7 @@ install:
   - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
   - echo %PATH%
   - echo %GOPATH%
+  - unset GOROOT
   - set PATH=%GOPATH%\bin;C:\Program Files\go\bin;%PATH%
   - go version
   - go env

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
   - echo %PATH%
   - echo %GOPATH%
-  - unset GOROOT
+  - set GOROOT=
   - set PATH=%GOPATH%\bin;C:\Program Files\go\bin;%PATH%
   - go version
   - go env

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,10 +9,11 @@ image:
   # - Visual Studio 2017
 
 cache:
-  - c:\go\pkg\mod -> go.mod, go.sum
+  - c:\Program Files\Go\pkg\mod -> go.mod, go.sum
 
 environment:
   GOPATH: c:\gopath
+  GOROOT: c:\Program Files\Go
   GOVERSION: 1.16.3
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
@@ -29,8 +30,7 @@ install:
   - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
   - echo %PATH%
   - echo %GOPATH%
-  - set GOROOT=
-  - set PATH=%GOPATH%\bin;C:\Program Files\go\bin;%PATH%
+  - set PATH=%GOPATH%\bin;c:\Program Files\Go\bin;%PATH%
   - go version
   - go env
   - mkdir %GOPATH%\bin

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
   - msiexec /i go%GOVERSION%.windows-%GOARCH%.msi /q
   - echo %PATH%
   - echo %GOPATH%
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - set PATH=%GOPATH%\bin;C:\Program Files\go\bin;%PATH%
   - go version
   - go env
   - mkdir %GOPATH%\bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 - There are currently no unreleased changes.
+- Added API key authentication support to sensuctl
 
 ## [6.3.0] - 2021-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- There are currently no unreleased changes.
+- Added `etcd-log-level` configuration flag for setting the log level of the
+  embedded etcd server.
 - Added API key authentication support to sensuctl
 
 ## [6.3.0] - 2021-04-07

--- a/cli/client/authentication_test.go
+++ b/cli/client/authentication_test.go
@@ -28,6 +28,7 @@ func TestCreateAccessToken(t *testing.T) {
 
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&corev2.Tokens{})
+	mockConfig.On("APIKey").Return("")
 
 	token, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.NoError(t, err)
@@ -47,6 +48,7 @@ func TestCreateAccessTokenForbidden(t *testing.T) {
 
 	mockConfig.On("APIUrl").Return("")
 	mockConfig.On("Tokens").Return(&corev2.Tokens{})
+	mockConfig.On("APIKey").Return("")
 
 	_, err := client.CreateAccessToken(server.URL, "foo", "bar")
 	assert.Error(t, err)
@@ -69,6 +71,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 	mockConfig.On("APIUrl").Return(server.URL)
 	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
 
 	token, err := client.RefreshAccessToken(corev2.FixtureTokens("foo", "bar"))
 	assert.NoError(t, err)
@@ -88,6 +91,7 @@ func TestRefreshAccessTokenForbidden(t *testing.T) {
 
 	mockConfig.On("APIUrl").Return(server.URL)
 	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
 
 	_, err := client.RefreshAccessToken(corev2.FixtureTokens("foo", "bar"))
 	assert.Error(t, err)

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -52,61 +52,66 @@ func New(config config.Config) *RestClient {
 	// Set the User-Agent header
 	restyInst.SetHeader("User-Agent", "sensuctl/"+version.Semver())
 
-	// Check that Access-Token has not expired
-	restyInst.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
-		// Guard against requests that are not sending auth details
-		if c.Token == "" || r.UserInfo != nil {
+	// Check for the API key. If present use that otherwise use the access token
+	if config.APIKey() != "" {
+		restyInst.SetAuthScheme("Key").SetAuthToken(config.APIKey())
+	} else {
+		// Check that Access-Token has not expired
+		restyInst.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
+			// Guard against requests that are not sending auth details
+			if c.Token == "" || r.UserInfo != nil {
+				return nil
+			}
+
+			// If the client access token is expired, it means this request is trying to
+			// retrieve a new access token and therefore we do not need to do it again
+			// otherwise we will have an infinite loop!
+			if client.expiredToken {
+				return nil
+			}
+
+			tokens := config.Tokens()
+			expiry := time.Unix(tokens.ExpiresAt, 0)
+
+			// No-op if token has not yet expired
+			if hasExpired := expiry.Before(time.Now()); !hasExpired {
+				return nil
+			}
+
+			if tokens.Refresh == "" {
+				return errors.New("configured access token has expired")
+			}
+
+			// Mark the token as expired to prevent an infinite loop in this method
+			client.expiredToken = true
+
+			// TODO: Move this into it's own file / package
+			// Request a new access token from the server
+			tokens, err := client.RefreshAccessToken(tokens)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to request new refresh token; client returned '%s'",
+					err,
+				)
+			}
+
+			// Write new tokens to disk
+			err = config.SaveTokens(tokens)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to update configuration with new refresh token (%s)",
+					err,
+				)
+			}
+
+			// We can now mark the token as valid
+			client.expiredToken = false
+
+			c.SetAuthToken(tokens.Access)
+
 			return nil
-		}
-
-		// If the client access token is expired, it means this request is trying to
-		// retrieve a new access token and therefore we do not need to do it again
-		// otherwise we will have an infinite loop!
-		if client.expiredToken {
-			return nil
-		}
-
-		tokens := config.Tokens()
-		expiry := time.Unix(tokens.ExpiresAt, 0)
-
-		// No-op if token has not yet expired
-		if hasExpired := expiry.Before(time.Now()); !hasExpired {
-			return nil
-		}
-
-		if tokens.Refresh == "" {
-			return errors.New("configured access token has expired")
-		}
-
-		// Mark the token as expired to prevent an infinite loop in this method
-		client.expiredToken = true
-
-		// TODO: Move this into it's own file / package
-		// Request a new access token from the server
-		tokens, err := client.RefreshAccessToken(tokens)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to request new refresh token; client returned '%s'",
-				err,
-			)
-		}
-
-		// Write new tokens to disk
-		err = config.SaveTokens(tokens)
-		if err != nil {
-			return fmt.Errorf(
-				"failed to update configuration with new refresh token (%s)",
-				err,
-			)
-		}
-
-		// We can now mark the token as valid
-		client.expiredToken = false
-
-		c.SetAuthToken(tokens.Access)
-
-		return nil
-	})
+		})
+	}
 
 	restyInst.SetLogger(logger)
 
@@ -139,7 +144,7 @@ func (client *RestClient) Reset() {
 // ClearAuthToken clears the authorization token from the client config
 func (client *RestClient) ClearAuthToken() {
 	client.configure()
-	client.resty.SetAuthToken("")
+	client.resty.SetAuthScheme("").SetAuthToken("")
 }
 
 func (client *RestClient) configure() {
@@ -154,7 +159,10 @@ func (client *RestClient) configure() {
 	restyInst.SetHostURL(config.APIUrl())
 
 	tokens := config.Tokens()
-	if tokens != nil && tokens.Access != "" {
+	apiKey := config.APIKey()
+	if apiKey != "" {
+		restyInst.SetAuthScheme("Key").SetAuthToken(apiKey)
+	} else if tokens != nil && tokens.Access != "" {
 		restyInst.SetAuthToken(tokens.Access)
 	}
 

--- a/cli/client/config/basic/basic.go
+++ b/cli/client/config/basic/basic.go
@@ -35,6 +35,7 @@ type Cluster struct {
 	TrustedCAFile         string `json:"trusted-ca-file"`
 	InsecureSkipTLSVerify bool   `json:"insecure-skip-tls-verify"`
 	*types.Tokens
+	APIKey  string
 	Timeout time.Duration `json:"timeout"`
 }
 
@@ -111,6 +112,10 @@ func (c *Config) flags(flags *pflag.FlagSet) {
 
 	if value, err := flags.GetString("trusted-ca-file"); err == nil && value != "" {
 		c.Cluster.TrustedCAFile = value
+	}
+
+	if value, err := flags.GetString("api-key"); err == nil && value != "" {
+		c.Cluster.APIKey = value
 	}
 
 	if value, err := flags.GetString("timeout"); err == nil && value != "" {

--- a/cli/client/config/basic/reader.go
+++ b/cli/client/config/basic/reader.go
@@ -46,6 +46,10 @@ func (c *Config) Tokens() *types.Tokens {
 	return c.Cluster.Tokens
 }
 
+func (c *Config) APIKey() string {
+	return c.Cluster.APIKey
+}
+
 // TrustedCAFile returns the trusted CA file
 func (c *Config) TrustedCAFile() string {
 	return c.Cluster.TrustedCAFile

--- a/cli/client/config/basic/reader_test.go
+++ b/cli/client/config/basic/reader_test.go
@@ -49,3 +49,9 @@ func TestTokens(t *testing.T) {
 	conf := &Config{Cluster: Cluster{Tokens: tokens}}
 	assert.Equal(t, tokens.Access, conf.Tokens().Access)
 }
+
+func TestAPIKey(t *testing.T) {
+	apiKey := "f70f5a0a-c443-453e-8354-76e40b8b73bd"
+	conf := &Config{Cluster: Cluster{APIKey: apiKey}}
+	assert.Equal(t, apiKey, conf.APIKey())
+}

--- a/cli/client/config/config.go
+++ b/cli/client/config/config.go
@@ -43,6 +43,7 @@ type Read interface {
 	InsecureSkipTLSVerify() bool
 	Namespace() string
 	Tokens() *types.Tokens
+	APIKey() string
 	Timeout() time.Duration
 	TrustedCAFile() string
 }

--- a/cli/client/config/mock.go
+++ b/cli/client/config/mock.go
@@ -99,3 +99,8 @@ func (m *MockConfig) Tokens() *corev2.Tokens {
 	args := m.Called()
 	return args.Get(0).(*corev2.Tokens)
 }
+
+func (m *MockConfig) APIKey() string {
+	args := m.Called()
+	return args.String(0)
+}

--- a/cli/client/testing/mock_config.go
+++ b/cli/client/testing/mock_config.go
@@ -93,6 +93,11 @@ func (m *MockConfig) Tokens() *types.Tokens {
 	return args.Get(0).(*types.Tokens)
 }
 
+func (m *MockConfig) APIKey() string {
+	args := m.Called()
+	return args.String(0)
+}
+
 // SaveTrustedCAFile ...
 func (m *MockConfig) SaveTrustedCAFile(file string) error {
 	args := m.Called(file)

--- a/cli/commands/env/env_test.go
+++ b/cli/commands/env/env_test.go
@@ -17,6 +17,7 @@ func testSetupMocks(t *testing.T, config *mockclient.MockConfig) {
 	config.On("Tokens").Return(
 		corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"),
 	)
+	config.On("APIKey").Return("")
 	config.On("TrustedCAFile").Return("")
 	config.On("InsecureSkipTLSVerify").Return(false)
 }

--- a/cli/commands/hooks/ensure_configured.go
+++ b/cli/commands/hooks/ensure_configured.go
@@ -40,14 +40,16 @@ func ConfigurationPresent(cmd *cobra.Command, cli *cli.SensuCli) error {
 
 	if cli.Config.APIUrl() == "" {
 		return fmt.Errorf(
-			"No API URL is defined. You can configure an API URL by running \"%s configure\"",
+			"No API URL is defined. You can either configure an API URL by running \"%s configure\" "+
+				"or by using the --api-url command line option",
 			os.Args[0],
 		)
 	}
 
-	if tokens == nil || tokens.Access == "" {
+	if (tokens == nil || tokens.Access == "") && cli.Config.APIKey() == "" {
 		return fmt.Errorf(
-			"Unable to locate credentials. You can configure credentials by running \"%s configure\"",
+			"Unable to locate credentials. You can either configure credentials by running \"%s configure\" "+
+				"or by using the --api-key command line option",
 			os.Args[0],
 		)
 	}

--- a/cli/commands/hooks/ensure_configured_test.go
+++ b/cli/commands/hooks/ensure_configured_test.go
@@ -1,0 +1,118 @@
+package hooks
+
+import (
+	"testing"
+
+	clientMock "github.com/sensu/sensu-go/cli/client/testing"
+	cmdTesting "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigurationPresent(t *testing.T) {
+	testAssert := assert.New(t)
+
+	cmdNoCheck := &cobra.Command{
+		Annotations: map[string]string{
+			ConfigurationRequirement: ConfigurationNotRequired,
+		},
+	}
+
+	cmdWithCheck := &cobra.Command{
+		Annotations: map[string]string{},
+	}
+
+	validTokens := &types.Tokens{
+		Access:    "accesstoken",
+		ExpiresAt: 1617721168,
+		Refresh:   "refreshtoken",
+	}
+
+	invalidTokens := &types.Tokens{
+		Access:    "",
+		ExpiresAt: 1617721168,
+		Refresh:   "",
+	}
+
+	apiKey := "de48ef7e-db2a-4333-bedf-7549de9541f4"
+	noApiKey := ""
+
+	apiURL := "http://localhost:8080"
+
+	tests := []struct {
+		name          string
+		cmd           *cobra.Command
+		apiKey        string
+		apiURL        string
+		tokens        *types.Tokens
+		errorExpected bool
+	}{
+		{
+			name:          "NoCheck",
+			cmd:           cmdNoCheck,
+			apiKey:        noApiKey,
+			apiURL:        "",
+			tokens:        nil,
+			errorExpected: false,
+		}, {
+			name:          "NoURL",
+			cmd:           cmdWithCheck,
+			apiKey:        apiKey,
+			apiURL:        "",
+			tokens:        validTokens,
+			errorExpected: true,
+		}, {
+			name:          "ApiKeyNoTokens",
+			cmd:           cmdWithCheck,
+			apiKey:        apiKey,
+			apiURL:        apiURL,
+			tokens:        nil,
+			errorExpected: false,
+		}, {
+			name:          "NoAPIKeyValidTokens",
+			cmd:           cmdWithCheck,
+			apiKey:        noApiKey,
+			apiURL:        apiURL,
+			tokens:        validTokens,
+			errorExpected: false,
+		}, {
+			name:          "NoAPIKeyNoTokens",
+			cmd:           cmdWithCheck,
+			apiKey:        noApiKey,
+			apiURL:        apiURL,
+			tokens:        nil,
+			errorExpected: true,
+		}, {
+			name:          "NoAPIKeyInvalidAccessToken",
+			cmd:           cmdWithCheck,
+			apiKey:        noApiKey,
+			apiURL:        apiURL,
+			tokens:        invalidTokens,
+			errorExpected: true,
+		}, {
+			name:          "APIKeyInvalidAccessToken",
+			cmd:           cmdWithCheck,
+			apiKey:        apiKey,
+			apiURL:        apiURL,
+			tokens:        invalidTokens,
+			errorExpected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCli := cmdTesting.NewMockCLI()
+			mockConfig := mockCli.Config.(*clientMock.MockConfig)
+			mockConfig.On("APIKey").Return(test.apiKey)
+			mockConfig.On("APIUrl").Return(test.apiURL)
+			mockConfig.On("Tokens").Return(test.tokens)
+
+			if test.errorExpected {
+				testAssert.Error(ConfigurationPresent(test.cmd, mockCli))
+			} else {
+				testAssert.NoError(ConfigurationPresent(test.cmd, mockCli))
+			}
+		})
+	}
+}

--- a/cli/commands/root/root.go
+++ b/cli/commands/root/root.go
@@ -41,6 +41,7 @@ func Command() *cobra.Command {
 	cmd.PersistentFlags().String("cache-dir", path.UserCacheDir("sensuctl"), "path to directory containing cache & temporary files")
 	cmd.PersistentFlags().String("namespace", config.DefaultNamespace, "namespace in which we perform actions")
 	cmd.PersistentFlags().Duration("timeout", 15*time.Second, "timeout when communicating with sensu backend")
+	cmd.PersistentFlags().String("api-key", "", "API key to use for authentication")
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.1.0
 	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-resty/resty/v2 v2.1.0
+	github.com/go-resty/resty/v2 v2.5.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.3.3
@@ -78,8 +78,8 @@ require (
 	go.etcd.io/etcd v3.4.15+incompatible
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
-	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980
+	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20200207224406-61798d64f025 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect


### PR DESCRIPTION
- Add the --api-key command-line parameter to sensuctl
- If `sensuctl config` has not been run the --api-url argument is also required
- If `sensuctl config` has been run the --api-key argument will have precedence over the access/refresh tokens

Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Add the `--api-key` command line parameter to sensuctl to bypass username/password authentication.

## Why is this change necessary?

Prevents having to run `sensuctl configure` beforehand which is useful for automated tasks or CI/CD pipeline integrations.

## Does your change need a Changelog entry?

Added the following:
- Added API key authentication support to sensuctl

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is necessary to document the new --api-key option for sensuctl. Will link to this PR once updated.
<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

- Generate an API key using `sensuctl api-key grant`
- Write down the API key

There are two scenarios where this can be used, with or without a configured sensuctl.

### Unconfigured `sensuctl`

To run in an unconfigured sensuctl environment first clear up the `sensuctl` configuration by deleting  the `~/.config/sensu` directory. Then run the following.

**Missing API URL**
You should see an error message saying the API URL is not configured. 

```
> sensuctl  --api-key 9b93e3d4-1063-4692-b588-eae03b0d9fe7 entity list
Error: No API URL is defined. You can either configure an API URL by running "./bin/darwin/amd64/sensuctl configure" or by using the --api-url command line option
```

**With API URL**
This should work since and an endpoint is being defined.
```
> sensuctl --api-url http://localhost:8080 --api-key 9b93e3d4-1063-4692-b588-eae03b0d9fe7 event list
        Entity            Check                                        Output                                       Status   Silenced             Timestamp                             UUID                  
 ───────────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── ────────────────────────────────────── 
  sensu-francis.local   keepalive   Keepalive last sent from sensu-francis.local at 2021-04-07 13:56:40 -0400 EDT        0   false      2021-04-07 13:56:40 -0400 EDT   86e1d204-4aa0-4a7a-b889-e6ee42275ac6  
```

### Configured `sensuctl`

Run the `event list` command with and without an API key. You should be getting the same results. Using Wireshark you can inspect the network packets being exchanged between sensuctl and the sensu-backend and observe the way authentication is being used. With the API key the `Authorization` header uses the `Key` based information while it uses `Bearer` token authentication without the API key.

```
/sensuctl --api-key 9b93e3d4-1063-4692-b588-eae03b0d9fe7 event list 
        Entity            Check                                        Output                                       Status   Silenced             Timestamp                             UUID
 ───────────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── ──────────────────────────────────────
  sensu-francis.local   keepalive   Keepalive last sent from sensu-francis.local at 2021-04-08 09:47:15 -0400 EDT        0   false      2021-04-08 09:47:15 -0400 EDT   e856c488-7e9c-446c-8419-12eba1c9e6ab

> sensuctl event list                                                                                                                                    ✔
        Entity            Check                                        Output                                       Status   Silenced             Timestamp                             UUID
 ───────────────────── ─────────── ─────────────────────────────────────────────────────────────────────────────── ──────── ────────── ─────────────────────────────── ──────────────────────────────────────
  sensu-francis.local   keepalive   Keepalive last sent from sensu-francis.local at 2021-04-08 09:47:05 -0400 EDT        0   false      2021-04-08 09:47:05 -0400 EDT   add9c988-66df-4546-92fa-49cc991d5672
```

## Is this change a patch?

No

Fixes #4012 
Closes #4012 