### PR TITLE
Treat the timeout flag for sensu-backend init as a duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `etcd-log-level` configuration flag for setting the log level of the
 embedded etcd server.
 - Added API key authentication support to sensuctl.
+- Added wait flag to the sensu-backend init command which toggles waiting
+indefinitely for etcd to become available.
 
 ### Changed
 - Upgraded Go version from 1.13.15 to 1.16.5.
@@ -20,6 +22,9 @@ embedded etcd server.
 - Some Prometheus metric names have changed with the upgrade to Etcd 3.5. See
 https://etcd.io/docs/v3.5/metrics/etcd-metrics-latest.txt for the metrics that
 Etcd 3.5 exposes.
+- The timeout flag for `sensu-backend init` is now treated as a duration instead
+of seconds. If the value is less than 1 second, the value is converted to
+seconds.
 
 ### Fixed
 - Fixed config deprecation warnings from being shown when deprecated config
@@ -62,9 +67,6 @@ in OSS builds.
 - Fixed a potential deadlock in agentd.
 - Fixed a bug where some Etcd watchers could try to process watch events holding
 invalid pointers.
-### Added
-- Added wait flag to the sensu-backend init command which toggles waiting
-indefinitely for etcd to become available.
 
 ## [6.2.3] - 2021-01-21
 

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultTimeout = "5"
+	defaultTimeout = "5s"
 
 	flagInitAdminUsername = "cluster-admin-username"
 	flagInitAdminPassword = "cluster-admin-password"
@@ -139,13 +139,18 @@ func InitCommand() *cobra.Command {
 				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
 			}
 
+			timeout := viper.GetDuration(flagTimeout)
+			if timeout < 1 * time.Second {
+				timeout = timeout * time.Second
+			}
+
 			initConfig := initConfig{
 				Config: *cfg,
 				SeedConfig: seeds.Config{
 					AdminUsername: viper.GetString(flagInitAdminUsername),
 					AdminPassword: viper.GetString(flagInitAdminPassword),
 				},
-				Timeout: viper.GetDuration(flagTimeout),
+				Timeout: timeout,
 			}
 
 			wait := viper.GetBool(flagWait)
@@ -199,8 +204,8 @@ func InitCommand() *cobra.Command {
 	cmd.Flags().String(flagInitAdminUsername, "", "cluster admin username")
 	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")
-	cmd.Flags().String(flagTimeout, defaultTimeout, "timeout, in seconds, for failing to establish a connection to etcd")
-	cmd.Flags().Bool(flagWait, false, "wait indefinitely to establish a connection to etcd (takes precedence over timeout)")
+	cmd.Flags().String(flagTimeout, defaultTimeout, "duration to wait before a connection attempt to etcd is considered failed (must be >= 1s)")
+	cmd.Flags().Bool(flagWait, false, "continuously retry to establish a connection to etcd until it is successful")
 
 	setupErr = handleConfig(cmd, os.Args[1:], false)
 
@@ -209,7 +214,7 @@ func InitCommand() *cobra.Command {
 
 func initializeStore(clientConfig clientv3.Config, initConfig initConfig, endpoint string) error {
 	ctx, cancel := context.WithTimeout(
-		clientv3.WithRequireLeader(context.Background()), initConfig.Timeout*time.Second)
+		clientv3.WithRequireLeader(context.Background()), initConfig.Timeout)
 	defer cancel()
 
 	clientConfig.Context = ctx


### PR DESCRIPTION
## What is this change?

Treats the `--timeout` flag for `sensu-backend init` as a duration instead of converting it to seconds. If the timeout is less than 1 second, the value is converted to seconds. (e.g. a value of `5` is read as `5ns` which is less than 1 second, it will be converted to `5s`.

## Why is this change necessary?

The `--timeout` flag has always had a type of duration but we've mistakingly been converting it to seconds. This can cause confusion and and different behaviours when the value is set to `1` vs `1s`.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation will likely need to be updated. cc @hillaryfraley 

## How did you verify this change?

I tested various inputs to the timeout flag:
* `1` becomes `1s`
* `5` becomes `5s`
* `1s` does not change

## Is this change a patch?

No.