### PR TITLE
bugfix: assets & handlers sharing prefix erroneously included

### DIFF
--- a/backend/apid/graphql/check.go
+++ b/backend/apid/graphql/check.go
@@ -34,7 +34,7 @@ func (r *checkCfgImpl) Handlers(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.CheckConfig)
 	results, err := loadHandlers(p.Context, src.Namespace)
 	records := filterHandlers(results, func(obj *corev2.Handler) bool {
-		return strings.FoundInArray(obj.Name, src.Handlers)
+		return strings.InArray(obj.Name, src.Handlers)
 	})
 	return records, err
 }
@@ -44,7 +44,7 @@ func (r *checkCfgImpl) OutputMetricHandlers(p graphql.ResolveParams) (interface{
 	src := p.Source.(*corev2.CheckConfig)
 	results, err := loadHandlers(p.Context, src.Namespace)
 	records := filterHandlers(results, func(obj *corev2.Handler) bool {
-		return strings.FoundInArray(obj.Name, src.OutputMetricHandlers)
+		return strings.InArray(obj.Name, src.OutputMetricHandlers)
 	})
 	return records, err
 }
@@ -99,7 +99,7 @@ func (r *checkCfgImpl) RuntimeAssets(p graphql.ResolveParams) (interface{}, erro
 	src := p.Source.(*corev2.CheckConfig)
 	records, err := loadAssets(p.Context, src.Namespace)
 	results := filterAssets(records, func(obj *corev2.Asset) bool {
-		return strings.FoundInArray(obj.Name, src.RuntimeAssets)
+		return strings.InArray(obj.Name, src.RuntimeAssets)
 	})
 	return results, err
 }
@@ -168,7 +168,7 @@ func (r *checkImpl) Handlers(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.Check)
 	results, err := loadHandlers(p.Context, src.Namespace)
 	records := filterHandlers(results, func(obj *corev2.Handler) bool {
-		return strings.FoundInArray(obj.Name, src.Handlers)
+		return strings.InArray(obj.Name, src.Handlers)
 	})
 	return records, err
 }
@@ -184,7 +184,7 @@ func (r *checkImpl) Silences(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.Check)
 	results, err := loadSilenceds(p.Context, src.Namespace)
 	records := filterSilenceds(results, func(obj *corev2.Silenced) bool {
-		return strings.FoundInArray(obj.Name, src.Silenced)
+		return strings.InArray(obj.Name, src.Silenced)
 	})
 	return records, err
 }
@@ -209,7 +209,7 @@ func (r *checkImpl) OutputMetricHandlers(p graphql.ResolveParams) (interface{}, 
 	src := p.Source.(*corev2.Check)
 	results, err := loadHandlers(p.Context, src.Namespace)
 	records := filterHandlers(results, func(obj *corev2.Handler) bool {
-		return strings.FoundInArray(obj.Name, src.OutputMetricHandlers)
+		return strings.InArray(obj.Name, src.OutputMetricHandlers)
 	})
 	return records, err
 }
@@ -219,7 +219,7 @@ func (r *checkImpl) RuntimeAssets(p graphql.ResolveParams) (interface{}, error) 
 	src := p.Source.(*corev2.Check)
 	records, err := loadAssets(p.Context, src.Namespace)
 	results := filterAssets(records, func(obj *corev2.Asset) bool {
-		return strings.FoundInArray(obj.Name, src.RuntimeAssets)
+		return strings.InArray(obj.Name, src.RuntimeAssets)
 	})
 	return results, err
 }

--- a/backend/apid/graphql/check_test.go
+++ b/backend/apid/graphql/check_test.go
@@ -213,7 +213,7 @@ func TestCheckConfigTypeRuntimeAssetsField(t *testing.T) {
 
 func TestCheckConfigTypeHandlersField(t *testing.T) {
 	check := corev2.FixtureCheckConfig("my-check")
-	check.Handlers = []string{"one", "two"}
+	check.Handlers = []string{"one", "two", "four", "six:seven"}
 
 	impl := &checkCfgImpl{}
 
@@ -225,6 +225,8 @@ func TestCheckConfigTypeHandlersField(t *testing.T) {
 		corev2.FixtureHandler("one"),
 		corev2.FixtureHandler("two"),
 		corev2.FixtureHandler("three"),
+		corev2.FixtureHandler("four:five"),
+		corev2.FixtureHandler("six:seven"),
 	}, nil).Once()
 
 	cfg := ServiceConfig{HandlerClient: client}
@@ -233,12 +235,12 @@ func TestCheckConfigTypeHandlersField(t *testing.T) {
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 3)
 }
 
 func TestCheckTypeHandlersField(t *testing.T) {
 	check := corev2.FixtureCheck("my-check")
-	check.Handlers = []string{"one", "two"}
+	check.Handlers = []string{"one", "two", "four", "six:seven"}
 
 	client := new(MockHandlerClient)
 	impl := &checkImpl{}
@@ -253,16 +255,18 @@ func TestCheckTypeHandlersField(t *testing.T) {
 		corev2.FixtureHandler("one"),
 		corev2.FixtureHandler("two"),
 		corev2.FixtureHandler("three"),
+		corev2.FixtureHandler("four:five"),
+		corev2.FixtureHandler("six:seven"),
 	}, nil).Once()
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 3)
 }
 
 func TestCheckConfigTypeOutputMetricHandlersField(t *testing.T) {
 	check := corev2.FixtureCheckConfig("my-check")
-	check.OutputMetricHandlers = []string{"one", "two"}
+	check.OutputMetricHandlers = []string{"one", "two", "four", "six:seven"}
 
 	client := new(MockHandlerClient)
 	impl := &checkCfgImpl{}
@@ -277,16 +281,18 @@ func TestCheckConfigTypeOutputMetricHandlersField(t *testing.T) {
 		corev2.FixtureHandler("one"),
 		corev2.FixtureHandler("two"),
 		corev2.FixtureHandler("three"),
+		corev2.FixtureHandler("four:five"),
+		corev2.FixtureHandler("six:seven"),
 	}, nil).Once()
 
 	res, err := impl.OutputMetricHandlers(params)
 	require.NoError(t, err)
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 3)
 }
 
 func TestCheckTypeOutputMetricHandlersField(t *testing.T) {
 	check := corev2.FixtureCheck("my-check")
-	check.OutputMetricHandlers = []string{"one", "two"}
+	check.OutputMetricHandlers = []string{"one", "two", "four", "six:seven"}
 
 	client := new(MockHandlerClient)
 	impl := &checkImpl{}
@@ -301,11 +307,13 @@ func TestCheckTypeOutputMetricHandlersField(t *testing.T) {
 		corev2.FixtureHandler("one"),
 		corev2.FixtureHandler("two"),
 		corev2.FixtureHandler("three"),
+		corev2.FixtureHandler("four:five"),
+		corev2.FixtureHandler("six:seven"),
 	}, nil).Once()
 
 	res, err := impl.OutputMetricHandlers(params)
 	require.NoError(t, err)
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 3)
 }
 
 func TestCheckTypeToJSONField(t *testing.T) {

--- a/backend/apid/graphql/event_filter.go
+++ b/backend/apid/graphql/event_filter.go
@@ -53,7 +53,7 @@ func (r *eventFilterImpl) RuntimeAssets(p graphql.ResolveParams) (interface{}, e
 	src := p.Source.(*corev2.EventFilter)
 	records, err := loadAssets(p.Context, src.Namespace)
 	results := filterAssets(records, func(obj *corev2.Asset) bool {
-		return strings.FoundInArray(obj.Name, src.RuntimeAssets)
+		return strings.InArray(obj.Name, src.RuntimeAssets)
 	})
 	return results, err
 }

--- a/backend/apid/graphql/event_filter_test.go
+++ b/backend/apid/graphql/event_filter_test.go
@@ -13,13 +13,15 @@ import (
 
 func TestEventFilterTypeRuntimeAssetsField(t *testing.T) {
 	filter := corev2.FixtureEventFilter("my-filter")
-	filter.RuntimeAssets = []string{"one", "two"}
+	filter.RuntimeAssets = []string{"one", "two", "four", "six:seven"}
 
 	assetClient := new(MockAssetClient)
 	assetClient.On("ListAssets", mock.Anything, mock.Anything).Return([]*corev2.Asset{
 		corev2.FixtureAsset("one"),
 		corev2.FixtureAsset("two"),
 		corev2.FixtureAsset("three"),
+		corev2.FixtureAsset("four:five"),
+		corev2.FixtureAsset("six:seven"),
 	}, nil).Once()
 
 	// return associated silence
@@ -28,7 +30,7 @@ func TestEventFilterTypeRuntimeAssetsField(t *testing.T) {
 	ctx := contextWithLoaders(context.Background(), cfg)
 	res, err := impl.RuntimeAssets(graphql.ResolveParams{Source: filter, Context: ctx})
 	require.NoError(t, err)
-	assert.Len(t, res, 2)
+	assert.Len(t, res, 3)
 }
 
 func TestEventFilterTypeToJSONField(t *testing.T) {

--- a/backend/apid/graphql/handler.go
+++ b/backend/apid/graphql/handler.go
@@ -44,7 +44,7 @@ func (r *handlerImpl) Handlers(p graphql.ResolveParams) (interface{}, error) {
 	src := p.Source.(*corev2.Handler)
 	results, err := loadHandlers(p.Context, src.Namespace)
 	records := filterHandlers(results, func(obj *corev2.Handler) bool {
-		return strings.FoundInArray(obj.Name, src.Handlers)
+		return strings.InArray(obj.Name, src.Handlers)
 	})
 	return records, err
 }

--- a/backend/apid/graphql/handler_test.go
+++ b/backend/apid/graphql/handler_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHandlerTypeHandlersField(t *testing.T) {
 	handler := corev2.FixtureHandler("my-handler")
-	handler.Handlers = []string{"one", "two"}
+	handler.Handlers = []string{"one", "two", "four", "six:seven"}
 
 	client := new(MockHandlerClient)
 	impl := &handlerImpl{}
@@ -28,11 +28,13 @@ func TestHandlerTypeHandlersField(t *testing.T) {
 		corev2.FixtureHandler("one"),
 		corev2.FixtureHandler("two"),
 		corev2.FixtureHandler("three"),
+		corev2.FixtureHandler("four:five"),
+		corev2.FixtureHandler("six:seven"),
 	}, nil).Once()
 
 	res, err := impl.Handlers(params)
 	require.NoError(t, err)
-	assert.NotEmpty(t, res)
+	assert.Len(t, res, 3)
 }
 
 func TestHandlerTypeMutatorField(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where assets & handlers associated with events could return neighbouring resources from their respective resolvers. As an example if the assets field on the Check type had the value `[]string{"one:two"}` and the namespace contained the assets `one:two` & `one:three`, the field resolver would return both assets. This is because the resolver was erroneously using `strings.FoundInArray` which normalizes its input. 

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>