### PR TITLE
Avoid overwriting etcd defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Empty and zero value configuration parameters for `etcd` do not overwrite
+  defaults anymore.
+
 ## [6.5.3, 6.5.4] - 2021-10-29
 
 ### Added

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/util/path"
-	"go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	etcdTypes "go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter"
 	zapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -187,20 +187,28 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	}
 
 	cfg := embed.NewConfig()
-	cfg.Name = config.Name
+	if config.Name != "" {
+		cfg.Name = config.Name
+	}
 
 	cfg.Dir = filepath.Join(config.DataDir, "etcd", "data")
-	cfg.WalDir = filepath.Join(config.DataDir, "etcd", "wal")
 	if err := ensureDir(cfg.Dir); err != nil {
 		return nil, err
 	}
+
+	cfg.WalDir = filepath.Join(config.DataDir, "etcd", "wal")
 	if err := ensureDir(cfg.WalDir); err != nil {
 		return nil, err
 	}
 
 	// Heartbeat and Election timeouts
-	cfg.TickMs = config.TickMs
-	cfg.ElectionMs = config.ElectionMs
+	if config.TickMs != 0 {
+		cfg.TickMs = config.TickMs
+	}
+
+	if config.ElectionMs != 0 {
+		cfg.ElectionMs = config.ElectionMs
+	}
 
 	// Client config
 	cfg.ACUrls = acURLs
@@ -212,25 +220,50 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	cfg.LPUrls = lpURLs
 	cfg.PeerTLSInfo = (transport.TLSInfo)(config.PeerTLSInfo)
 
-	cfg.CipherSuites = config.CipherSuites
+	if len(config.CipherSuites) > 0 {
+		cfg.CipherSuites = config.CipherSuites
+	}
 
 	// Cluster config
-	cfg.InitialClusterToken = config.InitialClusterToken
-	cfg.InitialCluster = config.InitialCluster
-	cfg.ClusterState = config.InitialClusterState
-	cfg.Durl = config.Discovery
-	cfg.DNSCluster = config.DiscoverySrv
+	if config.InitialClusterToken != "" {
+		cfg.InitialClusterToken = config.InitialClusterToken
+	}
+
+	if config.InitialCluster != "" {
+		cfg.InitialCluster = config.InitialCluster
+	}
+
+	if config.InitialClusterState != "" {
+		cfg.ClusterState = config.InitialClusterState
+	}
+
+	if config.Discovery != "" {
+		cfg.Durl = config.Discovery
+	}
+
+	if config.DiscoverySrv != "" {
+		cfg.DNSCluster = config.DiscoverySrv
+	}
 
 	// Every 5 minutes, we will prune all values in etcd to only their latest
 	// revision.
 	cfg.AutoCompactionMode = "revision"
 	cfg.AutoCompactionRetention = "2"
-	cfg.QuotaBackendBytes = config.QuotaBackendBytes
-	cfg.MaxRequestBytes = config.MaxRequestBytes
+
+	if config.QuotaBackendBytes != 0 {
+		cfg.QuotaBackendBytes = config.QuotaBackendBytes
+	}
+
+	if config.MaxRequestBytes != 0 {
+		cfg.MaxRequestBytes = config.MaxRequestBytes
+	}
 
 	cfg.Logger = "zap"
-	cfg.LogLevel = config.LogLevel
-	logutil.DefaultZapLoggerConfig.Level.SetLevel(levelToZap(config.LogLevel))
+
+	if config.LogLevel != "" {
+		cfg.LogLevel = config.LogLevel
+		logutil.DefaultZapLoggerConfig.Level.SetLevel(levelToZap(config.LogLevel))
+	}
 
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {


### PR DESCRIPTION
## What is this change?

This change makes it so etcd related configuration flags parsed by Sensu are only applied if they are not a zero value (`""`, 0, empty slice, ...). This is to avoid overwriting default values set by the etcd developers.

## Why is this change necessary?

Fix #3952.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

I think it's a good change to make, but I'm not sure if this had caused any problem so far; the issue (#3952) doesn't give information.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't think any documentation needs to be changed.

## How did you verify this change?

- All unit tests passing
- All integration tests passing
- Manual tests

## Is this change a patch?

No.