### PR TITLE
Displaying resource type when deleting item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ init command for returning exit code 0 when a cluster has already been
 initialized.
 
 ### Changed
+- When deleting resource with sensuctl, the resource type will now be displayed
+in the confirmation prompt
 - When keepalived encounters round-robin ring errors, the backend no longer
 internally restarts.
 

--- a/cli/commands/apikey/revoke.go
+++ b/cli/commands/apikey/revoke.go
@@ -24,7 +24,7 @@ func RevokeCommand(cli *cli.SensuCli) *cobra.Command {
 
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "apikey"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/asset/delete.go
+++ b/cli/commands/asset/delete.go
@@ -25,7 +25,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "asset"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/check/delete.go
+++ b/cli/commands/check/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "check"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/clusterrole/delete.go
+++ b/cli/commands/clusterrole/delete.go
@@ -23,7 +23,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			}
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "cluster-role"); !confirmed {
 					_, err := fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return err
 				}

--- a/cli/commands/command/delete.go
+++ b/cli/commands/command/delete.go
@@ -25,7 +25,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 
 			name := args[0]
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "command"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/entity/delete.go
+++ b/cli/commands/entity/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "entity"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/event/delete.go
+++ b/cli/commands/event/delete.go
@@ -27,7 +27,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(fmt.Sprintf("%s/%s", entity, check)); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(fmt.Sprintf("%s/%s", entity, check), "event"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/filter/delete.go
+++ b/cli/commands/filter/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "filter"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/handler/delete.go
+++ b/cli/commands/handler/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "handler"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/helpers/prompts.go
+++ b/cli/commands/helpers/prompts.go
@@ -17,6 +17,16 @@ func ConfirmDelete(name string) bool {
 	return ok
 }
 
+// ConfirmDeleteResource confirm a deletion operation before it is completed.
+func ConfirmDeleteResource(name string, resourceType string) bool {
+	confirm := &ConfirmDestructiveOp{
+		Type: fmt.Sprintf("%s resource", resourceType),
+		Op:   "delete",
+	}
+	ok, _ := confirm.Ask(name)
+	return ok
+}
+
 // ConfirmDestructiveOp presents prompt for a destructive operation.
 type ConfirmDestructiveOp struct {
 	Type string

--- a/cli/commands/hook/delete.go
+++ b/cli/commands/hook/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "hook"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/mutator/delete.go
+++ b/cli/commands/mutator/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "mutator"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/namespace/delete.go
+++ b/cli/commands/namespace/delete.go
@@ -25,7 +25,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := args[0]
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(namespace); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(namespace, "namespace"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/role/delete.go
+++ b/cli/commands/role/delete.go
@@ -25,7 +25,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "role"); !confirmed {
 					_, err := fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return err
 				}

--- a/cli/commands/rolebinding/delete.go
+++ b/cli/commands/rolebinding/delete.go
@@ -25,7 +25,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "role-binding"); !confirmed {
 					_, err := fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return err
 				}

--- a/cli/commands/silenced/delete.go
+++ b/cli/commands/silenced/delete.go
@@ -28,7 +28,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDelete(name); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(name, "silence"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}


### PR DESCRIPTION
Signed-off-by: Luc Dandoy <luc.dandoy@gmail.com>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->
Displaying resource type in the deletion confirmation prompt.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
Proposal to fix #3812.

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->
An entry was added to the changelog file

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->
No.


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

Not really. Not sure if my fix is the most "efficient"/"beautiful" one

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
I don't think so as it's mainly a "cosmetic" change

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->
I've been deleting various resource on a test environment to check if the new prompt was correctly displayed.

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
no
