### PR TITLE
Add PrometheusOutputMetricFormat to aliases.go

### DIFF
--- a/types/aliases.go
+++ b/types/aliases.go
@@ -171,7 +171,11 @@ const (
 	// InfluxDBOutputMetricFormat is the accepted string to represent the output metric format of
 	// InfluxDB Line
 	InfluxDBOutputMetricFormat = v2.InfluxDBOutputMetricFormat
-
+	
+	// PrometheusOutputMetricFormat is the accepted string to represent the output metric format of
+	// Prometheus Line
+	PrometheusOutputMetricFormat = v2.PrometheusOutputMetricFormat
+	
 	// CoreEdition represents the Sensu Core Edition (CE)
 	CoreEdition = v2.CoreEdition
 


### PR DESCRIPTION
Need to add PrometheusOutputMetricFormat , as plugins which export to prometheus wont work.

## What is this change?

Need to add PrometheusOutputMetricFormat , as plugins which export to prometheus wont work.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

plugins which export to prometheus wont work.

## Do you need clarification on anything?

No
## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No required

## How did you verify this change?

with push gateway handler [](https://github.com/portertech/sensu-prometheus-pushgateway-handler)
## Is this change a patch?

Looks like
