### PR TITLE
Backport event size metrics to 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,42 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [6.4.1] - 2021-08-24
 ## Unreleased
 
-### Fixed
-- Agent events API now accepts metrics event
-
 ### Added
-- Added `ignore-already-initialized` configuration flag to the sensu-backend
-init command for returning exit code 0 when a cluster has already been
-initialized.
-- Added javascript mutators, which can be selected by setting
-"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
-code in the "eval" field. See documentation for details.
-- Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
-for controlling agent retry exponential backoff behaviour. --retry-min and
---retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
-a decimal multiplier value.
-- Added ProcessedBy field to check results. The ProcessedBy field indicates which
-agent processed a particular event.
-- Added `core/v2.Pipeline` resource for configuring Pipeline resources.
-- Added `pipelines` field to `Check` and `CheckConfig`.
 - Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
 metrics to the `/metrics` endpoint.
 
-### Changed
-- When deleting resource with sensuctl, the resource type will now be displayed
-in the confirmation prompt
-- When keepalived encounters round-robin ring errors, the backend no longer
-internally restarts.
-- The core/v2.Mutator type now has a Type field which can be used to tell
-Sensu that the mutator is a different type from the default (pipe). Currently,
-the supported types are "pipe" and "javascript".
-- The default retry values have been increased from a minimum of 10ms to 1s, a
-maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
-- The backend internal bus default buffer sizes have been increased from 100
-to 1000 items.
+## [6.4.1] - 2021-08-24
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [6.4.1] - 2021-08-24
+## Unreleased
+
+### Fixed
+- Agent events API now accepts metrics event
+
+### Added
+- Added `ignore-already-initialized` configuration flag to the sensu-backend
+init command for returning exit code 0 when a cluster has already been
+initialized.
+- Added javascript mutators, which can be selected by setting
+"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
+code in the "eval" field. See documentation for details.
+- Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
+for controlling agent retry exponential backoff behaviour. --retry-min and
+--retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
+a decimal multiplier value.
+- Added ProcessedBy field to check results. The ProcessedBy field indicates which
+agent processed a particular event.
+- Added `core/v2.Pipeline` resource for configuring Pipeline resources.
+- Added `pipelines` field to `Check` and `CheckConfig`.
+- Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
+metrics to the `/metrics` endpoint.
+
+### Changed
+- When deleting resource with sensuctl, the resource type will now be displayed
+in the confirmation prompt
+- When keepalived encounters round-robin ring errors, the backend no longer
+internally restarts.
+- The core/v2.Mutator type now has a Type field which can be used to tell
+Sensu that the mutator is a different type from the default (pipe). Currently,
+the supported types are "pipe" and "javascript".
+- The default retry values have been increased from a minimum of 10ms to 1s, a
+maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
+- The backend internal bus default buffer sizes have been increased from 100
+to 1000 items.
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/authorization/rbac"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/metrics"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/cache"
@@ -60,9 +61,18 @@ var (
 )
 
 func init() {
-	_ = prometheus.Register(websocketUpgradeDuration)
-	_ = prometheus.Register(websocketErrorCounter)
-	_ = prometheus.Register(sessionErrorCounter)
+	if err := prometheus.Register(websocketUpgradeDuration); err != nil {
+		metrics.LogError(logger, WebsocketUpgradeDuration, err)
+	}
+	if err := prometheus.Register(websocketErrorCounter); err != nil {
+		metrics.LogError(logger, websocketErrorCounterName, err)
+	}
+	if err := prometheus.Register(sessionErrorCounter); err != nil {
+		metrics.LogError(logger, sessionErrorCounterName, err)
+	}
+	if err := prometheus.Register(eventBytesSummary); err != nil {
+		metrics.LogError(logger, EventBytesSummaryName, err)
+	}
 }
 
 // Agentd is the backend HTTP API.

--- a/backend/metrics/events.go
+++ b/backend/metrics/events.go
@@ -1,0 +1,34 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	// EventTypeLabelName is the name of the label for event type.
+	EventTypeLabelName = "type"
+
+	// EventTypeLabelCheck is the event type name for events with only checks.
+	EventTypeLabelCheck = "check"
+
+	// EventTypeLabelMetrics is the event type name for events with only
+	// metrics.
+	EventTypeLabelMetrics = "metrics"
+
+	// EventTypeLabelCheckAndMetrics is the event type name for events with a
+	// check & metrics.
+	EventTypeLabelCheckAndMetrics = "check+metrics"
+)
+
+func NewEventBytesSummaryVec(name, help string) *prometheus.SummaryVec {
+	return prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: name,
+			Help: help,
+			Objectives: map[float64]float64{
+				0.5:  0.05,
+				0.9:  0.01,
+				0.99: 0.001,
+			},
+		},
+		[]string{EventTypeLabelName},
+	)
+}

--- a/backend/metrics/metrics.go
+++ b/backend/metrics/metrics.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/sirupsen/logrus"
+
+func LogError(logger *logrus.Entry, name string, err error) {
+	fields := logrus.Fields{
+		"name":  name,
+		"error": err,
+	}
+	logger.WithFields(fields).Errorf("failed to register metric")
+}

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sensu/sensu-go/types"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )


### PR DESCRIPTION
## What is this change?

Backports the event size metrics from the `main` branch into the `release/6.4` branch.

## Does your change need a Changelog entry?

Yes.

## Is this change a patch?

Yes.
