### PR TITLE
Bugfix/event log file crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - New agent sessions will no longer result in a leaked Etcd lease.
+- sensu-backend now prints warning and continues instead of crashing
+when --event-log-file cannot be written to.
 
 ## [6.6.1, 6.6.2] - 2021-11-29
 

--- a/backend/eventd/logger.go
+++ b/backend/eventd/logger.go
@@ -41,7 +41,6 @@ func (f *FileLogger) Start() error {
 	consumerName := fmt.Sprintf("filelogger://%s", f.Path)
 	subscription, err := f.Bus.Subscribe(messaging.SignalTopic(syscall.SIGHUP), consumerName, f)
 	if err != nil {
-		logger.WithError(err).Error("could not start event logging")
 		return fmt.Errorf("failed to subscribe event logger to SIGHUP: %v", err)
 	}
 	f.subscription = subscription

--- a/backend/eventd/logger_test.go
+++ b/backend/eventd/logger_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package eventd
@@ -39,13 +40,13 @@ func TestLogger(t *testing.T) {
 	}
 
 	// Providing an empty path should return an error
-	l.Start()
-	assert.Contains(t, hook.LastEntry().Message, "event logging is disabled")
+	err := l.Start()
+	assert.Error(t, err)
 
 	// Providing an invalid path should return an error
 	l.Path = "/"
-	l.Start()
-	assert.Contains(t, hook.LastEntry().Message, "could not start event logging")
+	err = l.Start()
+	assert.Error(t, err)
 
 	// Providing a valid path should start the logger
 	file, err := ioutil.TempFile(os.TempDir(), "event.*.log")
@@ -54,7 +55,8 @@ func TestLogger(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 	l.Path = file.Name()
-	l.Start()
+	err = l.Start()
+	assert.NoError(t, err)
 	assert.Contains(t, hook.LastEntry().Message, "event logging using 1 JSON encoder")
 }
 


### PR DESCRIPTION
## What is this change?

Fix sensu-backend crash when --event-log-file is not writable.


## Why is this change necessary?

https://github.com/sensu/sensu-go/issues/4491

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

Yes. Just my notes under **Is this a change a patch?**

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Y

## How did you verify this change?

Manual/local validation - built + started sensu-backend, saw expected log message, posted an event to confirm there was no crash.

```
christian@alder bugfix/event-logfile-crash (bugfix/event-logfile-crash) » ./sensu-backend start --state-dir /tmp/sensu-backend --cache-dir /tmp/sensu-backend --event-log-file /mnt/does/not/exist                         130 ↵
{"component":"etcd","level":"warning","caller":"auth/store.go:1220","msg":"simple token is not cryptographically signed","time":"2021-12-13T14:28:53-08:00"}
{"component":"pipelined","level":"warning","msg":"StoreTimeout not configured","time":"2021-12-13T14:28:53-08:00"}
{"component":"eventd","error":"could not start event logging: open /mnt/does/not/exist: no such file or directory","level":"warning","msg":"event log file could not be configured. event logs will not be recorded.","time":"2021-12-13T14:28:53-08:00"}
{"component":"agentd","level":"warning","msg":"starting agentd on address: [::]:8081","time":"2021-12-13T14:28:53-08:00"}
{"component":"apid","level":"warning","msg":"starting apid on address: [::]:8080","time":"2021-12-13T14:28:53-08:00"}
{"component":"backend","error":"open /var/log/sensu/backend-stats.log: no such file or directory","level":"error","msg":"unable to open platform metrics log file","time":"2021-12-13T14:28:53-08:00"}
{"component":"backend","level":"warning","msg":"backend is running and ready to accept events","time":"2021-12-13T14:28:53-08:00"}
{"check_name":"server-health","check_namespace":"default","component":"pipelined","entity_name":"server1","entity_namespace":"default","event_id":"91dfd289-2259-4288-89fe-8ad410b5c0f0","level":"warning","msg":"pipeline has no workflows, skipping execution of pipeline","pipeline_adapter":"AdapterV1","pipeline_reference":"core/v2.LegacyPipeline(Name=legacy-pipeline)","time":"2021-12-13T14:28:57-08:00"}
```
## Is this change a patch?

Excellent Question. I was not careful about making breaking changes if we are concerned about our public API as a go library.

While I'd be bewildered if someone out there were using the `github.com/sensu/sensu-go/backend/eventd` `FileLogger`, the change to the Start function signature is a breaking change. 