### PR TITLE
Add platform metrics logging and event logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ a decimal multiplier value.
 agent processed a particular event.
 - Added `core/v2.Pipeline` resource for configuring Pipeline resources.
 - Added `pipelines` field to `Check` and `CheckConfig`
+- Added the platform metrics log. This log contains a listing of core Sensu
+metrics in influx-line format. It is enabled by default but can be disabled
+with the --disable-platform-metrics flag. By default the log is appended to
+every 60s, and written to /var/lib/sensu/sensu-backend/stats.log.
+- Open-sourced the previously enterprise-only event logger. The event logger
+can be used to send the events a backend processes to a rotatable log file.
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -549,7 +549,9 @@ func (b *Backend) runOnce() error {
 			logger.WithError(err).Error("unable to subscribe to SIGHUP signal notifications")
 			return err
 		}
-		defer subscription.Cancel()
+		defer func() {
+			_ = subscription.Cancel()
+		}()
 		metricsLogWriter, err := logging.NewRotateWriter(b.cfg.PlatformMetricsLogFile, sighup)
 		if err != nil {
 			logger.WithError(err).Error("unable to open platform metrics log file")

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -64,15 +64,12 @@ func (e ErrStartup) Error() string {
 
 var selectedMetrics = []string{
 	"sensu_go_wizard_bus",
-	"sensu_go_wizard_bus",
-	"sensu_go_wizard_bus",
-	"sensu_go_wizard_bus",
-	"sensu_go_wizard_bus",
 	"sensu_go_event_handler_duration",
 	"sensu_go_events_processed",
-	"sensu_go_events_processed",
-	"sensu_go_events_processed",
 	"sensu_go_agent_sessions",
+	"sensu_go_session_errors",
+	"sensu_go_websocket_errors",
+	"sensu_go_agentd_event_bytes",
 	"etcd_debugging_mvcc_keys_total",
 	"etcd_debugging_mvcc_delete_total",
 	"etcd_debugging_mvcc_put_total",

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -96,6 +96,7 @@ func TestBackendHTTPListener(t *testing.T) {
 				EtcdPeerTLSInfo:              tlsInfo,
 				EtcdUseEmbeddedClient:        true,
 				EtcdLogLevel:                 "info",
+				DisablePlatformMetrics:       true,
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			b, err := Initialize(ctx, cfg)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -160,7 +160,7 @@ var (
 	// platform metric logging defaults
 	defaultDisablePlatformMetrics         = false
 	defaultPlatformMetricsLoggingInterval = 60 * time.Second
-	defaultPlatformMetricsLogFile         = filepath.Join(path.SystemDataDir("sensu-backend"), "stats.log")
+	defaultPlatformMetricsLogFile         = filepath.Join(path.SystemLogDir(), "backend-stats.log")
 )
 
 // InitializeFunc represents the signature of an initialization function, used
@@ -580,9 +580,9 @@ func flagSet(server bool) *pflag.FlagSet {
 		// Use a default value of 10ms for the full buffer wait time. When the buffer
 		// is full, the logger will wait for the writer to consume events from the buffer.
 		// This helps reduce event data loss but comes at the cost of event back-pressure
-		// for the backend and it's agent sessions. If the buffer fills and the wait time
+		// for the backend and its agent sessions. If the buffer fills and the wait time
 		// is too low, it will dicard too many events. If the wait time is too high,
-		// event back-pressure could stop the backend and it's agent sessions from
+		// event back-pressure could stop the backend and its agent sessions from
 		// producing and processing new events and possibly lead to a crash.
 		_ = flagSet.String(flagEventLogBufferWait, "10ms", "full buffer wait time")
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"time"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/etcd"
 	"golang.org/x/time/rate"
@@ -107,4 +109,12 @@ type Config struct {
 
 	LogLevel     string
 	EtcdLogLevel string
+
+	DisablePlatformMetrics         bool
+	PlatformMetricsLoggingInterval time.Duration
+	PlatformMetricsLogFile         string
+
+	EventLogBufferSize int
+	EventLogBufferWait time.Duration
+	EventLogFile       string
 }

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -58,7 +58,7 @@ func newEventd(store storev2.Interface, eventStore store.Store, bus messaging.Me
 		eventChan:       make(chan interface{}, 100),
 		wg:              &sync.WaitGroup{},
 		mu:              &sync.Mutex{},
-		Logger:          &RawLogger{},
+		Logger:          NoopLogger{},
 		workerCount:     5,
 		storeTimeout:    time.Minute,
 		silencedCache:   &cache.Resource{},
@@ -122,6 +122,7 @@ func TestEventHandling(t *testing.T) {
 	// Make sure the event has been marked with the proper state
 	assert.Equal(t, corev2.EventPassingState, event.Check.State)
 	assert.Equal(t, event.Timestamp, event.Check.LastOK)
+
 }
 
 func TestEventMonitor(t *testing.T) {
@@ -265,7 +266,7 @@ func TestCheckTTL(t *testing.T) {
 				livenessFactory: newFakeFactory(switches),
 				workerCount:     1,
 				wg:              &sync.WaitGroup{},
-				Logger:          &RawLogger{},
+				Logger:          NoopLogger{},
 				silencedCache:   &cache.Resource{},
 			}
 

--- a/backend/eventd/logger.go
+++ b/backend/eventd/logger.go
@@ -63,7 +63,7 @@ func (f *FileLogger) Receiver() chan<- interface{} {
 }
 
 func (f *FileLogger) Stop() {
-	f.subscription.Cancel()
+	_ = f.subscription.Cancel()
 	f.rawLogger.Stop()
 }
 

--- a/backend/eventd/logger.go
+++ b/backend/eventd/logger.go
@@ -1,0 +1,177 @@
+package eventd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/sensu/sensu-go/backend/logging"
+	"github.com/sensu/sensu-go/backend/messaging"
+)
+
+// FileLogger is a rotatable logger.
+type FileLogger struct {
+	Path       string
+	BufferSize int
+	BufferWait time.Duration
+	Bus        messaging.MessageBus
+	notify     chan interface{}
+	rawLogger  *rawLogger
+}
+
+// Start replaces the core event logger with the enteprise one, which logs
+// events to a log file
+func (f *FileLogger) Start() {
+	if f.Path == "" {
+		logger.Info("no event log file specified, event logging is disabled")
+		return
+	}
+
+	f.notify = make(chan interface{}, 1)
+	consumerName := fmt.Sprintf("filelogger://%s", f.Path)
+	f.Bus.Subscribe(messaging.SignalTopic(syscall.SIGHUP), consumerName, f)
+
+	rawLogger, err := newRawLogger(f.Path, f.BufferSize, f.BufferWait, f.notify)
+	if err != nil {
+		logger.WithError(err).Error("could not start event logging")
+		return
+	}
+
+	f.rawLogger = rawLogger
+
+	logger.Infof("event logging is now enabled and writing to %q", f.Path)
+
+	// Start the ring buffer
+	go rawLogger.ringBuffer()
+	// Listen to the output channel of the ring buffer and write it to the log
+	go rawLogger.write()
+}
+
+// Receiver implements messaging.Subscriber
+func (f *FileLogger) Receiver() chan<- interface{} {
+	return f.notify
+}
+
+func (f *FileLogger) Stop() {
+	f.rawLogger.Stop()
+}
+
+func (f *FileLogger) Println(v interface{}) {
+	f.rawLogger.Println(v)
+}
+
+type LogWriter interface {
+	io.WriteCloser
+	Sync() error
+}
+
+// rawLogger represents the raw events logger and consists of a ring buffer and
+// a writer
+type rawLogger struct {
+	input  chan interface{}
+	output chan interface{}
+	writer LogWriter
+	wait   time.Duration
+}
+
+// newRawLogger initializes the raw event logger
+func newRawLogger(path string, bufferSize int, bufferWait time.Duration, sighup chan interface{}) (*rawLogger, error) {
+	l := &rawLogger{
+		input:  make(chan interface{}),
+		output: make(chan interface{}, bufferSize),
+		wait:   bufferWait,
+	}
+
+	writer, err := logging.NewRotateWriter(path, sighup)
+	if err != nil {
+		return nil, err
+	}
+
+	l.writer = writer
+
+	return l, nil
+}
+
+// Println takes a raw event and sends it over to the ring buffer
+func (l *rawLogger) Println(v interface{}) {
+	l.input <- v
+}
+
+// Stop ends the ring buffer by closing the input channel, which in turns closes
+// the output channel
+func (l *rawLogger) Stop() {
+	close(l.input)
+}
+
+// ringBuffer forwards events from the input channel to the output buffered
+// channel and eliminates the oldest events when full
+func (l *rawLogger) ringBuffer() {
+	var eventsDropped int
+	mu := sync.Mutex{}
+
+	// Keep an eye on the eventsDropper counter and log an error when events are
+	// dropped
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	defer close(l.output)
+	go func() {
+		for range ticker.C {
+			mu.Lock()
+			if eventsDropped > 0 {
+				logger.Errorf("the event buffer is full, %d event(s) lost", eventsDropped)
+				eventsDropped = 0
+			}
+			mu.Unlock()
+		}
+	}()
+
+	for v := range l.input {
+		select {
+		case l.output <- v:
+		case <-time.After(l.wait):
+			// The new event could not be placed on the outgoing channel, therefore
+			// take the oldest event in the buffer, drop it, and place the new event
+			// at its place
+			<-l.output
+			l.output <- v
+
+			// Increment the eventsDropped counter
+			mu.Lock()
+			eventsDropped++
+			mu.Unlock()
+		}
+	}
+}
+
+// write reads events from the ring buffer and sends them over the writer
+func (l *rawLogger) write() {
+	encoder := json.NewEncoder(l.writer)
+	ticker := time.NewTicker(time.Second * 30)
+	defer ticker.Stop()
+	defer func() {
+		// At this point the output channel was closed, which means the writer needs
+		// to clean up after itself
+		if err := l.writer.Close(); err != nil {
+			logger.WithError(err).Error("could not close the event log file")
+		}
+	}()
+	for {
+		select {
+		case v, ok := <-l.output:
+			if !ok {
+				return
+			}
+			if err := encoder.Encode(v); err != nil {
+				logger.WithError(err).Warning("could not encode event")
+				continue
+			}
+		case <-ticker.C:
+			if err := l.writer.Sync(); err != nil {
+				logger.WithError(err).Error("error syncing event log")
+			}
+		}
+	}
+}

--- a/backend/eventd/logger_test.go
+++ b/backend/eventd/logger_test.go
@@ -1,0 +1,300 @@
+// +build !windows
+
+package eventd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sirupsen/logrus"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLogger(t *testing.T) {
+	// Hook ourselves into logrus to capture the log entries
+	log, hook := test.NewNullLogger()
+	logger = log.WithField("test", "TestLogger")
+
+	bus, _ := messaging.NewWizardBus(messaging.WizardBusConfig{})
+	_ = bus.Start()
+
+	wt, _ := time.ParseDuration("10ms")
+	l := &FileLogger{
+		BufferSize: 1,
+		BufferWait: wt,
+		Bus:        bus,
+	}
+
+	// Providing an empty path should return an error
+	l.Start()
+	assert.Contains(t, hook.LastEntry().Message, "event logging is disabled")
+
+	// Providing an invalid path should return an error
+	l.Path = "/"
+	l.Start()
+	assert.Contains(t, hook.LastEntry().Message, "could not start event logging")
+
+	// Providing a valid path should start the logger
+	file, err := ioutil.TempFile(os.TempDir(), "event.*.log")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	l.Path = file.Name()
+	l.Start()
+	assert.Contains(t, hook.LastEntry().Message, "event logging is now enabled")
+}
+
+func TestNewRawLogger(t *testing.T) {
+	// temporary file
+	file, err := ioutil.TempFile(os.TempDir(), "event.*.log")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	tests := []struct {
+		name       string
+		path       string
+		bufferSize int
+		bufferWait string
+		wantErr    bool
+	}{
+		{
+			name:    "cannot open file",
+			wantErr: true,
+		},
+		{
+			name: "valid file",
+			path: file.Name(),
+		},
+	}
+
+	wt, _ := time.ParseDuration("10ms")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newRawLogger(tt.path, tt.bufferSize, wt, make(chan interface{}, 1))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newRawLogger() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+type mockWriter struct {
+	mock.Mock
+	wg *sync.WaitGroup
+}
+
+func (w *mockWriter) Write(b []byte) (int, error) {
+	args := w.Called(string(b))
+	w.wg.Done()
+	return args.Int(0), args.Error(1)
+}
+
+func (w *mockWriter) Close() error {
+	_ = w.Called()
+	return nil
+}
+
+func (w *mockWriter) Sync() error {
+	return nil
+}
+
+type testHook struct {
+	wg *sync.WaitGroup
+}
+
+func (h *testHook) Fire(entry *logrus.Entry) error {
+	h.wg.Done()
+	return nil
+}
+
+func (h *testHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+	}
+}
+
+func TestrawLogger(t *testing.T) {
+	type writeFunc func(*mockWriter)
+
+	tests := []struct {
+		name     string
+		msg      interface{}
+		preMock  writeFunc
+		postMock writeFunc
+	}{
+		{
+			name: "JSON log message",
+			msg:  json.RawMessage(`{"foo":"bar"}`),
+			preMock: func(w *mockWriter) {
+				w.wg.Add(1)
+				w.On("Write", fmt.Sprintln(`{"foo":"bar"}`)).Return(0, nil)
+				w.On("Close")
+			},
+			postMock: func(w *mockWriter) {
+				w.AssertCalled(t, "Write", mock.AnythingOfType("string"))
+			},
+		},
+		{
+			name: "invalid JSON message",
+			msg:  json.RawMessage(`{"foo"}`),
+			preMock: func(w *mockWriter) {
+				w.wg.Add(1)
+				w.On("Write", mock.AnythingOfType("string")).Return(0, nil)
+				w.On("Close")
+			},
+			postMock: func(w *mockWriter) {
+				w.AssertNotCalled(t, "Write", mock.AnythingOfType("string"))
+			},
+		},
+		{
+			name: "writer error",
+			msg:  json.RawMessage(`{"foo":"bar"}`),
+			preMock: func(w *mockWriter) {
+				w.wg.Add(2)
+				w.On("Write", mock.AnythingOfType("string")).Return(0, errors.New("err"))
+				w.On("Close")
+			},
+			postMock: func(w *mockWriter) {
+				w.AssertCalled(t, "Write", mock.AnythingOfType("string"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wg := &sync.WaitGroup{}
+			writer := &mockWriter{
+				wg: wg,
+			}
+			log := logrus.New()
+			log.AddHook(&testHook{wg: wg})
+			logger = log.WithField("test", tt.name)
+			tt.preMock(writer)
+
+			// Once the waitgroup is done, close the c channel
+			c := make(chan struct{})
+			go func() {
+				wg.Wait()
+				c <- struct{}{}
+			}()
+
+			wt, _ := time.ParseDuration("10ms")
+			l := &rawLogger{
+				input:  make(chan interface{}),
+				output: make(chan interface{}, 1),
+				writer: writer,
+				wait:   wt,
+			}
+			go l.ringBuffer()
+			go l.write()
+
+			l.Println(tt.msg)
+
+			// Wait for the waitgroup to close the c channel
+			select {
+			case <-c:
+				l.Stop()
+				tt.postMock(writer)
+			case <-time.After(5 * time.Second):
+				l.Stop()
+				t.Fatal("timed out")
+			}
+		})
+	}
+}
+
+type nilWriter struct{}
+
+func (w *nilWriter) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (w *nilWriter) Close() error {
+	return nil
+}
+
+func (w *nilWriter) Sync() error {
+	return nil
+}
+
+func TestrawLogger_ringBuffer(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   chan interface{}
+		output  chan interface{}
+		writer  LogWriter
+		want    interface{}
+		wantLog bool
+	}{
+		{
+			name:   "all messages are passed when within buffer size",
+			input:  make(chan interface{}),
+			output: make(chan interface{}, 5),
+			writer: &nilWriter{},
+			want:   []interface{}{0, 1, 2, 3, 4},
+		},
+		{
+			name:    "older messages are removed from the buffer when over the buffer size",
+			input:   make(chan interface{}),
+			output:  make(chan interface{}, 4),
+			writer:  &nilWriter{},
+			want:    []interface{}{1, 2, 3, 4},
+			wantLog: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nullLogger, hook := test.NewNullLogger()
+			logger = nullLogger.WithField("test", tt.name)
+
+			wt, _ := time.ParseDuration("10ms")
+			l := &rawLogger{
+				input:  tt.input,
+				output: tt.output,
+				writer: tt.writer,
+				wait:   wt,
+			}
+			go l.ringBuffer()
+
+			// Send messages over input channel
+			for i := 0; i < 5; i++ {
+				l.input <- i
+			}
+
+			// Wait for any event to be logged
+			time.Sleep(time.Second * 2)
+			l.Stop()
+
+			// Get the resulting messages sent over the output channel
+			var results []interface{}
+			for result := range l.output {
+				results = append(results, result)
+			}
+
+			if !reflect.DeepEqual(results, tt.want) {
+				t.Errorf("rawLogger.ringBuffer() = %#v, want %#v", results, tt.want)
+			}
+
+			if tt.wantLog && len(hook.AllEntries()) == 0 {
+				t.Error("rawLogger.ringBuffer() expected a log entry, got 0")
+			}
+			fmt.Println(hook.LastEntry())
+		})
+	}
+}

--- a/backend/eventd/logger_test.go
+++ b/backend/eventd/logger_test.go
@@ -130,7 +130,7 @@ func (h *testHook) Levels() []logrus.Level {
 	}
 }
 
-func TestrawLogger(t *testing.T) {
+func TestRawLogger(t *testing.T) {
 	type writeFunc func(*mockWriter)
 
 	tests := []struct {
@@ -233,7 +233,7 @@ func (w *nilWriter) Sync() error {
 	return nil
 }
 
-func TestrawLogger_ringBuffer(t *testing.T) {
+func TestRawLogger_ringBuffer(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   chan interface{}

--- a/backend/eventd/logging.go
+++ b/backend/eventd/logging.go
@@ -1,16 +1,14 @@
 package eventd
 
-// Logger ...
+// Logger is the logging interface for eventd.
 type Logger interface {
 	Stop()
 	Println(v interface{})
 }
 
-// RawLogger ...
-type RawLogger struct{}
+type NoopLogger struct {
+}
 
-// Println ...
-func (l *RawLogger) Println(v interface{}) {}
+func (NoopLogger) Stop() {}
 
-// Stop ...
-func (l *RawLogger) Stop() {}
+func (NoopLogger) Println(interface{}) {}

--- a/backend/eventd/silenced_test.go
+++ b/backend/eventd/silenced_test.go
@@ -296,7 +296,7 @@ func TestEventd_handleMessage(t *testing.T) {
 				livenessFactory: newFakeFactory(switches),
 				workerCount:     1,
 				wg:              &sync.WaitGroup{},
-				Logger:          &RawLogger{},
+				Logger:          NoopLogger{},
 				silencedCache:   cache,
 			}
 			if err := e.handleMessage(&tt.event); (err != nil) != tt.wantErr {

--- a/backend/logging/logrus.go
+++ b/backend/logging/logrus.go
@@ -1,0 +1,7 @@
+package logging
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "backend",
+})

--- a/backend/logging/rotate_writer.go
+++ b/backend/logging/rotate_writer.go
@@ -1,0 +1,96 @@
+package logging
+
+import (
+	"os"
+	"sync"
+)
+
+// RotateWriter is a special writer that re-opens the path it was opened at
+// when it receives a rotate signal.
+type RotateWriter struct {
+	file      *os.File
+	isSpecial bool
+	mu        sync.Mutex
+	path      string
+	rotate    chan interface{}
+}
+
+// NewRotateWriter creates a new RotateWriter. It will open the path given and
+// use it for writing. It will also create a goroutine that will attempt to
+// receive from the rotate channel. Whenever a message is sent on the rotate
+// channel, the writer will close the currently open file and re-open it at
+// the given path. When the rotate channel is closed, the goroutine started
+// by this function will terminate.
+func NewRotateWriter(path string, rotate chan interface{}) (*RotateWriter, error) {
+	writer := &RotateWriter{
+		path:   path,
+		rotate: rotate,
+	}
+	if err := writer.open(); err != nil {
+		return nil, err
+	}
+	go writer.listenSignal()
+	return writer, nil
+}
+
+// Close will stop the signal listener and close the opened file.
+func (w *RotateWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.file.Close()
+}
+
+// Write will dispatch writes to the currently-opened file. It is goroutine-safe.
+func (w *RotateWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.file.Write(b)
+}
+
+// Sync syncs the currently opened file.
+func (w *RotateWriter) Sync() error {
+	if w.isSpecial {
+		return nil
+	} else {
+		return w.file.Sync()
+	}
+}
+
+// listenSignal listens for the HUP signal and re-opens the log file once
+// received
+func (w *RotateWriter) listenSignal() {
+	for range w.rotate {
+		logger.Infof("reopening log file %q", w.path)
+		if err := w.open(); err != nil {
+			logger.WithError(err).Errorf("error reopening log file %q", w.path)
+		}
+	}
+}
+
+// open will open a file and assign it to the writer underlying file. It can
+// also re-open a file.
+func (w *RotateWriter) open() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Close the file handle in case we already had a file open
+	_ = w.file.Close()
+
+	// Open the file and keep it in the writer
+	fp, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	w.file = fp
+
+	info, err := w.file.Stat()
+	if err != nil {
+		return err
+	}
+
+	if !info.Mode().IsRegular() {
+		w.isSpecial = true
+	}
+
+	return nil
+}

--- a/backend/logging/rotate_writer_test.go
+++ b/backend/logging/rotate_writer_test.go
@@ -1,0 +1,91 @@
+package logging
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRotateWriter(t *testing.T) {
+	// Create a temporary files that will be used as the event log file
+	file, err := ioutil.TempFile(os.TempDir(), "event.*.log")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	rotatedFilename := file.Name() + ".1"
+	defer os.Remove(rotatedFilename)
+
+	// Setup our custom writer
+	rotate := make(chan interface{}, 1)
+	defer close(rotate)
+	w, err := NewRotateWriter(file.Name(), rotate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should be able to write 3 bytes to our log file
+	_, err = w.Write([]byte("foo"))
+	assert.NoError(t, err)
+
+	// Rename our file to simulate a log rotation and make sure the original filename does not exist anymore
+	err = os.Rename(file.Name(), rotatedFilename)
+	assert.NoError(t, err)
+	_, err = os.Stat(file.Name())
+	assert.Error(t, err)
+
+	// Hook ourselves into logrus to capture the log entry sent by the code below
+	l, hook := test.NewNullLogger()
+	logger = l.WithField("test", "TestRotateWriter")
+
+	// Send SIGHUP to our test process so the writer re-open the log file
+	go func() {
+		rotate <- syscall.SIGHUP
+	}()
+
+	// Wait the log file to be reopened, which is done by waiting for logrus to
+	// receive a log entry
+	max := 5 * time.Second
+	start := time.Now()
+	for {
+		entries := hook.AllEntries()
+		if len(entries) > 0 {
+			break
+		}
+		if time.Since(start) > max {
+			t.Fatal("log file was not reopened in a timely manner")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Write to our new log file and make sure it's the right size and does
+	// contain what was wrote before
+	_, err = w.Write([]byte("foobar"))
+	assert.NoError(t, err)
+	info, _ := os.Stat(file.Name())
+	assert.Equal(t, int64(6), info.Size())
+
+	w.Close()
+}
+
+func TestSpecialFileSync(t *testing.T) {
+	stdoutPath := "/dev/stdout"
+
+	w, err := NewRotateWriter(stdoutPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if w.isSpecial != true {
+		t.Errorf("expected %s to be detected as special", stdoutPath)
+	}
+	if err := w.Sync(); err != nil {
+		t.Error(err)
+	}
+}

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -68,6 +68,12 @@ func (t Subscription) Cancel() error {
 	return t.cancel(t.id)
 }
 
+type ChanSubscriber chan interface{}
+
+func (c ChanSubscriber) Receiver() chan<- interface{} {
+	return c
+}
+
 // MessageBus is the interface to the internal messaging system.
 //
 // The MessageBus is a simple implementation of Event Sourcing where you have

--- a/backend/messaging/signal_multiplexer.go
+++ b/backend/messaging/signal_multiplexer.go
@@ -1,0 +1,37 @@
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+// MultiplexSignal creates a signal handler for the provided signal, and publishes
+// all received instances of the signal to wizard bus. The topic it will be published
+// to is the topic that would be returned for the signal by SignalTopic(sig).
+//
+// If the signal is already handled elsewhere, it will stop being handled there,
+// as MultiplexSignal will call signal.Reset(sig) before calling signal.Notify.
+func MultiplexSignal(ctx context.Context, bus MessageBus, sig os.Signal) {
+	ch := make(chan os.Signal, 1)
+	signal.Reset(sig)
+	signal.Notify(ch, sig)
+	topic := SignalTopic(sig)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case sig := <-ch:
+				_ = bus.Publish(topic, sig)
+			}
+		}
+	}()
+}
+
+// SignalTopic returns the topic name for the given signal. It can be used to
+// subscribe to particular signals that have been multiplexed.
+func SignalTopic(sig os.Signal) string {
+	return fmt.Sprintf("signal:%s", sig.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/gxed/GoEndian v0.0.0-20160916112711-0f5c6873267e // indirect
 	github.com/gxed/eventfd v0.0.0-20160916113412-80a92cca79a8 // indirect
 	github.com/hashicorp/go-version v1.2.0
+	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097
 	github.com/ipfs/go-log v1.0.4 // indirect
 	github.com/jbenet/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect
 	github.com/libp2p/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097 h1:vilfsDSy7TDxedi9gyBkMvAirat/oRcL0lFdJBf6tdM=
+github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/ipfs/go-log v1.0.4 h1:6nLQdX4W8P9yZZFH7mO+X/PzjN8Laozm/lMJ6esdgzY=
 github.com/ipfs/go-log v1.0.4/go.mod h1:oDCg2FkjogeFOhqqb+N39l2RpTNPL6F/StPkB3kPgcs=
 github.com/ipfs/go-log/v2 v2.0.5 h1:fL4YI+1g5V/b1Yxr1qAiXTMg1H8z9vx/VmJxBuQMHvU=

--- a/metrics/influx_bridge.go
+++ b/metrics/influx_bridge.go
@@ -1,0 +1,164 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	influx "github.com/influxdata/line-protocol"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+)
+
+var selectedMetricNames = map[string]struct{}{}
+
+// InfluxBridge is a bridge between prometheus metrics and influxdb line metrics,
+// similar to the graphite bridge published by prometheus.
+// https://github.com/prometheus/client_golang/blob/v1.11.0/prometheus/graphite
+//
+// See here for details about how to transform prometheus metrics into influx metrics:
+// https://www.influxdata.com/blog/prometheus-remote-write-support-with-influxdb-2-0/
+type InfluxBridge struct {
+	interval  time.Duration
+	gatherer  prometheus.Gatherer
+	writer    io.Writer
+	errLogger *logrus.Entry
+	filter    map[string]struct{}
+}
+
+// InfluxBridgeConfig configures an InfluxBridge.
+type InfluxBridgeConfig struct {
+	// Writer specifies the writer to use. Required.
+	Writer io.Writer
+
+	// Interval specifies the logging interval to use. Required.
+	Interval time.Duration
+
+	// Gatherer specifies the prometheus gatherer to get metrics from. Required.
+	Gatherer prometheus.Gatherer
+
+	// ErrLogger specifies the logrus logger to use. Set to a default if not
+	// supplied.
+	ErrLogger *logrus.Entry
+
+	// Select, if non-nil, will limit the exported metrics to the names present
+	// in the list.
+	Select []string
+}
+
+// NewInfluxBridge creates a new InfluxBridge. If the supplied InfluxBridgeConfig
+// is not correctly formed, an error will be returned.
+func NewInfluxBridge(cfg *InfluxBridgeConfig) (*InfluxBridge, error) {
+	bridge := &InfluxBridge{
+		filter: make(map[string]struct{}),
+	}
+	for _, selectedMetric := range cfg.Select {
+		bridge.filter[selectedMetric] = struct{}{}
+	}
+	if cfg.Interval == 0 {
+		return nil, errors.New("influx bridge interval not set")
+	}
+	bridge.interval = cfg.Interval
+	if bridge.interval < time.Second {
+		bridge.interval = time.Second * bridge.interval
+	}
+	if cfg.Gatherer == nil {
+		return nil, errors.New("nil gatherer")
+	}
+	bridge.gatherer = cfg.Gatherer
+	bridge.writer = cfg.Writer
+	bridge.errLogger = cfg.ErrLogger
+	if bridge.errLogger == nil {
+		bridge.errLogger = logrus.NewEntry(logrus.StandardLogger())
+	}
+	return bridge, nil
+}
+
+// Run starts the bridge. It operates in a blocking fashion, and runs until the
+// supplied context is cancelled.
+func (b *InfluxBridge) Run(ctx context.Context) {
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := b.Push(); err != nil {
+				b.errLogger.WithError(err).Error("error logging platform metrics")
+			}
+		}
+	}
+}
+
+// Push pushes the current set of gathered metrics to b's writer.
+func (b *InfluxBridge) Push() error {
+	metrics, err := b.gatherer.Gather()
+	if err != nil {
+		return err
+	}
+	return b.logMetrics(metrics)
+}
+
+type promSampleInfluxMetric model.Sample
+
+func (p *promSampleInfluxMetric) Time() time.Time {
+	nanos := int64(p.Timestamp) * int64(time.Millisecond)
+	return time.Unix(0, nanos)
+}
+
+func (p *promSampleInfluxMetric) Name() string {
+	name := string(p.Metric[model.MetricNameLabel])
+	return name
+}
+
+func (p *promSampleInfluxMetric) TagList() []*influx.Tag {
+	tags := []*influx.Tag{}
+	for k, v := range p.Metric {
+		if k == model.MetricNameLabel {
+			continue
+		}
+		tags = append(tags, &influx.Tag{Key: string(k), Value: string(v)})
+	}
+	return tags
+}
+
+func (p *promSampleInfluxMetric) FieldList() []*influx.Field {
+	fields := []*influx.Field{
+		&influx.Field{
+			Key:   p.Name(),
+			Value: float64(p.Value),
+		},
+	}
+	return fields
+}
+
+func (b *InfluxBridge) logMetrics(families []*dto.MetricFamily) error {
+	now := model.Now() // milliseconds since the epoch, excluding leap seconds
+	samples, err := expfmt.ExtractSamples(&expfmt.DecodeOptions{Timestamp: now}, families...)
+	if err != nil {
+		// some metrics might have been successfully extracted, soldier on
+		b.errLogger.WithError(err).Error("error extracting prometheus metric samples")
+	}
+
+	encoder := influx.NewEncoder(b.writer)
+	encoder.FailOnFieldErr(true)
+
+	for _, sample := range samples {
+		metric := (*promSampleInfluxMetric)(sample)
+		if len(b.filter) > 0 {
+			if _, ok := b.filter[metric.Name()]; !ok {
+				continue
+			}
+		}
+		if _, err := encoder.Encode(metric); err != nil {
+			b.errLogger.WithError(err).Error("error encoding metric")
+		}
+	}
+
+	return err
+}

--- a/metrics/influx_bridge.go
+++ b/metrics/influx_bridge.go
@@ -14,8 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var selectedMetricNames = map[string]struct{}{}
-
 // InfluxBridge is a bridge between prometheus metrics and influxdb line metrics,
 // similar to the graphite bridge published by prometheus.
 // https://github.com/prometheus/client_golang/blob/v1.11.0/prometheus/graphite

--- a/metrics/influx_bridge_test.go
+++ b/metrics/influx_bridge_test.go
@@ -1,0 +1,99 @@
+package metrics
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	influx "github.com/influxdata/line-protocol"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+func newTestGatherer() prometheus.Gatherer {
+	collector := collectors.NewGoCollector()
+	gatherer := prometheus.NewRegistry()
+	gatherer.MustRegister(collector)
+	return gatherer
+}
+
+func TestInfluxBridgePush(t *testing.T) {
+	gatherer := newTestGatherer()
+	buf := new(bytes.Buffer)
+	cfg := InfluxBridgeConfig{
+		Writer:   buf,
+		Interval: time.Minute,
+		Gatherer: gatherer,
+	}
+	bridge, err := NewInfluxBridge(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Push(); err != nil {
+		t.Fatal(err)
+	}
+	// expect to get at least N metrics
+	metrics := strings.Split(buf.String(), "\n")
+	if got, want := len(metrics), 35; got < want {
+		t.Errorf("expected at least %d metrics, got %d", got, want)
+	}
+	parser := influx.NewStreamParser(buf)
+	for {
+		metric, err := parser.Next()
+		if err == influx.EOF {
+			break
+		}
+		if err != nil {
+			t.Error(err)
+		}
+		if !strings.HasPrefix(metric.Name(), "go") {
+			t.Errorf("unexpected metric name: %q", metric.Name())
+		}
+		if len(metric.FieldList()) == 0 {
+			t.Errorf("empty metric field list: %s", metric.Name())
+		}
+	}
+}
+
+func TestInfluxBridgeFilter(t *testing.T) {
+	gatherer := newTestGatherer()
+	buf := new(bytes.Buffer)
+	cfg := InfluxBridgeConfig{
+		Writer:   buf,
+		Interval: time.Minute,
+		Gatherer: gatherer,
+		Select:   []string{"go_gc_duration_seconds"},
+	}
+	bridge, err := NewInfluxBridge(&cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Push(); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	parser := influx.NewStreamParser(strings.NewReader(output))
+	count := 0
+	for {
+		metric, err := parser.Next()
+		if err == influx.EOF {
+			break
+		}
+		count++
+		if err != nil {
+			t.Error(err)
+		}
+		if metric.Name() != "go_gc_duration_seconds" {
+			t.Errorf("unexpected metric name: %q", metric.Name())
+		}
+		if len(metric.FieldList()) == 0 {
+			t.Errorf("empty metric field list: %s", metric.Name())
+		}
+	}
+	if got, want := count, 5; got != want {
+		t.Errorf("bad count: got %d, want %d", got, want)
+		fmt.Println(output)
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit adds platform metrics logging to sensu-go. The feature
defaults to being enabled, but can be disabled via flag, config file, or
environment variable. See documentation for details.

This commit also adds event logging, previously an enterprise-only
feature, to OSS sensu. The flag names and behaviours for this feature
are the same as in the enterprise product.

Both of these logs can be rotated by sending SIGHUP to sensu-backend
after mv-ing the log files.

## Why is this change necessary?

Closes #4299

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

I had to do some significant refactoring to send one signal to two different components. I also moved the enterprise-only event logging into OSS (with leadership's blessing).

## Have you reviewed and updated the documentation for this change? Is new documentation required?

@hillaryfraley documentation updates will be needed, as there are several new flags available. Please schedule some time with me to go over the changes before we release 6.5, if you feel a demo/explanation is needed. :)

## How did you verify this change?

In addition to unit testing I manually ran the backend and verified that logging was working when configured, and rotation worked as expected.

## Is this change a patch?

Nein!