### PR TITLE
Register Viper aliases after Cobra commands are added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ embedded etcd server.
 ### Changed
 - Upgraded Go version from 1.13.15 to 1.16.
 - Upgraded Etcd version from 3.3.22 to 3.4.15.
+## Unreleased
+
+### Fixed
+- Fixed config deprecation warnings from being shown when deprecated config
+options weren't set.
 
 ## [6.3.0] - 2021-04-07
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -312,10 +312,13 @@ func handleConfig(cmd *cobra.Command, arguments []string) error {
 	viper.AutomaticEnv()
 
 	deprecatedConfigAttributes(logger)
-	viper.RegisterAlias(deprecatedFlagAgentID, flagAgentName)
-	viper.RegisterAlias(deprecatedFlagKeepaliveTimeout, flagKeepaliveWarningTimeout)
 
 	return nil
+}
+
+func RegisterConfigAliases() {
+	viper.RegisterAlias(deprecatedFlagAgentID, flagAgentName)
+	viper.RegisterAlias(deprecatedFlagKeepaliveTimeout, flagKeepaliveWarningTimeout)
 }
 
 func aliasNormalizeFunc(logger *logrus.Entry) func(*pflag.FlagSet, string) pflag.NormalizedName {

--- a/cmd/sensu-agent/main.go
+++ b/cmd/sensu-agent/main.go
@@ -26,6 +26,8 @@ func main() {
 	}
 	rootCmd.AddCommand(startCmd)
 
+	cmd.RegisterConfigAliases()
+
 	if err := rootCmd.Execute(); err != nil {
 		logger.WithError(err).Fatal("error executing sensu-agent")
 	}

--- a/cmd/sensu-agent/main_windows.go
+++ b/cmd/sensu-agent/main_windows.go
@@ -22,8 +22,14 @@ func main() {
 	}
 
 	rootCmd.AddCommand(cmd.VersionCommand())
-	rootCmd.AddCommand(cmd.StartCommand(agent.NewAgentContext))
+	startCmd, err := cmd.StartCommandWithError(agent.NewAgentContext)
+	if err != nil {
+		logger.WithError(err).Fatal("error handling agent config")
+	}
+	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(cmd.NewWindowsServiceCommand())
+
+	cmd.RegisterConfigAliases()
 
 	if err := rootCmd.Execute(); err != nil {
 		logger.WithError(err).Fatal("error executing sensu-agent")


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Moves the Viper aliases to their own function which is called after all Cobra commands have been added.

## Why is this change necessary?

Fixes deprecation warnings from showing when the deprecated configuration options aren't being set. On Windows the `handleConfig` function is called multiple times as its used within the start & service commands.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I reproduced the deprecation warnings on Windows and then ensured they no longer showed after making this change, with and without using a config.

## Is this change a patch?

No.
