### PR TITLE
Don't let javascript mutators have command defined

### DIFF
--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -55,6 +55,9 @@ func (m *Mutator) Validate() error {
 	if m.Command == "" && m.Eval == "" {
 		return errors.New("mutator command or eval must be set")
 	}
+	if m.Type == JavascriptMutator && m.Command != "" {
+		return errors.New(`"command" used with javascript mutator, should be "eval"`)
+	}
 
 	if m.Namespace == "" {
 		return errors.New("namespace must be set")

--- a/api/core/v2/mutator_test.go
+++ b/api/core/v2/mutator_test.go
@@ -107,6 +107,10 @@ func TestValidateMutatorTypes(t *testing.T) {
 	for _, test := range passTests {
 		mutator := FixtureMutator("foo")
 		mutator.Type = test
+		if mutator.Type == JavascriptMutator {
+			mutator.Command = ""
+			mutator.Eval = "return 'asdf';"
+		}
 		if err := mutator.Validate(); err != nil {
 			t.Fatal(err)
 		}
@@ -117,5 +121,14 @@ func TestValidateMutatorTypes(t *testing.T) {
 		if err := mutator.Validate(); err == nil {
 			t.Fatal("expecte non-nil error")
 		}
+	}
+}
+
+func TestValidateMutatorCommandWithJavascript(t *testing.T) {
+	mutator := FixtureMutator("foo")
+	mutator.Command = "asdfasdf"
+	mutator.Type = JavascriptMutator
+	if err := mutator.Validate(); err == nil {
+		t.Fatal("expected non-nil error")
 	}
 }


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where mutators can be defined that are of type
javascript, but have command instead of eval. The combination is now
considered to be an error.

## Why is this change necessary?

This configuration error pattern was encountered when doing QA.

## Does your change need a Changelog entry?

No, unreleased code.