### PR TITLE
Add deadline to etcd health field resolver

### DIFF
--- a/backend/apid/actions/error.go
+++ b/backend/apid/actions/error.go
@@ -46,6 +46,12 @@ const (
 	// PreconditionFailed is used to indicate that a precondition header (e.g.
 	// If-Match) is not matching the server side state
 	PreconditionFailed
+
+	// The deadline expired before the operation could complete. For operations
+	// that change the state of the system, this error may be returned even if
+	// the operation has completed successfully. For example, a successful
+	// response from a server could have been delayed long
+	DeadlineExceeded
 )
 
 // Default error messages if not message is provided.
@@ -58,6 +64,7 @@ var standardErrorMessages = map[ErrCode]string{
 	Unauthenticated:    "unauthenticated",
 	PaymentRequired:    "license required",
 	PreconditionFailed: "precondition failed",
+	DeadlineExceeded:   "deadline exceeded",
 }
 
 // Error describes an issue that ocurred while performing the action.

--- a/backend/apid/graphql/health.go
+++ b/backend/apid/graphql/health.go
@@ -7,7 +7,6 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
-	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/graphql"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
@@ -27,8 +26,8 @@ type clusterHealthImpl struct {
 
 // Etcd implements response to request for 'etcd' field.
 func (r *clusterHealthImpl) Etcd(p schema.ClusterHealthEtcdFieldResolverParams) (interface{}, error) {
-	timeout := time.Duration(p.Args.Timeout) * time.Millisecond
-	ctx := context.WithValue(p.Context, store.ContextKeyTimeout, timeout)
+	ctx, cancel := context.WithTimeout(p.Context, time.Duration(p.Args.Timeout)*time.Millisecond)
+	defer cancel()
 	resp := r.healthController.GetClusterHealth(ctx)
 	return resp, nil
 }

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -299,3 +299,12 @@ func (m *MockMetricGatherer) Gather() ([]*dto.MetricFamily, error) {
 	args := m.Called()
 	return args.Get(0).([]*dto.MetricFamily), args.Error(1)
 }
+
+type MockEtcdHealthController struct {
+	mock.Mock
+}
+
+func (m *MockEtcdHealthController) GetClusterHealth(ctx context.Context) *corev2.HealthResponse {
+	args := m.Called(ctx)
+	return args.Get(0).(*corev2.HealthResponse)
+}

--- a/backend/apid/graphql/query.go
+++ b/backend/apid/graphql/query.go
@@ -169,8 +169,7 @@ func (r *queryImpl) Versions(p graphql.ResolveParams) (interface{}, error) {
 
 // Health implements response to request for 'health' field.
 func (r *queryImpl) Health(p graphql.ResolveParams) (interface{}, error) {
-	resp := r.svc.HealthController.GetClusterHealth(p.Context)
-	return resp, nil
+	return struct{}{}, nil
 }
 
 // Metrics implements response to request for 'metrics' field.

--- a/backend/apid/graphql/schema/health.gql.go
+++ b/backend/apid/graphql/schema/health.gql.go
@@ -503,7 +503,7 @@ func _ObjectTypeClusterHealthConfigFn() graphql1.ObjectConfig {
 			Args: graphql1.FieldConfigArgument{"timeout": &graphql1.ArgumentConfig{
 				DefaultValue: 2500,
 				Description:  "time (in milliseconds) to wait for response from clusters",
-				Type:         graphql1.NewNonNull(graphql1.Int),
+				Type:         graphql1.Int,
 			}},
 			DeprecationReason: "",
 			Description:       "Returns health of the etcd cluster.",

--- a/backend/apid/graphql/schema/health.graphql
+++ b/backend/apid/graphql/schema/health.graphql
@@ -51,9 +51,8 @@ Describes the health of the Sensu backend and it's components
 """
 type ClusterHealth {
   "Returns health of the etcd cluster."
-  etcd: EtcdClusterHealth
-
-  # The store interface does not currently return an error if one occurs.
-  # "Holds the string representation of any errors encountered while checking the member's health."
-  # etcdErr: String
+  etcd(
+    "time (in milliseconds) to wait for response from clusters"
+    timeout: Int! = 2500
+  ): EtcdClusterHealth
 }

--- a/backend/apid/graphql/schema/health.graphql
+++ b/backend/apid/graphql/schema/health.graphql
@@ -53,6 +53,6 @@ type ClusterHealth {
   "Returns health of the etcd cluster."
   etcd(
     "time (in milliseconds) to wait for response from clusters"
-    timeout: Int! = 2500
+    timeout: Int = 2500
   ): EtcdClusterHealth
 }

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -131,7 +131,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	schema.RegisterHandlerSocket(svc, &handlerSocketImpl{})
 
 	// Register health types
-	schema.RegisterClusterHealth(svc, &clusterHealthImpl{})
+	schema.RegisterClusterHealth(svc, &clusterHealthImpl{healthController: cfg.HealthController})
 	schema.RegisterEtcdAlarmMember(svc, &etcdAlarmMemberImpl{})
 	schema.RegisterEtcdAlarmType(svc)
 	schema.RegisterEtcdClusterHealth(svc, &etcdClusterHealthImpl{})

--- a/backend/apid/routers/graphql.go
+++ b/backend/apid/routers/graphql.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/graphql"
+)
+
+var (
+	graphqlDefaultTimeout = 10 * time.Second
 )
 
 type GraphQLService interface {
@@ -19,6 +25,7 @@ type GraphQLService interface {
 // GraphQLRouter handles requests for /events
 type GraphQLRouter struct {
 	Service GraphQLService
+	Timeout time.Duration
 }
 
 // Mount the GraphQLRouter to a parent Router
@@ -27,8 +34,15 @@ func (r *GraphQLRouter) Mount(parent *mux.Router) {
 }
 
 func (r *GraphQLRouter) query(req *http.Request) (interface{}, error) {
+	timeout := r.Timeout
+	if timeout == 0 {
+		timeout = graphqlDefaultTimeout
+	}
+
 	// Setup context
 	ctx := context.WithValue(req.Context(), corev2.NamespaceKey, "")
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	// Parse request body
 	var reqBody interface{}
@@ -57,6 +71,7 @@ func (r *GraphQLRouter) query(req *http.Request) (interface{}, error) {
 
 	// Execute each operation; maybe this could be done in parallel in the future.
 	results := make([]interface{}, 0, len(ops))
+	var timedOut bool
 	for _, op := range ops {
 		// Extract query and variables
 		query, _ := op["query"].(string)
@@ -74,13 +89,25 @@ func (r *GraphQLRouter) query(req *http.Request) (interface{}, error) {
 			"errors": result.Errors,
 			"auth":   claims != nil,
 		})
-		if len(result.Errors) > 0 {
+		if result.HasErrors() {
 			logger.
 				WithField("errors", result.Errors).
 				Error("error(s) occurred while executing GraphQL operation")
+
+			// When the default graphql-go execuctor encounters an exceeded
+			// deadline it will wrap the error. Since client's typically
+			// consider service errors as equivelant to an unrecoverable server
+			// error we instead capture the error and respond with a 504 status.
+			if err := result.Errors[0]; err.Message == context.DeadlineExceeded.Error() {
+				timedOut = true
+				break
+			}
 		}
 	}
 
+	if timedOut {
+		return results, actions.NewErrorf(actions.DeadlineExceeded)
+	}
 	if receivedList {
 		return results, nil
 	}

--- a/backend/apid/routers/routers.go
+++ b/backend/apid/routers/routers.go
@@ -117,6 +117,8 @@ func HTTPStatusFromCode(code actions.ErrCode) int {
 		return http.StatusUnauthorized
 	case actions.PreconditionFailed:
 		return http.StatusPreconditionFailed
+	case actions.DeadlineExceeded:
+		return http.StatusGatewayTimeout
 	}
 
 	logger.WithField("code", code).Error("unknown error code")


### PR DESCRIPTION


Closes https://github.com/sensu/sensu-enterprise-go/issues/1781

---

* Previously no deadline was provided when querying etcd health from the GraphQL service,
  this meant that in cases where the health was irretrievable the http server's writetimeout would
  trigger before the query completed. In the web client this led to the offline banner being
  displayed briefly and the health dialog being stuck in an infinite loading state.
* I've also updated the GraphQL endpoint with a deadline and now respond with a 504 if the service
  takes too long to finish resolving the query. This change should make it easier to capture, and possibly
  retry the request later.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>