### PR TITLE
Guard against nil etcd response header in member-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Sensu Go OSS can now be built on `darwin/arm64`.
 - Fixed a regression in `sensu-backend init` where the exit status returned 0
 if the store was already initialized.
+- Guard against potential crash in the sensuctl cluster member-list command when
+the etcd response header is nil.
 
 ## [6.4.0] - 2021-06-23
 

--- a/cli/commands/cluster/member-list.go
+++ b/cli/commands/cluster/member-list.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -9,8 +10,8 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sensu/sensu-go/cli/elements/table"
 	"github.com/spf13/cobra"
-	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/client/v3"
 )
 
 // MemberListCommand lists the cluster members
@@ -23,6 +24,9 @@ func MemberListCommand(cli *cli.SensuCli) *cobra.Command {
 			result, err := cli.Client.MemberList()
 			if err != nil {
 				return fmt.Errorf("error listing cluster members: %s", err)
+			}
+			if result.Header == nil {
+				return errors.New("result header was empty, etcd cluster may be down")
 			}
 			err = helpers.PrintTitle(helpers.GetChangedStringValueFlag("format", cmd.Flags()), cli.Config.Format(), fmt.Sprintf("Etcd Cluster ID: %x", result.Header.ClusterId), cmd.OutOrStdout())
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

The same fix as https://github.com/sensu/sensu-go/pull/4339 but for the sensuctl cluster member-list command.

## Why is this change necessary?

Guards against a potential crash.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## Is this change a patch?

Yes.