### PR TITLE
Add corev2.Pipeline to cli resources

### DIFF
--- a/cli/resource/resolve.go
+++ b/cli/resource/resolve.go
@@ -28,6 +28,7 @@ var (
 		&corev2.Handler{},
 		&corev2.HookConfig{},
 		&corev2.Mutator{},
+		&corev2.Pipeline{},
 		&corev2.Role{},
 		&corev2.RoleBinding{},
 		&corev2.Silenced{},


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds `corev2.Pipeline` to the list of resources that are returned when running `sensuctl dump all`.

## Does your change need a Changelog entry?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation changes have already been made.

## How did you verify this change?

I ran the `sensuctl dump all` command and saw a pipeline resource that I had created.

## Is this change a patch?

No.