### PR TITLE
Event bytes per second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ a decimal multiplier value.
 - Added ProcessedBy field to check results. The ProcessedBy field indicates which
 agent processed a particular event.
 - Added `core/v2.Pipeline` resource for configuring Pipeline resources.
-- Added `pipelines` field to `Check` and `CheckConfig`
+- Added `pipelines` field to `Check` and `CheckConfig`.
+- Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
+metrics to the `/metrics` endpoint.
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/metrics"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/cache"
@@ -60,10 +61,18 @@ var (
 )
 
 func init() {
-	_ = prometheus.Register(websocketUpgradeDuration)
-	_ = prometheus.Register(websocketErrorCounter)
-	_ = prometheus.Register(sessionErrorCounter)
-	_ = prometheus.Register(eventBytesSummary)
+	if err := prometheus.Register(websocketUpgradeDuration); err != nil {
+		metrics.LogError(logger, WebsocketUpgradeDuration, err)
+	}
+	if err := prometheus.Register(websocketErrorCounter); err != nil {
+		metrics.LogError(logger, websocketErrorCounterName, err)
+	}
+	if err := prometheus.Register(sessionErrorCounter); err != nil {
+		metrics.LogError(logger, sessionErrorCounterName, err)
+	}
+	if err := prometheus.Register(eventBytesSummary); err != nil {
+		metrics.LogError(logger, EventBytesSummaryName, err)
+	}
 }
 
 // Agentd is the backend HTTP API.

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -32,7 +32,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store/v2/etcdstore"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var (
@@ -63,6 +63,7 @@ func init() {
 	_ = prometheus.Register(websocketUpgradeDuration)
 	_ = prometheus.Register(websocketErrorCounter)
 	_ = prometheus.Register(sessionErrorCounter)
+	_ = prometheus.Register(eventBytesSummary)
 }
 
 // Agentd is the backend HTTP API.

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -31,6 +31,15 @@ const (
 	// Time to wait before force close on connection.
 	closeGracePeriod = 10 * time.Second
 
+	// Name of the sessions counter metric
+	sessionCounterName = "sensu_go_agent_sessions"
+
+	// Name of the session errors counter metric
+	sessionErrorCounterName = "sensu_go_session_errors"
+
+	// Name of the websocket errors metric
+	websocketErrorCounterName = "sensu_go_websocket_errors"
+
 	// EventBytesSummaryName is the name of the prometheus summary vec used to
 	// track event sizes (in bytes).
 	EventBytesSummaryName = "sensu_go_agentd_event_bytes"
@@ -45,21 +54,21 @@ var (
 
 	sessionCounter = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "sensu_go_agent_sessions",
+			Name: sessionCounterName,
 			Help: "Number of active agent sessions on this backend",
 		},
 		[]string{"namespace"},
 	)
 	websocketErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sensu_go_websocket_errors",
+			Name: websocketErrorCounterName,
 			Help: "The total number of websocket errors",
 		},
 		[]string{"op", "error"},
 	)
 	sessionErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "sensu_go_session_errors",
+			Name: sessionErrorCounterName,
 			Help: "The total number of session errors",
 		},
 		[]string{"error"},

--- a/backend/metrics/events.go
+++ b/backend/metrics/events.go
@@ -1,0 +1,34 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	// EventTypeLabelName is the name of the label for event type.
+	EventTypeLabelName = "type"
+
+	// EventTypeLabelCheck is the event type name for events with only checks.
+	EventTypeLabelCheck = "check"
+
+	// EventTypeLabelMetrics is the event type name for events with only
+	// metrics.
+	EventTypeLabelMetrics = "metrics"
+
+	// EventTypeLabelCheckAndMetrics is the event type name for events with a
+	// check & metrics.
+	EventTypeLabelCheckAndMetrics = "check+metrics"
+)
+
+func NewEventBytesSummaryVec(name, help string) *prometheus.SummaryVec {
+	return prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: name,
+			Help: help,
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		},
+		[]string{EventTypeLabelName},
+	)
+}

--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/sirupsen/logrus"
+
+func LogError(logger *logrus.Entry, name string, err error) {
+	fields := logrus.Fields{
+		"name":  name,
+		"error": err,
+	}
+	logger.WithFields(fields).Errorf("failed to register metric")
+}

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -40,7 +40,9 @@ var (
 )
 
 func init() {
-	_ = prometheus.Register(EventBytesSummary)
+	if err := prometheus.Register(EventBytesSummary); err != nil {
+		metrics.LogError(logger, EventBytesSummaryName, err)
+	}
 }
 
 func getEventPath(event *corev2.Event) string {

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -36,11 +36,11 @@ const (
 var (
 	eventKeyBuilder = store.NewKeyBuilder(eventsPathPrefix)
 
-	eventBytesSummary = metrics.NewEventBytesSummaryVec(EventBytesSummaryName, EventBytesSummaryHelp)
+	EventBytesSummary = metrics.NewEventBytesSummaryVec(EventBytesSummaryName, EventBytesSummaryHelp)
 )
 
 func init() {
-	_ = prometheus.Register(eventBytesSummary)
+	_ = prometheus.Register(EventBytesSummary)
 }
 
 func getEventPath(event *corev2.Event) string {
@@ -311,9 +311,7 @@ func (s *Store) UpdateEvent(ctx context.Context, event *corev2.Event) (*corev2.E
 		return nil, nil, &store.ErrEncode{Err: err}
 	}
 
-	// only record event size for check events as all events will have a check
-	// and no metrics by this point
-	eventBytesSummary.WithLabelValues(typeLabelValue).Observe(float64(len(eventBytes)))
+	EventBytesSummary.WithLabelValues(typeLabelValue).Observe(float64(len(eventBytes)))
 
 	cmp := namespaceExistsForResource(event.Entity)
 	req := clientv3.OpPut(getEventPath(event), string(eventBytes))

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sensu/sensu-go/types"
@@ -22,10 +21,6 @@ const (
 	// EtcdRoot is the root of all sensu storage.
 	EtcdRoot = "/sensu.io"
 )
-
-func init() {
-	_ = prometheus.Register(eventBytesSummary)
-}
 
 // Store is an implementation of the sensu-go/backend/store.Store iface.
 type Store struct {

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sensu/sensu-go/types"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
@@ -21,6 +22,10 @@ const (
 	// EtcdRoot is the root of all sensu storage.
 	EtcdRoot = "/sensu.io"
 )
+
+func init() {
+	_ = prometheus.Register(eventBytesSummary)
+}
 
 // Store is an implementation of the sensu-go/backend/store.Store iface.
 type Store struct {


### PR DESCRIPTION
## What is this change?

Adds event size, in bytes, Prometheus metrics for check, metric, and check+metric events in both the agentd & store (etcd/postgres) packages.

## Why is this change necessary?

Closes #4298.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't believe that we document all of the metrics exposed by the `/metrics` endpoint, so no new documentation should be required.

## How did you verify this change?

Deployed to the perf cluster.

## Is this change a patch?

No.
