### PR TITLE
Add CountEvents store method

### DIFF
--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -422,19 +422,10 @@ func handleExpireOnResolveEntries(ctx context.Context, event *corev2.Event, st s
 // CountEvents counts events in the namespace. The SelectionPredicate is not
 // supported.
 func (s *Store) CountEvents(ctx context.Context, _ *store.SelectionPredicate) (int64, error) {
-	var count int64
-
 	key := GetEventsPath(ctx, "")
 	if !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
 
-	err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
-		resp, err := s.client.Get(ctx, key, clientv3.WithCountOnly(), clientv3.WithPrefix())
-		if err == nil {
-			count = resp.Count
-		}
-		return kvc.RetryRequest(n, err)
-	})
-	return count, err
+	return Count(ctx, s.client, key)
 }

--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -67,6 +67,13 @@ func (s *StoreProxy) UpdateEvent(ctx context.Context, event *corev2.Event) (old,
 	return s.do().UpdateEvent(ctx, event)
 }
 
+// CountEvents counts the events in a namespace. The namespace is psecified as
+// part of the context. In the enterprise prodcut, filtering is also taken into
+// account.
+func (s *StoreProxy) CountEvents(ctx context.Context, pred *SelectionPredicate) (int64, error) {
+	return s.do().CountEvents(ctx, pred)
+}
+
 // DeleteAssetByName deletes an asset using the given name and the
 // namespace stored in ctx.
 func (s *StoreProxy) DeleteAssetByName(ctx context.Context, name string) error {

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -402,6 +402,10 @@ type EventStore interface {
 	// event, which may be the same as the event that was passed in, and the
 	// previous event, if one existed, as well as any error that occurred.
 	UpdateEvent(ctx context.Context, event *types.Event) (old, new *types.Event, err error)
+
+	// CountEvents counts the number of events in the namespace. The namespace is
+	// provided as part of the context.
+	CountEvents(context.Context, *SelectionPredicate) (int64, error)
 }
 
 // EventFilterStore provides methods for managing events filters

--- a/testing/mockstore/events.go
+++ b/testing/mockstore/events.go
@@ -36,3 +36,8 @@ func (s *MockStore) UpdateEvent(ctx context.Context, event *corev2.Event) (*core
 	args := s.Called(event)
 	return args.Get(0).(*corev2.Event), args.Get(1).(*corev2.Event), args.Error(2)
 }
+
+func (s *MockStore) CountEvents(ctx context.Context, pred *store.SelectionPredicate) (int64, error) {
+	args := s.Called(ctx, pred)
+	return args.Get(0).(int64), args.Error(1)
+}


### PR DESCRIPTION
## What is this change?

The CountEvents store method will be used by the Web UI to know how many
pages of results are available, when using pagination.

## Why is this change necessary?

Supporting work for ongoing maintenance related to #4487

## Does your change need a Changelog entry?

No

## How did you verify this change?

Integration testing.

## Is this change a patch?

No.