### PR TITLE
Partition silenced entry transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ environment variables.
 `SENSU_TIMEOUT` variables to the command's environment.
 - Fixed a crash when running the backend on `darwin/arm64` when compressing a
 wrapped resource.
+- Fixed a bug where large number of silences could cause etcd errors by not
+exceeding etcd'd default maximum number of transaction operations.
 
 ### Changed
 - Upgraded Go version from 1.16.5 to 1.17.1.

--- a/backend/store/etcd/misc_test.go
+++ b/backend/store/etcd/misc_test.go
@@ -1,0 +1,25 @@
+package etcd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testPartitionStrings(t *testing.T) {
+	data := []string{"a", "a", "a", "a", "a", "a", "a", "a", "a"}
+	want := [][]string{
+		{"a", "a", "a", "a"},
+		{"a", "a", "a", "a"},
+		{"a"},
+	}
+
+	if got := partitionStrings(data, 4); !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad partitionStrings: got %v, want %v", got, want)
+	}
+
+	want = [][]string{{"a", "a", "a", "a", "a", "a", "a", "a", "a"}}
+
+	if got := partitionStrings(data, 16); !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad partitionStrings: got %v, want %v", got, want)
+	}
+}

--- a/backend/store/etcd/misc_test.go
+++ b/backend/store/etcd/misc_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func testPartitionStrings(t *testing.T) {
+func TestPartitionStrings(t *testing.T) {
 	data := []string{"a", "a", "a", "a", "a", "a", "a", "a", "a"}
 	want := [][]string{
 		{"a", "a", "a", "a"},


### PR DESCRIPTION
## What is this change?

The number of silenced entries in a given transaction could exceed the
default number of etcd transaction operations, which is 128. This commit
changes the silenced entry store so that it makes at most 64 transaction
operations, and handles silenced expiration by creating multiple
transactions that are each no longer than 64 items.

Signed-off-by: Eric Chlebek <eric@sensu.io>

## Why is this change necessary?

Closes #4384

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

On the contrary, this change was easy to make, and that's what I decided to make it ahead of 6.6.

## How did you verify this change?

I tested that the partitioning logic I wrote functions as expected. Beyond that, I expect the existing integration tests to hold water.

## Is this change a patch?

Yes.