### PR TITLE
Use jsoniter instead of encoding/json for json encoding

### DIFF
--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -10,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
@@ -113,7 +113,7 @@ func (e *Entity) MarshalJSON() ([]byte, error) {
 	type Clone Entity
 	clone := (*Clone)(e)
 
-	return json.Marshal(clone)
+	return jsoniter.Marshal(clone)
 }
 
 // GetEntitySubscription returns the entity subscription, using the format

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	jsoniter "github.com/json-iterator/go"
 	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
@@ -498,7 +499,7 @@ func (e *Event) GetUUID() uuid.UUID {
 
 func (e Event) MarshalJSON() ([]byte, error) {
 	type clone Event
-	b, err := json.Marshal((*clone)(&e))
+	b, err := jsoniter.Marshal((*clone)(&e))
 	if err != nil {
 		return nil, err
 	}
@@ -512,10 +513,10 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid event ID: %s", err)
 		}
-		idBytes, _ := json.Marshal(uid.String())
+		idBytes, _ := jsoniter.Marshal(uid.String())
 		msg["id"] = (*json.RawMessage)(&idBytes)
 	}
-	return json.Marshal(msg)
+	return jsoniter.Marshal(msg)
 }
 
 func (e *Event) UnmarshalJSON(b []byte) error {
@@ -533,7 +534,7 @@ func (e *Event) UnmarshalJSON(b []byte) error {
 	}
 	if len(id) > 0 {
 		delete(msg, "id")
-		b, _ = json.Marshal(msg)
+		b, _ = jsoniter.Marshal(msg)
 	}
 	if err := json.Unmarshal(b, (*clone)(e)); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Instead of using the default library use the json-tier library to encode events to JSON. This increase performance by about 75%. This is part of https://app.zenhub.com/workspaces/sensu-go-5ca3b7d249384649e4b7964e/issues/sensu/sensu-enterprise-go/1620. This change will be included in sensu-enterprise-go.

## Why is this change necessary?

Slow performance was observed when encoding events.

## Does your change need a Changelog entry?

No there will be one in the sensu-enterprise-go change.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

n/a

## How did you verify this change?

Local encoding performance test.

## Is this change a patch?

No