### PR TITLE
Use temp dirs in sensuctl tests which create configs

### DIFF
--- a/cli/client/config/basic/basic_test.go
+++ b/cli/client/config/basic/basic_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFlags(t *testing.T) {
 	flags := pflag.NewFlagSet("api-url", pflag.ContinueOnError)
 	flags.String("api-url", "foo", "")
+	flags.String("config-dir", t.TempDir(), "")
 	v := viper.New()
 	_ = v.BindPFlags(flags)
 
@@ -29,6 +29,7 @@ func TestFlags(t *testing.T) {
 func TestEnv(t *testing.T) {
 	flags := pflag.NewFlagSet("api-url", pflag.ContinueOnError)
 	_ = os.Setenv("SENSU_API_URL", "foo_env")
+	_ = os.Setenv("SENSU_CONFIG_DIR", t.TempDir())
 	v, _ := helpers.InitViper(flags)
 
 	config := Load(flags, v)
@@ -39,10 +40,7 @@ func TestEnv(t *testing.T) {
 
 func TestLoad(t *testing.T) {
 	// Create a dummy directory for testing
-	dir, _ := ioutil.TempDir("", "sensu")
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -69,9 +67,12 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadMissingFiles(t *testing.T) {
+	// Create a dummy directory for testing
+	dir := t.TempDir()
+
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
-	flags.String("config-dir", "/tmp/sensu", "")
+	flags.String("config-dir", dir, "")
 	v := viper.New()
 	_ = v.BindPFlags(flags)
 
@@ -81,11 +82,7 @@ func TestLoadMissingFiles(t *testing.T) {
 
 func TestOpen(t *testing.T) {
 	// Create a dummy directory for testing
-	dir, err := ioutil.TempDir("", "sensu")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	// Create a dummy cluster file
 	cluster := &Cluster{APIUrl: "localhost"}
@@ -99,8 +96,11 @@ func TestOpen(t *testing.T) {
 }
 
 func TestOpenMissingFile(t *testing.T) {
+	// Create a dummy directory for testing
+	dir := t.TempDir()
+
 	config := &Config{}
 
-	err := config.open("/tmp/sensu/missingfile")
+	err := config.open(filepath.Join(dir, "missingfile"))
 	assert.Error(t, err)
 }

--- a/cli/client/config/basic/writer_test.go
+++ b/cli/client/config/basic/writer_test.go
@@ -3,7 +3,6 @@ package basic
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -15,26 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func tmpDir(t *testing.T) (string, func()) {
-	t.Helper()
-
-	dir, err := ioutil.TempDir("", "sensu")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cleanup := func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return dir, cleanup
-}
-
 func TestSaveAPIUrl(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -50,8 +32,8 @@ func TestSaveAPIUrl(t *testing.T) {
 }
 
 func TestSaveFormat(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -67,8 +49,8 @@ func TestSaveFormat(t *testing.T) {
 }
 
 func TestSaveNamespace(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -84,8 +66,8 @@ func TestSaveNamespace(t *testing.T) {
 }
 
 func TestSaveTimeout(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -101,8 +83,8 @@ func TestSaveTimeout(t *testing.T) {
 }
 
 func TestSaveTokens(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)
@@ -119,12 +101,13 @@ func TestSaveTokens(t *testing.T) {
 
 func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 	// In case the API URL is passed with a flag, we don't want to save it
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("api-url", pflag.ContinueOnError)
 	flags.String("api-url", "setFromFlag", "")
+	flags.String("config-dir", dir, "")
 	v := viper.New()
 	_ = v.BindPFlags(flags)
 
@@ -152,8 +135,8 @@ func TestSaveTokensWithAPIUrlFlag(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	dir, cleanup := tmpDir(t)
-	defer cleanup()
+	// Create a dummy directory for testing
+	dir := t.TempDir()
 
 	// Set flags
 	flags := pflag.NewFlagSet("config-dir", pflag.ContinueOnError)


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Creates a temporary directories for any sensuctl tests which result in a config being created.

## Why is this change necessary?

Running tests prior to this would result in dirtying the git state as it was using the local directory whenever `config-dir` was empty.

## Does your change need a Changelog entry?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Tests pass and no longer dirty the git state.

## Is this change a patch?

No as this only affects the `main` branch at the moment.