### PR TITLE
Use level instead of cfg.LogLevel, use proper types

### DIFF
--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -274,11 +274,13 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 
 			// Etcd log level
 			if cfg.EtcdLogLevel == "" {
-				switch cfg.LogLevel {
-				case "trace":
+				switch level {
+				case logrus.TraceLevel:
 					cfg.EtcdLogLevel = "debug"
+				case logrus.WarnLevel:
+					cfg.EtcdLogLevel = "warn"
 				default:
-					cfg.EtcdLogLevel = cfg.LogLevel
+					cfg.EtcdLogLevel = level.String()
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

`cfg.LogLevel` is not set; compare against `level` variable. Use `logrus.Level` types for comparisons. Logrus also outputs its `warn` level as `warning`; use `warn` in that case.

## Why is this change necessary?

The `main` branch will fail without this change unless `--etcd-log-level` is explicitly set.