### PR TITLE
The init command does not return SSL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- In addition to the context error print the connection error when sensu-go can't connect to etcd.
+
 ## [6.5.3, 6.5.4] - 2021-10-29
 
 ### Added

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -201,13 +201,13 @@ func InitCommand() *cobra.Command {
 							Username:    etcdClientUsername,
 							Password:    etcdClientPassword,
 							TLS:         tlsConfig,
-							DialOptions: []grpc.DialOption{grpc.WithBlock()},
+							DialOptions: []grpc.DialOption{grpc.WithReturnConnectionError()},
 						}
 					} else {
 						clientConfig = clientv3.Config{
 							Endpoints:   []string{url},
 							TLS:         tlsConfig,
-							DialOptions: []grpc.DialOption{grpc.WithBlock()},
+							DialOptions: []grpc.DialOption{grpc.WithReturnConnectionError()},
 						}
 					}
 					err := initializeStore(clientConfig, initConfig, url)
@@ -254,7 +254,7 @@ func initializeStore(clientConfig clientv3.Config, initConfig initConfig, endpoi
 	if err != nil {
 		return fmt.Errorf("error connecting to etcd endpoint: %w", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// Check if etcd endpoint is reachable
 	if _, err := client.Status(ctx, endpoint); err != nil {

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/sensu/sensu-go/util/path"
-	"go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	etcdTypes "go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/v3rpc"
 	"go.etcd.io/etcd/server/v3/proxy/grpcproxy/adapter"
 	zapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -285,7 +285,7 @@ func (e *Etcd) NewClientContext(ctx context.Context) (*clientv3.Client, error) {
 		DialTimeout: 60 * time.Second,
 		TLS:         tlsConfig,
 		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(),
+			grpc.WithReturnConnectionError(),
 		},
 		Context: ctx,
 	})


### PR DESCRIPTION
The SSL or other connection error is now logged as part of the context error.

Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

On `backend init` the SSL error generated when connecting to etcd was not logged at all, making troubleshooting complex. Change the behaviour to log the SSL error (or any other connectivity error) alongside the context error.

Closes #3663 

## Why is this change necessary?

To help with troubleshooting etcd connection issues.

## Does your change need a Changelog entry?

Created one. 

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual testing.

- Generate certificates using the instructions at https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/generate-certificates/
- On an separate machine (etcd1) launch an etcd container with the proper certificates
```
docker volume create --name etcd-data
export NODE1=192.168.7.160
export DATA_DIR="etcd-data"
export REGISTRY=gcr.io/etcd-development/etcd
docker run
   -p 2379:2379 \
   -p 2380:2380 \
   --volume=${DATA_DIR}:/etcd-data \
   --volume=/etc/sensu/tls/:/certs \
   --name etcd ${REGISTRY}:latest \
   /usr/local/bin/etcd \
   --data-dir=/etcd-data \
   --name node1 \
   --initial-advertise-peer-urls https://${NODE1}:2380 \
   --listen-peer-urls https://0.0.0.0:2380 \
   --advertise-client-urls https://${NODE1}:2379 \
   --listen-client-urls https://0.0.0.0:2379 \
   --initial-cluster node1=https://${NODE1}:2380 \
   --cert-file /certs/etcd1.pem \
   --key-file /certs/etcd1-key.pem \
   --peer-cert-file /certs/etcd1.pem \
   --peer-key-file /certs/etcd1-key.pem \
   --trusted-ca-file /certs/ca.pem \
   --peer-trusted-ca-file /certs/ca.pem
```
- Edit your `/etc/hosts` file to add the following line
```
192.168.7.160 etcd1 dummyhost
```  
- Create the following `backend.yml` file 
```
state-dir: "./backend-secure-etcd/state"
cache-dir: "./backend-secure-etcd/cache"
log-level: "info"
no-embed-etcd: true
etcd-cert-file: "./tls/agent.pem"
etcd-key-file: "./tls/agent-key.pem"
etcd-trusted-ca-file: "./tls/ca.pem"
etcd-client-urls: "https://dummyhost:2379"
timeout: "15s"
```
- Launch `backend init` using that file:
```
sensu-backend init -c ./backend-secure-etcd/backend.yml --cluster-admin-username admin --cluster-admin-password P@ssw0rd!
```
The following error should be logged.
```
{"component":"cmd","level":"error","msg":"error connecting to etcd endpoint: context deadline exceeded: connection error: desc = \"transport: authentication handshake failed: x509: certificate is valid for localhost, etcd1, not dummyhost\"","time":"2021-11-04T11:16:41-04:00"}
```

## Is this change a patch?

No.