### PR TITLE
Fix missing env vars in env and command exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ every 60s, and written to /var/lib/sensu/sensu-backend/stats.log.
 - Open-sourced the previously enterprise-only event logger. The event logger
 can be used to send the events a backend processes to a rotatable log file.
 
+### Fixed
+- `sensuctl env` now properly displays the `SENSU_API_KEY` and `SENSU_TIMEOUT`
+environment variables.
+- `sensuctl command exec` now properly adds the `SENSU_API_KEY` and
+`SENSU_TIMEOUT` variables to the command's environment.
+
 ### Changed
 - Upgraded Go version from 1.16.5 to 1.17.1.
 

--- a/cli/commands/command/exec.go
+++ b/cli/commands/command/exec.go
@@ -50,11 +50,13 @@ func execCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []strin
 			fmt.Sprintf("SENSU_API_URL=%s", cli.Config.APIUrl()),
 			fmt.Sprintf("SENSU_NAMESPACE=%s", cli.Config.Namespace()),
 			fmt.Sprintf("SENSU_FORMAT=%s", cli.Config.Format()),
+			fmt.Sprintf("SENSU_API_KEY=%s", cli.Config.APIKey()),
 			fmt.Sprintf("SENSU_ACCESS_TOKEN=%s", cli.Config.Tokens().Access),
 			fmt.Sprintf("SENSU_ACCESS_TOKEN_EXPIRES_AT=%d", cli.Config.Tokens().ExpiresAt),
 			fmt.Sprintf("SENSU_REFRESH_TOKEN=%s", cli.Config.Tokens().Refresh),
 			fmt.Sprintf("SENSU_TRUSTED_CA_FILE=%s", cli.Config.TrustedCAFile()),
 			fmt.Sprintf("SENSU_INSECURE_SKIP_TLS_VERIFY=%s", strconv.FormatBool(cli.Config.InsecureSkipTLSVerify())),
+			fmt.Sprintf("SENSU_TIMEOUT=%s", cli.Config.Timeout().String()),
 		}
 
 		ctx := context.TODO()

--- a/cli/commands/env/env.go
+++ b/cli/commands/env/env.go
@@ -17,11 +17,13 @@ const (
 	envTmpl = `{{ .Prefix }}SENSU_API_URL{{ .Delimiter }}{{ .APIURL }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_NAMESPACE{{ .Delimiter }}{{ .Namespace }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_FORMAT{{ .Delimiter }}{{ .Format }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_API_KEY{{ .Delimiter }}{{ .APIKey }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_ACCESS_TOKEN{{ .Delimiter }}{{ .AccessToken }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_ACCESS_TOKEN_EXPIRES_AT{{ .Delimiter }}{{ .AccessTokenExpiresAt }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_REFRESH_TOKEN{{ .Delimiter }}{{ .RefreshToken }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_TRUSTED_CA_FILE{{ .Delimiter }}{{ .TrustedCAFile }}{{ .LineEnding }}` +
 		`{{ .Prefix }}SENSU_INSECURE_SKIP_TLS_VERIFY{{ .Delimiter }}{{ .InsecureSkipTLSVerify }}{{ .LineEnding }}` +
+		`{{ .Prefix }}SENSU_TIMEOUT{{ .Delimiter }}{{ .Timeout }}{{ .LineEnding }}` +
 		`{{ .UsageHint }}`
 
 	shellFlag = "shell"
@@ -56,11 +58,13 @@ type shellConfig struct {
 	APIURL                string
 	Namespace             string
 	Format                string
+	APIKey                string
 	AccessToken           string
 	AccessTokenExpiresAt  int64
 	RefreshToken          string
 	TrustedCAFile         string
 	InsecureSkipTLSVerify string
+	Timeout               string
 }
 
 func (s shellConfig) UsageHint() string {
@@ -89,11 +93,13 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			APIURL:                cli.Config.APIUrl(),
 			Namespace:             cli.Config.Namespace(),
 			Format:                cli.Config.Format(),
+			APIKey:                cli.Config.APIKey(),
 			AccessToken:           cli.Config.Tokens().Access,
 			AccessTokenExpiresAt:  cli.Config.Tokens().ExpiresAt,
 			RefreshToken:          cli.Config.Tokens().Refresh,
 			TrustedCAFile:         cli.Config.TrustedCAFile(),
 			InsecureSkipTLSVerify: strconv.FormatBool(cli.Config.InsecureSkipTLSVerify()),
+			Timeout:               cli.Config.Timeout().String(),
 		}
 
 		// Get the user shell

--- a/cli/commands/env/env_test.go
+++ b/cli/commands/env/env_test.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"testing"
+	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	mockclient "github.com/sensu/sensu-go/cli/client/testing"
@@ -17,9 +18,10 @@ func testSetupMocks(t *testing.T, config *mockclient.MockConfig) {
 	config.On("Tokens").Return(
 		corev2.FixtureTokens("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjIxODkzMTcsImp0aSI6IjAwZDFlYTE2OGU1MTQ1ZGEzN2U2Njg0YmRlOTgwNDM4Iiwic3ViIjoiYWRtaW4iLCJncm91cHMiOlsiY2x1c3Rlci1hZG1pbnMiLCJzeXN0ZW06dXNlcnMiXSwicHJvdmlkZXIiOnsicHJvdmlkZXJfaWQiOiJiYXNpYyIsInVzZXJfaWQiOiJhZG1pbiJ9fQ.ksuMGCJtkN5724CQ7e2W1P7T2ZPpR8IxU3fH9WhBMLk", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0MGVhYTRiMzRkMzU4YTkzNTY5YzIzZWM1YjcxNmZiMiIsInN1YiI6ImFkbWluIiwiZ3JvdXBzIjpudWxsLCJwcm92aWRlciI6eyJwcm92aWRlcl9pZCI6IiIsInVzZXJfaWQiOiIifX0.7t0qoBvKEkHD1DJbhP-VfSj95yhsFyrPoeFhqEbKOn8"),
 	)
-	config.On("APIKey").Return("")
+	config.On("APIKey").Return("some-api-key")
 	config.On("TrustedCAFile").Return("")
 	config.On("InsecureSkipTLSVerify").Return(false)
+	config.On("Timeout").Return(time.Duration(42) * time.Second)
 }
 
 func TestEnvCommandBash(t *testing.T) {
@@ -29,8 +31,10 @@ func TestEnvCommandBash(t *testing.T) {
 	cmd := Command(cli)
 	_ = cmd.Flags().Set("shell", "bash")
 	out, err := test.RunCmd(cmd, nil)
-	assert.Regexp(t, `export SENSU_API_URL="http://127.0.0.1:8080"`, out)
 	assert.NoError(t, err)
+	assert.Regexp(t, `export SENSU_API_URL="http://127.0.0.1:8080"`, out)
+	assert.Regexp(t, `export SENSU_API_KEY="some-api-key"`, out)
+	assert.Regexp(t, `export SENSU_TIMEOUT="42s"`, out)
 }
 
 func TestEnvCommandCmd(t *testing.T) {
@@ -40,8 +44,10 @@ func TestEnvCommandCmd(t *testing.T) {
 	cmd := Command(cli)
 	_ = cmd.Flags().Set("shell", "cmd")
 	out, err := test.RunCmd(cmd, nil)
-	assert.Regexp(t, `SET SENSU_API_URL=http://127.0.0.1:8080`, out)
 	assert.NoError(t, err)
+	assert.Regexp(t, `SET SENSU_API_URL=http://127.0.0.1:8080`, out)
+	assert.Regexp(t, `SET SENSU_API_KEY=some-api-key`, out)
+	assert.Regexp(t, `SET SENSU_TIMEOUT=42s`, out)
 }
 
 func TestEnvCommandPowershell(t *testing.T) {
@@ -51,6 +57,8 @@ func TestEnvCommandPowershell(t *testing.T) {
 	cmd := Command(cli)
 	_ = cmd.Flags().Set("shell", "powershell")
 	out, err := test.RunCmd(cmd, nil)
-	assert.Regexp(t, `\$Env:SENSU_API_URL = "http://127.0.0.1:8080"`, out)
 	assert.NoError(t, err)
+	assert.Regexp(t, `\$Env:SENSU_API_URL = "http://127.0.0.1:8080"`, out)
+	assert.Regexp(t, `\$Env:SENSU_API_KEY = "some-api-key"`, out)
+	assert.Regexp(t, `\$Env:SENSU_TIMEOUT = "42s"`, out)
 }


### PR DESCRIPTION
## What is this change?

- Make `sensuctl env` include `SENSU_API_KEY` and `SENSU_TIMEOUT` in its output
- Make `sensuctl command exec` include `SENSU_API_KEY` and `SENSU_TIMEOUT` in the executed command's environment

## Why is this change necessary?

Fixes #4411.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

@hillaryfraley 
Are there example outputs that we need to update in the docs for `sensuctl env` maybe?

## How did you verify this change?

Updated existing unit tests and manual testing.

## Is this change a patch?

No.
