### PR TITLE
Add updates to sensuctl for mutator type and eval

### DIFF
--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -52,8 +52,8 @@ func (m *Mutator) Validate() error {
 	if err := ValidateName(m.Name); err != nil {
 		return errors.New("mutator name " + err.Error())
 	}
-	if m.Command == "" {
-		return errors.New("mutator command must be set")
+	if m.Command == "" && m.Eval == "" {
+		return errors.New("mutator command or eval must be set")
 	}
 
 	if m.Namespace == "" {

--- a/cli/commands/mutator/create.go
+++ b/cli/commands/mutator/create.go
@@ -71,6 +71,8 @@ func CreateCommand(cli *cli.SensuCli) *cobra.Command {
 	cmd.Flags().String("env-vars", "", "comma separated list of key=value environment variables for the mutator command")
 	cmd.Flags().StringP("timeout", "t", "", "execution duration timeout in seconds (hard stop)")
 	cmd.Flags().StringP("runtime-assets", "r", "", "comma separated list of assets this mutator depends on")
+	cmd.Flags().String("type", "pipe", "type of mutator to create")
+	cmd.Flags().String("eval", "", "javascript expression to use when type is javascript")
 	helpers.AddInteractiveFlag(cmd.Flags())
 	return cmd
 }

--- a/cli/commands/mutator/interactive.go
+++ b/cli/commands/mutator/interactive.go
@@ -11,11 +11,13 @@ import (
 )
 
 type mutatorOpts struct {
+	Type          string `survey:"type"`
 	Name          string `survey:"name"`
 	Command       string `survey:"command"`
+	Eval          string `survey:"eval"`
 	Timeout       string `survey:"timeout"`
 	EnvVars       string `survey:"env-vars"`
-	Namespace     string
+	Namespace     string `survey:"namespace"`
 	RuntimeAssets string `survey:"assets"`
 }
 
@@ -27,7 +29,8 @@ func newMutatorOpts() *mutatorOpts {
 func (opts *mutatorOpts) withMutator(mutator *types.Mutator) {
 	opts.Name = mutator.Name
 	opts.Namespace = mutator.Namespace
-
+	opts.Type = mutator.Type
+	opts.Eval = mutator.Eval
 	opts.Command = mutator.Command
 	opts.Timeout = strconv.FormatUint(uint64(mutator.Timeout), 10)
 	opts.EnvVars = strings.Join(mutator.EnvVars, ",")
@@ -39,6 +42,8 @@ func (opts *mutatorOpts) withFlags(flags *pflag.FlagSet) {
 	opts.Timeout, _ = flags.GetString("timeout")
 	opts.EnvVars, _ = flags.GetString("env-vars")
 	opts.RuntimeAssets, _ = flags.GetString("runtime-assets")
+	opts.Type, _ = flags.GetString("type")
+	opts.Eval, _ = flags.GetString("eval")
 
 	if namespace := helpers.GetChangedStringValueFlag("namespace", flags); namespace != "" {
 		opts.Namespace = namespace
@@ -67,10 +72,24 @@ func (opts *mutatorOpts) administerQuestionnaire(editing bool) error {
 		}...)
 	}
 	qs = append(qs, []*survey.Question{
-		{Name: "command",
+		{
+			Name: "type",
+			Prompt: &survey.Input{
+				Message: "Type:",
+				Default: "pipe",
+			},
+		},
+		{
+			Name: "command",
 			Prompt: &survey.Input{
 				Message: "Command:",
 				Default: opts.Command,
+			},
+		},
+		{
+			Name: "eval",
+			Prompt: &survey.Input{
+				Message: "Eval:",
 			},
 		},
 		{
@@ -104,7 +123,8 @@ func (opts *mutatorOpts) administerQuestionnaire(editing bool) error {
 func (opts *mutatorOpts) Copy(mutator *types.Mutator) {
 	mutator.Name = opts.Name
 	mutator.Namespace = opts.Namespace
-
+	mutator.Type = opts.Type
+	mutator.Eval = opts.Eval
 	mutator.Command = opts.Command
 	mutator.EnvVars = helpers.SafeSplitCSV(opts.EnvVars)
 


### PR DESCRIPTION
## What is this change?

This is work that got missed in the initial implementation of javascript mutators. Without this work, it's not possible to create javascript mutators with sensuctl.

## Does your change need a Changelog entry?

No