### PR TITLE
Store Based Event Filtering Aware Graphql Field Resolver

### DIFF
--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -23,9 +23,9 @@ type EventClient struct {
 	bus   Publisher
 }
 
-// EventsStoreSupportsFiltering stub impl
-func (EventClient) EventsStoreSupportsFiltering(ctx context.Context) bool {
-	return false
+// EventStoreSupportsFiltering stub impl
+func (c EventClient) EventStoreSupportsFiltering(ctx context.Context) bool {
+	return c.store.EventStoreSupportsFiltering(ctx)
 }
 
 // CountEvents proxies to store client

--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -23,7 +23,7 @@ type EventClient struct {
 	bus   Publisher
 }
 
-// EventStoreSupportsFiltering stub impl
+// EventStoreSupportsFiltering proxies to store client
 func (c EventClient) EventStoreSupportsFiltering(ctx context.Context) bool {
 	return c.store.EventStoreSupportsFiltering(ctx)
 }

--- a/backend/api/event.go
+++ b/backend/api/event.go
@@ -23,6 +23,16 @@ type EventClient struct {
 	bus   Publisher
 }
 
+// EventsStoreSupportsFiltering stub impl
+func (EventClient) EventsStoreSupportsFiltering(ctx context.Context) bool {
+	return false
+}
+
+// CountEvents proxies to store client
+func (c EventClient) CountEvents(ctx context.Context, pred *store.SelectionPredicate) (int64, error) {
+	return c.store.CountEvents(ctx, pred)
+}
+
 // NewEventClient creates a new EventClient, given a store, authorizer, and bus.
 func NewEventClient(store store.EventStore, auth authorization.Authorizer, bus Publisher) *EventClient {
 	return &EventClient{

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -39,7 +39,7 @@ type EventClient interface {
 	ListEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error)
 	ListEventsByEntity(ctx context.Context, entity string, pred *store.SelectionPredicate) ([]*corev2.Event, error)
 	CountEvents(ctx context.Context, pred *store.SelectionPredicate) (int64, error)
-	EventsStoreSupportsFiltering(context.Context) bool
+	EventStoreSupportsFiltering(context.Context) bool
 }
 
 type EventFilterClient interface {

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -38,6 +38,8 @@ type EventClient interface {
 	DeleteEvent(ctx context.Context, entity, check string) error
 	ListEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error)
 	ListEventsByEntity(ctx context.Context, entity string, pred *store.SelectionPredicate) ([]*corev2.Event, error)
+	CountEvents(ctx context.Context, pred *store.SelectionPredicate) (int64, error)
+	EventsStoreSupportsFiltering(context.Context) bool
 }
 
 type EventFilterClient interface {

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -172,7 +172,7 @@ func (c *MockEventClient) CountEvents(ctx context.Context, _ *store.SelectionPre
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (c *MockEventClient) EventsStoreSupportsFiltering(ctx context.Context) bool {
+func (c *MockEventClient) EventStoreSupportsFiltering(ctx context.Context) bool {
 	return c.Called(ctx).Get(0).(bool)
 }
 

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -167,6 +167,15 @@ func (c *MockEventClient) ListEventsByEntity(ctx context.Context, entity string,
 	return args.Get(0).([]*corev2.Event), args.Error(1)
 }
 
+func (c *MockEventClient) CountEvents(ctx context.Context, _ *store.SelectionPredicate) (int64, error) {
+	args := c.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (c *MockEventClient) EventsStoreSupportsFiltering(ctx context.Context) bool {
+	return c.Called(ctx).Get(0).(bool)
+}
+
 type MockMutatorClient struct {
 	mock.Mock
 }

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -295,7 +295,7 @@ func (r *namespaceImpl) eventsWithInStoreFiltering(p schema.NamespaceEventsField
 
 // Events implements response to request for 'events' field.
 func (r *namespaceImpl) Events(p schema.NamespaceEventsFieldResolverParams) (interface{}, error) {
-	if r.eventClient.EventsStoreSupportsFiltering(p.Context) {
+	if r.eventClient.EventStoreSupportsFiltering(p.Context) {
 		return r.eventsWithInStoreFiltering(p)
 	}
 

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -13,12 +13,6 @@ import (
 
 var _ schema.NamespaceFieldResolvers = (*namespaceImpl)(nil)
 
-const (
-	storeOffset   = "io.sensu.store.filtering.offset"
-	storeLimit    = "io.sensu.store.filtering.limit"
-	storeOrdering = "io.sensu.store.filtering.ordering"
-)
-
 //
 // Implement NamespaceFieldResolvers
 //

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -69,7 +69,7 @@ func TestNamespaceTypeEntitiesField(t *testing.T) {
 
 func TestNamespaceTypeEventsField(t *testing.T) {
 	client := new(MockEventClient)
-	client.On("EventsStoreSupportsFiltering", mock.Anything).Return(false)
+	client.On("EventStoreSupportsFiltering", mock.Anything).Return(false)
 	client.On("ListEvents", mock.Anything, mock.Anything).Return([]*corev2.Event{
 		corev2.FixtureEvent("a", "b"),
 		corev2.FixtureEvent("b", "c"),
@@ -98,7 +98,7 @@ func TestNamespaceTypeEventsField(t *testing.T) {
 func TestNamespaceTypeEventsFieldWithStoreFiltering(t *testing.T) {
 	client := new(MockEventClient)
 	// event client with filtering enabled
-	client.On("EventsStoreSupportsFiltering", mock.Anything).Return(true)
+	client.On("EventStoreSupportsFiltering", mock.Anything).Return(true)
 	client.On("CountEvents", mock.Anything, mock.Anything).Return(int64(128), nil)
 
 	client.On("ListEvents", mock.Anything, mock.Anything).Return([]*corev2.Event{

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -66,7 +66,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	// Register types
 	schema.RegisterAsset(svc, &assetImpl{})
 	schema.RegisterCoreV2Secret(svc, &schema.CoreV2SecretAliases{})
-	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient})
+	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient, eventClient: cfg.EventClient})
 	schema.RegisterErrCode(svc)
 	schema.RegisterEvent(svc, &eventImpl{})
 	schema.RegisterEventsListOrder(svc)

--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -429,3 +429,9 @@ func (s *Store) CountEvents(ctx context.Context, _ *store.SelectionPredicate) (i
 
 	return Count(ctx, s.client, key)
 }
+
+// EventStoreSupportsFiltering the etcd store does not currently support
+// filtering.
+func (s *Store) EventStoreSupportsFiltering(context.Context) bool {
+	return false
+}

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -141,4 +142,9 @@ func Test_updateEventHistory(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEventStoreSupportsFilteringUnsupported(t *testing.T) {
+	store := NewStore(nil, "")
+	assert.Equal(t, false, store.EventStoreSupportsFiltering(context.Background()), "etcd event store not expected to support filtering")
 }

--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -74,6 +74,12 @@ func (s *StoreProxy) CountEvents(ctx context.Context, pred *SelectionPredicate) 
 	return s.do().CountEvents(ctx, pred)
 }
 
+// EventStoreSupportsFiltering signals whether an event store implementation
+// supporting filtering, ordering and offsets. Currently an enterprise postgres store feature.
+func (s *StoreProxy) EventStoreSupportsFiltering(ctx context.Context) bool {
+	return s.do().EventStoreSupportsFiltering(ctx)
+}
+
 // DeleteAssetByName deletes an asset using the given name and the
 // namespace stored in ctx.
 func (s *StoreProxy) DeleteAssetByName(ctx context.Context, name string) error {

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -410,6 +410,10 @@ type EventStore interface {
 	// CountEvents counts the number of events in the namespace. The namespace is
 	// provided as part of the context.
 	CountEvents(context.Context, *SelectionPredicate) (int64, error)
+
+	// EventStoreSupportsFiltering signals whether an event store implementation
+	// supporting filtering, ordering and offsets. Currently an enterprise postgres store feature.
+	EventStoreSupportsFiltering(ctx context.Context) bool
 }
 
 // EventFilterStore provides methods for managing events filters

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -101,6 +101,8 @@ type SelectionPredicate struct {
 	Continue string
 	// Limit indicates the number of resources to retrieve
 	Limit int64
+	// Offset into the collection
+	Offset int64
 	// Subcollection represents a sub-collection of the primary collection
 	Subcollection string
 	// Ordering indicates the property to sort on, if supported by the store

--- a/testing/mockstore/events.go
+++ b/testing/mockstore/events.go
@@ -41,3 +41,7 @@ func (s *MockStore) CountEvents(ctx context.Context, pred *store.SelectionPredic
 	args := s.Called(ctx, pred)
 	return args.Get(0).(int64), args.Error(1)
 }
+
+func (s *MockStore) EventStoreSupportsFiltering(ctx context.Context) bool {
+	return s.Called(ctx).Get(0).(bool)
+}


### PR DESCRIPTION
## What is this change?

Overwrites the Namespace Events graphql field resolver for situations where the backing event store supports filtering and sorting (i.e. postgres in the enterprise product)


## Why is this change necessary?

Prevents the web ui from using excessive memory by loading large collections of events.

## Does your change need a Changelog entry?

? 😬 

## Do you need clarification on anything?



## Were there any complications while making this change?



## Have you reviewed and updated the documentation for this change? Is new documentation required?


## How did you verify this change?



## Is this change a patch?

No
