### PR TITLE
command: set Pdeathsig

### DIFF
--- a/command/proc_unix.go
+++ b/command/proc_unix.go
@@ -15,7 +15,7 @@ func Command(ctx context.Context, command string) *exec.Cmd {
 
 // SetProcessGroup sets the process group of the command process
 func SetProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pdeathsig: syscall.SIGTERM}
 }
 
 // KillProcess kills the command process and any child processes


### PR DESCRIPTION
## What is this change?

Sets Pdeathsig to subprocesses to be sure of their termination on agent restart.

## Why is this change necessary?

Usually that isn't something required, but you'll be more sure that nothing left from previous execution.

## Does your change need a Changelog entry?

Possibly no. It's likely that user won't ever notice that.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No doc changes required.

## How did you verify this change?

Runs on our systems.

## Is this change a patch?

That change may be backported, but probably not required.