### PR TITLE
Create a new entity when an agent comes online.

### DIFF
--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -26,6 +26,9 @@ const (
 	// EntityBackendClass is the name of the class given to backend entities.
 	EntityBackendClass = "backend"
 
+	// EntityOpAMPClass is the name of the class given to OpAMP entities.
+	EntityOpAMPClass = "opamp"
+
 	// EntityServiceClass is the name of the class given to BSM service entities.
 	EntityServiceClass = "service"
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -644,7 +644,7 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 		return false
 	}
 
-	if event.Entity.EntityClass != corev2.EntityAgentClass {
+	if event.Entity.EntityClass != corev2.EntityAgentClass && event.Entity.EntityClass != corev2.EntityOpAMPClass {
 		return false
 	}
 

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -5,17 +5,27 @@ import (
 	"fmt"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
+)
+
+const (
+	entityNamespace = "default"
 )
 
 const supportedCapabilities = protobufs.ServerCapabilities_AcceptsStatus | protobufs.ServerCapabilities_OffersRemoteConfig
 
 type Protocol struct {
-	Store     store.OpampStore
+	Store     store.Store
 	PartyMode bool
 }
 
 func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusReport) (*protobufs.ServerToAgent, error) {
+	err := p.createEntity(instanceUid, report)
+	if err != nil {
+		return nil, err
+	}
+
 	c := report.Capabilities
 	s2a := &protobufs.ServerToAgent{
 		InstanceUid:  instanceUid,
@@ -39,6 +49,7 @@ func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusRe
 			},
 		}
 	}
+
 	return s2a, nil
 }
 
@@ -55,4 +66,38 @@ func (p *Protocol) OnAgentInstallStatus(instanceUid string, status *protobufs.Ag
 func (p *Protocol) OnAgentDisconnect(instanceUid string, disconnect *protobufs.AgentDisconnect) (*protobufs.ServerToAgent, error) {
 	//TODO implement me
 	return nil, fmt.Errorf("implement me")
+}
+
+func (p *Protocol) createEntity(instanceUid string, report *protobufs.StatusReport) error {
+	entity, err := p.Store.GetEntityByName(context.WithValue(context.Background(), corev2.NamespaceKey, entityNamespace), instanceUid)
+
+	if err != nil {
+		return err
+	}
+
+	entity = &corev2.Entity{
+		EntityClass:        corev2.EntityAgentClass,
+		System:             corev2.System{},
+		Subscriptions:      []string{"opamp"},
+		LastSeen:           0,
+		Deregister:         true,
+		Deregistration:     corev2.Deregistration{},
+		User:               "",
+		ExtendedAttributes: nil,
+		Redact:             nil,
+		ObjectMeta: corev2.ObjectMeta{
+			Name:      instanceUid,
+			Namespace: entityNamespace,
+			Labels: map[string]string{
+				"opamp-instanceid": instanceUid,
+				"opamp-agent-type": report.AgentDescription.AgentType,
+			},
+			Annotations: nil,
+			CreatedBy:   "",
+		},
+		SensuAgentVersion: report.AgentDescription.AgentVersion,
+		KeepaliveHandlers: nil,
+	}
+
+	return p.Store.UpdateEntity(context.WithValue(context.Background(), corev2.NamespaceKey, entityNamespace), entity)
 }

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -69,13 +69,7 @@ func (p *Protocol) OnAgentDisconnect(instanceUid string, disconnect *protobufs.A
 }
 
 func (p *Protocol) createEntity(instanceUid string, report *protobufs.StatusReport) error {
-	entity, err := p.Store.GetEntityByName(context.WithValue(context.Background(), corev2.NamespaceKey, entityNamespace), instanceUid)
-
-	if err != nil {
-		return err
-	}
-
-	entity = &corev2.Entity{
+	entity := &corev2.Entity{
 		EntityClass:        corev2.EntityAgentClass,
 		System:             corev2.System{},
 		Subscriptions:      []string{"opamp"},

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -69,8 +69,14 @@ func (p *Protocol) OnAgentDisconnect(instanceUid string, disconnect *protobufs.A
 }
 
 func (p *Protocol) createEntity(instanceUid string, report *protobufs.StatusReport) error {
+	agentType := ""
+	agentVersion := ""
+	if report.AgentDescription != nil {
+		agentType = report.AgentDescription.AgentType
+		agentVersion = report.AgentDescription.AgentVersion
+	}
 	entity := &corev2.Entity{
-		EntityClass:        corev2.EntityAgentClass,
+		EntityClass:        corev2.EntityOpAMPClass,
 		System:             corev2.System{},
 		Subscriptions:      []string{"opamp"},
 		LastSeen:           0,
@@ -83,13 +89,14 @@ func (p *Protocol) createEntity(instanceUid string, report *protobufs.StatusRepo
 			Name:      instanceUid,
 			Namespace: entityNamespace,
 			Labels: map[string]string{
-				"opamp-instanceid": instanceUid,
-				"opamp-agent-type": report.AgentDescription.AgentType,
+				"opamp-instanceid":    instanceUid,
+				"opamp-agent-type":    agentType,
+				"opamp-agent-version": agentVersion,
 			},
 			Annotations: nil,
 			CreatedBy:   "",
 		},
-		SensuAgentVersion: report.AgentDescription.AgentVersion,
+		SensuAgentVersion: "",
 		KeepaliveHandlers: nil,
 	}
 


### PR DESCRIPTION
## What is this change?

Create a new Sensu entity when a new opamp agent connects to the WS server.
