### PR TITLE
Use gofmt to add new build constraint syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Removed unused rate limiting code in the liveness package.
+- Include new Go 1.17+ build constraint syntax by running gofmt
 
 ## [6.6.1, 6.6.2] - 2021-11-29
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package agent

--- a/agent/check_handler_env_unix_test.go
+++ b/agent/check_handler_env_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package agent

--- a/agent/check_handler_env_windows_test.go
+++ b/agent/check_handler_env_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package agent

--- a/agent/cmd/install_windows.go
+++ b/agent/cmd/install_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package cmd

--- a/agent/cmd/logger_unix.go
+++ b/agent/cmd/logger_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmd

--- a/agent/cmd/windows.go
+++ b/agent/cmd/windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package cmd

--- a/agent/debug_test.go
+++ b/agent/debug_test.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package agent

--- a/agent/sockets_test.go
+++ b/agent/sockets_test.go
@@ -39,9 +39,9 @@ func TestHandleTCPMessages(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
-		Source: "proxyEnt",
+		Name:    "app_01",
+		Output:  "could not connect to something",
+		Source:  "proxyEnt",
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
@@ -92,9 +92,9 @@ func TestHandleTCPMessagesWithClient(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
-		Client: "proxyEnt",
+		Name:    "app_01",
+		Output:  "could not connect to something",
+		Client:  "proxyEnt",
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
@@ -145,9 +145,9 @@ func TestHandleTCPMessagesWithAgent(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
-		Source: cfg.AgentName,
+		Name:    "app_01",
+		Output:  "could not connect to something",
+		Source:  cfg.AgentName,
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
@@ -198,8 +198,8 @@ func TestHandleTCPMessagesNoSource(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
+		Name:    "app_01",
+		Output:  "could not connect to something",
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
@@ -251,9 +251,9 @@ func TestHandleUDPMessages(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
-		Source: "proxyEnt",
+		Name:    "app_01",
+		Output:  "could not connect to something",
+		Source:  "proxyEnt",
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)
@@ -349,9 +349,9 @@ func TestReceiveMultiWriteTCP(t *testing.T) {
 	}
 
 	payload := corev1.CheckResult{
-		Name:   "app_01",
-		Output: "could not connect to something",
-		Source: "proxyEnt",
+		Name:    "app_01",
+		Output:  "could not connect to something",
+		Source:  "proxyEnt",
 		Command: "command",
 	}
 	bytes, _ := json.Marshal(payload)

--- a/agent/statsd_server.go
+++ b/agent/statsd_server.go
@@ -1,3 +1,4 @@
+//go:build !solaris
 // +build !solaris
 
 // Package agent is the running Sensu agent. Agents connect to a Sensu backend,

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !solaris
 // +build integration,!solaris
 
 package agent

--- a/asset/fetcher_unix.go
+++ b/asset/fetcher_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package asset

--- a/asset/fetcher_windows.go
+++ b/asset/fetcher_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package asset

--- a/backend/apid/actions/actions_test.go
+++ b/backend/apid/actions/actions_test.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package actions

--- a/backend/apid/handlers/patch_integration_test.go
+++ b/backend/apid/handlers/patch_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package handlers

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package backend

--- a/backend/cmd/logger_unix.go
+++ b/backend/cmd/logger_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package cmd

--- a/backend/debug_test.go
+++ b/backend/debug_test.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package backend

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/etcd/sequence_test.go
+++ b/backend/etcd/sequence_test.go
@@ -1,4 +1,5 @@
-//+build integration
+//go:build integration
+// +build integration
 
 package etcd
 

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package eventd

--- a/backend/eventd/logger_test.go
+++ b/backend/eventd/logger_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package eventd

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package keepalived

--- a/backend/liveness/liveness_test.go
+++ b/backend/liveness/liveness_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package liveness

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package queue

--- a/backend/ringv2/pool_test.go
+++ b/backend/ringv2/pool_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package ringv2

--- a/backend/ringv2/ringv2_test.go
+++ b/backend/ringv2/ringv2_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 // These tests are unfortunately quite slow. This is somewhat mitigated by the

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package schedulerd

--- a/backend/schedulerd/debug_test.go
+++ b/backend/schedulerd/debug_test.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package schedulerd

--- a/backend/schedulerd/executor_test.go
+++ b/backend/schedulerd/executor_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package schedulerd

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package schedulerd

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package cache

--- a/backend/store/cache/v2/cache_integration_test.go
+++ b/backend/store/cache/v2/cache_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package v2

--- a/backend/store/etcd/asset_store_test.go
+++ b/backend/store/etcd/asset_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/authentication_test.go
+++ b/backend/store/etcd/authentication_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/cluster_id_store_test.go
+++ b/backend/store/etcd/cluster_id_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/debug_test.go
+++ b/backend/store/etcd/debug_test.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package etcd

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/event_store_integration_test.go
+++ b/backend/store/etcd/event_store_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/filter_store_test.go
+++ b/backend/store/etcd/filter_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/handler_store_test.go
+++ b/backend/store/etcd/handler_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/health_store_test.go
+++ b/backend/store/etcd/health_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/hook_store_test.go
+++ b/backend/store/etcd/hook_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/keepalive_store_test.go
+++ b/backend/store/etcd/keepalive_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/migrations_test.go
+++ b/backend/store/etcd/migrations_test.go
@@ -1,3 +1,4 @@
+//go:build !race && integration
 // +build !race,integration
 
 package etcd

--- a/backend/store/etcd/mutator_store_test.go
+++ b/backend/store/etcd/mutator_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/namespace_store_test.go
+++ b/backend/store/etcd/namespace_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/resource_integration_test.go
+++ b/backend/store/etcd/resource_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/silenced_store_test.go
+++ b/backend/store/etcd/silenced_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/tessen_store_test.go
+++ b/backend/store/etcd/tessen_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/version_test.go
+++ b/backend/store/etcd/version_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/etcd/watcher_test.go
+++ b/backend/store/etcd/watcher_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcd

--- a/backend/store/v2/etcdstore/store_test.go
+++ b/backend/store/v2/etcdstore/store_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package etcdstore_test

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -1,3 +1,4 @@
+//go:build integration && !race
 // +build integration,!race
 
 package tessend

--- a/command/command_unix_test.go
+++ b/command/command_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package command

--- a/command/command_windows_test.go
+++ b/command/command_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package command

--- a/command/proc_group_unix.go
+++ b/command/proc_group_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows
 // +build !linux,!windows
 
 package command

--- a/command/proc_unix.go
+++ b/command/proc_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package command

--- a/command/proc_windows.go
+++ b/command/proc_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package command

--- a/system/cpu_arm.go
+++ b/system/cpu_arm.go
@@ -1,3 +1,4 @@
+//go:build arm
 // +build arm
 
 package system

--- a/system/cpu_other.go
+++ b/system/cpu_other.go
@@ -1,3 +1,4 @@
+//go:build !arm
 // +build !arm
 
 package system

--- a/util/environment/environment_posix.go
+++ b/util/environment/environment_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package environment

--- a/util/environment/environment_posix_test.go
+++ b/util/environment/environment_posix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package environment

--- a/util/environment/environment_windows.go
+++ b/util/environment/environment_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package environment

--- a/util/environment/environment_windows_test.go
+++ b/util/environment/environment_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package environment


### PR DESCRIPTION
## What is this change?

Ran `go fmt` on most of sensu-go. Wanted to be careful to not format generated code unnecessarily, so only targeted directories with go build constraints. To reproduce - pardon my terrible bash: `rg '\+build' -l . | xargs dirname | uniq | xargs go fmt`


## Why is this change necessary?

Go has introduced a new build constraint syntax that it is migrating towards. More info out here: https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md#transition

## Does your change need a Changelog entry?

Probably not.

## Do you need clarification on anything?

N

## Were there any complications while making this change?
N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Y

## How did you verify this change?

N/A - build pipeline is what likely matters here.

## Is this change a patch?

Y
