### PR TITLE
unit test: command test failing on windows

### DIFF
--- a/command/command_test.go
+++ b/command/command_test.go
@@ -91,14 +91,4 @@ func TestExecute(t *testing.T) {
 	assert.Equal(t, "Execution timed out\n", testutil.CleanOutput(sleepExec.Output))
 	assert.Equal(t, 2, sleepExec.Status)
 	assert.NotEqual(t, 0, sleepExec.Duration)
-
-	// test that multiple commands can time out
-	sleepMultiple := FakeCommand("sleep 10 && echo foo")
-	sleepMultiple.Timeout = 1
-
-	sleepMultipleExec, sleepMultipleErr := sleepMultiple.Execute(context.Background(), sleepMultiple)
-	assert.Equal(t, nil, sleepMultipleErr)
-	assert.Equal(t, "Execution timed out\n", testutil.CleanOutput(sleepMultipleExec.Output))
-	assert.Equal(t, 2, sleepMultipleExec.Status)
-	assert.NotEqual(t, 0, sleepMultipleExec.Duration)
 }

--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -1,0 +1,23 @@
+// +build !windows
+
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/testing/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecuteUnix(t *testing.T) {
+	// test that multiple commands can time out
+	sleepMultiple := FakeCommand("sleep 10 && echo foo")
+	sleepMultiple.Timeout = 1
+
+	sleepMultipleExec, sleepMultipleErr := sleepMultiple.Execute(context.Background(), sleepMultiple)
+	assert.Equal(t, nil, sleepMultipleErr)
+	assert.Equal(t, "Execution timed out\n", testutil.CleanOutput(sleepMultipleExec.Output))
+	assert.Equal(t, 2, sleepMultipleExec.Status)
+	assert.NotEqual(t, 0, sleepMultipleExec.Duration)
+}


### PR DESCRIPTION
move test to non-windows platform

Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

One of the kill command test kept failing on windows. Moved it to non-Windows build.


## Why is this change necessary?

To prevent the build from failing.

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not necessary.

## How did you verify this change?

Local test run and CI pipeline succeeded.

## Is this change a patch?

No.