### PR TITLE
On daemon stop, crash when not responding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ the etcd client used internally within sensu-backend.
 in memory usage.
 - The agentd daemon now starts up after all other daemons which improves the
 chances of a cluster recovering after the loss of a backend.
+- The `etcd-log-level` flag now applies to the internal Etcd client.
+- sensu-backend will now crash when its daemons do not stop within 30s. This can
+happen as the result of an intentional shutdown, or when an internal restart is
+triggered by database unavailability. This only applies when --no-embed-etcd is
+true. Embedded etcd sensu-backend will do everything it can to avoid crashing,
+which is necessary to avoid member corruption.
 
 ### Fixed
 - New agent sessions will no longer result in a leaked Etcd lease.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -675,7 +675,8 @@ func (b *Backend) runOnce() error {
 		}()
 	}
 
-	sg := stopGroup{}
+	// crash the stopgroup after a hard-coded timeout, when etcd is not embedded.
+	sg := &stopGroup{crashOnTimeout: b.Cfg.NoEmbedEtcd, waitTime: 30 * time.Second}
 
 	// Loop across the daemons in order to start them, then add them to our groups
 	for _, d := range b.Daemons {
@@ -689,7 +690,7 @@ func (b *Backend) runOnce() error {
 		eg.daemons = append(eg.daemons, d)
 
 		// Add the daemon to our stopGroup
-		sg = append(sg, d)
+		sg.Add(d)
 	}
 
 	if !b.Cfg.DisablePlatformMetrics {
@@ -723,13 +724,6 @@ func (b *Backend) runOnce() error {
 			}
 			go metricsBridge.Run(b.RunContext())
 		}
-	}
-
-	// Reverse the order of our stopGroup so daemons are stopped in the proper
-	// order (last one started is first one stopped)
-	for i := len(sg)/2 - 1; i >= 0; i-- {
-		opp := len(sg) - 1 - i
-		sg[i], sg[opp] = sg[opp], sg[i]
 	}
 
 	if b.Etcd != nil {
@@ -839,15 +833,46 @@ type stopper interface {
 	Name() string
 }
 
-type stopGroup []stopper
+type stopGroup struct {
+	stoppers       []stopper
+	crashOnTimeout bool
+	waitTime       time.Duration
+}
+
+func (s *stopGroup) Add(stopper stopper) {
+	s.stoppers = append(s.stoppers, stopper)
+}
 
 func (s stopGroup) Stop() (err error) {
-	for _, stopper := range s {
-		logger.Info("shutting down ", stopper.Name())
-		e := stopper.Stop()
-		if err == nil {
-			err = e
-		}
+	// Reverse the order of our stopGroup so daemons are stopped in the proper
+	// order (last one started is first one stopped)
+	stoppers := make([]stopper, 0, len(s.stoppers))
+	for _, stpr := range s.stoppers {
+		stoppers = append(stoppers, stpr)
+	}
+	for i := len(stoppers)/2 - 1; i >= 0; i-- {
+		opp := len(stoppers) - 1 - i
+		stoppers[i], stoppers[opp] = stoppers[opp], stoppers[i]
+	}
+
+	for _, stpr := range stoppers {
+		func() {
+			logger.Info("shutting down ", stpr.Name())
+			if s.crashOnTimeout {
+				ctx, cancel := context.WithTimeout(context.Background(), s.waitTime)
+				defer cancel()
+				go func() {
+					<-ctx.Done()
+					if ctx.Err() == context.DeadlineExceeded {
+						panic(fmt.Sprintf("%s did not stop within %s", stpr.Name(), s.waitTime))
+					}
+				}()
+			}
+			e := stpr.Stop()
+			if err == nil {
+				err = e
+			}
+		}()
 	}
 	return err
 }

--- a/backend/backend_unit_test.go
+++ b/backend/backend_unit_test.go
@@ -1,0 +1,36 @@
+package backend
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockStopper struct {
+	hang bool
+	err  error
+}
+
+func (s mockStopper) Stop() error {
+	if s.hang {
+		select {}
+	}
+	return s.err
+}
+
+func (s mockStopper) Name() string {
+	return "hi"
+}
+
+func TestStopGroupNormalStop(t *testing.T) {
+	var sg stopGroup
+	sg.Add(mockStopper{})
+	sg.Add(mockStopper{})
+	sg.Add(mockStopper{})
+	if err := sg.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	sg.Add(mockStopper{err: errors.New("err")})
+	if err := sg.Stop(); err == nil {
+		t.Fatal("expected non-nil error")
+	}
+}


### PR DESCRIPTION
## What is this change?

sensu-backend now crashes with a panic when daemons are asked to
stop but do not respond.

## Why is this change necessary?

If daemons hang, then the overall ability to operate sensu-backend is compromised. This change ensures that when asked to stop, sensu-backend will do so within 30s.

## Does your change need a Changelog entry?

Yes

## How did you verify this change?

Verification on SPDC pending.

## Is this change a patch?

Yes.
