### PR TITLE
Update Install Sensu link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sensu Go installer packages are available for a number of computing
 platforms (e.g. Debian/Ubuntu, RHEL/Centos, etc), but the easiest way
 to get started is with the official Docker image, sensu/sensu.
 
-See the [installation documentation](https://docs.sensu.io/sensu-go/latest/installation/install-sensu/) to get started.
+See the [installation documentation](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/) to get started.
 
 **NOTE**: Starting with Sensu Go version 6.0, for instances built from source, the web UI is now a [standalone product](https://github.com/sensu/web) — it is no longer included with the Sensu backend. To build the web UI from source, use the [installation instructions](https://github.com/sensu/web/blob/master/INSTALL.md) in the Sensu Go Web repository.
 


### PR DESCRIPTION
## What is this change?

The link to the install Sensu page in the docs is incorrect (although it does redirect to the correct page). I replaced this redirected link with a direct link to the correct page.


## Why is this change necessary?

Just eliminating a redirected incoming link.

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None needed

## How did you verify this change?

Correct link is https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/

## Is this change a patch?

No
