### PR TITLE
Log errors returned by cron library when validating Checks & CheckConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Check & CheckConfig validation errors related to cron now provide additional
+context.
+
 ### Fixed
 - Fixed a bug where sensu-backend could crash if the BackendIDGetter encounters
 etcd client unavailability.

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -175,7 +175,7 @@ func (c *Check) Validate() error {
 			}
 
 			if _, err := cron.ParseStandard(c.Cron); err != nil {
-				return errors.New("check cron string is invalid")
+				return fmt.Errorf("check cron string is invalid: %w", err)
 			}
 		} else {
 			if c.Interval < 1 {

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -109,7 +109,7 @@ func (c *CheckConfig) Validate() error {
 		}
 
 		if _, err := cron.ParseStandard(c.Cron); err != nil {
-			return errors.New("check cron string is invalid")
+			return fmt.Errorf("check cron string is invalid: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## What is this change?

Adds the error returned by the cron library to the validation error we return when validating the Check & CheckConfig resources.

## Why is this change necessary?

Is can be unclear why the validation fails without this change.

Closes https://github.com/sensu/sensu-go/issues/4385.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is needed.

## How did you verify this change?

Spun up a Docker container before and after this commit. Analyzed the output returned by `sensuctl create -f` when using the following file:

```yaml
---
type: CheckConfig
api_version: core/v2
metadata:
  name: cron_test
spec:
  command: "true"
  cron: 'CRON_TZ=Asia/Tokyo * * * * *'
  handlers: []
  publish: true
  subscriptions:
  - system/linux
---
type: CheckConfig
api_version: core/v2
metadata:
  name: cron_test
spec:
  command: "true"
  cron: 'TZ=Asia/Tokyo * * * * *'
  handlers: []
  publish: true
  subscriptions:
  - system/linux
```

Before:

```
Error: error putting resource #0 with name "cron_test" and namespace "default" (/api/core/v2/namespaces/default/checks/cron_test): resource is invalid: check cron string is invalid
```

After:

```
Error: error putting resource #0 with name "cron_test" and namespace "default" (/api/core/v2/namespaces/default/checks/cron_test): resource is invalid: check cron string is invalid: provided bad location Asia/Tokyo: unknown time zone Asia/Tokyo
```

## Is this change a patch?

Yes.
