### PR TITLE
[Graphql] Entity to return -1 if no events present

### DIFF
--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -118,6 +118,11 @@ func (r *entityImpl) Status(p graphql.ResolveParams) (interface{}, error) {
 		return obj.Entity.Name == src.Name
 	})
 
+	// return -1 (unknown) if no events found
+	if len(evs) == 0 {
+		return -1
+	}
+
 	// find MAX value
 	var st uint32
 	for _, ev := range evs {

--- a/backend/apid/graphql/entity.go
+++ b/backend/apid/graphql/entity.go
@@ -120,7 +120,7 @@ func (r *entityImpl) Status(p graphql.ResolveParams) (interface{}, error) {
 
 	// return -1 (unknown) if no events found
 	if len(evs) == 0 {
-		return -1
+		return -1, nil
 	}
 
 	// find MAX value

--- a/backend/apid/graphql/schema/entity.graphql
+++ b/backend/apid/graphql/schema/entity.graphql
@@ -30,7 +30,7 @@ type Entity implements Node & Namespaced & Silenceable & Resource {
 
   """
   Status represents the MAX status of all events associated with the entity. If
-  no events are present value is 0.
+  no events are present value is -1.
   """
   status: Uint!
 


### PR DESCRIPTION
## What is this change?
Closes #1461

## Why is this change necessary?
If an entity doesn't have any events that's strange, we don't really know what's up with it because it doesn't even have a keepalive. This is more correct than saying it's passing
