### PR TITLE
Add backend label to logged metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Add backend label to logged metrics.
+
 ### Fixed
 - In addition to the context error print the connection error when sensu-go can't connect to etcd.
-### Changed
 
+### Changed
 - Empty and zero value configuration parameters for `etcd` do not overwrite
   defaults anymore.
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -686,11 +686,12 @@ func (b *Backend) runOnce() error {
 		} else {
 			defer func() { _ = metricsLogWriter.Close() }()
 			metricsBridge, err := metrics.NewInfluxBridge(&metrics.InfluxBridgeConfig{
-				Writer:    metricsLogWriter,
-				Interval:  b.Cfg.PlatformMetricsLoggingInterval,
-				Gatherer:  prometheus.DefaultGatherer,
-				ErrLogger: logger,
-				Select:    SelectedMetrics,
+				Writer:      metricsLogWriter,
+				Interval:    b.Cfg.PlatformMetricsLoggingInterval,
+				Gatherer:    prometheus.DefaultGatherer,
+				ErrLogger:   logger,
+				Select:      SelectedMetrics,
+				ExtraLabels: map[string]string{"backend": getDefaultBackendID()},
 			})
 			if err != nil {
 				logger.WithError(err).Error("unable to start the platform metrics bridge")


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Add the backend label to the logged metrics.

Closes #4450 

## Why is this change necessary?

We need the ability to associate metrics from the metrics log file with the backend they were generated on.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.


## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Unit test. Also tested manually by adding the following to my backend.yml:
```
platform-metrics-log-file: "/Users/fguimond/sensu/sensu-backend/logs/backend-stats.log"
```

## Is this change a patch?

No.