### PR TITLE
Fix a bug where asset expansion err not handled

### DIFF
--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -188,6 +188,9 @@ func (b *boltDBAssetManager) Get(ctx context.Context, asset *corev2.Asset) (*Run
 
 		// expand
 		assetPath, err := b.expandWithDuration(tmpFile, asset)
+		if err != nil {
+			return err
+		}
 
 		localAsset = &RuntimeAsset{
 			Path: assetPath,


### PR DESCRIPTION
A recent PR made a change to assets that changes the way expansion
happens, but the error from the new function call was not handled.

Signed-off-by: Eric Chlebek <eric@sensu.io>