### PR TITLE
Only reference deathsig on linux platform

### DIFF
--- a/command/proc_group_linux.go
+++ b/command/proc_group_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package command
 
 import (

--- a/command/proc_group_linux.go
+++ b/command/proc_group_linux.go
@@ -1,0 +1,13 @@
+// +build linux
+
+package command
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// SetProcessGroup sets the process group of the command process
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pdeathsig: syscall.SIGTERM}
+}

--- a/command/proc_group_unix.go
+++ b/command/proc_group_unix.go
@@ -1,0 +1,13 @@
+// +build !linux,!windows
+
+package command
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// SetProcessGroup sets the process group of the command process
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/command/proc_group_windows.go
+++ b/command/proc_group_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package command
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// SetProcessGroup sets the process group of the command process
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
+}

--- a/command/proc_group_windows.go
+++ b/command/proc_group_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package command
 
 import (

--- a/command/proc_unix.go
+++ b/command/proc_unix.go
@@ -13,11 +13,6 @@ func Command(ctx context.Context, command string) *exec.Cmd {
 	return exec.CommandContext(ctx, "sh", "-c", command)
 }
 
-// SetProcessGroup sets the process group of the command process
-func SetProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pdeathsig: syscall.SIGTERM}
-}
-
 // KillProcess kills the command process and any child processes
 func KillProcess(cmd *exec.Cmd) error {
 	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/command/proc_windows.go
+++ b/command/proc_windows.go
@@ -21,11 +21,6 @@ func Command(ctx context.Context, command string) *exec.Cmd {
 	return cmd
 }
 
-// SetProcessGroup sets the process group of the command process
-func SetProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
-}
-
 // KillProcess kills the command process and any child processes
 func KillProcess(cmd *exec.Cmd) error {
 	return cmd.Process.Kill()


### PR DESCRIPTION
Addresses https://github.com/sensu/sensu-go/pull/4281#issuecomment-839367779

> Unfortunately this PR is breaking the build for every platform except Windows and Linux because [that `.Pdeathsig` field is available on Linux only](https://golang.org/src/syscall/exec_linux.go) but it has been added in a file that's used for all Unices!
> 
> The CI for sensu-go didn't catch that because it only runs in a Linux environment.
> 
> I think a quick fix to be able to include this work would be to create a new file, proc_linux.go, that's specific to Linux and change the build tags so that proc_unix.go is not used for Linux.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
