### PR TITLE
Start agentd after all other daemons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- The agentd daemon now starts up after all other daemons which improves the
+chances of a cluster recovering after the loss of a backend.
+- The `etcd-log-level` flag now applies to the internal Etcd client.
+
 ### Fixed
 - New agent sessions will no longer result in a leaked Etcd lease.
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -224,7 +224,8 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 		atomicLogLevel := zap.NewAtomicLevel()
 		atomicLogLevel.SetLevel(zap.ErrorLevel)
 		clientv3Config.LogConfig = &zap.Config{
-			Level: atomicLogLevel,
+			Level:    atomicLogLevel,
+			Encoding: "json",
 		}
 
 		// Don't start up an embedded etcd, return a client that connects to an

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -681,6 +681,7 @@ func (b *Backend) runOnce() error {
 
 	// Loop across the daemons in order to start them, then add them to our groups
 	for _, d := range b.Daemons {
+		logger.Infof("starting daemon: %s", d.Name())
 		if err := d.Start(); err != nil {
 			_ = sg.Stop()
 			return ErrStartup{Err: err, Name: d.Name()}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -16,6 +16,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
@@ -220,9 +221,25 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 			}
 		}
 
-		// Set etcd client log level to error
+		var level zapcore.Level
+		switch config.EtcdLogLevel {
+		case "debug", "trace":
+			level = zapcore.DebugLevel
+		case "error":
+			level = zapcore.ErrorLevel
+		case "fatal":
+			level = zapcore.FatalLevel
+		case "info":
+			level = zapcore.InfoLevel
+		case "panic":
+			level = zapcore.PanicLevel
+		case "warn":
+			level = zapcore.DebugLevel
+		}
+
+		// Set etcd client log level
 		atomicLogLevel := zap.NewAtomicLevel()
-		atomicLogLevel.SetLevel(zap.ErrorLevel)
+		atomicLogLevel.SetLevel(level)
 		clientv3Config.LogConfig = &zap.Config{
 			Level:    atomicLogLevel,
 			Encoding: "json",


### PR DESCRIPTION
## What is this change?

Updates the daemon start order so that agentd starts after all of the other daemons. This change works best when paired with the `agent-rate-limit` flag set to something low enough for the cluster to handle.

Also applies EtcdLogLevel to the internal Etcd client.

## Why is this change necessary?

When agentd starts before keepalived, the backend will start processing events and putting load on the store(s) before we can process keepalive events. The `initFromStore` method in keepalived can time out when the cluster is under heavy load which prevents apid from starting and triggers an internal restart.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I reproduced a crash loop where `initFromStore` would fail. Using a combination of this change and `agent-rate-limit` set to something low enough (I used 5 in the test but is likely overkill) for the cluster to handle, backends were able to recover after a crash.

## Is this change a patch?

Yes.