### PR TITLE
Regression: RuleTemplate not automatically created with Namespace

### DIFF
--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -122,6 +122,12 @@ func SeedCluster(ctx context.Context, store storev1.Store, client *clientv3.Clie
 			logger.WithError(err).Error("error bringing the database to the latest version")
 			return fmt.Errorf("error bringing the database to the latest version: %w", err)
 		}
+		if len(etcd.EnterpriseMigrations) > 0 {
+			if err = etcd.MigrateEnterpriseDB(ctx, client, etcd.EnterpriseMigrations); err != nil {
+				logger.WithError(err).Error("error bringing the enterprise database to the latest version")
+				return
+			}
+		}
 	}
 
 	// Set initialized flag


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

The RuleTemplates were not automatically created alongside the Namespace.


## Why is this change necessary?

Yes this broke all the BSM tests.

## Does your change need a Changelog entry?

No, the regression was never shipped.

## Do you need clarification on anything?

no

## Were there any complications while making this change?

no 
## Have you reviewed and updated the documentation for this change? Is new documentation required?

no

## How did you verify this change?

Using **sensu-enterprise-go**:

* Fresh install/etcd db
* sensu-backend init
* sensuctl create namespace francis
* sensuctl dump bsm/v1.RuleTemplate --format yaml --namespace francis

The RuleTemplate should be displayed

## Is this change a patch?

No