### PR TITLE
Bump snappy to v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 metrics to the `/metrics` endpoint.
 
 ## [6.4.1] - 2021-08-24
+## Unreleased
+
+### Fixed
+- Agent events API now accepts metrics event
+
+### Added
+- Added `ignore-already-initialized` configuration flag to the sensu-backend
+init command for returning exit code 0 when a cluster has already been
+initialized.
+- Added javascript mutators, which can be selected by setting
+"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
+code in the "eval" field. See documentation for details.
+- Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
+for controlling agent retry exponential backoff behaviour. --retry-min and
+--retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
+a decimal multiplier value.
+- Added ProcessedBy field to check results. The ProcessedBy field indicates which
+agent processed a particular event.
+- Added `core/v2.Pipeline` resource for configuring Pipeline resources.
+- Added `pipelines` field to `Check` and `CheckConfig`.
+- Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
+metrics to the `/metrics` endpoint.
+
+### Changed
+- When deleting resource with sensuctl, the resource type will now be displayed
+in the confirmation prompt
+- When keepalived encounters round-robin ring errors, the backend no longer
+internally restarts.
+- The core/v2.Mutator type now has a Type field which can be used to tell
+Sensu that the mutator is a different type from the default (pipe). Currently,
+the supported types are "pipe" and "javascript".
+- The default retry values have been increased from a minimum of 10ms to 1s, a
+maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
+- The backend internal bus default buffer sizes have been increased from 100
+to 1000 items.
 
 ### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed a crash when running the backend on `darwin/arm64` when compressing a
+wrapped resource.
+
 ## [6.4.2] - 2021-08-31
 
 ### Added
@@ -15,7 +19,6 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 metrics to the `/metrics` endpoint.
 
 ## [6.4.1] - 2021-08-24
-## Unreleased
 
 ### Fixed
 - Agent events API now accepts metrics event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,40 +21,6 @@ metrics to the `/metrics` endpoint.
 ## [6.4.1] - 2021-08-24
 
 ### Fixed
-- Agent events API now accepts metrics event
-
-### Added
-- Added `ignore-already-initialized` configuration flag to the sensu-backend
-init command for returning exit code 0 when a cluster has already been
-initialized.
-- Added javascript mutators, which can be selected by setting
-"type": "javascript" on core/v2.Mutators, and specifying valid ECMAScript 5
-code in the "eval" field. See documentation for details.
-- Added --retry-min, --retry-max, and --retry-multiplier flags to sensu-agent
-for controlling agent retry exponential backoff behaviour. --retry-min and
---retry-max expect duration values like 1s, 10m, 4h. --retry-multiplier expects
-a decimal multiplier value.
-- Added ProcessedBy field to check results. The ProcessedBy field indicates which
-agent processed a particular event.
-- Added `core/v2.Pipeline` resource for configuring Pipeline resources.
-- Added `pipelines` field to `Check` and `CheckConfig`.
-- Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
-metrics to the `/metrics` endpoint.
-
-### Changed
-- When deleting resource with sensuctl, the resource type will now be displayed
-in the confirmation prompt
-- When keepalived encounters round-robin ring errors, the backend no longer
-internally restarts.
-- The core/v2.Mutator type now has a Type field which can be used to tell
-Sensu that the mutator is a different type from the default (pipe). Currently,
-the supported types are "pipe" and "javascript".
-- The default retry values have been increased from a minimum of 10ms to 1s, a
-maximum of 10s to 120s, and the multiplier decreased from 10.0 to 2.0.
-- The backend internal bus default buffer sizes have been increased from 100
-to 1000 items.
-
-### Fixed
 - Sensu Go OSS can now be built on `darwin/arm64`.
 - Fixed a regression in `sensu-backend init` where the exit status returned 0
 if the store was already initialized.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-resty/resty/v2 v2.5.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
-	github.com/golang/snappy v0.0.1
+	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,9 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=


### PR DESCRIPTION
## What is this change?

Fixes a crash when running the backend on `darwin/arm64`.

## Why is this change necessary?

The following segfault occurs when running the backend on `darwin/arm64`, which affects some of our development machines:
```
{"component":"backend","level":"warning","msg":"backend is running and ready to accept events","time":"2021-09-02T15:55:44-07:00"}                                                                                                            
unexpected fault address 0xa1a3832312f3396                                                                                                                                                                                                    
fatal error: fault                                                                                                                                                                                                                            
[signal SIGSEGV: segmentation violation code=0x2 addr=0xa1a3832312f3396 pc=0x1035977a0]                                                                                                                                                       
                                                                                                                                                                                                                                              
goroutine 287 [running]:                                                                                                                                                                                                                      
runtime.throw(0x103e0f2a9, 0x5)
        /opt/homebrew/Cellar/go/1.16.5/libexec/src/runtime/panic.go:1117 +0x54 fp=0x14001768c80 sp=0x14001768c50 pc=0x102d6d154
runtime.sigpanic()
        /opt/homebrew/Cellar/go/1.16.5/libexec/src/runtime/signal_unix.go:741 +0x230 fp=0x14001768cc0 sp=0x14001768c80 pc=0x102d84b70
github.com/golang/snappy.encodeBlock(0x1400061c802, 0x3ac, 0x3ac, 0x14001974000, 0x30c, 0x30c, 0x14001770d01)
        /Users/amdprophet/go/pkg/mod/github.com/golang/snappy@v0.0.2/encode_arm64.s:666 +0x360 fp=0x14001770d60 sp=0x14001768cd0 pc=0x1035977a0
github.com/golang/snappy.Encode(0x1400061c800, 0x3ae, 0x3ae, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /Users/amdprophet/go/pkg/mod/github.com/golang/snappy@v0.0.2/encode.go:39 +0x17c fp=0x14001770db0 sp=0x14001770d60 pc=0x103596cdc
github.com/sensu/sensu-go/backend/store/v2/wrap.Compression.Compress(...)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/store/v2/wrap/wrapper.go:69
github.com/sensu/sensu-go/backend/store/v2/wrap.wrapWithoutValidation(0x1045d5ae0, 0x1400181c600, 0x1400080eaa0, 0x1, 0x1, 0x1057c6101, 0x8, 0x1400080eaa0)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/store/v2/wrap/wrapper.go:185 +0x3b8 fp=0x14001770eb0 sp=0x14001770db0 pc=0x1035981b8
github.com/sensu/sensu-go/backend/store/v2/wrap.wrap(0x1045d5ae0, 0x1400181c600, 0x1400080eaa0, 0x1, 0x1, 0x104321d20, 0x1, 0x1400080eaa0)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/store/v2/wrap/wrapper.go:198 +0xac fp=0x14001770f00 sp=0x14001770eb0 pc=0x10359848c
github.com/sensu/sensu-go/backend/store/v2/wrap.Resource(...)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/store/v2/wrap/wrapper.go:140
github.com/sensu/sensu-go/backend/store/v2.glob..func1(0x10468b168, 0x1400181c600, 0x1400080eaa0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x140017711c8)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/store/v2/resource.go:23 +0x50 fp=0x14001770f50 sp=0x14001770f00 pc=0x10359c320
github.com/sensu/sensu-go/backend/keepalived.(*Keepalived).handleUpdate(0x14000b5a0c0, 0x1400074ec00, 0x0, 0x0)
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/keepalived/keepalived.go:690 +0x140 fp=0x14001771670 sp=0x14001770f50 pc=0x103741530
github.com/sensu/sensu-go/backend/keepalived.(*Keepalived).processKeepalives(0x14000b5a0c0, 0x10467ced8, 0x14000b047c0) 
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/keepalived/keepalived.go:350 +0xb5c fp=0x14001771fc0 sp=0x14001771670 pc=0x10373d20c
runtime.goexit()
        /opt/homebrew/Cellar/go/1.16.5/libexec/src/runtime/asm_arm64.s:1130 +0x4 fp=0x14001771fc0 sp=0x14001771fc0 pc=0x102da4864
created by github.com/sensu/sensu-go/backend/keepalived.(*Keepalived).startWorkers
        /Users/amdprophet/go/pkg/mod/github.com/sensu/sensu-go@v0.0.0-20210831192712-72904600283c/backend/keepalived/keepalived.go:259 +0x94
```

## Does your change need a Changelog entry?

Yes

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

The crash no longer happens after this change.

## Is this change a patch?

Yes.
