### PR TITLE
Test that handlers don't run if filter cancelled

### DIFF
--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -107,6 +107,7 @@ func (a *AdapterV1) Run(ctx context.Context, ref *corev2.ResourceReference, reso
 
 		// Process the event through the workflow filters
 		filtered, err := a.processFilters(ctx, workflow.Filters, event)
+		fmt.Println(filtered, err)
 		if err != nil {
 			return err
 		}

--- a/backend/pipeline/adapterv1_test.go
+++ b/backend/pipeline/adapterv1_test.go
@@ -410,6 +410,101 @@ func TestAdapterV1_Run(t *testing.T) {
 	}
 }
 
+type cancelContextFilterAdapter struct {
+	Cancel context.CancelFunc
+	Run    *bool
+}
+
+func (cancelContextFilterAdapter) Name() string {
+	return "cancel_context_filter_adapter"
+}
+
+func (cancelContextFilterAdapter) CanFilter(*corev2.ResourceReference) bool {
+	return true
+}
+
+func (c cancelContextFilterAdapter) Filter(context.Context, *corev2.ResourceReference, *corev2.Event) (bool, error) {
+	c.Cancel()
+	*c.Run = true
+	// returning false means to _not_ filter the event
+	return false, context.Canceled
+}
+
+type failIfRunHandlerAdapter struct {
+	T *testing.T
+}
+
+func (failIfRunHandlerAdapter) Name() string {
+	return "fail_if_run_handler_adapter"
+}
+
+func (failIfRunHandlerAdapter) CanHandle(*corev2.ResourceReference) bool {
+	return true
+}
+
+func (f failIfRunHandlerAdapter) Handle(context.Context, *corev2.ResourceReference, *corev2.Event, []byte) error {
+	f.T.Fatal("handler was run")
+	return nil
+}
+
+func TestHandlerDoesNotRunAfterFilterContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var filterRun bool
+	filterAdapters := []FilterAdapter{
+		cancelContextFilterAdapter{
+			Run:    &filterRun,
+			Cancel: cancel,
+		},
+	}
+	handlerAdapters := []HandlerAdapter{
+		failIfRunHandlerAdapter{T: t},
+	}
+	stor := func() store.Store {
+		pipeline := &corev2.Pipeline{
+			ObjectMeta: corev2.NewObjectMeta("pipeline1", "default"),
+			Workflows: []*corev2.PipelineWorkflow{
+				{
+					Name: "send metrics to prometheus",
+					Handler: &corev2.ResourceReference{
+						APIVersion: "core/v2",
+						Type:       "Handler",
+						Name:       "handler1",
+					},
+					Filters: []*corev2.ResourceReference{
+						&corev2.ResourceReference{
+							APIVersion: "core/v2",
+							Type:       "EventFilter",
+							Name:       "filter1",
+						},
+					},
+				},
+			},
+		}
+		stor := &mockstore.MockStore{}
+		stor.On("GetPipelineByName", mock.Anything, mock.Anything).Return(pipeline, nil)
+		return stor
+	}()
+	a := &AdapterV1{
+		Store:          stor,
+		FilterAdapters: filterAdapters,
+		MutatorAdapters: []MutatorAdapter{
+			&mutator.JSONAdapter{},
+		},
+		HandlerAdapters: handlerAdapters,
+	}
+	if err := a.Run(ctx, new(corev2.ResourceReference), corev2.FixtureEvent("foo", "bar")); err != nil {
+		if err != context.Canceled {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal("no error from adapter Run()")
+	}
+	if !filterRun {
+		t.Fatal("filter was never run")
+	}
+}
+
 func TestAdapterV1_resolvePipelineReference(t *testing.T) {
 	type fields struct {
 		Store           store.Store


### PR DESCRIPTION
## What is this change?

This test shows that when filters have their context cancelled, for
instance when a backend is shut down, the handlers in the workflow will
not subsequently run.

## Why is this change necessary?

Closes #4112 

## Does your change need a Changelog entry?

No

## How did you verify this change?

The change is only a test.

## Is this change a patch?

Yes, but can just be applied to the main branch.
