### PR TITLE
Retry keepalive lease grant requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ milliseconds to match other duration metrics.
 concurrent websocket writes.
 - The sensu-backend's /version API has updated to reflect the version of a an
 external etcd cluster.
+- When keepalive lease grant operations fail due to rate limiting, they are now
+retried.
 
 ## [6.5.3, 6.5.4] - 2021-10-29
 

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/time/rate"
 )
 
@@ -240,11 +240,15 @@ func (t *SwitchSet) getLeaseIDFromKV(ctx context.Context, kv *mvccpb.KeyValue, t
 }
 
 func (t *SwitchSet) newLease(ctx context.Context, ttl int64) (clientv3.LeaseID, error) {
-	lease, err := t.client.Grant(ctx, ttl)
-	if err != nil {
-		return 0, err
-	}
-	return lease.ID, nil
+	var leaseID clientv3.LeaseID
+	err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		lease, err := t.client.Grant(ctx, ttl)
+		if err == nil {
+			leaseID = lease.ID
+		}
+		return kvc.RetryRequest(n, err)
+	})
+	return leaseID, err
 }
 
 func (t *SwitchSet) getLeaseID(ctx context.Context, ttl int64, switchID string) (clientv3.LeaseID, error) {


### PR DESCRIPTION
## What is this change?

Adds retry behaviour to lease grants, since they can fail due to rate limiting.

## Why is this change necessary?

Closes #4500. I found this issue as part of an ongoing investigation into sensu-backend stability and error handling.

## Does your change need a Changelog entry?

Included!

## How did you verify this change?

Verified by load testing and is also covered by existing integration tests. While the retry behaviour itself is not tested for, the retry mechanism itself is well tested.

## Is this change a patch?

Yes.
