### PR TITLE
Internally generated deregistration events are invalid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -24,6 +25,7 @@ options weren't set.
 - Fixed a bug where role bindings that refer to missing roles would cause the
 wrong status to be returned from the HTTP API, and the dashboard to go into a
 crash loop.
+- Fixed a bug where an empty subscription was present in the deregistration event's check.
 
 ## [6.3.0] - 2021-04-07
 

--- a/backend/keepalived/deregisterer.go
+++ b/backend/keepalived/deregisterer.go
@@ -70,7 +70,7 @@ func (d *Deregistration) Deregister(entity *types.Entity) error {
 		deregistrationCheck := &types.Check{
 			ObjectMeta:    corev2.NewObjectMeta("deregistration", entity.Namespace),
 			Interval:      1,
-			Subscriptions: []string{""},
+			Subscriptions: []string{},
 			Command:       "",
 			Handlers:      []string{entity.Deregistration.Handler},
 			Status:        1,

--- a/backend/keepalived/deregisterer_test.go
+++ b/backend/keepalived/deregisterer_test.go
@@ -66,6 +66,8 @@ func TestDeregistrationHandler(t *testing.T) {
 	mockBus.On("Publish", messaging.TopicEvent, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		event := args[1].(*types.Event)
 		assert.Equal("deregistration", event.Entity.Deregistration.Handler)
+		assert.Equal("deregistration", event.Check.Name)
+		assert.Equal(0, len(event.Check.Subscriptions))
 		if event.Timestamp == 0 {
 			t.Fatal("event timestamp is nil, expected a timestamp in the deregistration event")
 		}


### PR DESCRIPTION
## What is this change?

Removes the empty subscription from the deregistration handler's event check.

Fixes #4307  

## Why is this change necessary?

Breaks the handler's event validation.

## Does your change need a Changelog entry?

Yes, added one.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No docs required.

## How did you verify this change?

Validated the email deregistration handler doesn't fail on event validation anymore.

## Is this change a patch?

No.