### PR TITLE
Improve logging somewhat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ if the store was already initialized.
 - Guard against potential crash in the sensuctl cluster member-list command when
 the etcd response header is nil.
 
+### Changed
+- API and agent services now log at warn level when the start up, not at info.
+- Backend now reports when it is ready to process events at warn level.
+
 ## [6.4.0] - 2021-06-23
 
 ### Added

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -32,7 +32,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store/v2/etcdstore"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var (
@@ -194,7 +194,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 
 // Start Agentd.
 func (a *Agentd) Start() error {
-	logger.Info("starting agentd on address: ", a.httpServer.Addr)
+	logger.Warn("starting agentd on address: ", a.httpServer.Addr)
 	ln, err := net.Listen("tcp", a.httpServer.Addr)
 	if err != nil {
 		return fmt.Errorf("failed to start agentd: %s", err)

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/graphql"
@@ -269,7 +269,7 @@ func notFoundHandler(w http.ResponseWriter, req *http.Request) {
 
 // Start APId.
 func (a *APId) Start() error {
-	logger.Info("starting apid on address: ", a.HTTPServer.Addr)
+	logger.Warn("starting apid on address: ", a.HTTPServer.Addr)
 	ln, err := net.Listen("tcp", a.HTTPServer.Addr)
 	if err != nil {
 		return fmt.Errorf("failed to start apid: %s", err)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
@@ -512,6 +512,8 @@ func (b *Backend) runOnce() error {
 	errCtx, errCancel := context.WithCancel(b.RunContext())
 	defer errCancel()
 	eg.Go(errCtx)
+
+	logger.Warn("backend is running and ready to accept events")
 
 	select {
 	case err := <-eg.Err():


### PR DESCRIPTION
## What is this change?

This PR improves logging of sensu-go readiness. A warning is now issued when the backend is ready to process events, and info-level logs that mention that APId and Agentd have started on a particular address are now at warn level.

## Why is this change necessary?

Closes #4390

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Manual testing.

## Is this change a patch?

Yes