### PR TITLE
Customise settings in loadit for username, password, and test hostname.

### DIFF
--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/types"
 	"github.com/sirupsen/logrus"
@@ -29,6 +28,9 @@ var (
 	flagKeepaliveTimeout  = flag.Int("keepalive-timeout", types.DefaultKeepaliveTimeout, "Keepalive timeout")
 	flagProfilingPort     = flag.Int("pprof-port", 6060, "pprof port to bind to")
 	flagPromBinding       = flag.String("prom", ":8080", "binding for prometheus server")
+	flagUser              = flag.String("user", agent.DefaultUser, "user to authenticate with server")
+	flagPassword          = flag.String("password", agent.DefaultPassword, "password to authenticate with server")
+	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number.")
 )
 
 func main() {
@@ -48,11 +50,7 @@ func main() {
 
 	start := time.Now()
 	for i := 0; i < *flagCount; i++ {
-		uuidBytes, err := uuid.NewRandom()
-		if err != nil {
-			log.Fatal(err)
-		}
-		name := uuidBytes.String()
+		name := fmt.Sprintf("%s-%d", *flagBaseEntityName, i+1)
 
 		cfg := agent.NewConfig()
 		cfg.API.Host = agent.DefaultAPIHost
@@ -70,10 +68,10 @@ func main() {
 		cfg.KeepaliveInterval = uint32(*flagKeepaliveInterval)
 		cfg.KeepaliveWarningTimeout = uint32(*flagKeepaliveTimeout)
 		cfg.Namespace = *flagNamespace
-		cfg.Password = agent.DefaultPassword
+		cfg.Password = *flagPassword
 		cfg.Socket.Host = agent.DefaultAPIHost
 		cfg.Socket.Port = agent.DefaultAPIPort
-		cfg.User = agent.DefaultUser
+		cfg.User = *flagUser
 		cfg.Subscriptions = subscriptions
 		cfg.AgentName = name
 		cfg.BackendURLs = backends


### PR DESCRIPTION
## What is this change?

Customise settings for user, password, and test hostname.
This does change the default hostname from random uuid, to: test-host-1, test-host-2, test-host-n

## Why is this change necessary?

The user and password change were required to be able to connect if the default credentials are not being used.
The test host allows easily checking on events and such in api.

## Does your change need a Changelog entry?

### Added
- Added -user and -password flags for loadit to set credentials if required (still defaults to default settings).
- Changed test entity name for loadit to "test-entity-1"... "test-entity-n". The "test-entity" can be customized with new -base-entity-name flag

## Do you need clarification on anything?

None

## Were there any complications while making this change?

So far no complications.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation for loadit

## How did you verify this change?

Verified against my test sensu cluster.

## Is this change a patch?

Yes.