### PR TITLE
Metadata configuration for keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
 init command for returning exit code 0 when a cluster has already been
 initialized.
+- Added `keepalive-labels`and `keepalive-annotations` configuration flags to the sensu-agent
 
 ### Changed
 - When keepalived encounters round-robin ring errors, the backend no longer

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -586,6 +586,10 @@ func (a *Agent) newKeepalive() *transport.Message {
 		Timeout:    a.config.KeepaliveWarningTimeout,
 		Ttl:        int64(a.config.KeepaliveCriticalTimeout),
 	}
+
+	keepalive.ObjectMeta.Labels = a.config.KeepaliveLabels
+	keepalive.ObjectMeta.Annotations = a.config.KeepaliveAnnotations
+
 	keepalive.Entity = entity
 	keepalive.Timestamp = time.Now().Unix()
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -23,6 +23,8 @@ import (
 var (
 	annotations               map[string]string
 	labels                    map[string]string
+	keepaliveLabels           map[string]string
+	keepaliveAnnotations      map[string]string
 	configFileDefaultLocation = filepath.Join(path.SystemConfigDir(), "agent.yml")
 )
 
@@ -50,6 +52,8 @@ const (
 	flagKeepaliveInterval        = "keepalive-interval"
 	flagKeepaliveWarningTimeout  = "keepalive-warning-timeout"
 	flagKeepaliveCriticalTimeout = "keepalive-critical-timeout"
+	flagKeepaliveLabels          = "keepalive-labels"
+	flagKeepaliveAnnotations     = "keepalive-annotations"
 	flagNamespace                = "namespace"
 	flagPassword                 = "password"
 	flagRedact                   = "redact"
@@ -117,6 +121,8 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
 	cfg.KeepaliveWarningTimeout = uint32(viper.GetInt(flagKeepaliveWarningTimeout))
 	cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
+	cfg.KeepaliveLabels = viper.GetStringMapString(flagKeepaliveLabels)
+	cfg.KeepaliveAnnotations = viper.GetStringMapString(flagKeepaliveAnnotations)
 	cfg.Namespace = viper.GetString(flagNamespace)
 	cfg.Password = viper.GetString(flagPassword)
 	cfg.Socket.Host = viper.GetString(flagSocketHost)
@@ -412,6 +418,8 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagKeepaliveInterval, viper.GetInt(flagKeepaliveInterval), "number of seconds to send between keepalive events")
 	flagSet.Uint32(flagKeepaliveWarningTimeout, uint32(viper.GetInt(flagKeepaliveWarningTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
 	flagSet.Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
+	flagSet.StringToStringVar(&keepaliveLabels, flagKeepaliveLabels, nil, "keepalive labels map")
+	flagSet.StringToStringVar(&keepaliveAnnotations, flagKeepaliveAnnotations, nil, "keepalive annotations map")
 	flagSet.Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	flagSet.Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	flagSet.Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -51,6 +51,44 @@ func TestNewAgentConfigFlags(t *testing.T) {
 	}
 }
 
+func TestNewAgentConfigKeepaliveLabelsFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagKeepaliveLabels, "foo=bar")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.KeepaliveLabels, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveLabels, `{"foo":"bar"}`)
+	}
+}
+
+func TestNewAgentConfigKeepaliveAnnotationsFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagKeepaliveAnnotations, "foo=bar")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.KeepaliveAnnotations, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveAnnotations, `{"foo":"bar"}`)
+	}
+}
+
 func TestNewAgentConfig_AgentManagedEntityFlag(t *testing.T) {
 	cmd := &cobra.Command{
 		Use: "test",

--- a/agent/config.go
+++ b/agent/config.go
@@ -142,6 +142,12 @@ type Config struct {
 	// by the backend to create a critical event.
 	KeepaliveCriticalTimeout uint32
 
+	// KeepaliveLabels are key-value pairs that users can provide to keepalive events
+	KeepaliveLabels map[string]string
+
+	// KeepaliveAnnotations are key-value pairs that users can provide to keepalive events
+	KeepaliveAnnotations map[string]string
+
 	// Labels are key-value pairs that users can provide to agent entities
 	Labels map[string]string
 


### PR DESCRIPTION
Signed-off-by: Luc Dandoy <luc.dandoy@gmail.com>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

This Pull Request is adding the possibility to configure metadata (labels & annotations) for keepalive event

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
This will solve issue #4042

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->
Yes I add an entry for the modification

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->
I'm not sure if the modification is "efficient" but it's working properly on my tests environment

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

I will have to open a PR to document the addition of 2 new flags for sensu-agent

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

- Compile the agent
- Launch sensu-agent without any labels and check at backend level, that keepalive is correctly recieved on backend
- Stop sensu-agent and delete the entity on backend side
- Launch again the agent with labels & annotations
- check that annotations & labels are visible in the event received by the backend.

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
No