### PR TITLE
add restclient apikey support

### DIFF
--- a/cli/client/apikey.go
+++ b/cli/client/apikey.go
@@ -1,5 +1,13 @@
 package client
 
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
 // PostAPIKey sends a POST request with obj as the payload to the given path
 // and returns the location header of the key.
 func (client *RestClient) PostAPIKey(path string, obj interface{}) (string, error) {
@@ -13,4 +21,87 @@ func (client *RestClient) PostAPIKey(path string, obj interface{}) (string, erro
 	}
 
 	return res.Header().Get("Location"), nil
+}
+
+// CreateAPIKey creates a new api-key.
+func (client *RestClient) CreateAPIKey(username string) (string, error) {
+
+	apikey := &corev2.APIKey{
+		Username: username,
+	}
+
+	location, err := client.PostAPIKey(apikey.URIPath(), apikey)
+	if err != nil {
+		return "", err
+	}
+
+	location_arr := strings.Split(location, "/")
+	result := location_arr[len(location_arr)-1]
+
+	return result, nil
+}
+
+// DeleteAPIKey deletes an api-key.
+func (client *RestClient) DeleteAPIKey(name string) error {
+	apikey := &corev2.APIKey{
+		ObjectMeta: corev2.ObjectMeta{
+			Name: name,
+		},
+	}
+	return client.Delete(apikey.URIPath())
+}
+
+// ListAPIKeys fetches all api-key from configured Sensu instance
+func (client *RestClient) ListAPIKeys(options *ListOptions, header *http.Header) ([]corev2.APIKey, error) {
+	apikey := &corev2.APIKey{}
+	request := client.R()
+	ApplyListOptions(request, options)
+	resp, err := request.Get(apikey.URIPath())
+	if err != nil {
+		return nil, err
+	}
+	*header = resp.Header()
+	if resp.StatusCode() >= 400 {
+		return nil, UnmarshalError(resp)
+	}
+
+	var result []corev2.APIKey
+	err = json.Unmarshal(resp.Body(), &result)
+	return result, err
+}
+
+// FetchAPIKey fetches an api-key from configured Sensu instance
+func (client *RestClient) FetchAPIKey(name string) (*corev2.APIKey, error) {
+	apikey := &corev2.APIKey{
+		ObjectMeta: corev2.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	resp, err := client.R().Get(apikey.URIPath())
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, UnmarshalError(resp)
+	}
+	var result corev2.APIKey
+	return &result, json.Unmarshal(resp.Body(), &result)
+}
+
+// UpdateAPIKey update an api-key from configured Sensu instance
+func (client *RestClient) UpdateAPIKey(name, username string) error {
+	apikey := &corev2.APIKey{
+		ObjectMeta: corev2.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	obj := &corev2.APIKey{
+		Username: username,
+	}
+	request := client.R()
+	request.Header.Add("Content-Type", "application/merge-patch+json")
+	_, err := request.SetBody(obj).Patch(apikey.URIPath())
+	return err
 }

--- a/cli/client/apikey_test.go
+++ b/cli/client/apikey_test.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli/client/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAPIKey(t *testing.T) {
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodPost)
+		assert.NotEmpty(t, r.Header["Authorization"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`83abef1e-e7d7-4beb-91fc-79ad90084d5b`))
+	}
+	server := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer server.Close()
+
+	mockConfig := &config.MockConfig{}
+	restyInst := resty.New()
+	client := &RestClient{resty: restyInst, config: mockConfig}
+
+	mockConfig.On("APIUrl").Return(server.URL)
+	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
+
+	apikey, err := client.CreateAPIKey("user1")
+	assert.NoError(t, err)
+	assert.NotNil(t, apikey)
+}
+
+func TestFetchAPIKey(t *testing.T) {
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodGet)
+		assert.NotEmpty(t, r.Header["Authorization"])
+		_, _ = w.Write([]byte(`{
+"metadata": {
+    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+    "created_by": "user1"
+  },
+  "username": "user1",
+  "created_at": 1570640363
+}`))
+	}
+	server := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer server.Close()
+
+	mockConfig := &config.MockConfig{}
+	restyInst := resty.New()
+	client := &RestClient{resty: restyInst, config: mockConfig}
+
+	mockConfig.On("APIUrl").Return(server.URL)
+	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
+
+	apikey, err := client.FetchAPIKey("83abef1e-e7d7-4beb-91fc-79ad90084d5b")
+	assert.NoError(t, err)
+	assert.Equal(t, apikey.Username, "user1")
+}
+
+func TestListAPIKeys(t *testing.T) {
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodGet)
+		assert.NotEmpty(t, r.Header["Authorization"])
+		_, _ = w.Write([]byte(`[{
+"metadata": {
+    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
+    "created_by": "admin"
+  },
+  "username": "user1",
+  "created_at": 1570640363
+},{
+"metadata": {
+    "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5p",
+    "created_by": "admin"
+  },
+  "username": "user2",
+  "created_at": 1570640370
+}]`))
+	}
+	server := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer server.Close()
+
+	mockConfig := &config.MockConfig{}
+	restyInst := resty.New()
+	client := &RestClient{resty: restyInst, config: mockConfig}
+
+	mockConfig.On("APIUrl").Return(server.URL)
+	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
+
+	var header http.Header
+	var opts ListOptions
+	apikeys, err := client.ListAPIKeys(&opts, &header)
+	assert.NoError(t, err)
+	assert.Equal(t, apikeys[0].Username, "user1")
+	assert.Equal(t, apikeys[1].Username, "user2")
+}
+
+func TestUpdateAPIKey(t *testing.T) {
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodPatch)
+		assert.NotEmpty(t, r.Header["Authorization"])
+
+		w.Header().Set("Content-Type", "application/merge-patch+json")
+		_, _ = w.Write([]byte(`{"username": "devteam"}`))
+	}
+	server := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer server.Close()
+
+	mockConfig := &config.MockConfig{}
+	restyInst := resty.New()
+	client := &RestClient{resty: restyInst, config: mockConfig}
+
+	mockConfig.On("APIUrl").Return(server.URL)
+	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
+
+	err := client.UpdateAPIKey("83abef1e-e7d7-4beb-91fc-79ad90084d5b", "devteam")
+	assert.NoError(t, err)
+}
+
+func TestDeleteAPIKey(t *testing.T) {
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodDelete)
+		assert.NotEmpty(t, r.Header["Authorization"])
+	}
+	server := httptest.NewServer(http.HandlerFunc(testHandler))
+	defer server.Close()
+
+	mockConfig := &config.MockConfig{}
+	restyInst := resty.New()
+	client := &RestClient{resty: restyInst, config: mockConfig}
+
+	mockConfig.On("APIUrl").Return(server.URL)
+	mockConfig.On("Tokens").Return(&corev2.Tokens{Access: "foo"})
+	mockConfig.On("APIKey").Return("")
+
+	err := client.DeleteAPIKey("83abef1e-e7d7-4beb-91fc-79ad90084d5b")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## What is this change?

This commit adds the support of apikey lifecycle for the restclient.


## Why is this change necessary?

This change is necessary in order to align the cli with the restclient and also as some others modules are using this module like https://github.com/jtopjian/terraform-provider-sensu.


## How did you verify this change?

This change has been tested with the forked project [terraform-provider-sensu](https://github.com/fgouteroux/terraform-provider-sensu/commit/0fd372c57dbd3a132839e2d1a16151d48ca7ecc3)