### PR TITLE
Sensuctl env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,21 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
-  init command for returning exit code 0 when a cluster has already been
-  initialized.
+init command for returning exit code 0 when a cluster has already been
+initialized.
 - Added javascript mutators, which can be selected by setting
-  "type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
-  code in the "eval" field. See documentation for details.
+"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
+code in the "eval" field. See documentation for details.
 - Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
-  for controlling agent retry exponential backoff behaviour. --retry-min and
-  --retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
-  a decimal multiplier value.
+for controlling agent retry exponential backoff behaviour. --retry-min and
+--retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
+a decimal multiplier value.
 - Added ProcessedBy field to check results. The ProcessedBy field indicates which
-  agent processed a particular event.
+agent processed a particular event.
 - Added `core/v2.Pipeline` resource for configuring Pipeline resources.
 - Added `pipelines` field to `Check` and `CheckConfig`.
 - Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
-  metrics to the `/metrics` endpoint.
+metrics to the `/metrics` endpoint.
 - Added support for environment variable arguments in `sensuctl`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,22 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added `ignore-already-initialized` configuration flag to the sensu-backend
-init command for returning exit code 0 when a cluster has already been
-initialized.
+  init command for returning exit code 0 when a cluster has already been
+  initialized.
 - Added javascript mutators, which can be selected by setting
-"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
-code in the "eval" field. See documentation for details.
+  "type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
+  code in the "eval" field. See documentation for details.
 - Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
-for controlling agent retry exponential backoff behaviour. --retry-min and
---retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
-a decimal multiplier value.
+  for controlling agent retry exponential backoff behaviour. --retry-min and
+  --retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
+  a decimal multiplier value.
 - Added ProcessedBy field to check results. The ProcessedBy field indicates which
-agent processed a particular event.
+  agent processed a particular event.
 - Added `core/v2.Pipeline` resource for configuring Pipeline resources.
 - Added `pipelines` field to `Check` and `CheckConfig`.
 - Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
-metrics to the `/metrics` endpoint.
+  metrics to the `/metrics` endpoint.
+- Added support for environment variable arguments in `sensuctl`.
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/cli/client/config"
 	"github.com/sensu/sensu-go/cli/client/config/basic"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
@@ -29,8 +30,13 @@ type SensuCli struct {
 
 // New SensuCLI given persistent flags from command
 func New(flags *pflag.FlagSet) *SensuCli {
-	conf := basic.Load(flags)
-	client := client.New(conf)
+	v, err := helpers.InitViper(flags)
+	if err != nil {
+		return nil
+	}
+
+	conf := basic.Load(flags, v)
+	cliClient := client.New(conf)
 	logger := logrus.WithFields(logrus.Fields{
 		"component": "cli-client",
 	})
@@ -49,10 +55,10 @@ func New(flags *pflag.FlagSet) *SensuCli {
 	tlsConfig.InsecureSkipVerify = conf.InsecureSkipTLSVerify()
 	tlsConfig.CipherSuites = corev2.DefaultCipherSuites
 
-	client.SetTLSClientConfig(&tlsConfig)
+	cliClient.SetTLSClientConfig(&tlsConfig)
 
 	return &SensuCli{
-		Client: client,
+		Client: cliClient,
 		Config: conf,
 		Logger: logger,
 		InFile: os.Stdin,

--- a/cli/client/config/basic/basic.go
+++ b/cli/client/config/basic/basic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sensu/sensu-go/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -46,11 +47,12 @@ type Profile struct {
 }
 
 // Load imports the CLI configuration and returns an initialized Config struct
-func Load(flags *pflag.FlagSet) *Config {
+//func Load(flags *pflag.FlagSet) *Config {
+func Load(flags *pflag.FlagSet, v *viper.Viper) *Config {
 	conf := &Config{}
 
 	// Retrieve the path of the configuration directory
-	if flags != nil {
+	if flags != nil && v != nil {
 		// When Load() is called, some sub-command local flags, such as
 		// --format, are not registered yet and this leads to "unknown flags"
 		// errors being returned by cobra. Such an error can throw off the cobra
@@ -68,7 +70,7 @@ func Load(flags *pflag.FlagSet) *Config {
 		flags.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 		_ = flags.Parse(os.Args[1:])
 
-		if value, err := flags.GetString("config-dir"); err == nil && value != "" {
+		if value := v.GetString("config-dir"); value != "" {
 			conf.path = value
 		}
 	}
@@ -83,42 +85,37 @@ func Load(flags *pflag.FlagSet) *Config {
 		logger.Debug(err)
 	}
 
-	if flags != nil {
+	if v != nil {
 		// Override namespace
-		if value := helpers.GetChangedStringValueFlag("namespace", flags); value != "" {
+		if value := helpers.GetChangedStringValueEnv("namespace", v); value != "" {
 			conf.Profile.Namespace = value
 		}
 	}
 
 	// Load the flags config
-	conf.flags(flags)
+	conf.flags(v)
 
 	return conf
 }
 
-func (c *Config) flags(flags *pflag.FlagSet) {
-	if flags == nil {
+func (c *Config) flags(v *viper.Viper) {
+	if v == nil {
 		return
 	}
 
-	// Set the API URL
-	if value, err := flags.GetString("api-url"); err == nil && value != "" {
+	if value := v.GetString("api-url"); value != "" {
 		c.Cluster.APIUrl = value
 	}
-
-	if value, err := flags.GetBool("insecure-skip-tls-verify"); err == nil && value {
-		c.Cluster.InsecureSkipTLSVerify = value
-	}
-
-	if value, err := flags.GetString("trusted-ca-file"); err == nil && value != "" {
-		c.Cluster.TrustedCAFile = value
-	}
-
-	if value, err := flags.GetString("api-key"); err == nil && value != "" {
+	if value := v.GetString("api-key"); value != "" {
 		c.Cluster.APIKey = value
 	}
-
-	if value, err := flags.GetString("timeout"); err == nil && value != "" {
+	if value := v.GetBool("insecure-skip-tls-verify"); value {
+		c.Cluster.InsecureSkipTLSVerify = value
+	}
+	if value := v.GetString("trusted-ca-file"); value != "" {
+		c.Cluster.TrustedCAFile = value
+	}
+	if value := v.GetString("timeout"); value != "" {
 		duration, err := time.ParseDuration(value)
 		if err == nil {
 			c.Cluster.Timeout = duration

--- a/cli/client/config/basic/writer_test.go
+++ b/cli/client/config/basic/writer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sensu/sensu-go/types"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,8 +39,10 @@ func TestSaveAPIUrl(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	url := "http://127.0.0.1:8080"
 	require.NoError(t, config.SaveAPIUrl(url))
@@ -53,8 +56,10 @@ func TestSaveFormat(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	format := "json"
 	require.NoError(t, config.SaveFormat(format))
@@ -68,8 +73,10 @@ func TestSaveNamespace(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	namespace := "json"
 	require.NoError(t, config.SaveNamespace(namespace))
@@ -83,8 +90,10 @@ func TestSaveTimeout(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	timeout := 30 * time.Second
 	require.NoError(t, config.SaveTimeout(timeout))
@@ -98,8 +107,10 @@ func TestSaveTokens(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	tokens := &types.Tokens{Access: "foo"}
 	_ = config.SaveTokens(tokens)
@@ -114,10 +125,14 @@ func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("api-url", pflag.ContinueOnError)
 	flags.String("api-url", "setFromFlag", "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
 	dirFlag := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	dirFlag.String("config-dir", dir, "")
 	flags.AddFlagSet(dirFlag)
+	dirViper := viper.New()
+	_ = dirViper.BindPFlags(dirFlag)
 
 	// Create a dummy cluster file
 	cluster := &Cluster{APIUrl: "setFromFile"}
@@ -125,14 +140,14 @@ func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 	clusterPath := filepath.Join(dir, clusterFilename)
 	require.NoError(t, ioutil.WriteFile(clusterPath, clusterBytes, 0644))
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	tokens := &types.Tokens{Access: "foo"}
 	require.NoError(t, config.SaveTokens(tokens))
 	assert.Equal(t, tokens, config.Tokens())
 
-	// Make sure we didn't override the orginal API URL
-	configFile := Load(dirFlag)
+	// Make sure we didn't override the original API URL
+	configFile := Load(flags, dirViper)
 	assert.Equal(t, "setFromFile", configFile.APIUrl())
 }
 
@@ -143,14 +158,16 @@ func TestWrite(t *testing.T) {
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
 	flags.String("config-dir", dir, "")
+	v := viper.New()
+	_ = v.BindPFlags(flags)
 
-	config := Load(flags)
+	config := Load(flags, v)
 
 	url := "http://127.0.0.1:8080"
 	require.NoError(t, config.SaveAPIUrl(url))
 	assert.Equal(t, url, config.APIUrl())
 
 	// Reload the config files to make sure the changes were saved
-	config2 := Load(flags)
+	config2 := Load(flags, v)
 	assert.Equal(t, config.APIUrl(), config2.APIUrl())
 }

--- a/cli/commands/apikey/info_test.go
+++ b/cli/commands/apikey/info_test.go
@@ -58,7 +58,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	apikey := &corev2.APIKey{
 		ObjectMeta: corev2.ObjectMeta{

--- a/cli/commands/apikey/list_test.go
+++ b/cli/commands/apikey/list_test.go
@@ -79,7 +79,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	apikey := corev2.FixtureAPIKey("my-api-key", "user1")
 	client := cli.Client.(*client.MockClient)

--- a/cli/commands/asset/info_test.go
+++ b/cli/commands/asset/info_test.go
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchAsset", "in").Return(types.FixtureAsset("name-one"), nil)
 

--- a/cli/commands/check/info_test.go
+++ b/cli/commands/check/info_test.go
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchCheck", "in").Return(types.FixtureCheckConfig("name-one"), nil)
 

--- a/cli/commands/check/list_test.go
+++ b/cli/commands/check/list_test.go
@@ -57,10 +57,10 @@ func TestListCommandRunEClosure(t *testing.T) {
 func TestListCommandRunEClosureWithAll(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
-	client := cli.Client.(*client.MockClient)
+	cli := test.NewCLIWithValue("none")
+	mockClient := cli.Client.(*client.MockClient)
 	resources := []corev2.CheckConfig{}
-	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+	mockClient.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
 		func(args mock.Arguments) {
 			resources := args[1].(*[]corev2.CheckConfig)
 			*resources = []corev2.CheckConfig{
@@ -68,7 +68,8 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 			}
 		},
 	)
-
+	mockConfig := cli.Config.(*client.MockConfig)
+	mockConfig.Mock.ExpectedCalls[1].Return("tabular")
 	cmd := ListCommand(cli)
 	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
 	require.NoError(t, cmd.Flags().Set(flags.AllNamespaces, "t"))
@@ -79,7 +80,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	check := corev2.FixtureCheckConfig("name-one")
 	check.RuntimeAssets = []string{"asset-one"}

--- a/cli/commands/cluster/health_test.go
+++ b/cli/commands/cluster/health_test.go
@@ -56,7 +56,7 @@ func TestHealthCommandAlarmCorrupt(t *testing.T) {
 	healthResponse.ClusterHealth = clusterHealth
 	healthResponse.Alarms = alarms
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("Health").Return(healthResponse, nil)
 
@@ -104,7 +104,7 @@ func TestHealthCommandAlarmNoSpace(t *testing.T) {
 	healthResponse.ClusterHealth = clusterHealth
 	healthResponse.Alarms = alarms
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("Health").Return(healthResponse, nil)
 

--- a/cli/commands/configure/configure_test.go
+++ b/cli/commands/configure/configure_test.go
@@ -37,11 +37,10 @@ func TestCommand(t *testing.T) {
 func TestCommandRunEClosureWithFlags(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewMockCLI()
+	cli := test.NewCLIWithValue(config.DefaultFormat)
 	mockClient := cli.Client.(*client.MockClient)
 	mockConfig := cli.Config.(*client.MockConfig)
 	mockConfig.On("APIUrl").Return("http://127.0.0.1:8080")
-	mockConfig.On("Format").Return(config.DefaultFormat)
 	mockConfig.On("SaveAPIUrl", mock.Anything).Return(nil)
 	mockClient.On("CreateAccessToken", mock.Anything, mock.Anything, mock.Anything).Return(&types.Tokens{}, nil)
 	mockConfig.On("SaveTokens", mock.Anything).Return(nil)
@@ -50,6 +49,7 @@ func TestCommandRunEClosureWithFlags(t *testing.T) {
 	mockConfig.On("SaveNamespace", mock.Anything).Return(nil)
 	mockConfig.On("SaveInsecureSkipTLSVerify", mock.Anything).Return(nil)
 	mockConfig.On("SaveTrustedCAFile", mock.Anything).Return(nil)
+	mockConfig.On("SaveTimeout", mock.Anything).Return(nil)
 	mockConfig.On("Timeout").Return(time.Second * 15)
 
 	// We need to call the "configure" command via the rootCmd so the global flags

--- a/cli/commands/entity/info_test.go
+++ b/cli/commands/entity/info_test.go
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchEntity", "in").Return(types.FixtureEntity("name-one"), nil)
 

--- a/cli/commands/entity/list_test.go
+++ b/cli/commands/entity/list_test.go
@@ -79,10 +79,10 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
-	client := cli.Client.(*client.MockClient)
+	cli := test.NewCLIWithValue("none")
+	mockClient := cli.Client.(*client.MockClient)
 	resources := []corev2.Entity{}
-	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+	mockClient.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
 		func(args mock.Arguments) {
 			resources := args[1].(*[]corev2.Entity)
 			*resources = []corev2.Entity{

--- a/cli/commands/event/list_test.go
+++ b/cli/commands/event/list_test.go
@@ -79,7 +79,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := newConfiguredCLI()
+	cli := newConfiguredCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	resources := []corev2.Event{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
@@ -135,9 +135,13 @@ func TestListFlags(t *testing.T) {
 }
 
 func newConfiguredCLI() *cli.SensuCli {
+	return newConfiguredCLIWithValue("json")
+}
+
+func newConfiguredCLIWithValue(format string) *cli.SensuCli {
 	cli := test.NewMockCLI()
 	config := cli.Config.(*client.MockConfig)
-	config.On("Format").Return("json")
+	config.On("Format").Return(format)
 	return cli
 }
 

--- a/cli/commands/filter/info_test.go
+++ b/cli/commands/filter/info_test.go
@@ -53,7 +53,7 @@ func TestShowCommandRunMissingArgs(t *testing.T) {
 func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchFilter", "in").Return(types.FixtureEventFilter("name-one"), nil)
 

--- a/cli/commands/filter/list_test.go
+++ b/cli/commands/filter/list_test.go
@@ -78,7 +78,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	filter := corev2.FixtureEventFilter("name-one")
 
@@ -162,7 +162,7 @@ func TestListFlags(t *testing.T) {
 
 func TestListCommandRunEClosureWithTableAllow(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	filter := corev2.FixtureEventFilter("name-one")
 	filter.Expressions = append(filter.Expressions, "event.check.name == 'dev'")
@@ -192,7 +192,7 @@ func TestListCommandRunEClosureWithTableAllow(t *testing.T) {
 
 func TestListCommandRunEClosureWithTableDeny(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	filter := corev2.FixtureEventFilter("name-one")
 	filter.Expressions = append(filter.Expressions, "event.check.name == 'dev'")

--- a/cli/commands/handler/list_test.go
+++ b/cli/commands/handler/list_test.go
@@ -77,7 +77,7 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	resources := []corev2.Handler{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(

--- a/cli/commands/hook/info_test.go
+++ b/cli/commands/hook/info_test.go
@@ -53,7 +53,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchHook", "in").Return(types.FixtureHookConfig("name-one"), nil)
 

--- a/cli/commands/hook/list_test.go
+++ b/cli/commands/hook/list_test.go
@@ -79,7 +79,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	hook := corev2.FixtureHookConfig("name-one")
 

--- a/cli/commands/mutator/info_test.go
+++ b/cli/commands/mutator/info_test.go
@@ -53,7 +53,7 @@ func TestShowCommandRunMissingArgs(t *testing.T) {
 func TestShowCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchMutator", "in").Return(types.FixtureMutator("name-one"), nil)
 

--- a/cli/commands/mutator/list_test.go
+++ b/cli/commands/mutator/list_test.go
@@ -79,7 +79,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	mutator := corev2.FixtureMutator("name-one")
 

--- a/cli/commands/silenced/info_test.go
+++ b/cli/commands/silenced/info_test.go
@@ -56,7 +56,7 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("FetchSilenced", mock.Anything).Return(types.FixtureSilenced("foo:bar"), nil)
 

--- a/cli/commands/silenced/list_test.go
+++ b/cli/commands/silenced/list_test.go
@@ -67,7 +67,7 @@ func TestListCommandRunEClosureWithAll(t *testing.T) {
 
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	silenced := corev2.FixtureSilenced("foo:bar")
 	silenced.Reason = "justcause!"

--- a/cli/commands/tessen/info_test.go
+++ b/cli/commands/tessen/info_test.go
@@ -54,7 +54,7 @@ func TestInfoCommandWithArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 	client := cli.Client.(*client.MockClient)
 	client.On("Get", mock.Anything, &corev2.TessenConfig{OptOut: false}).Return(nil)
 

--- a/cli/commands/testing/cli.go
+++ b/cli/commands/testing/cli.go
@@ -12,33 +12,42 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCLI returns a SensuCLI instace with mocked values with json format
 func NewCLI() *cli.SensuCli {
-	cli := NewMockCLI()
-	config := cli.Config.(*clientmock.MockConfig)
-	config.On("Format").Return("json")
-
-	return cli
+	return NewCLIWithValue("json")
 }
 
-// NewMockCLI return SensuCLI instance w/ mocked values
+// NewCLIWithValue returns a SensuCLI instace with mocked values with json format
+func NewCLIWithValue(format string) *cli.SensuCli {
+	mockCLI := NewMockCLI()
+	config := mockCLI.Config.(*clientmock.MockConfig)
+	config.On("Format").Return(format)
+
+	return mockCLI
+}
+
+// NewMockCLI return SensuCLI instance w/ default mocked values
 func NewMockCLI() *cli.SensuCli {
-	config := &clientmock.MockConfig{}
-	client := &clientmock.MockClient{}
+	return NewMockCLIWithValue("default")
+}
+
+// NewMockCLIWithValue return SensuCLI instance w/ mocked values
+func NewMockCLIWithValue(namespace string) *cli.SensuCli {
+	mockConfig := &clientmock.MockConfig{}
+	mockClient := &clientmock.MockClient{}
 
 	// Set defaults ...
-	config.On("Namespace").Return("default")
+	mockConfig.On("Namespace").Return(namespace)
 
 	return &cli.SensuCli{
-		Client: client,
-		Config: config,
+		Client: mockClient,
+		Config: mockConfig,
 		InFile: os.Stdin,
 	}
 }
 
 // SimpleSensuCLI return SensuCLI instance w/ given client & live config
 func SimpleSensuCLI(apiClient client.APIClient) *cli.SensuCli {
-	c := basic.Load(nil)
+	c := basic.Load(nil, nil)
 
 	return &cli.SensuCli{
 		Client: apiClient,

--- a/cli/commands/user/list_test.go
+++ b/cli/commands/user/list_test.go
@@ -70,7 +70,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 // subtests, to at least share the common initialization code.
 func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
-	cli := test.NewCLI()
+	cli := test.NewCLIWithValue("none")
 
 	client := cli.Client.(*client.MockClient)
 	resources := []corev2.User{}


### PR DESCRIPTION
## What is this change?

Add support for the following configuration flags:

SENSU_API_URL (and/or SENSU_BACKEND_URL)
SENSU_API_KEY
SENSU_TRUSTED_CA_FILE
SENSU_NAMESPACE
SENSU_USERNAME
SENSU_PASSWORD
SENSU_CONFIG_DIR
SENSU_CACHE_DIR
SENSU_FORMAT
SENSU_OIDC
SENSU_PORT
SENSU_INSECURE_SKIP_VERIFY
SENSU_TIMEOUT

## Why is this change necessary?

To quickly switch between clusters.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New docs required.

## How did you verify this change?

Manually running sensuctl with the various environment variables instead of using command line switches.

Example:
```
> export SENSU_URL=http://localhost:8080
> export SENSU_USERNAME=fguimond
> export SENSU_PASSWORD=pwd
> export SENSU_FORMAT=json
> export SENSU_NAMESPACE=default
> export SENSU_TIMEOUT=60s
> export SENSU_NON_INTERACTIVE=true
> sensuctl configure
```

Verify config:
```
> sensuctl config
{
  "api-url": "http://localhost:8080",
  "format": "json",
  "jwt_expires_at": "1629477919",
  "namespace": "default",
  "timeout": "15s",
  "username": "fguimond"
}
```

## Is this change a patch?

No
