### PR TITLE
Use milliseconds for new duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `graphql_duration_seconds`, `graphql_duration_seconds_sum` &
 `graphql_duration_seconds_count` to the metrics log.
 
+### Fixed
+- Duration metrics for assets, pipeline, and eventd have been updated to use
+milliseconds to match other duration metrics.
+
 ## [6.5.3, 6.5.4] - 2021-10-29
 
 ### Added

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -222,7 +222,7 @@ func (b *boltDBAssetManager) fetchWithDuration(ctx context.Context, asset *corev
 		}
 		fetchDuration.
 			WithLabelValues(status, asset.ObjectMeta.Name, asset.ObjectMeta.Namespace).
-			Observe(v)
+			Observe(v * float64(1000))
 	}))
 	defer timer.ObserveDuration()
 
@@ -237,7 +237,7 @@ func (b *boltDBAssetManager) expandWithDuration(tmpFile *os.File, asset *corev2.
 		}
 		expandDuration.
 			WithLabelValues(status, asset.ObjectMeta.Name, asset.ObjectMeta.Namespace).
-			Observe(v)
+			Observe(v * float64(1000))
 	}))
 	defer timer.ObserveDuration()
 

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -575,7 +575,7 @@ func (e *Eventd) handleMessage(msg interface{}) (fEvent *corev2.Event, fErr erro
 			if err != nil {
 				status = metricspkg.StatusLabelError
 			}
-			switchesAliveDuration.WithLabelValues(status).Observe(v)
+			switchesAliveDuration.WithLabelValues(status).Observe(v * float64(1000))
 		}))
 		err = switches.Alive(ctx, switchKey, timeout)
 		aliveTimer.ObserveDuration()
@@ -592,7 +592,7 @@ func (e *Eventd) handleMessage(msg interface{}) (fEvent *corev2.Event, fErr erro
 			if err != nil {
 				status = metricspkg.StatusLabelError
 			}
-			switchesBuryDuration.WithLabelValues(status).Observe(v)
+			switchesBuryDuration.WithLabelValues(status).Observe(v * float64(1000))
 		}))
 		err = switches.Bury(ctx, switchKey)
 		buryTimer.ObserveDuration()

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -725,7 +725,7 @@ func (k *Keepalived) handleUpdate(e *corev2.Event) error {
 				"entity":       entity.Name,
 				"namespace":    entity.Namespace,
 				"subscription": sub,
-				"timeout":      time.Duration(e.Check.Timeout) * time.Second,
+				"timeout":      time.Duration(e.Check.Timeout),
 			})
 			if err := ring.Add(tctx, entity.Name, int64(e.Check.Timeout)); err != nil {
 				lager.WithError(err).Error("error adding entity to ring")

--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -237,7 +237,7 @@ func (a *AdapterV1) resolvePipelineReference(ctx context.Context, ref *corev2.Re
 		if isLegacy {
 			pipelineType = PipelineTypeLabelLegacy
 		}
-		pipelineResolveDuration.WithLabelValues(status, pipelineType).Observe(v)
+		pipelineResolveDuration.WithLabelValues(status, pipelineType).Observe(v * float64(1000))
 	}))
 	defer resolveTimer.ObserveDuration()
 

--- a/backend/pipeline/filter.go
+++ b/backend/pipeline/filter.go
@@ -59,7 +59,7 @@ func (a *AdapterV1) processFilter(ctx context.Context, ref *corev2.ResourceRefer
 		if fErr != nil {
 			status = metricspkg.StatusLabelError
 		}
-		filterDuration.WithLabelValues(status, ref.ResourceID()).Observe(v)
+		filterDuration.WithLabelValues(status, ref.ResourceID()).Observe(v * float64(1000))
 	}))
 	defer filterTimer.ObserveDuration()
 

--- a/backend/pipeline/handler.go
+++ b/backend/pipeline/handler.go
@@ -44,7 +44,7 @@ func (a *AdapterV1) processHandler(ctx context.Context, ref *corev2.ResourceRefe
 		if fErr != nil {
 			status = metricspkg.StatusLabelError
 		}
-		handlerDuration.WithLabelValues(status, ref.ResourceID()).Observe(v)
+		handlerDuration.WithLabelValues(status, ref.ResourceID()).Observe(v * float64(1000))
 	}))
 	defer handlerTimer.ObserveDuration()
 

--- a/backend/pipeline/mutator.go
+++ b/backend/pipeline/mutator.go
@@ -44,7 +44,7 @@ func (a *AdapterV1) processMutator(ctx context.Context, ref *corev2.ResourceRefe
 		if fErr != nil {
 			status = metricspkg.StatusLabelError
 		}
-		mutatorDuration.WithLabelValues(status, ref.ResourceID()).Observe(v)
+		mutatorDuration.WithLabelValues(status, ref.ResourceID()).Observe(v * float64(1000))
 	}))
 	defer mutatorTimer.ObserveDuration()
 


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

The `timer.ObserveDuration()` method in Prometheus uses seconds but the rest of our metrics in these packages are in milliseconds. This updates the observation of the timer to use milliseconds for consistency.

Also fixes a bug in the timeout duration that is logged when adding entities to the ring.

## Why is this change necessary?

We had meant to use milliseconds.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I created a handler with the command `sleep 60` & a check that uses the handler. The metrics are returned in milliseconds (60000.0).

```
sensuctl handler create sleepy --command "sleep 60 && cat"
sensuctl check create foo --command "false" --subscriptions "all" --interval 60 --handlers "sleepy"
```
 
 ```
 # HELP sensu_go_pipelined_message_handler_duration pipelined message handler latency distribution
# TYPE sensu_go_pipelined_message_handler_duration summary
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="error",quantile="0.5"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="error",quantile="0.9"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="error",quantile="0.99"} NaN
sensu_go_pipelined_message_handler_duration_sum{has_pipelines="0",status="error"} 0
sensu_go_pipelined_message_handler_duration_count{has_pipelines="0",status="error"} 0
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="success",quantile="0.5"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="success",quantile="0.9"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="0",status="success",quantile="0.99"} NaN
sensu_go_pipelined_message_handler_duration_sum{has_pipelines="0",status="success"} 0
sensu_go_pipelined_message_handler_duration_count{has_pipelines="0",status="success"} 0
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="error",quantile="0.5"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="error",quantile="0.9"} NaN
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="error",quantile="0.99"} NaN
sensu_go_pipelined_message_handler_duration_sum{has_pipelines="1",status="error"} 0
sensu_go_pipelined_message_handler_duration_count{has_pipelines="1",status="error"} 0
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="success",quantile="0.5"} 18.431416
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="success",quantile="0.9"} 60044.866125
sensu_go_pipelined_message_handler_duration{has_pipelines="1",status="success",quantile="0.99"} 60044.866125
sensu_go_pipelined_message_handler_duration_sum{has_pipelines="1",status="success"} 60206.723414
sensu_go_pipelined_message_handler_duration_count{has_pipelines="1",status="success"} 8
 ```

```
# HELP sensu_go_pipeline_handler_duration pipeline handler execution latency distribution
# TYPE sensu_go_pipeline_handler_duration summary
sensu_go_pipeline_handler_duration{resource_ref="core/v2.Handler(Name=sleepy)",status="success",quantile="0.5"} 60011.918708000005
sensu_go_pipeline_handler_duration{resource_ref="core/v2.Handler(Name=sleepy)",status="success",quantile="0.9"} 60011.918708000005
sensu_go_pipeline_handler_duration{resource_ref="core/v2.Handler(Name=sleepy)",status="success",quantile="0.99"} 60011.918708000005
sensu_go_pipeline_handler_duration_sum{resource_ref="core/v2.Handler(Name=sleepy)",status="success"} 60011.918708000005
sensu_go_pipeline_handler_duration_count{resource_ref="core/v2.Handler(Name=sleepy)",status="success"} 1
```

## Is this change a patch?

Yes.