### PR TITLE
Increase eventd, keepalived, and pipelined buffer defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ initialized.
 "type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
 code in the "eval" field. See documentation for details.
 - Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
-for controlling agent retry exponential backoff behaviour. --retry-min and 
+for controlling agent retry exponential backoff behaviour. --retry-min and
 --retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
 a decimal multiplier value.
 
@@ -31,6 +31,8 @@ Sensu that the mutator is a different type from the default (pipe). Currently,
 the supported types are "pipe" and "javascript".
 - The default retry values have been increased from a minimum of 10ms to 1s, a
 maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
+- The backend internal bus default buffer sizes have been increased from 100
+to 1000 items.
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -364,11 +364,11 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 		viper.SetDefault(flagInsecureSkipTLSVerify, false)
 		viper.SetDefault(flagLogLevel, "warn")
 		viper.SetDefault(backend.FlagEventdWorkers, 100)
-		viper.SetDefault(backend.FlagEventdBufferSize, 100)
+		viper.SetDefault(backend.FlagEventdBufferSize, 1000)
 		viper.SetDefault(backend.FlagKeepalivedWorkers, 100)
-		viper.SetDefault(backend.FlagKeepalivedBufferSize, 100)
+		viper.SetDefault(backend.FlagKeepalivedBufferSize, 1000)
 		viper.SetDefault(backend.FlagPipelinedWorkers, 100)
-		viper.SetDefault(backend.FlagPipelinedBufferSize, 100)
+		viper.SetDefault(backend.FlagPipelinedBufferSize, 1000)
 		viper.SetDefault(backend.FlagAgentWriteTimeout, 15)
 	}
 


### PR DESCRIPTION
Increase eventd, keepalived, and pipelined buffer defaults from 100 to 1000.

## What is this change?

Increasing the Sensu Go backend internal bus buffer default size from 100 to 1000 (items). The default values are generally too low, new users typically need to increase the buffer size even with a small testing deployment.

## Why is this change necessary?

Improve initial Sensu Go deployment experience with little to no downside for local/laptop deployments.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not yet.

## How did you verify this change?

Local build.

## Is this change a patch?

No.
