### PR TITLE
Invert ordering of events by severity

### DIFF
--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -274,7 +274,7 @@ func listEventsOrdering(order schema.EventsListOrder) (string, bool) {
 	case schema.EventsListOrders.OLDEST:
 		return corev2.EventSortTimestamp, false
 	case schema.EventsListOrders.SEVERITY:
-		return corev2.EventSortSeverity, true
+		return corev2.EventSortSeverity, false
 	default:
 		return corev2.EventSortLastOk, true
 	}


### PR DESCRIPTION
The previous commit fixed severity ordering but got the direction wrong.