### PR TITLE
Keepalive status OK with last seen 44 hours ago

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ embedded etcd server.
 ### Fixed
 - Fixed config deprecation warnings from being shown when deprecated config
 options weren't set.
+- Fixed issue with keepalive status remaining in OK status after agent shutdown.
 
 ## [6.3.0] - 2021-04-07
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -405,6 +405,12 @@ func (a *Agent) Run(ctx context.Context) error {
 func (a *Agent) connectionManager(ctx context.Context, cancel context.CancelFunc) {
 	defer logger.Info("shutting down connection manager")
 	for {
+		// Make sure the process is not shutting down before trying to connect
+		if ctx.Err() != nil {
+			logger.Warning("not retrying to connect")
+			return
+		}
+
 		a.connectedMu.Lock()
 		a.connected = false
 		a.connectedMu.Unlock()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -356,5 +356,5 @@ func TestConnectionManager(t *testing.T) {
 	}
 
 	// Give time for a potential reconnect by the connection manager
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 }


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

The keep alive status sometimes didn't update after an agent was shutdown.

Fixes #4265 
Closes #4265 

## Why is this change necessary?

To properly display the keepliave/agent status when it goes offline.

## Does your change need a Changelog entry?

Added the following:
- Fixed issue with keepalive status remaining in OK status after agent shutdown.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

On a Windows system which somehow exhibited the problem more frequently shutdown the agent and make sure the keep alive status status changes to warning and then critical properly.

Also looking at the agent and backend logs make sure the agent doesn't try to reconnect before completely shutting down.

Integration tests.

## Is this change a patch?

No.
