### PR TITLE
Fix windows command execution test

### DIFF
--- a/command/command_windows_test.go
+++ b/command/command_windows_test.go
@@ -13,8 +13,8 @@ import (
 func TestExecuteWindows(t *testing.T) {
 	// test that commands can time out on windows
 	timeoutRequest := ExecutionRequest{
-		Command: "PowerShell.exe Write-Host \"start sleep\"; Start-Sleep -s 10 ; Write-Host \"sleep done\"",
-		Timeout: 1,
+		Command: "PowerShell.exe Write-Host \"start sleep\"; Start-Sleep -s 20 ; Write-Host \"sleep done\"",
+		Timeout: 10,
 		Name:    "sleep-test",
 	}
 	timeout := NewExecutor()


### PR DESCRIPTION
On appveyor it appears the windows command doesn't have time to execute before timing out. Increase the timeout and sleep time to give it more time.

Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Increase the command timeout to 10s and the timeout to 20s to give it enough time to launch and be killed. With a one second timeout the pre-sleep part of the command is not even executed before the command is killed.


## Why is this change necessary?

To prevent unit tests from failing.

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not necessary

## How did you verify this change?

Ran the unit test locally.

## Is this change a patch?

No
