### PR TITLE
Fix several websocket handling bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Duration metrics for assets, pipeline, and eventd have been updated to use
 milliseconds to match other duration metrics.
+- Fixed an error where sensu-backend or sensu-agent could panic due to
+concurrent websocket writes.
 
 ## [6.5.3, 6.5.4] - 2021-10-29
 


### PR DESCRIPTION
## What is this change?

This commit changes the way websocket connections are handled, by both
the backend and the agent.

It replaces one sync.RWMutex with two sync.Mutex values, one for reads,
and one for writes. The gorilla websocket docs state that reads and
writes can be concurrent, so it's not correct to use a single mutex for
both resources.

The commit also avoids setting the internal "closed" flag to true when a
connection error is encountered. Instead, it only sets the flag to true
when a ClosedError is found on receive.

The commit also makes sure the write mutex is locked when sending a
close message.

The commit also removes sync.Pool use for transport messages, which was
a speculative optimization we applied. However, it seems unlikely that
this optimization is really necessary, so I have removed it in service
of making the code clearer.

## Why is this change necessary?

Closes #4492 

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

So far I've only run the existing tests to make sure everything is still working.

## Is this change a patch?

Yes
