### PR TITLE
Add sensuctl pipeline commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ with the --disable-platform-metrics flag. By default the log is appended to
 every 60s, and written to /var/lib/sensu/sensu-backend/stats.log.
 - Open-sourced the previously enterprise-only event logger. The event logger
 can be used to send the events a backend processes to a rotatable log file.
+- Added sensuctl commands for pipeline list, info, and delete.
 
 ### Fixed
 - `sensuctl env` now properly displays the `SENSU_API_KEY` and `SENSU_TIMEOUT`

--- a/backend/pipeline/adapter.go
+++ b/backend/pipeline/adapter.go
@@ -13,3 +13,10 @@ type Adapter interface {
 	CanRun(*corev2.ResourceReference) bool
 	Run(context.Context, *corev2.ResourceReference, interface{}) error
 }
+
+// ErrNoWorkflows is returned when a pipeline has no workflows
+type ErrNoWorkflows struct{}
+
+func (e *ErrNoWorkflows) Error() string {
+	return "pipeline has no workflows"
+}

--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -67,7 +67,7 @@ func (a *AdapterV1) Run(ctx context.Context, ref *corev2.ResourceReference, reso
 	ctx = context.WithValue(ctx, corev2.PipelineKey, pipeline.Name)
 
 	if len(pipeline.Workflows) < 1 {
-		return errors.New("pipeline has no workflows")
+		return &ErrNoWorkflows{}
 	}
 
 	for _, workflow := range pipeline.Workflows {

--- a/backend/pipelined/pipelined.go
+++ b/backend/pipelined/pipelined.go
@@ -208,7 +208,13 @@ func (p *Pipelined) handleMessage(ctx context.Context, msg interface{}) error {
 					if _, ok := err.(*store.ErrInternal); ok {
 						return err
 					}
-					logger.WithFields(fields).Errorf("%s, skipping execution of pipeline", err.Error())
+					skipPipelineErr := fmt.Errorf("%w, skipping execution of pipeline", err)
+					if _, ok := err.(*pipeline.ErrNoWorkflows); ok {
+						logger.WithFields(fields).Warn(skipPipelineErr)
+					} else {
+						logger.WithFields(fields).Error(skipPipelineErr)
+					}
+
 				}
 				adapterFound = true
 			}

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -40,6 +40,7 @@ type APIClient interface {
 	HookAPIClient
 	MutatorAPIClient
 	NamespaceAPIClient
+	PipelineAPIClient
 	RoleAPIClient
 	RoleBindingAPIClient
 	UserAPIClient
@@ -176,6 +177,12 @@ type NamespaceAPIClient interface {
 	UpdateNamespace(*corev2.Namespace) error
 	DeleteNamespace(string) error
 	FetchNamespace(string) (*corev2.Namespace, error)
+}
+
+// PipelineAPIClient client methods for pipelines
+type PipelineAPIClient interface {
+	DeletePipeline(string, string) error
+	FetchPipeline(string) (*corev2.Pipeline, error)
 }
 
 // UserAPIClient client methods for users

--- a/cli/client/pipeline.go
+++ b/cli/client/pipeline.go
@@ -51,3 +51,23 @@ func (client *RestClient) UpdatePipeline(pipeline *corev2.Pipeline) error {
 
 	return nil
 }
+
+// CreatePipeline creates a new pipeline
+func (client *RestClient) CreatePipeline(pipeline *corev2.Pipeline) (err error) {
+	bytes, err := json.Marshal(pipeline)
+	if err != nil {
+		return err
+	}
+
+	path := EntitiesPath(pipeline.Namespace)
+	res, err := client.R().SetBody(bytes).Post(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}

--- a/cli/client/pipeline.go
+++ b/cli/client/pipeline.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"encoding/json"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// PipelinesPath is the api path for pipelines.
+var PipelinesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "pipelines")
+
+// FetchPipeline fetches a specific pipeline
+func (client *RestClient) FetchPipeline(name string) (*corev2.Pipeline, error) {
+	var pipeline *corev2.Pipeline
+
+	path := PipelinesPath(client.config.Namespace(), name)
+	res, err := client.R().Get(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode() >= 400 {
+		return nil, UnmarshalError(res)
+	}
+
+	err = json.Unmarshal(res.Body(), &pipeline)
+	return pipeline, err
+}
+
+// DeletePipeline deletes a pipeline.
+func (client *RestClient) DeletePipeline(namespace, name string) error {
+	return client.Delete(PipelinesPath(namespace, name))
+}
+
+// UpdatePipeline updates a pipeline.
+func (client *RestClient) UpdatePipeline(pipeline *corev2.Pipeline) error {
+	bytes, err := json.Marshal(pipeline)
+	if err != nil {
+		return err
+	}
+
+	path := PipelinesPath(pipeline.GetNamespace(), pipeline.GetName())
+	res, err := client.R().SetBody(bytes).Put(path)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode() >= 400 {
+		return UnmarshalError(res)
+	}
+
+	return nil
+}

--- a/cli/client/testing/mock_pipeline_client.go
+++ b/cli/client/testing/mock_pipeline_client.go
@@ -1,0 +1,29 @@
+package testing
+
+import (
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// FetchPipeline for use with mock lib
+func (c *MockClient) FetchPipeline(name string) (*corev2.Pipeline, error) {
+	args := c.Called(name)
+	return args.Get(0).(*corev2.Pipeline), args.Error(1)
+}
+
+// DeletePipeline for use with mock lib
+func (c *MockClient) DeletePipeline(namespace, name string) error {
+	args := c.Called(namespace, name)
+	return args.Error(0)
+}
+
+// UpdatePipeline for use with mock lib
+func (c *MockClient) UpdatePipeline(pipeline *corev2.Pipeline) error {
+	args := c.Called(pipeline)
+	return args.Error(0)
+}
+
+// CreatePipeline for use with mock lib
+func (c *MockClient) CreatePipeline(pipeline *corev2.Pipeline) error {
+	args := c.Called(pipeline)
+	return args.Error(0)
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sensu/sensu-go/cli/commands/logout"
 	"github.com/sensu/sensu-go/cli/commands/mutator"
 	"github.com/sensu/sensu-go/cli/commands/namespace"
+	"github.com/sensu/sensu-go/cli/commands/pipeline"
 	"github.com/sensu/sensu-go/cli/commands/role"
 	"github.com/sensu/sensu-go/cli/commands/rolebinding"
 	"github.com/sensu/sensu-go/cli/commands/silenced"
@@ -51,6 +52,7 @@ func AddCommands(rootCmd *cobra.Command, cli *cli.SensuCli) {
 		clusterrolebinding.HelpCommand(cli),
 		entity.HelpCommand(cli),
 		event.HelpCommand(cli),
+		pipeline.HelpCommand(cli),
 		filter.HelpCommand(cli),
 		handler.HelpCommand(cli),
 		hook.HelpCommand(cli),

--- a/cli/commands/pipeline/LICENSE
+++ b/cli/commands/pipeline/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Sensu Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cli/commands/pipeline/delete.go
+++ b/cli/commands/pipeline/delete.go
@@ -26,7 +26,7 @@ func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
 			namespace := cli.Config.Namespace()
 
 			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
-				if confirmed := helpers.ConfirmDeleteResource(fmt.Sprintf("%s", pipeline), "pipeline"); !confirmed {
+				if confirmed := helpers.ConfirmDeleteResource(pipeline, "pipeline"); !confirmed {
 					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
 					return nil
 				}

--- a/cli/commands/pipeline/delete.go
+++ b/cli/commands/pipeline/delete.go
@@ -1,0 +1,48 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCommand deletes a pipeline
+func DeleteCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete [PIPELINE]",
+		Short:        "delete pipelines",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			// Delete pipeline via API
+			pipeline := args[0]
+			namespace := cli.Config.Namespace()
+
+			if skipConfirm, _ := cmd.Flags().GetBool("skip-confirm"); !skipConfirm {
+				if confirmed := helpers.ConfirmDeleteResource(fmt.Sprintf("%s", pipeline), "pipeline"); !confirmed {
+					fmt.Fprintln(cmd.OutOrStdout(), "Canceled")
+					return nil
+				}
+			}
+
+			err := cli.Client.DeletePipeline(namespace, pipeline)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), "Deleted")
+			return err
+		},
+	}
+
+	_ = cmd.Flags().Bool("skip-confirm", false, "skip interactive confirmation prompt")
+
+	return cmd
+}

--- a/cli/commands/pipeline/delete_test.go
+++ b/cli/commands/pipeline/delete_test.go
@@ -1,0 +1,73 @@
+package pipeline
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCommand(t *testing.T) {
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+
+	assert.NotNil(t, cmd, "cmd should be returned")
+	assert.NotNil(t, cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp(t, "delete", cmd.Use)
+	assert.Regexp(t, "pipeline", cmd.Short)
+}
+
+func TestDeleteCommandRunEClosure(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Client.(*client.MockClient).
+		On("DeletePipeline", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "Deleted")
+	assert.Nil(t, err)
+}
+
+func TestDeleteCommandRunMissingArgs(t *testing.T) {
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	require.Error(t, err)
+	assert.Contains(t, out, "Usage")
+}
+
+func TestDeleteCommandRunEClosureWithErr(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Client.(*client.MockClient).
+		On("DeletePipeline", mock.Anything, mock.Anything, mock.Anything).
+		Return(fmt.Errorf("error"))
+
+	cmd := DeleteCommand(cli)
+	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "error", err.Error())
+	assert.Empty(t, out)
+}
+
+func TestDeleteCommandRunEFailConfirm(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	cmd := DeleteCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+
+	assert.Contains(out, "Canceled")
+	assert.NoError(err)
+}

--- a/cli/commands/pipeline/delete_test.go
+++ b/cli/commands/pipeline/delete_test.go
@@ -29,7 +29,7 @@ func TestDeleteCommandRunEClosure(t *testing.T) {
 
 	cmd := DeleteCommand(cli)
 	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 
 	assert.NotEmpty(t, out)
 	assert.Contains(t, out, "Deleted")
@@ -54,7 +54,7 @@ func TestDeleteCommandRunEClosureWithErr(t *testing.T) {
 
 	cmd := DeleteCommand(cli)
 	require.NoError(t, cmd.Flags().Set("skip-confirm", "t"))
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "error", err.Error())
@@ -66,7 +66,7 @@ func TestDeleteCommandRunEFailConfirm(t *testing.T) {
 
 	cli := test.NewMockCLI()
 	cmd := DeleteCommand(cli)
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 
 	assert.Contains(out, "Canceled")
 	assert.NoError(err)

--- a/cli/commands/pipeline/help.go
+++ b/cli/commands/pipeline/help.go
@@ -1,0 +1,23 @@
+package pipeline
+
+import (
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/spf13/cobra"
+)
+
+// HelpCommand defines new pipeline command
+func HelpCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pipeline",
+		Short: "Manage pipelines",
+		RunE:  helpers.DefaultSubCommandRunE,
+	}
+
+	// Add sub-commands
+	cmd.AddCommand(ListCommand(cli))
+	cmd.AddCommand(InfoCommand(cli))
+	cmd.AddCommand(DeleteCommand(cli))
+
+	return cmd
+}

--- a/cli/commands/pipeline/info.go
+++ b/cli/commands/pipeline/info.go
@@ -1,0 +1,95 @@
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/list"
+	"github.com/spf13/cobra"
+)
+
+// InfoCommand defines new pipeline info command
+func InfoCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info [PIPELINE]",
+		Short:        "show detailed pipeline information",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+
+			// Fetch pipeline from API
+			name := args[0]
+			pipeline, err := cli.Client.FetchPipeline(name)
+			if err != nil {
+				return err
+			}
+
+			// Determine the format to use to output the data
+			flag := helpers.GetChangedStringValueViper("format", cmd.Flags())
+			format := cli.Config.Format()
+			return helpers.PrintFormatted(flag, format, pipeline, cmd.OutOrStdout(), printToList)
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+
+	return cmd
+}
+
+func printToList(v interface{}, writer io.Writer) error {
+	pipeline, ok := v.(*corev2.Pipeline)
+	if !ok {
+		return fmt.Errorf("%t is not a Pipeline", v)
+	}
+
+	cfg := &list.Config{
+		Title: pipeline.GetName(),
+		Rows: []*list.Row{
+			{
+				Label: "Name",
+				Value: pipeline.GetName(),
+			},
+			{
+				Label: "Workflows",
+				Value: "",
+			},
+		},
+	}
+
+	for _, workflow := range pipeline.GetWorkflows() {
+		cfg.Rows = append(cfg.Rows, &list.Row{
+			Label: fmt.Sprintf("  %s", workflow.GetName()),
+			Value: "",
+		})
+
+		for _, filter := range workflow.Filters {
+			cfg.Rows = append(cfg.Rows, &list.Row{
+				Label: "    Filter",
+				Value: filter.ResourceID(),
+			})
+		}
+
+		mutator := ""
+		if workflow.Mutator != nil {
+			mutator = workflow.Mutator.ResourceID()
+		}
+		cfg.Rows = append(cfg.Rows, &list.Row{
+			Label: "    Mutator",
+			Value: mutator,
+		})
+
+		cfg.Rows = append(cfg.Rows, &list.Row{
+			Label: "    Handler",
+			Value: workflow.Handler.ResourceID(),
+		})
+	}
+
+	return list.Print(writer, cfg)
+}

--- a/cli/commands/pipeline/info_test.go
+++ b/cli/commands/pipeline/info_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	client "github.com/sensu/sensu-go/cli/client/testing"
 	test "github.com/sensu/sensu-go/cli/commands/testing"
-	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,21 +19,21 @@ func TestInfoCommand(t *testing.T) {
 	assert.NotNil(t, cmd, "cmd should be returned")
 	assert.NotNil(t, cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp(t, "info", cmd.Use)
-	assert.Regexp(t, "event", cmd.Short)
+	assert.Regexp(t, "pipeline", cmd.Short)
 }
 
 func TestInfoCommandRunEClosure(t *testing.T) {
 	cli := test.NewMockCLI()
 	cli.Client.(*client.MockClient).
-		On("FetchEvent", "foo", "check_foo").
-		Return(types.FixtureEvent("foo", "check_foo"), nil)
+		On("FetchPipeline", "foo").
+		Return(corev2.FixturePipeline("foo", "default"), nil)
 	cli.Config.(*client.MockConfig).On("Format").Return("json")
 
 	cmd := InfoCommand(cli)
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 
 	assert.NotEmpty(t, out)
-	assert.Contains(t, out, "check_foo")
+	assert.Contains(t, out, "foo")
 	assert.Nil(t, err)
 }
 
@@ -50,29 +50,29 @@ func TestInfoCommandRunMissingArgs(t *testing.T) {
 func TestInfoCommandRunEClosureWithTable(t *testing.T) {
 	cli := test.NewMockCLI()
 	cli.Client.(*client.MockClient).
-		On("FetchEvent", "foo", "check_foo").
-		Return(types.FixtureEvent("foo", "check_foo"), nil)
+		On("FetchPipeline", "foo").
+		Return(corev2.FixturePipeline("foo", "default"), nil)
 	cli.Config.(*client.MockConfig).On("Format").Return("tabular")
 
 	cmd := InfoCommand(cli)
 	require.NoError(t, cmd.Flags().Set("format", "tabular"))
 
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, out)
-	assert.Contains(t, out, "Entity")
-	assert.Contains(t, out, "Check")
+	assert.Contains(t, out, "Name")
+	assert.Contains(t, out, "Workflows")
 }
 
 func TestInfoCommandRunEClosureWithErr(t *testing.T) {
 	cli := test.NewMockCLI()
 	cli.Client.(*client.MockClient).
-		On("FetchEvent", "foo", "check_foo").
-		Return(types.FixtureEvent("foo", "check_foo"), fmt.Errorf("error"))
+		On("FetchPipeline", "foo").
+		Return(corev2.FixturePipeline("foo", "default"), fmt.Errorf("error"))
 	cli.Config.(*client.MockConfig).On("Format").Return("json")
 
 	cmd := InfoCommand(cli)
-	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	out, err := test.RunCmd(cmd, []string{"foo"})
 
 	assert.NotNil(t, err)
 	assert.Equal(t, "error", err.Error())

--- a/cli/commands/pipeline/info_test.go
+++ b/cli/commands/pipeline/info_test.go
@@ -1,0 +1,80 @@
+package pipeline
+
+import (
+	"fmt"
+	"testing"
+
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoCommand(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+	cmd := InfoCommand(cli)
+
+	assert.NotNil(t, cmd, "cmd should be returned")
+	assert.NotNil(t, cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp(t, "info", cmd.Use)
+	assert.Regexp(t, "event", cmd.Short)
+}
+
+func TestInfoCommandRunEClosure(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Client.(*client.MockClient).
+		On("FetchEvent", "foo", "check_foo").
+		Return(types.FixtureEvent("foo", "check_foo"), nil)
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "check_foo")
+	assert.Nil(t, err)
+}
+
+func TestInfoCommandRunMissingArgs(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+	require.Error(t, err)
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "Usage")
+}
+
+func TestInfoCommandRunEClosureWithTable(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Client.(*client.MockClient).
+		On("FetchEvent", "foo", "check_foo").
+		Return(types.FixtureEvent("foo", "check_foo"), nil)
+	cli.Config.(*client.MockConfig).On("Format").Return("tabular")
+
+	cmd := InfoCommand(cli)
+	require.NoError(t, cmd.Flags().Set("format", "tabular"))
+
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "Entity")
+	assert.Contains(t, out, "Check")
+}
+
+func TestInfoCommandRunEClosureWithErr(t *testing.T) {
+	cli := test.NewMockCLI()
+	cli.Client.(*client.MockClient).
+		On("FetchEvent", "foo", "check_foo").
+		Return(types.FixtureEvent("foo", "check_foo"), fmt.Errorf("error"))
+	cli.Config.(*client.MockConfig).On("Format").Return("json")
+
+	cmd := InfoCommand(cli)
+	out, err := test.RunCmd(cmd, []string{"foo", "check_foo"})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "error", err.Error())
+	assert.Empty(t, out)
+}

--- a/cli/commands/pipeline/list.go
+++ b/cli/commands/pipeline/list.go
@@ -1,0 +1,96 @@
+package pipeline
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/client"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	"github.com/sensu/sensu-go/cli/elements/table"
+
+	"github.com/spf13/cobra"
+)
+
+// ListCommand defines new list pipelines command
+func ListCommand(cli *cli.SensuCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "list pipelines",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				_ = cmd.Help()
+				return errors.New("invalid argument(s) received")
+			}
+			namespace := cli.Config.Namespace()
+			if ok, _ := cmd.Flags().GetBool(flags.AllNamespaces); ok {
+				namespace = corev2.NamespaceTypeAll
+			}
+
+			opts, err := helpers.ListOptionsFromFlags(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			// Fetch pipelines from API
+			var header http.Header
+			results := []corev2.Pipeline{}
+			err = cli.Client.List(client.PipelinesPath(namespace), &results, &opts, &header)
+			if err != nil {
+				return err
+			}
+
+			// Print the results based on the user preferences
+			resources := []corev2.Resource{}
+			for i := range results {
+				resources = append(resources, &results[i])
+			}
+			return helpers.PrintList(cmd, cli.Config.Format(), printToTable, resources, results, header)
+		},
+	}
+
+	helpers.AddFormatFlag(cmd.Flags())
+	helpers.AddAllNamespace(cmd.Flags())
+	helpers.AddFieldSelectorFlag(cmd.Flags())
+	helpers.AddLabelSelectorFlag(cmd.Flags())
+	helpers.AddChunkSizeFlag(cmd.Flags())
+
+	return cmd
+}
+
+func printToTable(results interface{}, writer io.Writer) {
+	table := table.New([]*table.Column{
+		{
+			Title:       "Name",
+			ColumnStyle: table.PrimaryTextStyle,
+			CellTransformer: func(data interface{}) string {
+				pipeline, ok := data.(corev2.Pipeline)
+				if !ok {
+					return cli.TypeError
+				}
+				return pipeline.GetName()
+			},
+		},
+		{
+			Title: "Workflows",
+			CellTransformer: func(data interface{}) string {
+				pipeline, ok := data.(corev2.Pipeline)
+				if !ok {
+					return cli.TypeError
+				}
+				workflows := []string{}
+				for _, workflow := range pipeline.Workflows {
+					workflows = append(workflows, workflow.Name)
+				}
+				return strings.Join(workflows, ",")
+			},
+		},
+	})
+
+	table.Render(writer, results)
+}

--- a/cli/commands/pipeline/list_test.go
+++ b/cli/commands/pipeline/list_test.go
@@ -25,20 +25,20 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(cmd, "cmd should be returned")
 	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
 	assert.Regexp("list", cmd.Use)
-	assert.Regexp("events", cmd.Short)
+	assert.Regexp("pipelines", cmd.Short)
 }
 
 func TestListCommandRunEClosure(t *testing.T) {
 	assert := assert.New(t)
 	cli := newConfiguredCLI()
 	client := cli.Client.(*client.MockClient)
-	resources := []corev2.Event{}
+	resources := []corev2.Pipeline{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
 		func(args mock.Arguments) {
-			resources := args[1].(*[]corev2.Event)
-			*resources = []corev2.Event{
-				*corev2.FixtureEvent("1", "something"),
-				*corev2.FixtureEvent("2", "funny"),
+			resources := args[1].(*[]corev2.Pipeline)
+			*resources = []corev2.Pipeline{
+				*corev2.FixturePipeline("1", "something"),
+				*corev2.FixturePipeline("2", "funny"),
 			}
 		},
 	)
@@ -58,12 +58,12 @@ func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
 	assert := assert.New(t)
 	cli := newConfiguredCLI()
 	client := cli.Client.(*client.MockClient)
-	resources := []corev2.Event{}
+	resources := []corev2.Pipeline{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
 		func(args mock.Arguments) {
-			resources := args[1].(*[]corev2.Event)
-			*resources = []corev2.Event{
-				*corev2.FixtureEvent("1", "something"),
+			resources := args[1].(*[]corev2.Pipeline)
+			*resources = []corev2.Pipeline{
+				*corev2.FixturePipeline("1", "something"),
 			}
 		},
 	)
@@ -81,13 +81,13 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	assert := assert.New(t)
 	cli := newConfiguredCLI()
 	client := cli.Client.(*client.MockClient)
-	resources := []corev2.Event{}
+	resources := []corev2.Pipeline{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
 		func(args mock.Arguments) {
-			resources := args[1].(*[]corev2.Event)
-			*resources = []corev2.Event{
-				*corev2.FixtureEvent("1", "something"),
-				*corev2.FixtureEvent("2", "funny"),
+			resources := args[1].(*[]corev2.Pipeline)
+			*resources = []corev2.Pipeline{
+				*corev2.FixturePipeline("foo", "default"),
+				*corev2.FixturePipeline("bar", "default"),
 			}
 		},
 	)
@@ -97,12 +97,10 @@ func TestListCommandRunEClosureWithTable(t *testing.T) {
 	out, err := test.RunCmd(cmd, []string{})
 
 	assert.NotEmpty(out)
-	assert.Contains(out, "Entity")    // Heading
-	assert.Contains(out, "Check")     // Heading
-	assert.Contains(out, "Output")    // Heading
-	assert.Contains(out, "Timestamp") // Heading
-	assert.Contains(out, "something")
-	assert.Contains(out, "funny")
+	assert.Contains(out, "Name")      // Heading
+	assert.Contains(out, "Workflows") // Heading
+	assert.Contains(out, "foo")
+	assert.Contains(out, "bar")
 	assert.Nil(err)
 }
 
@@ -110,7 +108,7 @@ func TestListCommandRunEClosureWithErr(t *testing.T) {
 	assert := assert.New(t)
 	cli := newConfiguredCLI()
 	client := cli.Client.(*client.MockClient)
-	resources := []corev2.Event{}
+	resources := []corev2.Pipeline{}
 	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("fun-msg"))
 
 	cmd := ListCommand(cli)
@@ -150,11 +148,11 @@ func TestListCommandRunEClosureWithHeader(t *testing.T) {
 
 	client := cli.Client.(*client.MockClient)
 	var header http.Header
-	resources := []corev2.Event{}
+	resources := []corev2.Pipeline{}
 	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
 		func(args mock.Arguments) {
-			resources := args[1].(*[]corev2.Event)
-			*resources = []corev2.Event{}
+			resources := args[1].(*[]corev2.Pipeline)
+			*resources = []corev2.Pipeline{}
 			header := args[3].(*http.Header)
 			*header = make(http.Header)
 			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")

--- a/cli/commands/pipeline/list_test.go
+++ b/cli/commands/pipeline/list_test.go
@@ -1,0 +1,171 @@
+package pipeline
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/cli"
+	client "github.com/sensu/sensu-go/cli/client/testing"
+	"github.com/sensu/sensu-go/cli/commands/flags"
+	"github.com/sensu/sensu-go/cli/commands/helpers"
+	test "github.com/sensu/sensu-go/cli/commands/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListCommand(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newConfiguredCLI()
+	cmd := ListCommand(cli)
+
+	assert.NotNil(cmd, "cmd should be returned")
+	assert.NotNil(cmd.RunE, "cmd should be able to be executed")
+	assert.Regexp("list", cmd.Use)
+	assert.Regexp("events", cmd.Short)
+}
+
+func TestListCommandRunEClosure(t *testing.T) {
+	assert := assert.New(t)
+	cli := newConfiguredCLI()
+	client := cli.Client.(*client.MockClient)
+	resources := []corev2.Event{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Event)
+			*resources = []corev2.Event{
+				*corev2.FixtureEvent("1", "something"),
+				*corev2.FixtureEvent("2", "funny"),
+			}
+		},
+	)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "something")
+	assert.Contains(out, "funny")
+	assert.Nil(err)
+	assert.NotContains(out, "==")
+}
+
+func TestListCommandRunEClosureWithAllNamespaces(t *testing.T) {
+	assert := assert.New(t)
+	cli := newConfiguredCLI()
+	client := cli.Client.(*client.MockClient)
+	resources := []corev2.Event{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Event)
+			*resources = []corev2.Event{
+				*corev2.FixtureEvent("1", "something"),
+			}
+		},
+	)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set(flags.Format, "json"))
+	require.NoError(t, cmd.Flags().Set(flags.AllNamespaces, "t"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+}
+
+func TestListCommandRunEClosureWithTable(t *testing.T) {
+	assert := assert.New(t)
+	cli := newConfiguredCLI()
+	client := cli.Client.(*client.MockClient)
+	resources := []corev2.Event{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Event)
+			*resources = []corev2.Event{
+				*corev2.FixtureEvent("1", "something"),
+				*corev2.FixtureEvent("2", "funny"),
+			}
+		},
+	)
+
+	cmd := ListCommand(cli)
+	require.NoError(t, cmd.Flags().Set(flags.Format, "none"))
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Contains(out, "Entity")    // Heading
+	assert.Contains(out, "Check")     // Heading
+	assert.Contains(out, "Output")    // Heading
+	assert.Contains(out, "Timestamp") // Heading
+	assert.Contains(out, "something")
+	assert.Contains(out, "funny")
+	assert.Nil(err)
+}
+
+func TestListCommandRunEClosureWithErr(t *testing.T) {
+	assert := assert.New(t)
+	cli := newConfiguredCLI()
+	client := cli.Client.(*client.MockClient)
+	resources := []corev2.Event{}
+	client.On("List", mock.Anything, &resources, mock.Anything, mock.Anything).Return(errors.New("fun-msg"))
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.Empty(out)
+	assert.NotNil(err)
+	assert.Equal("fun-msg", err.Error())
+}
+
+func TestListFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := newConfiguredCLI()
+	cmd := ListCommand(cli)
+
+	flag := cmd.Flag("all-namespaces")
+	assert.NotNil(flag)
+
+	flag = cmd.Flag("format")
+	assert.NotNil(flag)
+}
+
+func newConfiguredCLI() *cli.SensuCli {
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("json")
+	return cli
+}
+
+func TestListCommandRunEClosureWithHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	cli := test.NewMockCLI()
+	config := cli.Config.(*client.MockConfig)
+	config.On("Format").Return("none")
+
+	client := cli.Client.(*client.MockClient)
+	var header http.Header
+	resources := []corev2.Event{}
+	client.On("List", mock.Anything, &resources, mock.Anything, &header).Return(nil).Run(
+		func(args mock.Arguments) {
+			resources := args[1].(*[]corev2.Event)
+			*resources = []corev2.Event{}
+			header := args[3].(*http.Header)
+			*header = make(http.Header)
+			header.Add(helpers.HeaderWarning, "E_TOO_MANY_ENTITIES")
+		},
+	)
+
+	cmd := ListCommand(cli)
+	out, err := test.RunCmd(cmd, []string{})
+
+	assert.NotEmpty(out)
+	assert.Nil(err)
+	assert.Contains(out, "E_TOO_MANY_ENTITIES")
+	assert.Contains(out, "==")
+}


### PR DESCRIPTION
## What is this change?

Adds pipeline commands to `sensuctl`:
* `sensuctl pipeline list`
* `sensuctl pipeline info [NAME]`
* `sensuctl pipeline delete [NAME]`

## Why is this change necessary?

It allows for quick viewing of configured pipelines & deleting pipelines without needing to use `sensuctl delete`.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes.

## How did you verify this change?

I created pipeline resources using `sensuctl create -f` and used the new commands against those resources.

## Is this change a patch?

No.