### PR TITLE
extend time helper functions for filters

### DIFF
--- a/js/js.go
+++ b/js/js.go
@@ -95,6 +95,30 @@ func addAssets(vm *otto.Otto, assets JavascriptAssets) error {
 
 func addTimeFuncs(vm *otto.Otto) error {
 	funcs := map[string]interface{}{
+		"seconds_since": func(args ...interface{}) interface{} {
+			if len(args) == 0 {
+				return 0
+			}
+			t := time.Unix(toInt64(args[0]), 0).UTC()
+			s := time.Since(t)
+			return s.Seconds()
+		},
+		// second returns the second within a minute
+		"second": func(args ...interface{}) interface{} {
+			if len(args) == 0 {
+				return 0
+			}
+			t := time.Unix(toInt64(args[0]), 0).UTC()
+			return t.Second()
+		},
+		// minute returns the minute within an hour
+		"minute": func(args ...interface{}) interface{} {
+			if len(args) == 0 {
+				return 0
+			}
+			t := time.Unix(toInt64(args[0]), 0).UTC()
+			return t.Minute()
+		},
 		// hour returns the hour within the day
 		"hour": func(args ...interface{}) interface{} {
 			if len(args) == 0 {

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -25,7 +25,47 @@ func TestEvaluateRaceCondition(t *testing.T) {
 
 func TestTimeFunctions(t *testing.T) {
 	timestamp := int64(7323)
-	t.Run("hour() function", func(t *testing.T) {
+	t.Run("failing hour() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("hour(event.timestamp) != 2", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+	t.Run("failing minute() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("minute(event.timestamp) != 2", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+	t.Run("failing second() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("second(event.timestamp) != 3", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+	t.Run("failing seconds_since() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("seconds_since(event.timestamp) <= 10000", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, false, result)
+	})
+	t.Run("passing hour() function", func(t *testing.T) {
 		entity := corev2.FixtureEvent("foo", "bar")
 		entity.Timestamp = timestamp
 		synth := dynamic.Synthesize(entity)
@@ -35,7 +75,7 @@ func TestTimeFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 	})
-	t.Run("minute() function", func(t *testing.T) {
+	t.Run("passing minute() function", func(t *testing.T) {
 		entity := corev2.FixtureEvent("foo", "bar")
 		entity.Timestamp = timestamp
 		synth := dynamic.Synthesize(entity)
@@ -45,7 +85,7 @@ func TestTimeFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 	})
-	t.Run("second() function", func(t *testing.T) {
+	t.Run("passing second() function", func(t *testing.T) {
 		entity := corev2.FixtureEvent("foo", "bar")
 		entity.Timestamp = timestamp
 		synth := dynamic.Synthesize(entity)
@@ -55,7 +95,7 @@ func TestTimeFunctions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
 	})
-	t.Run("seconds_since() function", func(t *testing.T) {
+	t.Run("passing seconds_since() function", func(t *testing.T) {
 		entity := corev2.FixtureEvent("foo", "bar")
 		entity.Timestamp = timestamp
 		synth := dynamic.Synthesize(entity)

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -5,6 +5,7 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/types/dynamic"
+	"github.com/stretchr/testify/assert"
 )
 
 // This is a unit test to cover the race condition found in
@@ -20,4 +21,48 @@ func TestEvaluateRaceCondition(t *testing.T) {
 	go func() {
 		_, _ = Evaluate("true", params, nil)
 	}()
+}
+
+func TestTimeFunctions(t *testing.T) {
+	timestamp := int64(7323)
+	t.Run("hour() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("hour(event.timestamp) == 2", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+	t.Run("minute() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("minute(event.timestamp) == 2", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+	t.Run("second() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("second(event.timestamp) == 3", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+	t.Run("seconds_since() function", func(t *testing.T) {
+		entity := corev2.FixtureEvent("foo", "bar")
+		entity.Timestamp = timestamp
+		synth := dynamic.Synthesize(entity)
+		params := map[string]interface{}{"event": synth}
+
+		result, err := Evaluate("seconds_since(event.timestamp) > 10000", params, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
 }


### PR DESCRIPTION
## What is this change?
Adding additional time helper functions for filter expressions.

- add minute() function output int 0-59 
- add second() function output int 0-59
- add seconds_since() function outputs float64, useful when needing to look at age of timestamp relative to current time. 
- added test for each function.

## Why is this change necessary?
we only expose hour() and weekday() right now, customer interested in minute() granularity.


## Does your change need a Changelog entry?
Yes and a docs PR as well once this is merged.



## Were there any complications while making this change?
nope

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required, but impact is limited just need to provide example filter examples for the additional functions.

## How did you verify this change?

wrote some additional golang tests that call the new functions inside an Otto vm with a fixture event with specified timestamp.

## Is this change a patch?
I think is qualifies as a new feature so, not a patch.
