### PR TITLE
Add ignore-already-initialized to backend init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added `ignore-already-initialized` configuration flag to the sensu-backend
+init command for returning exit code 0 when a cluster has already been
+initialized.
+
 ### Changed
 - When keepalived encounters round-robin ring errors, the backend no longer
 internally restarts.
+
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.
 - Fixed a regression in `sensu-backend init` where the exit status returned 0

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -23,6 +23,7 @@ import (
 const (
 	defaultTimeout = "5s"
 
+	flagIgnoreAlreadyInitialized = "ignore-already-initialized"
 	flagInitAdminUsername = "cluster-admin-username"
 	flagInitAdminPassword = "cluster-admin-password"
 	flagInteractive       = "interactive"
@@ -187,6 +188,9 @@ func InitCommand() *cobra.Command {
 					err := initializeStore(clientConfig, initConfig, url)
 					if err != nil {
 						if errors.Is(err, seeds.ErrAlreadyInitialized) {
+							if viper.GetBool(flagIgnoreAlreadyInitialized) {
+								return nil
+							}
 							return err
 						}
 						logger.Error(err.Error())
@@ -201,6 +205,7 @@ func InitCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().Bool(flagIgnoreAlreadyInitialized, false, "exit 0 if the cluster has already been initialized")
 	cmd.Flags().String(flagInitAdminUsername, "", "cluster admin username")
 	cmd.Flags().String(flagInitAdminPassword, "", "cluster admin password")
 	cmd.Flags().Bool(flagInteractive, false, "interactive mode")


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds a new `--ignore-already-initialized` flag to sensu-backend init which will exit 0 if a cluster has already been initialized.

## Why is this change necessary?

Closes #4161.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

The new flag will needs to be documented.

https://github.com/sensu/sensu-docs/issues/3246

## How did you verify this change?

Tested with and without the new flag against an initialized cluster. Without the flag it still exits 3. With the flag it exits 0.

## Is this change a patch?

No, but we could target `release/6.4` if required. cc @calebhailey 
