### PR TITLE
Add flag to configure API & dashboard's write timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added eventd, pipeline, & asset metrics from 6.5.2 to the metrics log.
+- Added `--api-write-timeout` & `--dashboard-write-timeout` flags to allow
+end users to configure the HTTP server's write timeout value
 
 ### Fixed
 - Fixed a bug where API validation caused javascript environment variable

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -237,7 +237,7 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	// The write timeout hangs up the request making it more difficult for
 	// clients to determine what occurred. As such give the service as much time
 	// as possible to produce results.
-	timeout := time.Duration(cfg.WriteTimeout) - (50 * time.Microsecond)
+	timeout := time.Duration(cfg.WriteTimeout*int64(time.Second)) - (50 * time.Microsecond)
 	if timeout <= 0 {
 		timeout = time.Duration(1)
 	}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -238,8 +238,8 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	// clients to determine what occurred. As such give the service as much time
 	// as possible to produce results.
 	timeout := time.Duration(cfg.WriteTimeout*int64(time.Second)) - (50 * time.Microsecond)
-	if timeout <= 0 {
-		timeout = time.Duration(1)
+	if timeout < 0 {
+		timeout = 0
 	}
 
 	mountRouters(

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -237,7 +237,7 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	// The write timeout hangs up the request making it more difficult for
 	// clients to determine what occurred. As such give the service as much time
 	// as possible to produce results.
-	timeout := time.Duration(cfg.WriteTimeout*int64(time.Second)) - (50 * time.Microsecond)
+	timeout := time.Duration(cfg.WriteTimeout*int64(time.Second)) - (50 * time.Millisecond)
 	if timeout < 0 {
 		timeout = 0
 	}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -35,6 +35,7 @@ type APId struct {
 	EntityLimitedCoreSubrouter *mux.Router
 	GraphQLSubrouter           *mux.Router
 	RequestLimit               int64
+	WriteTimeout               int64
 
 	stopping            chan struct{}
 	running             *atomic.Value
@@ -58,6 +59,7 @@ type Option func(*APId) error
 type Config struct {
 	ListenAddress       string
 	RequestLimit        int64
+	WriteTimeout        int64
 	URL                 string
 	Bus                 messaging.MessageBus
 	Store               store.Store
@@ -91,6 +93,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		Authenticator:       c.Authenticator,
 		clusterVersion:      c.ClusterVersion,
 		RequestLimit:        c.RequestLimit,
+		WriteTimeout:        c.WriteTimeout,
 	}
 
 	// prepare TLS config
@@ -113,7 +116,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 	a.HTTPServer = &http.Server{
 		Addr:         c.ListenAddress,
 		Handler:      router,
-		WriteTimeout: 15 * time.Second,
+		WriteTimeout: time.Duration(c.WriteTimeout) * time.Second,
 		ReadTimeout:  15 * time.Second,
 		TLSConfig:    tlsServerConfig,
 	}
@@ -231,9 +234,20 @@ func GraphQLSubrouter(router *mux.Router, cfg Config) *mux.Router {
 		middlewares.SimpleLogger{},
 	)
 
+	// The write timeout hangs up the request making it more difficult for
+	// clients to determine what occurred. As such give the service as much time
+	// as possible to produce results.
+	timeout := time.Duration(cfg.WriteTimeout) - (50 * time.Microsecond)
+	if timeout <= 0 {
+		timeout = time.Duration(1)
+	}
+
 	mountRouters(
 		subrouter,
-		&routers.GraphQLRouter{Service: cfg.GraphQLService},
+		&routers.GraphQLRouter{
+			Service: cfg.GraphQLService,
+			Timeout: timeout,
+		},
 	)
 
 	return subrouter

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -585,6 +585,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	b.APIDConfig = apid.Config{
 		ListenAddress:       config.APIListenAddress,
 		RequestLimit:        config.APIRequestLimit,
+		WriteTimeout:        config.APIWriteTimeout,
 		URL:                 config.APIURL,
 		Bus:                 bus,
 		Store:               b.Store,

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -222,14 +222,14 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				APIListenAddress:      viper.GetString(flagAPIListenAddress),
 				APIRequestLimit:       viper.GetInt64(flagAPIRequestLimit),
 				APIURL:                viper.GetString(flagAPIURL),
-				APIWriteTimeout:       viper.GetInt64(flagAPIWriteTimeout),
+				APIWriteTimeout:       viper.GetDuration(flagAPIWriteTimeout),
 				AssetsRateLimit:       rate.Limit(viper.GetFloat64(flagAssetsRateLimit)),
 				AssetsBurstLimit:      viper.GetInt(flagAssetsBurstLimit),
 				DashboardHost:         viper.GetString(flagDashboardHost),
 				DashboardPort:         viper.GetInt(flagDashboardPort),
 				DashboardTLSCertFile:  viper.GetString(flagDashboardCertFile),
 				DashboardTLSKeyFile:   viper.GetString(flagDashboardKeyFile),
-				DashboardWriteTimeout: viper.GetInt64(flagDashboardWriteTimeout),
+				DashboardWriteTimeout: viper.GetDuration(flagDashboardWriteTimeout),
 				DeregistrationHandler: viper.GetString(flagDeregistrationHandler),
 				CacheDir:              viper.GetString(flagCacheDir),
 				StateDir:              viper.GetString(flagStateDir),
@@ -391,14 +391,14 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 		viper.SetDefault(flagAPIListenAddress, "[::]:8080")
 		viper.SetDefault(flagAPIRequestLimit, middlewares.MaxBytesLimit)
 		viper.SetDefault(flagAPIURL, "http://localhost:8080")
-		viper.SetDefault(flagAPIWriteTimeout, 15)
+		viper.SetDefault(flagAPIWriteTimeout, "15s")
 		viper.SetDefault(flagAssetsRateLimit, asset.DefaultAssetsRateLimit)
 		viper.SetDefault(flagAssetsBurstLimit, asset.DefaultAssetsBurstLimit)
 		viper.SetDefault(flagDashboardHost, "[::]")
 		viper.SetDefault(flagDashboardPort, 3000)
 		viper.SetDefault(flagDashboardCertFile, "")
 		viper.SetDefault(flagDashboardKeyFile, "")
-		viper.SetDefault(flagDashboardWriteTimeout, 15)
+		viper.SetDefault(flagDashboardWriteTimeout, "15s")
 		viper.SetDefault(flagDeregistrationHandler, "")
 		viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-backend"))
 		viper.SetDefault(flagStateDir, path.SystemDataDir("sensu-backend"))
@@ -518,14 +518,14 @@ func flagSet(server bool) *pflag.FlagSet {
 		flagSet.String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")
 		flagSet.Int64(flagAPIRequestLimit, viper.GetInt64(flagAPIRequestLimit), "maximum API request body size, in bytes")
 		flagSet.String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
-		flagSet.Int64(flagAPIWriteTimeout, viper.GetInt64(flagAPIWriteTimeout), "maximum duration before timing out writes of responses")
+		flagSet.Duration(flagAPIWriteTimeout, viper.GetDuration(flagAPIWriteTimeout), "maximum duration before timing out writes of responses")
 		flagSet.Float64(flagAssetsRateLimit, viper.GetFloat64(flagAssetsRateLimit), "maximum number of assets fetched per second")
 		flagSet.Int(flagAssetsBurstLimit, viper.GetInt(flagAssetsBurstLimit), "asset fetch burst limit")
 		flagSet.String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")
 		flagSet.Int(flagDashboardPort, viper.GetInt(flagDashboardPort), "dashboard listener port")
 		flagSet.String(flagDashboardCertFile, viper.GetString(flagDashboardCertFile), "dashboard TLS certificate in PEM format")
 		flagSet.String(flagDashboardKeyFile, viper.GetString(flagDashboardKeyFile), "dashboard TLS certificate key in PEM format")
-		flagSet.Int64(flagDashboardWriteTimeout, viper.GetInt64(flagDashboardWriteTimeout), "maximum duration before timing out writes of responses")
+		flagSet.Duration(flagDashboardWriteTimeout, viper.GetDuration(flagDashboardWriteTimeout), "maximum duration before timing out writes of responses")
 		flagSet.String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "default deregistration handler")
 		flagSet.String(flagCacheDir, viper.GetString(flagCacheDir), "path to store cached data")
 		flagSet.StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -49,12 +49,14 @@ const (
 	flagAPIListenAddress      = "api-listen-address"
 	flagAPIRequestLimit       = "api-request-limit"
 	flagAPIURL                = "api-url"
+	flagAPIWriteTimeout       = "api-write-timeout"
 	flagAssetsRateLimit       = "assets-rate-limit"
 	flagAssetsBurstLimit      = "assets-burst-limit"
 	flagDashboardHost         = "dashboard-host"
 	flagDashboardPort         = "dashboard-port"
 	flagDashboardCertFile     = "dashboard-cert-file"
 	flagDashboardKeyFile      = "dashboard-key-file"
+	flagDashboardWriteTimeout = "dashboard-write-timeout"
 	flagDeregistrationHandler = "deregistration-handler"
 	flagCacheDir              = "cache-dir"
 	flagStateDir              = "state-dir"
@@ -101,7 +103,7 @@ const (
 	envEtcdClientUsername = "etcd-client-username"
 	envEtcdClientPassword = "etcd-client-password"
 
-  // Metric logging flags
+	// Metric logging flags
 	flagDisablePlatformMetrics         = "disable-platform-metrics"
 	flagPlatformMetricsLoggingInterval = "platform-metrics-logging-interval"
 	flagPlatformMetricsLogFile         = "platform-metrics-log-file"
@@ -220,12 +222,14 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				APIListenAddress:      viper.GetString(flagAPIListenAddress),
 				APIRequestLimit:       viper.GetInt64(flagAPIRequestLimit),
 				APIURL:                viper.GetString(flagAPIURL),
+				APIWriteTimeout:       viper.GetInt64(flagAPIWriteTimeout),
 				AssetsRateLimit:       rate.Limit(viper.GetFloat64(flagAssetsRateLimit)),
 				AssetsBurstLimit:      viper.GetInt(flagAssetsBurstLimit),
 				DashboardHost:         viper.GetString(flagDashboardHost),
 				DashboardPort:         viper.GetInt(flagDashboardPort),
 				DashboardTLSCertFile:  viper.GetString(flagDashboardCertFile),
 				DashboardTLSKeyFile:   viper.GetString(flagDashboardKeyFile),
+				DashboardWriteTimeout: viper.GetInt64(flagDashboardWriteTimeout),
 				DeregistrationHandler: viper.GetString(flagDeregistrationHandler),
 				CacheDir:              viper.GetString(flagCacheDir),
 				StateDir:              viper.GetString(flagStateDir),
@@ -247,7 +251,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				EtcdHeartbeatInterval:          viper.GetUint(flagEtcdHeartbeatInterval),
 				EtcdElectionTimeout:            viper.GetUint(flagEtcdElectionTimeout),
 				EtcdLogLevel:                   viper.GetString(flagEtcdLogLevel),
-        EtcdClientUsername:             viper.GetString(envEtcdClientUsername),
+				EtcdClientUsername:             viper.GetString(envEtcdClientUsername),
 				EtcdClientPassword:             viper.GetString(envEtcdClientPassword),
 				NoEmbedEtcd:                    viper.GetBool(flagNoEmbedEtcd),
 				Labels:                         viper.GetStringMapString(flagLabels),
@@ -387,12 +391,14 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 		viper.SetDefault(flagAPIListenAddress, "[::]:8080")
 		viper.SetDefault(flagAPIRequestLimit, middlewares.MaxBytesLimit)
 		viper.SetDefault(flagAPIURL, "http://localhost:8080")
+		viper.SetDefault(flagAPIWriteTimeout, 15)
 		viper.SetDefault(flagAssetsRateLimit, asset.DefaultAssetsRateLimit)
 		viper.SetDefault(flagAssetsBurstLimit, asset.DefaultAssetsBurstLimit)
 		viper.SetDefault(flagDashboardHost, "[::]")
 		viper.SetDefault(flagDashboardPort, 3000)
 		viper.SetDefault(flagDashboardCertFile, "")
 		viper.SetDefault(flagDashboardKeyFile, "")
+		viper.SetDefault(flagDashboardWriteTimeout, 15)
 		viper.SetDefault(flagDeregistrationHandler, "")
 		viper.SetDefault(flagCacheDir, path.SystemCacheDir("sensu-backend"))
 		viper.SetDefault(flagStateDir, path.SystemDataDir("sensu-backend"))
@@ -512,12 +518,14 @@ func flagSet(server bool) *pflag.FlagSet {
 		flagSet.String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")
 		flagSet.Int64(flagAPIRequestLimit, viper.GetInt64(flagAPIRequestLimit), "maximum API request body size, in bytes")
 		flagSet.String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
+		flagSet.Int64(flagAPIWriteTimeout, viper.GetInt64(flagAPIWriteTimeout), "maximum duration before timing out writes of responses")
 		flagSet.Float64(flagAssetsRateLimit, viper.GetFloat64(flagAssetsRateLimit), "maximum number of assets fetched per second")
 		flagSet.Int(flagAssetsBurstLimit, viper.GetInt(flagAssetsBurstLimit), "asset fetch burst limit")
 		flagSet.String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")
 		flagSet.Int(flagDashboardPort, viper.GetInt(flagDashboardPort), "dashboard listener port")
 		flagSet.String(flagDashboardCertFile, viper.GetString(flagDashboardCertFile), "dashboard TLS certificate in PEM format")
 		flagSet.String(flagDashboardKeyFile, viper.GetString(flagDashboardKeyFile), "dashboard TLS certificate key in PEM format")
+		flagSet.Int64(flagDashboardWriteTimeout, viper.GetInt64(flagDashboardWriteTimeout), "maximum duration before timing out writes of responses")
 		flagSet.String(flagDeregistrationHandler, viper.GetString(flagDeregistrationHandler), "default deregistration handler")
 		flagSet.String(flagCacheDir, viper.GetString(flagCacheDir), "path to store cached data")
 		flagSet.StringP(flagStateDir, "d", viper.GetString(flagStateDir), "path to sensu state storage")

--- a/backend/config.go
+++ b/backend/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	APIListenAddress string
 	APIRequestLimit  int64
 	APIURL           string
-	APIWriteTimeout  int64
+	APIWriteTimeout  time.Duration
 
 	// AssetsRateLimit is the maximum number of assets per second that will be fetched.
 	AssetsRateLimit rate.Limit
@@ -73,7 +73,7 @@ type Config struct {
 	DashboardPort         int
 	DashboardTLSCertFile  string
 	DashboardTLSKeyFile   string
-	DashboardWriteTimeout int64
+	DashboardWriteTimeout time.Duration
 
 	// Pipelined Configuration
 	DeregistrationHandler string

--- a/backend/config.go
+++ b/backend/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	APIListenAddress string
 	APIRequestLimit  int64
 	APIURL           string
+	APIWriteTimeout  int64
 
 	// AssetsRateLimit is the maximum number of assets per second that will be fetched.
 	AssetsRateLimit rate.Limit
@@ -68,10 +69,11 @@ type Config struct {
 	AssetsBurstLimit int
 
 	// Dashboardd Configuration
-	DashboardHost        string
-	DashboardPort        int
-	DashboardTLSCertFile string
-	DashboardTLSKeyFile  string
+	DashboardHost         string
+	DashboardPort         int
+	DashboardTLSCertFile  string
+	DashboardTLSKeyFile   string
+	DashboardWriteTimeout int64
 
 	// Pipelined Configuration
 	DeregistrationHandler string


### PR DESCRIPTION
Adds `api-write-timeout` & `dashboard-write-timeout` flags to allow users to configure the respective HTTP server's write timeout. Useful when some requests might reasonably take more than a few seconds to complete.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>