### PR TITLE
Fix severity ordering

### DIFF
--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -268,13 +268,15 @@ func listEventsOrdering(order schema.EventsListOrder) (string, bool) {
 	case schema.EventsListOrders.ENTITY_DESC:
 		return corev2.EventSortEntity, true
 	case schema.EventsListOrders.LASTOK:
-		return corev2.EventSortLastOk, false
+		return corev2.EventSortLastOk, true
 	case schema.EventsListOrders.NEWEST:
 		return corev2.EventSortTimestamp, true
 	case schema.EventsListOrders.OLDEST:
 		return corev2.EventSortTimestamp, false
+	case schema.EventsListOrders.SEVERITY:
+		return corev2.EventSortSeverity, true
 	default:
-		return corev2.EventSortTimestamp, true
+		return corev2.EventSortLastOk, true
 	}
 }
 


### PR DESCRIPTION
## What is this change?

Fixes a recent change to graphql event ordering, so that sorting by severity works.

@c-kruse I don't need you for review, as this is time sensitive. However, I don't have time to write a unit test for this. Would you mind back-filling one when you return next week?