### PR TITLE
Lease metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ metric.
 ### Added
 - Added new prometheus metrics for tracking lease operations.
 - Added pipeline workflow handler processing counters
+- Added new prometheus metrics for tracking lease operations.
 
 ## [6.5.0] - 2021-10-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `graphql_duration_seconds`, `graphql_duration_seconds_sum` &
 `graphql_duration_seconds_count` to the metrics log.
 - Added new prometheus metrics for tracking lease operations.
+- Added `sensu_go_lease_ops` to the metrics log.
 
 ### Fixed
 - Duration metrics for assets, pipeline, and eventd have been updated to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added objectives (0.5, 0.9, 0.99) to `graphql_duration_seconds` metric.
 - Added `graphql_duration_seconds`, `graphql_duration_seconds_sum` &
 `graphql_duration_seconds_count` to the metrics log.
+- Added new prometheus metrics for tracking lease operations.
 
 ### Fixed
 - Duration metrics for assets, pipeline, and eventd have been updated to use
@@ -55,9 +56,7 @@ metric.
 ## [6.5.1] - 2021-10-18
 
 ### Added
-- Added new prometheus metrics for tracking lease operations.
 - Added pipeline workflow handler processing counters
-- Added new prometheus metrics for tracking lease operations.
 
 ## [6.5.0] - 2021-10-12
 

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/middlewares"
@@ -308,8 +309,8 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 		duration := time.Since(then)
 		websocketUpgradeDuration.WithLabelValues().Observe(float64(duration) / float64(time.Millisecond))
 	}()
-	var marshal MarshalFunc
-	var unmarshal UnmarshalFunc
+	var marshal agent.MarshalFunc
+	var unmarshal agent.UnmarshalFunc
 	var contentType string
 
 	lager := logger.WithFields(logrus.Fields{
@@ -319,19 +320,19 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	responseHeader := make(http.Header)
-	responseHeader.Add("Accept", ProtobufSerializationHeader)
-	lager.WithField("header", fmt.Sprintf("Accept: %s", ProtobufSerializationHeader)).Debug("setting header")
-	responseHeader.Add("Accept", JSONSerializationHeader)
-	lager.WithField("header", fmt.Sprintf("Accept: %s", JSONSerializationHeader)).Debug("setting header")
-	if r.Header.Get("Accept") == ProtobufSerializationHeader {
+	responseHeader.Add("Accept", agent.ProtobufSerializationHeader)
+	lager.WithField("header", fmt.Sprintf("Accept: %s", agent.ProtobufSerializationHeader)).Debug("setting header")
+	responseHeader.Add("Accept", agent.JSONSerializationHeader)
+	lager.WithField("header", fmt.Sprintf("Accept: %s", agent.JSONSerializationHeader)).Debug("setting header")
+	if r.Header.Get("Accept") == agent.ProtobufSerializationHeader {
 		marshal = proto.Marshal
 		unmarshal = proto.Unmarshal
-		contentType = ProtobufSerializationHeader
+		contentType = agent.ProtobufSerializationHeader
 		lager.WithField("format", "protobuf").Debug("setting serialization/deserialization")
 	} else {
-		marshal = MarshalJSON
-		unmarshal = UnmarshalJSON
-		contentType = JSONSerializationHeader
+		marshal = agent.MarshalJSON
+		unmarshal = agent.UnmarshalJSON
+		contentType = agent.JSONSerializationHeader
 		lager.WithField("format", "JSON").Debug("setting serialization/deserialization")
 	}
 	responseHeader.Set("Content-Type", contentType)

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -2,7 +2,6 @@ package agentd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
@@ -75,24 +74,6 @@ var (
 	)
 )
 
-// ProtobufSerializationHeader is the Content-Type header which indicates protobuf serialization.
-const ProtobufSerializationHeader = "application/octet-stream"
-
-// JSONSerializationHeader is the Content-Type header which indicates JSON serialization.
-const JSONSerializationHeader = "application/json"
-
-// MarshalFunc is the function signature for protobuf/JSON marshaling.
-type MarshalFunc = func(pb proto.Message) ([]byte, error)
-
-// UnmarshalFunc is the function signature for protobuf/JSON unmarshaling.
-type UnmarshalFunc = func(buf []byte, pb proto.Message) error
-
-// UnmarshalJSON is a wrapper to deserialize proto messages with JSON.
-func UnmarshalJSON(b []byte, msg proto.Message) error { return json.Unmarshal(b, &msg) }
-
-// MarshalJSON is a wrapper to serialize proto messages with JSON.
-func MarshalJSON(msg proto.Message) ([]byte, error) { return json.Marshal(msg) }
-
 // A Session is a server-side connection between a Sensu backend server and
 // the Sensu agent process via the Sensu transport. It is responsible for
 // relaying messages to the message bus on behalf of the agent and from the
@@ -111,8 +92,8 @@ type Session struct {
 	ringPool         *ringv2.RingPool
 	ctx              context.Context
 	cancel           context.CancelFunc
-	marshal          MarshalFunc
-	unmarshal        UnmarshalFunc
+	marshal          agent.MarshalFunc
+	unmarshal        agent.UnmarshalFunc
 	entityConfig     *entityConfig
 	mu               sync.Mutex
 	subscriptionsMap map[string]subscription
@@ -161,8 +142,8 @@ type SessionConfig struct {
 	Store    store.Store
 	Storev2  storev2.Interface
 
-	Marshal   MarshalFunc
-	Unmarshal UnmarshalFunc
+	Marshal   agent.MarshalFunc
+	Unmarshal agent.UnmarshalFunc
 }
 
 // NewSession creates a new Session object given the triple of a transport

--- a/backend/agentd/session_test.go
+++ b/backend/agentd/session_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
@@ -283,8 +284,8 @@ func TestSession_sender(t *testing.T) {
 				Bus:           bus,
 				Store:         st,
 				Storev2:       storev2,
-				Unmarshal:     UnmarshalJSON,
-				Marshal:       MarshalJSON,
+				Unmarshal:     agent.UnmarshalJSON,
+				Marshal:       agent.MarshalJSON,
 			}
 			session, err := NewSession(context.Background(), cfg)
 			if err != nil {
@@ -341,7 +342,7 @@ func TestSession_Start(t *testing.T) {
 				conn.On("Send", mock.Anything).Run(func(args mock.Arguments) {
 					msg := args[0].(*transport.Message)
 					var entity corev3.EntityConfig
-					if err := UnmarshalJSON(msg.Payload, &entity); err != nil {
+					if err := agent.UnmarshalJSON(msg.Payload, &entity); err != nil {
 						t.Fatal(err)
 					}
 					if entity.Metadata.Name != corev3.EntityNotFound {
@@ -362,7 +363,7 @@ func TestSession_Start(t *testing.T) {
 				conn.On("Send", mock.Anything).Run(func(args mock.Arguments) {
 					msg := args[0].(*transport.Message)
 					var entity corev3.EntityConfig
-					if err := UnmarshalJSON(msg.Payload, &entity); err != nil {
+					if err := agent.UnmarshalJSON(msg.Payload, &entity); err != nil {
 						t.Fatal(err)
 					}
 					if entity.Metadata.Name != "testing" {
@@ -426,8 +427,8 @@ func TestSession_Start(t *testing.T) {
 				Bus:       bus,
 				Store:     st,
 				Storev2:   storev2,
-				Unmarshal: UnmarshalJSON,
-				Marshal:   MarshalJSON,
+				Unmarshal: agent.UnmarshalJSON,
+				Marshal:   agent.MarshalJSON,
 			}
 			session, err := NewSession(context.Background(), cfg)
 			if err != nil {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -99,6 +99,7 @@ var SelectedMetrics = []string{
 	"sensu_go_eventd_switches_bury_duration",
 	"sensu_go_eventd_switches_bury_duration_sum",
 	"sensu_go_eventd_switches_bury_duration_count",
+	"sensu_go_lease_ops",
 	"sensu_go_pipelined_message_handler_duration",
 	"sensu_go_pipelined_message_handler_duration_sum",
 	"sensu_go_pipelined_message_handler_duration_count",

--- a/backend/etcd/metrics.go
+++ b/backend/etcd/metrics.go
@@ -1,0 +1,44 @@
+package etcd
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	LeaseOperationsCounterVec = "sensu_go_lease_ops"
+
+	LeaseOperationTypeName      = "op"
+	LeaseOperationStatusName    = "status"
+	LeaseOperationComponentName = "component"
+
+	LeaseOperationTypeGrant     = "grant"
+	LeaseOperationTypeRevoke    = "revoke"
+	LeaseOperationTypePut       = "put"
+	LeaseOperationTypeKeepalive = "keepalive"
+	LeaseOperationTypeFind      = "find"
+	LeaseOperationTypeTTL       = "ttl"
+
+	LeaseOperationStatusOK      = "ok"
+	LeaseOperationStatusError   = "error"
+	LeaseOperationStatusAlive   = "alive"
+	LeaseOperationStatusExpired = "expired"
+)
+
+var LeaseOperationsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: LeaseOperationsCounterVec,
+		Help: "the total number of lease operations",
+	},
+	[]string{LeaseOperationComponentName, LeaseOperationTypeName, LeaseOperationStatusName},
+)
+
+func LeaseStatusFor(err error) string {
+	if err == nil {
+		return LeaseOperationStatusOK
+	}
+	return LeaseOperationStatusError
+}
+
+func init() {
+	if err := prometheus.Register(LeaseOperationsCounter); err != nil {
+		panic(err)
+	}
+}

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/time/rate"
 )
 
@@ -224,6 +225,7 @@ func (t *SwitchSet) ping(ctx context.Context, id string, ttl int64, alive bool) 
 
 	return kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
 		_, err = t.client.Put(ctx, key, val, clientv3.WithLease(leaseID), clientv3.WithPrevKV())
+		etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypePut, etcd.LeaseStatusFor(err)).Inc()
 		return kvc.RetryRequest(n, err)
 	})
 }
@@ -234,6 +236,7 @@ func (t *SwitchSet) getLeaseIDFromKV(ctx context.Context, kv *mvccpb.KeyValue, t
 		return t.getLeaseID(ctx, ttl, switchID)
 	}
 	if _, err := t.client.KeepAliveOnce(ctx, leaseID); err != nil {
+		etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypeKeepalive, etcd.LeaseOperationStatusExpired).Inc()
 		return t.newLease(ctx, ttl)
 	}
 	return leaseID, nil
@@ -241,6 +244,7 @@ func (t *SwitchSet) getLeaseIDFromKV(ctx context.Context, kv *mvccpb.KeyValue, t
 
 func (t *SwitchSet) newLease(ctx context.Context, ttl int64) (clientv3.LeaseID, error) {
 	lease, err := t.client.Grant(ctx, ttl)
+	etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypeGrant, etcd.LeaseStatusFor(err)).Inc()
 	if err != nil {
 		return 0, err
 	}
@@ -255,9 +259,11 @@ func (t *SwitchSet) getLeaseID(ctx context.Context, ttl int64, switchID string) 
 		return kvc.RetryRequest(n, err)
 	})
 	if err != nil {
+		etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypeFind, etcd.LeaseOperationStatusError).Inc()
 		return 0, err
 	}
 	if len(resp.Kvs) == 0 {
+		etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypeFind, etcd.LeaseOperationStatusExpired).Inc()
 		return t.newLease(ctx, ttl)
 	}
 	return t.getLeaseIDFromKV(ctx, resp.Kvs[0], ttl, switchID)
@@ -384,6 +390,7 @@ func (t *SwitchSet) handleEvent(ctx context.Context, event *clientv3.Event) {
 		// entity is not alive.
 		put := clientv3.OpPut(key, fmt.Sprintf("%d", ttl), clientv3.WithLease(leaseID))
 		resp, err := t.client.Txn(ctx).If(cmp).Then(put).Commit()
+		etcd.LeaseOperationsCounter.WithLabelValues("liveness", etcd.LeaseOperationTypePut, etcd.LeaseStatusFor(err)).Inc()
 		if err != nil {
 			t.logger.WithError(err).Errorf("error commiting keepalive tx for %s", key)
 			return

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -10,11 +10,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sensu/sensu-go/types"
-	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 const (
@@ -134,6 +135,7 @@ func (q *Queue) swapLane(ctx context.Context, currentKey, value string, lane str
 			response, err = q.kv.Txn(ctx).If(putCmp).Then(putReq, delReq).Commit()
 			return kvc.RetryRequest(n, err)
 		})
+		etcd.LeaseOperationsCounter.WithLabelValues("queue", etcd.LeaseOperationTypePut, etcd.LeaseStatusFor(err)).Inc()
 		if err != nil {
 			return err
 		}
@@ -177,6 +179,7 @@ func (q *Queue) Enqueue(ctx context.Context, value string) error {
 			response, err = q.kv.Txn(ctx).If(cmps...).Then(ops...).Commit()
 			return kvc.RetryRequest(n, err)
 		})
+		etcd.LeaseOperationsCounter.WithLabelValues("queue", etcd.LeaseOperationTypePut, etcd.LeaseStatusFor(err)).Inc()
 		if err == nil && response.Succeeded {
 			return nil
 		}

--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
@@ -29,11 +30,13 @@ func (store *Store) NewInitializer(ctx context.Context) (store.Initializer, erro
 
 	// Create a lease to associate with the lock
 	resp, err := client.Grant(ctx, 2)
+	etcd.LeaseOperationsCounter.WithLabelValues("init", etcd.LeaseOperationTypeGrant, etcd.LeaseStatusFor(err)).Inc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd lease: %w", err)
 	}
 
 	session, err := concurrency.NewSession(client, concurrency.WithLease(resp.ID)) // TODO: move session into etcdStore?
+	etcd.LeaseOperationsCounter.WithLabelValues("init", etcd.LeaseOperationTypePut, etcd.LeaseStatusFor(err)).Inc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to start etcd session: %w", err)
 	}

--- a/backend/store/etcd/silenced_store.go
+++ b/backend/store/etcd/silenced_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -257,6 +258,7 @@ func (s *Store) arraySilencedEntries(ctx context.Context, resp *clientv3.GetResp
 		if leaseID > 0 {
 			// legacy expiry mechanism
 			ttl, err := s.client.TimeToLive(ctx, leaseID)
+			etcd.LeaseOperationsCounter.WithLabelValues("store", etcd.LeaseOperationTypeTTL, etcd.LeaseStatusFor(err)).Inc()
 			if err != nil {
 				logger.WithError(err).Error("error setting TTL on silenced")
 				continue
@@ -302,6 +304,7 @@ func (s *Store) arrayTxnSilencedEntries(ctx context.Context, resp *clientv3.TxnR
 			if leaseID > 0 {
 				// legacy expiry mechanism
 				ttl, err := s.client.TimeToLive(ctx, leaseID)
+				etcd.LeaseOperationsCounter.WithLabelValues("store", etcd.LeaseOperationTypeTTL, etcd.LeaseStatusFor(err)).Inc()
 				if err != nil {
 					logger.WithError(err).Error("error setting TTL on silenced")
 					continue


### PR DESCRIPTION
## What is this change?

Cherry-pick lease metrics work from `main` to `release/6.5`. Fix the changelog that erroneously included the lease metrics as an addition to the 6.5.1 release.

## Why is this change necessary?

We want this functionality in the next 6.5 patch release.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

The 6.5.1 changelog on our website will need to be updated to remove the lease metrics addition.

## Is this change a patch?

Yes.
