### PR TITLE
Support cluster admin API keys on cluster init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ a decimal multiplier value.
 agent processed a particular event.
 - Added `core/v2.Pipeline` resource for configuring Pipeline resources.
 - Added `pipelines` field to `Check` and `CheckConfig`
+- Added API key support for admin user at cluster init time.
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"go.etcd.io/etcd/client/v3"
+	"github.com/AlecAivazis/survey/v2"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend"
 	"github.com/sensu/sensu-go/backend/etcd"
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/grpc"
-	"github.com/AlecAivazis/survey/v2"
 )
 
 const (
@@ -51,7 +51,7 @@ type initOpts struct {
 	AdminUsername             string `survey:"cluster-admin-username"`
 	AdminPassword             string `survey:"cluster-admin-password"`
 	AdminPasswordConfirmation string `survey:"cluster-admin-password-confirmation"`
-	AdminAPIKey 			  string `survey:"cluster-admin-api-key"`
+	AdminAPIKey               string `survey:"cluster-admin-api-key"`
 }
 
 func (i *initOpts) administerQuestionnaire() error {

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -20,6 +20,10 @@ type Config struct {
 
 	// AdminPassword is the password of the cluster admin.
 	AdminPassword string
+
+	// AdminAPIKey is the API key of the cluster admin. Can be used instead of
+	// AdminUsername and AdminPassword.
+	AdminAPIKey string
 }
 
 var ErrAlreadyInitialized = errors.New("sensu-backend already initialized")
@@ -69,7 +73,7 @@ func SeedCluster(ctx context.Context, store storev1.Store, client *clientv3.Clie
 	}
 
 	// Create the admin user
-	if err := setupAdminUser(ctx, store, config.AdminUsername, config.AdminPassword); err != nil {
+	if err := setupAdminUser(ctx, store, config.AdminUsername, config.AdminPassword, config.AdminAPIKey); err != nil {
 		switch err := err.(type) {
 		case *storev1.ErrAlreadyExists:
 			logger.Warn("admin user already exists")
@@ -334,7 +338,7 @@ func setupClusterRoles(ctx context.Context, store storev1.Store) error {
 	return store.CreateClusterRole(ctx, systemUser)
 }
 
-func setupAdminUser(ctx context.Context, store storev1.Store, username, password string) error {
+func setupAdminUser(ctx context.Context, store storev1.Store, username, password, apiKey string) error {
 	hash, err := bcrypt.HashPassword(password)
 	if err != nil {
 		return err
@@ -346,7 +350,21 @@ func setupAdminUser(ctx context.Context, store storev1.Store, username, password
 		PasswordHash: hash,
 		Groups:       []string{"cluster-admins"},
 	}
-	return store.CreateUser(ctx, admin)
+	if err := store.CreateUser(ctx, admin); err != nil {
+		return err
+	}
+	key := &corev2.APIKey{
+		ObjectMeta: corev2.ObjectMeta{
+			Name: apiKey,
+			CreatedBy: username,
+		},
+		Username: username,
+		CreatedAt: time.Now().Unix(),
+	}
+	if err := store.CreateResource(ctx, key); err != nil {
+		return err
+	}
+	return nil
 }
 
 func setupAgentUser(ctx context.Context, store storev1.Store, username, password string) error {

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -11,7 +11,7 @@ import (
 	storev1 "github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/sensu/sensu-go/types"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type Config struct {
@@ -353,16 +353,18 @@ func setupAdminUser(ctx context.Context, store storev1.Store, username, password
 	if err := store.CreateUser(ctx, admin); err != nil {
 		return err
 	}
-	key := &corev2.APIKey{
-		ObjectMeta: corev2.ObjectMeta{
-			Name: apiKey,
-			CreatedBy: username,
-		},
-		Username: username,
-		CreatedAt: time.Now().Unix(),
-	}
-	if err := store.CreateResource(ctx, key); err != nil {
-		return err
+	if apiKey != "" {
+		key := &corev2.APIKey{
+			ObjectMeta: corev2.ObjectMeta{
+				Name:      apiKey,
+				CreatedBy: username,
+			},
+			Username:  username,
+			CreatedAt: time.Now().Unix(),
+		}
+		if err := store.CreateResource(ctx, key); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What is this change?

Adds the ability to init the cluster with an API key.

## Why is this change necessary?

Closes #4162

## Does your change need a Changelog entry?

Included

## Have you reviewed and updated the documentation for this change? Is new documentation required?

@hillaryfraley we should update the documentation to reflect that API keys are now supported by sensu-backend init.

## How did you verify this change?

Manual testing in interactive and CLI mode.

## Is this change a patch?

No