### PR TITLE
Don't emit fatal ring errors from keepalived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - There are currently no unreleased changes.
+
+### Changed
+- When keepalived encounters round-robin ring errors, the backend no longer
+internally restarts.
 
 ## [6.4.0] - 2021-06-23
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -725,9 +725,6 @@ func (k *Keepalived) handleUpdate(e *corev2.Event) error {
 			})
 			if err := ring.Add(tctx, entity.Name, int64(e.Check.Timeout)); err != nil {
 				lager.WithError(err).Error("error adding entity to ring")
-				if _, ok := err.(*store.ErrInternal); ok {
-					return err
-				}
 			} else {
 				lager.Info("added entity to ring")
 			}


### PR DESCRIPTION
## What is this change?

This commit changes the behaviour of keepalived such that roundrobin
ring errors are now logged but don't result in an internal restart being
triggered.

Under extreme load, etcd rings can be highly unstable, but it's usually
preferable to continue on when there are lease faults but K/V operations
are still generally working.

## Why is this change necessary?

The etcd ring facility can emit errors under extreme load, when the lease that the ring is using expires before a key can be written using it. This circumstance has never been observed under regular operation, and is an attempt to bring greater stability to sensu-go when it is under load.

## Does your change need a Changelog entry?

Yes, included.