### PR TITLE
Relax mutator validation for env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where API validation caused javascript environment variable
+specifications to be rejected.
+
 ## [6.5.2] - 2021-10-28
 
 ### Added

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -69,12 +69,6 @@ func (m *Mutator) Validate() error {
 		}
 	}
 
-	for _, kv := range m.EnvVars {
-		if idx := strings.Index(kv, "="); idx <= 0 {
-			return fmt.Errorf("invalid mutator environment variable: %q is not of the form K=V", kv)
-		}
-	}
-
 	return nil
 }
 

--- a/api/core/v2/mutator_test.go
+++ b/api/core/v2/mutator_test.go
@@ -132,3 +132,11 @@ func TestValidateMutatorCommandWithJavascript(t *testing.T) {
 		t.Fatal("expected non-nil error")
 	}
 }
+
+func TestValidateMutatorEnv(t *testing.T) {
+	mutator := FixtureMutator("foo")
+	mutator.EnvVars = []string{"FOO"}
+	if err := mutator.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What is this change?

This change fixes a defect in the previous release.

## Why is this change necessary?

Javascript mutators are supposed to allow environment variables without an "=" now, but the validation for mutators was never updated to reflect this.

## Does your change need a Changelog entry?

Yes

## Is this change a patch?

Yes