### PR TITLE
Add help for retry related flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ the etcd response header is nil.
 downloading assets.
 - Forwards compatibility with newer Sensu backends has been improved. Users can
 now create resources with fields that are unknown to Sensu.
+- The `--retry-min`, `--retry-max` and `--retry-multiplier` flags are now listed
+in the `sensu-agent start --help` output.
 
 ### Changed
 - API and agent services now log at warn level when the start up, not at info.

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -438,6 +438,9 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagBackendHeartbeatInterval, viper.GetInt(flagBackendHeartbeatInterval), "interval at which the agent should send heartbeats to the backend")
 	flagSet.Int(flagBackendHeartbeatTimeout, viper.GetInt(flagBackendHeartbeatTimeout), "number of seconds the agent should wait for a response to a hearbeat")
 	flagSet.Bool(flagAgentManagedEntity, viper.GetBool(flagAgentManagedEntity), "manage this entity via the agent")
+	flagSet.Duration(flagRetryMin, viper.GetDuration(flagRetryMin), "minimum amount of time to wait before retrying an agent connection to the backend")
+	flagSet.Duration(flagRetryMax, viper.GetDuration(flagRetryMax), "maximum amount of time to wait before retrying an agent connection to the backend")
+	flagSet.Float64(flagRetryMultiplier, viper.GetFloat64(flagRetryMultiplier), "value multiplied with the current retry delay to produce a longer retry delay (bounded by --retry-max)")
 
 	flagSet.SetOutput(ioutil.Discard)
 


### PR DESCRIPTION
## What is this change?

`--retry-min`, `--retry-max` and `--retry-multiplier` were missing from the
output of `sensu-agent start --help`. This change adds them, along with a short
description.

## Why is this change necessary?

Closes #4406.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual testing to see that the aforementioned flags are now listed along with
their description.

## Is this change a patch?

No.