### PR TITLE
Add RandomUUIDV4 test helper, use UUIDv4 for loadit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ embedded etcd server.
 ### Changed
 - Upgraded Go version from 1.13.15 to 1.16.
 - Upgraded Etcd version from 3.3.22 to 3.4.15.
+- The loadit tool now uses UUIDv4 instead of UUIDv1 for agent names.
+
 ## Unreleased
 
 ### Fixed

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -47,7 +47,11 @@ func main() {
 
 	start := time.Now()
 	for i := 0; i < *flagCount; i++ {
-		name := uuid.New().String()
+		uuidBytes, err := uuid.NewRandom()
+		if err != nil {
+			log.Fatal(err)
+		}
+		name := uuidBytes.String()
 
 		cfg := agent.NewConfig()
 		cfg.API.Host = agent.DefaultAPIHost

--- a/testing/testutil/util.go
+++ b/testing/testutil/util.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // TempDir provides a test with a temporary directory (under os.TempDir())
@@ -43,4 +45,14 @@ func CommandPath(s string, p ...string) string {
 	params := strings.Join(p, " ")
 	fullCmd := fmt.Sprintf("%s %s", command, params)
 	return strings.Trim(fullCmd, " ")
+}
+
+// RandomUUIDV4 takes a testing.TB and will attempt to generate a random
+// Version 4 UUID. If an error is returned, a fatal testing error will occur.
+func RandomUUIDV4(tb testing.TB) uuid.UUID {
+	bytes, err := uuid.NewRandom()
+	if err != nil {
+		tb.Fatalf("failed to generate uuid: %s", err)
+	}
+	return bytes
 }


### PR DESCRIPTION
## What is this change?

Adds a new test helper to generate random V4 UUIDs. Updates loadit to use V4 UUIDs for agent names.

## Why is this change necessary?

From https://www.sohamkamani.com/uuid-versions-explained/#v1--uniqueness:

```
UUID v1 is generated by using a combination the host computers MAC address and the current date and time. In addition to this, it also introduces another random component just to be sure of its uniqueness.
```

As loadit is generating tens of thousands of UUIDs in a short amount of time there is a higher chance of collision. I believe we've seen these collisions in our PostgreSQL tests on our commercial repository. By moving to V4 we will significantly reducing the chance of any collisions.

## Does your change need a Changelog entry?

Yes.