### PR TITLE
Cleanup asset downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Fixed
-- Agent events API now accepts metrics event
-
 ### Added
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
 init command for returning exit code 0 when a cluster has already been
@@ -46,6 +43,9 @@ to 1000 items.
 if the store was already initialized.
 - Guard against potential crash in the sensuctl cluster member-list command when
 the etcd response header is nil.
+- Agent events API now accepts metrics event.
+- Fixed rare cases where the agent could fail to delete temporary files when
+downloading assets.
 
 ## [6.4.0] - 2021-06-23
 


### PR DESCRIPTION
## What is this change?

In some cases, it was possible for the agent to leave temporary files behind
when downloading assets. That shouldn't be the case anymore now.

## Why is this change necessary?

Fix #4180

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Issue was inaccurate. Otherwise no.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation change needed.

## How did you verify this change?

Local testing to the extent possible.

## Is this change a patch?

No.