### PR TITLE
Fix an RBAC bug where missing roles are fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ embedded etcd server.
 - Fixed config deprecation warnings from being shown when deprecated config
 options weren't set.
 - Fixed issue with keepalive status remaining in OK status after agent shutdown.
+- Fixed a bug where role bindings that refer to missing roles would cause the
+wrong status to be returned from the HTTP API, and the dashboard to go into a
+crash loop.
 
 ## [6.3.0] - 2021-04-07
 


### PR DESCRIPTION
## What is this change?

This CL fixes a bug where the HTTP API returns a 500 status instead of 403 when an RBAC role specified in a RoleBinding RoleRef is missing. The API now returns status 403 and also explains that the referred role is missing.

## Why is this change necessary?

Fixes #4268

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

It's unclear if anything needs to be done in `backend/api` or in the `graphql` layer.

## How did you verify this change?

I created tests that fail without the added changes. I also manually tested that a user bound to a nonexistent role would be given a better error message when using sensuctl.

## Is this change a patch?

Yes, but is not targeted for the current release branch.
