### PR TITLE
Revoke orphaned leases on bury

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- New agent sessions will no longer result in a leaked Etcd lease.
+
 ## [6.6.1, 6.6.2] - 2021-11-29
 
 ### Added

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -38,6 +38,10 @@ func (*fakeSwitchSet) Bury(context.Context, string) error {
 	return nil
 }
 
+func (*fakeSwitchSet) BuryAndRevokeLease(context.Context, string) error {
+	return nil
+}
+
 func newFakeFactory(f liveness.Interface) liveness.Factory {
 	return func(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
 		return f
@@ -187,6 +191,11 @@ func (m *mockSwitchSet) Dead(ctx context.Context, id string, ttl int64) error {
 }
 
 func (m *mockSwitchSet) Bury(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockSwitchSet) BuryAndRevokeLease(ctx context.Context, id string) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -53,6 +53,10 @@ func (fakeLivenessInterface) Bury(context.Context, string) error {
 	return nil
 }
 
+func (fakeLivenessInterface) BuryAndRevokeLease(context.Context, string) error {
+	return nil
+}
+
 // type assertion
 var _ liveness.Interface = fakeLivenessInterface{}
 

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -180,11 +180,10 @@ func (t *SwitchSet) BuryAndRevokeLease(ctx context.Context, id string) error {
 
 	// revoke the lease from earlier if it exists
 	if leaseID != 0 {
-		if err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
-			_, err = t.client.Revoke(ctx, leaseID)
-			return kvc.RetryRequest(n, err)
-		}); err != nil {
-			return fmt.Errorf("error burying switch: %s", err)
+		if _, err := t.client.Revoke(ctx, leaseID); err != nil {
+			t.logger.Debugf(
+				"error revoking lease for buried switch, lease may have already been revoked: %s",
+				err)
 		}
 	}
 

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -61,6 +61,9 @@ type Interface interface {
 
 	// Bury forgets an entity exists
 	Bury(ctx context.Context, id string) error
+
+	// BuryAndRevokeLease forgets an entity exists and revokes the lease associated with it
+	BuryAndRevokeLease(ctx context.Context, id string) error
 }
 
 // Factory is a function that can deliver an Interface
@@ -152,6 +155,42 @@ func (t *SwitchSet) Alive(ctx context.Context, id string, ttl int64) error {
 	})
 }
 
+// BuryAndRevokeLease is similar to Bury() but will revoke the lease associated
+// with the switch if one exists.
+func (t *SwitchSet) BuryAndRevokeLease(ctx context.Context, id string) error {
+	key := path.Join(t.prefix, id)
+
+	// find lease ID that we will revoke later on
+	var leaseID clientv3.LeaseID
+	var getResp *clientv3.GetResponse
+	if err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		getResp, err = t.client.Get(ctx, key, clientv3.WithIgnoreValue())
+		return kvc.RetryRequest(n, err)
+	}); err != nil {
+		return fmt.Errorf("switch retrieval failed: %s", err)
+	}
+	if len(getResp.Kvs) != 0 {
+		leaseID = clientv3.LeaseID(getResp.Kvs[0].Lease)
+	}
+
+	// bury the key as usual
+	if err := t.Bury(ctx, id); err != nil {
+		return err
+	}
+
+	// revoke the lease from earlier if it exists
+	if leaseID != 0 {
+		if err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+			_, err = t.client.Revoke(ctx, leaseID)
+			return kvc.RetryRequest(n, err)
+		}); err != nil {
+			return fmt.Errorf("error burying switch: %s", err)
+		}
+	}
+
+	return nil
+}
+
 // Bury buries a live or dead switch. The switch will no longer
 // or callbacks.
 func (t *SwitchSet) Bury(ctx context.Context, id string) error {
@@ -159,19 +198,21 @@ func (t *SwitchSet) Bury(ctx context.Context, id string) error {
 
 	t.logger.WithFields(logrus.Fields{"key": key}).Debug("burying key")
 
-	err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+	// set the value of the switch key to buried
+	if err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
 		_, err = t.client.Put(ctx, key, buried)
 		return kvc.RetryRequest(n, err)
-	})
-	if err != nil {
+	}); err != nil {
+		t.logger.WithFields(logrus.Fields{"key": key}).Errorf("error burying key: %s", err)
 		return fmt.Errorf("error burying switch: %s", err)
 	}
 
-	err = kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+	// delete the switch key
+	if err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
 		_, err = t.client.Delete(ctx, key)
 		return kvc.RetryRequest(n, err)
-	})
-	if err != nil {
+	}); err != nil {
+		t.logger.WithFields(logrus.Fields{"key": key}).Errorf("error deleting key: %s", err)
 		return fmt.Errorf("error burying switch: %s", err)
 	}
 


### PR DESCRIPTION
## What is this change?

Adds a new `BuryAndRevokeLease` method to SwitchSet which is used by keepalived instead of `Bury`. This allows the lease associated with a keepalive SwitchSet to be revoked when buried, preventing leases from being orphaned.

## Why is this change necessary?

It eliminates leases from being leaked when agents continuously reconnect.

## Does your change need a Changelog entry?

Yes.

## Were there any complications while making this change?

Our agent registration & lease code is tough to grok.

The first keepalive that the backend processes for an agent is generated by the backend when the session starts. This keepalive is generated using information from the HTTP headers on connection, which does not include keepalive thresholds. If we had access to the keepalive thresholds, we could conditionally bury keys depending on if the TTL has changed.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I wrote a tool to track lease usage (https://github.com/amdprophet/etcd-lease-tool). After this change, no leases are orphaned when stopping & starting an agent.

I ran benchmarks for 6.6.2 and 6.6.2 with this change. Notice the difference between active leases in both runs. Backend heap bytes allocated is significantly more stable after this change as well.

![Etcd by Prometheus (3 5) - Grafana (2)](https://user-images.githubusercontent.com/120659/145862487-f1bd5284-6c78-4a23-b49a-dc2b1a22df69.png)
![Sensu Benchmarks (_= 6 6 0) - Grafana (2)](https://user-images.githubusercontent.com/120659/145862494-96f4799e-6a43-448d-980e-999ecddd53ce.png)
![PostgreSQL Database - Grafana (4)](https://user-images.githubusercontent.com/120659/145862480-e3062dea-45f3-4855-9a80-2eeb17f0452c.png)
![PostgreSQL Statistics - Grafana (4)](https://user-images.githubusercontent.com/120659/145862475-43c60c3d-1915-4f93-8b03-71482cbc5820.png)

## Is this change a patch?

Yes.
