### PR TITLE
Fix backend init exit code when store already initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - There are currently no unreleased changes.
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.
+- Fixed a regression in `sensu-backend init` where the exit status returned 0
+if the store was already initialized.
 
 ## [6.4.0] - 2021-06-23
 

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -187,7 +187,7 @@ func InitCommand() *cobra.Command {
 					err := initializeStore(clientConfig, initConfig, url)
 					if err != nil {
 						if errors.Is(err, seeds.ErrAlreadyInitialized) {
-							return nil
+							return err
 						}
 						logger.Error(err.Error())
 						continue
@@ -235,7 +235,7 @@ func initializeStore(clientConfig clientv3.Config, initConfig initConfig, endpoi
 	store := etcdstore.NewStore(client, "")
 	if err := seeds.SeedCluster(ctx, store, client, initConfig.SeedConfig); err != nil {
 		if errors.Is(err, seeds.ErrAlreadyInitialized) {
-			return nil
+			return err
 		}
 		return fmt.Errorf("error seeding cluster, is cluster healthy? %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Fixes a regression that shipped with 6.4.0 where `sensu-backend init` returns an exit code of 0 when the store is already initialized.

## Why is this change necessary?

This is a regression causing issues with configuration management.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Tested with a new store and an existing store. New store initialization exits with 0 as expected. Existing store initialization exits with 3 as expected.

## Is this change a patch?

Yes.
