### PR TITLE
Hack21 opamp broadcast

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/backend/agentd"
 	"github.com/sensu/sensu-go/backend/api"
@@ -552,8 +553,9 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 			Store:     b.Store,
 			PartyMode: true,
 		},
-		EventBus:      bus,
-		BackendEntity: backendEntity,
+		EventBus:            bus,
+		BackendEntity:       backendEntity,
+		StoredConfigWatcher: etcdstore.Watch(ctx, b.Client, store.NewKeyBuilder("opamp").Build(corev3.OpampAgentConfigResource), false),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing OpAMP daemon: %s", err)

--- a/backend/opampd/protocol.go
+++ b/backend/opampd/protocol.go
@@ -77,10 +77,12 @@ func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusRe
 
 		case protobufs.RemoteConfigStatus_Applying:
 			// status code 3 meant to represent "applying"
+			event.Check.Output = "Applying remote configuration"
 			event.Check.Status = 3
 			event.Check.State = "applying"
 
 		case protobufs.RemoteConfigStatus_Applied:
+			event.Check.Output = "Remote configuration applied"
 			event.Check.Status = 0
 			event.Check.State = corev2.EventPassingState
 			event.Check.LastOK = time.Now().Unix()
@@ -97,6 +99,7 @@ func (p *Protocol) OnStatusReport(instanceUid string, report *protobufs.StatusRe
 		event.Check.Name = entity.Name
 		event.Check.Namespace = entity.Namespace
 		event.Check.Handlers = []string{"dummy"}
+		event.Check.Output = "Remote configuration applied"
 		event.Check.Status = 0
 		event.Check.State = corev2.EventPassingState
 		event.Check.LastOK = time.Now().Unix()


### PR DESCRIPTION
## What is this change?

Better manage incoming connections and provide a way to broadcast a message to all connected OT agents.

Note that for now connection cleanup is not implemented.

