### PR TITLE
Guard against nil etcd response header

### DIFF
--- a/cli/commands/cluster/health.go
+++ b/cli/commands/cluster/health.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -22,6 +23,9 @@ func HealthCommand(cli *cli.SensuCli) *cobra.Command {
 			result, err := cli.Client.Health()
 			if err != nil {
 				return err
+			}
+			if result.Header == nil {
+				return errors.New("result header was empty, etcd cluster may be down")
 			}
 			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Etcd Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>## What is this change?

## Why is this change necessary?

Prevents `sensuctl cluster health` from panic when running against a etcd cluster that has lost quorum.

## Does your change need a Changelog entry?

No. It's a fix for unreleased code.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation required.

## How did you verify this change?

Copied the new sensuctl to our QA stack and ran against etcd without quorum.

## Is this change a patch?

Yes.
