### PR TITLE
Remove over zealous log entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Remove debugging log entry.
+
 ## [6.6.0] - 2021-11-25
 
 ### Added

--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -182,7 +182,6 @@ func (a *AdapterV1) Run(ctx context.Context, ref *corev2.ResourceReference, reso
 
 		// Process the event through the workflow filters
 		filtered, err := a.processFilters(ctx, workflow.Filters, event)
-		fmt.Println(filtered, err)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## What is this change?

Removes the following log entry spamming the log files.
```
Nov 29 09:48:22 ensengoa001 sensu-backend[4179342]: true
Nov 29 09:48:22 ensengoa001 sensu-backend[4179342]: true
Nov 29 09:48:22 ensengoa001 sensu-backend[4179342]: true
Nov 29 09:48:22 ensengoa001 sensu-backend[4179342]: true
```


## Why is this change necessary?

To prevent log files from growing too big too fast.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not necessary.

## How did you verify this change?

Manual test.

## Is this change a patch?

Yes, submitting against release/6.6.
