### PR TITLE
disambiguate API URL from WebSocket URL

### DIFF
--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -123,7 +123,7 @@ func AskForURL(c config.Config) *survey.Question {
 	return &survey.Question{
 		Name: "url",
 		Prompt: &survey.Input{
-			Message: "Sensu Backend URL:",
+			Message: "Sensu Backend API URL:",
 			Default: url,
 		},
 	}


### PR DESCRIPTION
## What is this change?




## Why is this change necessary?

We refer to the WebSocket URL as "backend URL", leading users to incorrectly think the API here is the websocket port. Calling  it "Backend API URL" might help disambiguate it

## Does your change need a Changelog entry?

Unsure, seems too small :sweat_smile: 

## Do you need clarification on anything?

There may be a more specific term, like "Backend HTTP API URL" but that might confuse things more.

