### PR TITLE
Make agent API accept pure metrics events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Agent events API now accepts metrics event
+
 ### Added
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
 init command for returning exit code 0 when a cluster has already been

--- a/agent/event_test.go
+++ b/agent/event_test.go
@@ -226,7 +226,7 @@ func Test_prepareEvent(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing check",
+			name: "missing check and metrics",
 			args: args{
 				agent: &Agent{},
 				event: &corev2.Event{
@@ -234,6 +234,40 @@ func Test_prepareEvent(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "check event",
+			args: args{
+				agent: &Agent{
+					config: &Config{
+						AgentName: "agent1",
+						Namespace: "default",
+					},
+				},
+				event: &corev2.Event{
+					ObjectMeta: corev2.ObjectMeta{Namespace: "default"},
+					Check:      corev2.FixtureCheck("check1"),
+				},
+			},
+			wantErr:       false,
+			wantNamespace: "default",
+		},
+		{
+			name: "metrics event",
+			args: args{
+				agent: &Agent{
+					config: &Config{
+						AgentName: "agent1",
+						Namespace: "default",
+					},
+				},
+				event: &corev2.Event{
+					ObjectMeta: corev2.ObjectMeta{Namespace: "default"},
+					Metrics:    corev2.FixtureMetrics(),
+				},
+			},
+			wantErr:       false,
+			wantNamespace: "default",
 		},
 		{
 			name: "invalid check",


### PR DESCRIPTION
## What is this change?

This changes the payload validation so that events with only metrics in
them are accepted. Events that have neither check nor metrics are still
rejected.

## Why is this change necessary?

Fixes #4232.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation changes needed.

## How did you verify this change?

Unit testing.

## Is this change a patch?

No.
