### PR TITLE
Remove unused rate limiting code in liveness monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - New agent sessions will no longer result in a leaked Etcd lease.
 
+### Changed
+- Removed unused rate limiting code in the liveness package.
+
 ## [6.6.1, 6.6.2] - 2021-11-29
 
 ### Added

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -7,14 +7,12 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store/etcd/kvc"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"golang.org/x/time/rate"
 )
 
 // SwitchPrefix contains the base path for switchset, which are tracked under
@@ -356,8 +354,6 @@ func (t *SwitchSet) monitor(ctx context.Context) {
 	}()
 	go func() {
 		ctx := clientv3.WithRequireLeader(ctx)
-		limiter := rate.NewLimiter(rate.Every(time.Second), 1)
-		_ = limiter.Wait(ctx)
 	OUTER:
 		for {
 			select {


### PR DESCRIPTION
## What is this change?

Removes unused rate limiting code in the liveness monitor method.

## Why is this change necessary?

After discussing this with @echlebek it was determined that this code isn't actually doing anything.

## Does your change need a Changelog entry?

I added it but it may not be necessary for release notes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

@echlebek so graciously proved that this code doesn't change the function with a Go playground link.

## Is this change a patch?

No.
