### PR TITLE
Metricslog graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added objectives (0.5, 0.9, 0.99) to `graphql_duration_seconds` metric.
+
 ## [6.5.3, 6.5.4] - 2021-10-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added objectives (0.5, 0.9, 0.99) to `graphql_duration_seconds` metric.
+- Added `graphql_duration_seconds`, `graphql_duration_seconds_sum` &
+`graphql_duration_seconds_count` to the metrics log.
 
 ## [6.5.3, 6.5.4] - 2021-10-29
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -136,6 +136,9 @@ var SelectedMetrics = []string{
 	"etcd_network_peer_received_bytes_total",
 	"etcd_network_peer_sent_bytes_total",
 	"etcd_snap_db_fsync_duration_seconds_bucket",
+	"graphql_duration_seconds",
+	"graphql_duration_seconds_sum",
+	"graphql_duration_seconds_count",
 }
 
 // Backend represents the backend server, which is used to hold the datastore

--- a/graphql/tracing/prometheus.go
+++ b/graphql/tracing/prometheus.go
@@ -20,8 +20,9 @@ const (
 var (
 	Collector = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name: "graphql_duration_seconds",
-			Help: "Time spent in GraphQL operations, in seconds",
+			Name:       "graphql_duration_seconds",
+			Help:       "Time spent in GraphQL operations, in seconds",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
 		[]string{"key", "platform_key"},
 	)

--- a/graphql/tracing/prometheus_test.go
+++ b/graphql/tracing/prometheus_test.go
@@ -40,6 +40,9 @@ func TestPrometheusTracer_ParseDidStart(t *testing.T) {
 			delta:     200,
 			runs:      1,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.5"} 200
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.9"} 200
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.99"} 200
         graphql_duration_seconds_sum{key="parse",platform_key="graphql.parse"} 200
         graphql_duration_seconds_count{key="parse",platform_key="graphql.parse"} 1
       `,
@@ -50,6 +53,9 @@ func TestPrometheusTracer_ParseDidStart(t *testing.T) {
 			delta:     20,
 			runs:      5,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.5"} 20
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.9"} 20
+        graphql_duration_seconds{key="parse",platform_key="graphql.parse",quantile="0.99"} 20
         graphql_duration_seconds_sum{key="parse",platform_key="graphql.parse"} 100
         graphql_duration_seconds_count{key="parse",platform_key="graphql.parse"} 5
       `,
@@ -96,6 +102,9 @@ func TestPrometheusTracer_ValidationDidStart(t *testing.T) {
 			delta:     150,
 			runs:      1,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.5"} 150
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.9"} 150
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.99"} 150
         graphql_duration_seconds_sum{key="validate",platform_key="graphql.validate"} 150
         graphql_duration_seconds_count{key="validate",platform_key="graphql.validate"} 1
       `,
@@ -106,6 +115,9 @@ func TestPrometheusTracer_ValidationDidStart(t *testing.T) {
 			delta:     15,
 			runs:      8,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.5"} 15
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.9"} 15
+        graphql_duration_seconds{key="validate",platform_key="graphql.validate",quantile="0.99"} 15
         graphql_duration_seconds_sum{key="validate",platform_key="graphql.validate"} 120
         graphql_duration_seconds_count{key="validate",platform_key="graphql.validate"} 8
       `,
@@ -152,6 +164,9 @@ func TestPrometheusTracer_ExecutionDidStart(t *testing.T) {
 			delta:     120,
 			runs:      1,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.5"} 120
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.9"} 120
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.99"} 120
         graphql_duration_seconds_sum{key="execute_query",platform_key="graphql.execute"} 120
         graphql_duration_seconds_count{key="execute_query",platform_key="graphql.execute"} 1
       `,
@@ -162,6 +177,9 @@ func TestPrometheusTracer_ExecutionDidStart(t *testing.T) {
 			delta:     12,
 			runs:      9,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.5"} 12
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.9"} 12
+        graphql_duration_seconds{key="execute_query",platform_key="graphql.execute",quantile="0.99"} 12
         graphql_duration_seconds_sum{key="execute_query",platform_key="graphql.execute"} 108
         graphql_duration_seconds_count{key="execute_query",platform_key="graphql.execute"} 9
       `,
@@ -208,6 +226,9 @@ func TestPrometheusTracer_ResolveFieldDidStart(t *testing.T) {
 			delta:     120,
 			runs:      1,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.5"} 120
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.9"} 120
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.99"} 120
         graphql_duration_seconds_sum{key="execute_field",platform_key="Check.interval"} 120
         graphql_duration_seconds_count{key="execute_field",platform_key="Check.interval"} 1
       `,
@@ -218,6 +239,9 @@ func TestPrometheusTracer_ResolveFieldDidStart(t *testing.T) {
 			delta:     15,
 			runs:      7,
 			want: summaryMetadata + `
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.5"} 15
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.9"} 15
+        graphql_duration_seconds{key="execute_field",platform_key="Check.interval",quantile="0.99"} 15
         graphql_duration_seconds_sum{key="execute_field",platform_key="Check.interval"} 105
         graphql_duration_seconds_count{key="execute_field",platform_key="Check.interval"} 7
       `,


### PR DESCRIPTION
## What is this change?

Add objectives (0.5, 0.9, 0.99) to the `graphql_duration_seconds` metric and add GraphQL metrics to the metrics log.

## Why is this change necessary?

It adds clarity and allows us to look into the duration GraphQL operations.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation is required.

## How did you verify this change?

Spun up a backend, browsed the dashboard, and verified that `graphql_duration_seconds` metrics are in `/metrics` and the metrics log.

## Is this change a patch?

Yes.