### PR TITLE
Use LogLevel as default EtcdLogLevel

### DIFF
--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -272,6 +272,16 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				ClientCertAuth: viper.GetBool(flagEtcdPeerClientCertAuth),
 			}
 
+			// Etcd log level
+			if cfg.EtcdLogLevel == "" {
+				switch cfg.LogLevel {
+				case "trace":
+					cfg.EtcdLogLevel == "debug"
+				default:
+					cfg.EtcdLogLevel == cfg.LogLevel
+				}
+			}
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			sensuBackend, err := initialize(ctx, cfg)
@@ -375,7 +385,6 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 	viper.SetDefault(flagEtcdMaxRequestBytes, etcd.DefaultMaxRequestBytes)
 	viper.SetDefault(flagEtcdHeartbeatInterval, etcd.DefaultTickMs)
 	viper.SetDefault(flagEtcdElectionTimeout, etcd.DefaultElectionMs)
-	viper.SetDefault(flagEtcdLogLevel, "warn")
 
 	if server {
 		viper.SetDefault(flagNoEmbedEtcd, false)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -276,9 +276,9 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 			if cfg.EtcdLogLevel == "" {
 				switch cfg.LogLevel {
 				case "trace":
-					cfg.EtcdLogLevel == "debug"
+					cfg.EtcdLogLevel = "debug"
 				default:
-					cfg.EtcdLogLevel == cfg.LogLevel
+					cfg.EtcdLogLevel = cfg.LogLevel
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

If `EtcdLogLevel` is not specified, it will use the value of `LogLevel`, or use `debug` if `LogLevel` is set to `trace` as `trace` is not compatible with the etcd logger.

## Why is this change necessary?

Having to configure log levels with two separate flags is an inconvenience. This change still allows each log level to be configured independently if so desired.

## Does your change need a Changelog entry?

No, this is a change to unreleased code & there's already a changelog for the addition of `EtcdLogLevel`.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

https://github.com/sensu/sensu-docs/issues/3066

## Is this change a patch?

No.