### PR TITLE
Update semgrep-go config name

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,7 +10,7 @@ jobs:
         id: semgrep
         uses: returntocorp/semgrep-action@v1
         with:
-          config: p/dgryski.semgrep-go
+          config: p/semgrep-go-correctness
   semgrep-sensu: # looks for .semgrep.yml due to missing config section
     runs-on: ubuntu-latest
     name: Check


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

The semgrep config name was renamed from `p/dgryski.semgrep-go` to `p/semgrep-go-correctness`. This change should fix CI.