### PR TITLE
Add agent config for session retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
 init command for returning exit code 0 when a cluster has already been
 initialized.
+- Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
+for controlling agent retry exponential backoff behaviour. --retry-min and 
+--retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
+a decimal multiplier value.
 
 ### Changed
 - When keepalived encounters round-robin ring errors, the backend no longer
 internally restarts.
+- The default retry values have been increased from a minimum of 10ms to 1s, a
+maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -73,6 +74,9 @@ const (
 	flagBackendHeartbeatInterval = "backend-heartbeat-interval"
 	flagBackendHeartbeatTimeout  = "backend-heartbeat-timeout"
 	flagAgentManagedEntity       = "agent-managed-entity"
+	flagRetryMin                 = "retry-min"
+	flagRetryMax                 = "retry-max"
+	flagRetryMultiplier          = "retry-multiplier"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -131,6 +135,10 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.BackendHandshakeTimeout = viper.GetInt(flagBackendHandshakeTimeout)
 	cfg.BackendHeartbeatInterval = viper.GetInt(flagBackendHeartbeatInterval)
 	cfg.BackendHeartbeatTimeout = viper.GetInt(flagBackendHeartbeatTimeout)
+	cfg.RetryMin = viper.GetDuration(flagRetryMin)
+	cfg.RetryMax = viper.GetDuration(flagRetryMax)
+	cfg.RetryMultiplier = viper.GetFloat64(flagRetryMultiplier)
+
 	// Set the labels & annotations using values defined configuration files
 	// and/or environment variables for now
 	cfg.Labels = viper.GetStringMapString(flagLabels)
@@ -309,6 +317,9 @@ func handleConfig(cmd *cobra.Command, arguments []string) error {
 	viper.SetDefault(flagBackendHandshakeTimeout, 15)
 	viper.SetDefault(flagBackendHeartbeatInterval, 30)
 	viper.SetDefault(flagBackendHeartbeatTimeout, 45)
+	viper.SetDefault(flagRetryMin, time.Second)
+	viper.SetDefault(flagRetryMax, 120*time.Second)
+	viper.SetDefault(flagRetryMultiplier, 2.0)
 
 	// Merge in flag set so that it appears in command usage
 	flags := flagSet()

--- a/agent/config.go
+++ b/agent/config.go
@@ -198,6 +198,18 @@ type Config struct {
 
 	// PrometheusBinding, if set, serves prometheus metrics on this address. (e.g. localhost:8888)
 	PrometheusBinding string
+
+	// RetryMin is the minimum amount of time to wait before retrying an agent
+	// connection to the backend.
+	RetryMin time.Duration
+
+	// RetryMax is the maximum amount of time to wait before retrying an agent
+	// connection to the backend.
+	RetryMax time.Duration
+
+	// RetryMultiplier is multiplied with the current retry delay to produce
+	// a longer retry delay. It is bounded by RetryMax.
+	RetryMultiplier float64
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/transport/client.go
+++ b/transport/client.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +12,8 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/sensu/sensu-go/types"
 )
+
+var ErrTooManyRequests = errors.New("too many requests")
 
 // connect establish the connection to a given websocket backend and returns it
 // along with any error encountered
@@ -47,6 +50,9 @@ func connect(wsServerURL string, tlsOpts *types.TLSOptions, requestHeader http.H
 				}
 				return nil, resp.Header, err
 			}
+			if resp.StatusCode == http.StatusTooManyRequests {
+				return nil, nil, ErrTooManyRequests
+			}
 			return nil, resp.Header, fmt.Errorf("connection failed with status %d", resp.StatusCode)
 		}
 		return nil, nil, err
@@ -55,8 +61,8 @@ func connect(wsServerURL string, tlsOpts *types.TLSOptions, requestHeader http.H
 	return conn, resp.Header, nil
 }
 
-// Connect causes the transport Client to connect to a given websocket backend.
-// This is a thin wrapper around a websocket connection that makes the
+// Connect causes the transport Client to connect to a given websocket server.
+// Transport is a thin wrapper around a websocket connection that makes the
 // connection safe for concurrent use by multiple goroutines.
 func Connect(wsServerURL string, tlsOpts *types.TLSOptions, requestHeader http.Header, handshakeTimeout int) (Transport, http.Header, error) {
 	conn, resp, err := connect(wsServerURL, tlsOpts, requestHeader, handshakeTimeout)


### PR DESCRIPTION
## What is this change?

Three new flags have been added for configuring exponential backoff in
agent session connection retry scenarios. They are --retry-min,
--retry-max, and --retry-multiplier. Users can adjust these flags to
control how aggressive the agent's retry behaviour is. The --retry-min
and --retry-max flags expect duration values, like 1s, 10m, 4h. The
--retry-multiplier flag expects a multiplier expressed as a decimal
number.

Additionally, the default retry delays have been changed. Previously,
the initial delay was 10ms. It is now 1s. The maximum delay was 10s, it
is now 120s. The multiplier was 10.0, it is now 2.0.

## Why is this change necessary?

Closes #4328 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

I manually tested the change unfortunately. The agent code is quite difficult to unit test and I wasn't able to get any unit tests written in a timely fashion.

## Is this change a patch?

No
