### PR TITLE
Windows process timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ options weren't set.
 wrong status to be returned from the HTTP API, and the dashboard to go into a
 crash loop.
 - Fixed a bug where an empty subscription was present in the deregistration event's check.
+- Fixed issue with Windows agent not handling command timeouts properly
 
 ## [6.3.0] - 2021-04-07
 

--- a/command/command.go
+++ b/command/command.go
@@ -2,7 +2,6 @@
 package command
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/types"
+	bytesutil "github.com/sensu/sensu-go/util/bytes"
 	"github.com/sirupsen/logrus"
 )
 
@@ -147,7 +147,7 @@ func (e *ExecutionRequest) Execute(ctx context.Context, execution ExecutionReque
 
 	// Share an output buffer between STDOUT/ERR, following the
 	// Nagios plugin spec.
-	var output bytes.Buffer
+	var output bytesutil.SyncBuffer
 
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -222,7 +222,7 @@ func (e *ExecutionRequest) Execute(ctx context.Context, execution ExecutionReque
 		}
 	} else {
 		// Everything is A-OK.
-		resp.Status = 0
+		resp.Status = OKExitStatus
 	}
 
 	return resp, nil
@@ -244,7 +244,7 @@ func escapeZombie(ex *ExecutionRequest) {
 func FixtureExecutionResponse(status int, output string) *ExecutionResponse {
 	return &ExecutionResponse{
 		Output:   output,
-		Status:   0,
+		Status:   status,
 		Duration: 1,
 	}
 }

--- a/command/command_windows_test.go
+++ b/command/command_windows_test.go
@@ -1,0 +1,30 @@
+// +build windows
+
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/testing/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecuteWindows(t *testing.T) {
+	// test that commands can time out on windows
+	timeoutRequest := ExecutionRequest{
+		Command: "PowerShell.exe Write-Host \"start sleep\"; Start-Sleep -s 10 ; Write-Host \"sleep done\"",
+		Timeout: 1,
+		Name:    "sleep-test",
+	}
+	timeout := NewExecutor()
+
+	sleepExec, sleepErr := timeout.Execute(context.Background(), timeoutRequest)
+	assert.Equal(t, nil, sleepErr)
+	cleanOutput := testutil.CleanOutput(sleepExec.Output)
+	assert.Contains(t, cleanOutput, "Execution timed out\n")
+	assert.Contains(t, cleanOutput, "start sleep")
+	assert.NotContains(t, "sleep done", cleanOutput)
+	assert.Equal(t, TimeoutExitStatus, sleepExec.Status)
+	assert.NotEqual(t, 1, sleepExec.Duration)
+}

--- a/util/bytes/buffer.go
+++ b/util/bytes/buffer.go
@@ -1,0 +1,23 @@
+package bytes
+
+import (
+	"bytes"
+	"sync"
+)
+
+type SyncBuffer struct {
+	buf bytes.Buffer
+	mu  sync.Mutex
+}
+
+func (s *SyncBuffer) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *SyncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}


### PR DESCRIPTION
## What is this change?

Windows child processes were not getting killed correctly when processing the command timeout.

Closes #3979 

## Why is this change necessary?

To prevent having stale processes on the host.

## Does your change need a Changelog entry?

Added the following:
- Fixed issue with Windows agent not handling command timeouts properly

## Do you need clarification on anything?

No

## Were there any complications while making this change?



## Have you reviewed and updated the documentation for this change? Is new documentation required?

No

## How did you verify this change?

Create a check running on a Windows agent with the following command:
`PowerShell.exe Write-Host "start sleep"; Start-Sleep -s 20 ; Write-Host "sleep done"`

and a timeout of 2 seconds. When executing the check result should show the execution time to be close to 2 seconds. Also by looking at the Windows task manager make sure the `powershell.exe` process is terminated properly after 2 seconds.

## Is this change a patch?

No
