### PR TITLE
Set External etcd version in /version API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Duration metrics for assets, pipeline, and eventd have been updated to use
 milliseconds to match other duration metrics.
+- The sensu-backend's /version API has updated to reflect the version of a an
+external etcd cluster.
 
 ## [6.5.3, 6.5.4] - 2021-10-29
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -548,8 +548,19 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	authenticator.AddProvider(basic)
 
 	var clusterVersion string
-	// only retrieve the cluster version if etcd is embedded
-	if !config.NoEmbedEtcd {
+	if config.NoEmbedEtcd {
+		// get cluster version from first available etcd endpoint
+		endpoints := b.Client.Endpoints()
+		for _, ep := range endpoints {
+			status, err := b.Client.Status(ctx, ep)
+			if err != nil {
+				logger.WithError(err).Error("error getting etcd cluster version info")
+				continue
+			}
+			clusterVersion = status.Version
+			break
+		}
+	} else {
 		clusterVersion = b.Etcd.GetClusterVersion()
 	}
 


### PR DESCRIPTION
## What is this change?

When a sensu backend is initialized with an external etcd service `--no-embed-etcd`, pull the etcd cluster version from the remote service to reflect in the sensu `/version` endpoint. 

## Why is this change necessary?

https://github.com/sensu/sensu-go/issues/4174

The version API is currently tailored towards the situation where etcd is running embedded in sensu-backend.

It reflects both the version of that particular embedded instance of etcd, `etcdserver`, and the lowest common version of all cluster members, `etcdcluster`.

**Example with single sensu-backend instance:**
```
{
  "etcd": {
    "etcdserver": "3.5.0",
    "etcdcluster": "3.5.0"
  },
  "sensu_backend": "(devel)"
}
```


Today when using external etcd endpoints the output is misleading, sharing the etcd client version as `etcdserver` and leaving `etcdcluster` blank.

**Example version api output today with external etcd 3.3.8 (single instance):**
```
{
  "etcd": {
    "etcdserver": "3.5.0",
    "etcdcluster": ""
  },
  "sensu_backend": "(devel)"
}
```

This proposed solution pulls an etcd cluster version from the remote endpoint at startup:
**Resulting /version api output with external etcd 3.3.8 (single instance):**
```
{
  "etcd": {
    "etcdserver": "3.5.0", # more akin to etcd client version - admittedly still confusing
    "etcdcluster": "3.3.8"
  },
  "sensu_backend": "(devel)"
}
```
## Does your change need a Changelog entry?

Probably, yes!

## Do you need clarification on anything?

I definitely took the shortest path on this - A few areas I'd like y'all to consider to help us zero in on a solution.

1. Should we include etcd version info for remote clusters at all? I am actually leaning _no_ on this, but would like to hear from folks with more context.
2. Assuming we do want to display cluster version, what should we do about etcdserver version in this case?
3. Thoughts on moving this out of the initialization path and into the /version http handler? Presumably the cluster could be upgraded within the lifetime of a sensu backend instance.

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
The /version api docs were pretty sparse - I think we are probably okay without documenting this behavior.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->
Manually. Note: may be worth a todo to port the ansible updates for sensu-perf w/ external etcd over to sensu-staging.

## Is this change a patch?

I _think_ it is, but could be convinced that it's a minor. 
