### PR TITLE
Allow resources without unknown fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 if the store was already initialized.
 - Guard against potential crash in the sensuctl cluster member-list command when
 the etcd response header is nil.
+- Forwards compatibility with newer Sensu backends has been improved. Users can
+now create resources with fields that are unknown to Sensu.
 
 ### Changed
 - API and agent services now log at warn level when the start up, not at info.

--- a/backend/apid/graphql/mutations.go
+++ b/backend/apid/graphql/mutations.go
@@ -43,7 +43,6 @@ func (r *mutationsImpl) PutWrapped(p schema.MutationPutWrappedFieldResolverParam
 
 	// decode given
 	dec := json.NewDecoder(strings.NewReader(raw))
-	dec.DisallowUnknownFields()
 	if err = dec.Decode(&ret); err != nil {
 		return map[string]interface{}{
 			"errors": wrapInputErrors("raw", err),

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -167,7 +167,6 @@ func (w *Wrapper) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("no spec provided")
 	}
 	dec := json.NewDecoder(bytes.NewReader(*wrapper.Value))
-	dec.DisallowUnknownFields()
 	if err := dec.Decode(&resource); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What is this change?

This commit allows creating resources with unknown fields in them,
through sensuctl, the API, and federation.

To reduce sharp edges a warning system has been added to sensuctl, in
order to reduce the likelihood of typos.

## Does your change need a Changelog entry?

Yes

## Is this change a patch?

Yes