### PR TITLE
Separate event/keepalive websockets

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -373,11 +373,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		a.StartSocketListeners(ctx)
 	}
 
-	// REVIEW(ccressent): I really do not understand the comment below.  Added
-	// by Simon. I suggest deleting altogether?
-	// Increment the waitgroup counter here too in case none of the components
-	// above were started, and rely on the system info collector to decrement it
-	// once it exits
 	go a.connectionManager(ctx, cancel)
 	go a.refreshSystemInfoPeriodically(ctx)
 	go a.handleAPIQueue(ctx)


### PR DESCRIPTION
## What is this change?

In the backend, we keep the websocket handler on `/` for backwards compatibility, but there are now 2 extra routes, `/events` and `/keepalives`, that are each able to handle agent traffic for events and keepalives respectively.

In the agent, we now create 2 sessions: one dedicated to check requests/events, using the `/events` endpoint and the other dedicated to keepalives using the `/keepalives` endpoint.

## Why is this change necessary?

The idea is to have separate websockets for check requests/events and keepalives in order to not block keepalives "behind" events when there is backpressure from the backend, potentially leading to unnecessary disconnection/reconnection of the agent. We think it's especially important in cases where the backend is under heavy load: massive disconnection and reconnection of agents distabilize the cluster.

Closes #4273.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

Opinions from reviewers about other/better approaches, especially on the backend side.

## Were there any complications while making this change?

Two major complications:
- we are now doubling the number of connections between a backend and an agent
- the change in the backend's session code is very likely "dumb" but was aiming at minimal change in the old and critical session code

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe any documentation has to be created/altered.

## How did you verify this change?

- Local functional testing
- Load testing on our performance cluster

## Is this change a patch?

No.