### PR TITLE
Opampd Provide RemoteConfig

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -545,10 +545,13 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize the OpAMP daemon
 	opamp, err := opampd.New(&opampd.Config{
-		Host:    "0.0.0.0",
-		Port:    4320,
-		Path:    "/v1/opamp",
-		Handler: &opampd.Protocol{},
+		Host: "0.0.0.0",
+		Port: 4320,
+		Path: "/v1/opamp",
+		Handler: &opampd.Protocol{
+			Store:     b.Store,
+			PartyMode: true,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing OpAMP daemon: %s", err)

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -1,25 +1,42 @@
 package opampd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/sensu/sensu-go/backend/store"
 )
 
+const supportedCapabilities = protobufs.ServerCapabilities_AcceptsStatus | protobufs.ServerCapabilities_OffersRemoteConfig
+
 type Protocol struct {
+	Store     store.OpampStore
+	PartyMode bool
 }
 
 func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusReport) (*protobufs.ServerToAgent, error) {
-	//TODO implement me
+	c := report.Capabilities
 	s2a := &protobufs.ServerToAgent{
-		InstanceUid:           instanceUid,
-		ErrorResponse:         nil,
-		RemoteConfig:          nil,
-		ConnectionSettings:    nil,
-		AddonsAvailable:       nil,
-		AgentPackageAvailable: nil,
-		Flags:                 0,
-		Capabilities:          0,
+		InstanceUid:  instanceUid,
+		Capabilities: supportedCapabilities,
+	}
+	if (c&protobufs.AgentCapabilities_AcceptsRemoteConfig) > 0 || p.PartyMode {
+		logger.Infof("updating remote agent config for agent %s", instanceUid)
+		cfg, err := p.Store.GetAgentConfig(context.Background())
+		if err != nil {
+			return s2a, err
+		}
+		s2a.RemoteConfig = &protobufs.AgentRemoteConfig{
+			Config: &protobufs.AgentConfigMap{
+				ConfigMap: map[string]*protobufs.AgentConfigFile{
+					"sensu.io": {
+						Body:        []byte(cfg.Body),
+						ContentType: cfg.ContentType,
+					},
+				},
+			},
+		}
 	}
 	return s2a, nil
 }

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -25,7 +25,8 @@ func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusRe
 		logger.Infof("updating remote agent config for agent %s", instanceUid)
 		cfg, err := p.Store.GetAgentConfig(context.Background())
 		if err != nil {
-			return s2a, err
+			logger.WithError(err).Warn("unable to provide opamp agent with remote configuration")
+			return s2a, nil
 		}
 		s2a.RemoteConfig = &protobufs.AgentRemoteConfig{
 			Config: &protobufs.AgentConfigMap{

--- a/backend/opampd/types.go
+++ b/backend/opampd/types.go
@@ -1,6 +1,8 @@
 package opampd
 
-import "github.com/open-telemetry/opamp-go/protobufs"
+import (
+	"github.com/open-telemetry/opamp-go/protobufs"
+)
 
 type MessageHandler interface {
 	OnStatusReport(instanceUid string, report *protobufs.StatusReport) (*protobufs.ServerToAgent, error)

--- a/cli/commands/opampagent/configure.go
+++ b/cli/commands/opampagent/configure.go
@@ -42,7 +42,7 @@ func ConfigureCommand(cli *cli.SensuCli) *cobra.Command {
 		},
 	}
 	_ = cmd.Flags().StringP("file", "f", "", "otel collector configuration file")
-	_ = cmd.Flags().StringP("content-type", "c", "yaml", "otel collector configuration file content type")
+	_ = cmd.Flags().StringP("content-type", "c", "text/yaml", "otel collector configuration file content type")
 
 	return cmd
 }


### PR DESCRIPTION
## What is this change?

Update the StatusReport handler to include a RemoteConfig when an `api/opamp/agentconfig` is set in the backend.

## Workarounds

PartyMode is a silly name, but the issue I was working around was that the opamp client from otelcol-sumo doesn't announce that it is capable of remote config. Instead of just disobeying the spec on this capability and commenting out that gate, I am bypassing it with the PartyMode flag.

## Testing

* build/install sensuctl and sensu-backend. Start sensu-backend
* Using a valid otel conf `cfg.yaml`, configure sensu's opamp agent with `sensuctl opampagent configure -f /path/to/cfg.yml`
example cfg.yaml:
```
receivers:
  otlp:
    protocols:
      http:

exporters:
  logging:

extensions:
  opamp:
    config_path: /tmp/config-opamp.yaml
    endpoint: ws://localhost:4320/v1/opamp

service:
  pipelines:
    metrics:
      receivers: [ otlp ]
      exporters: [ logging ]

  extensions: [opamp]
```
* Verify with `sensuctl opampagent config`
* Start otelcol-sumo and watch it load this config on startup.
