### PR TITLE
Add test cases for missing orderings

### DIFF
--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -174,6 +174,27 @@ func TestNamespaceTypeEventsFieldWithStoreFiltering(t *testing.T) {
 			expectedLimit:      100,
 			expectedTotal:      128,
 		}, {
+			name:   "New query by last ok",
+			client: newClient(128, false),
+			args: schema.NamespaceEventsFieldResolverArgs{
+				Limit:   100,
+				OrderBy: schema.EventsListOrders.LASTOK,
+			},
+			expectedOrdering:   corev2.EventSortLastOk,
+			expectedDescending: true,
+			expectedLimit:      100,
+			expectedTotal:      128,
+		}, {
+			name:   "New query ordering not specified",
+			client: newClient(128, false),
+			args: schema.NamespaceEventsFieldResolverArgs{
+				Limit: 100,
+			},
+			expectedOrdering:   corev2.EventSortLastOk,
+			expectedDescending: true,
+			expectedLimit:      100,
+			expectedTotal:      128,
+		}, {
 			name:   "Store Error",
 			client: newClient(0, true),
 			args: schema.NamespaceEventsFieldResolverArgs{


### PR DESCRIPTION
Signed-off-by: c-kruse <ctkruse99@gmail.com>

## What is this change?

Adding unit test coverage around the sort ordering mapping per https://github.com/sensu/sensu-go/pull/4516.

## Why is this change necessary?

Documenting desired sort ordering.

## Does your change need a Changelog entry?

✅ 

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No

## How did you verify this change?

Unit test suite change only / N/A

## Is this change a patch?

Yes.
