### PR TITLE
Add sensu_go_keepalives prometheus counter metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ embedded etcd server.
 - Added API key authentication support to sensuctl.
 - Added wait flag to the sensu-backend init command which toggles waiting
 indefinitely for etcd to become available.
+- Added sensu_go_keepalives prometheus counter.
 
 ### Changed
 - Upgraded Go version from 1.13.15 to 1.16.5.


### PR DESCRIPTION
## What is this change?

Adds a prometheus metric for counting keepalive statuses over time.

## Why is this change necessary?

This will help identify instability due to keepalive failure storms.

## Does your change need a Changelog entry?

Included.