### PR TITLE
Add --etcd-client-log-level flag to sensu-backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Changed
+### Added
+- Added `etcd-client-log-level` configuration flag for setting the log level of
+the etcd client used internally within sensu-backend.
 
+### Changed
 - [GraphQL] Improvements to entity list response times and significant reduction
 in memory usage.
 - The agentd daemon now starts up after all other daemons which improves the
 chances of a cluster recovering after the loss of a backend.
-- The `etcd-log-level` flag now applies to the internal Etcd client.
 
 ### Fixed
 - New agent sessions will no longer result in a leaked Etcd lease.

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package backend
@@ -96,6 +97,7 @@ func TestBackendHTTPListener(t *testing.T) {
 				EtcdPeerTLSInfo:              tlsInfo,
 				EtcdUseEmbeddedClient:        true,
 				EtcdLogLevel:                 "info",
+				EtcdClientLogLevel:           "error",
 				DisablePlatformMetrics:       true,
 			}
 			ctx, cancel := context.WithCancel(context.Background())

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -440,7 +440,7 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 	viper.SetDefault(flagEtcdMaxRequestBytes, etcd.DefaultMaxRequestBytes)
 	viper.SetDefault(flagEtcdHeartbeatInterval, etcd.DefaultTickMs)
 	viper.SetDefault(flagEtcdElectionTimeout, etcd.DefaultElectionMs)
-	viper.SetDefault(flagEtcdClientLogLevel, "error")
+	viper.SetDefault(flagEtcdClientLogLevel, etcd.DefaultClientLogLevel)
 
 	if server {
 		viper.SetDefault(flagNoEmbedEtcd, false)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -85,6 +85,7 @@ const (
 	flagEtcdHeartbeatInterval        = "etcd-heartbeat-interval"
 	flagEtcdElectionTimeout          = "etcd-election-timeout"
 	flagEtcdLogLevel                 = "etcd-log-level"
+	flagEtcdClientLogLevel           = "etcd-client-log-level"
 
 	// Etcd TLS flag constants
 	flagEtcdCertFile           = "etcd-cert-file"
@@ -251,6 +252,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				EtcdHeartbeatInterval:          viper.GetUint(flagEtcdHeartbeatInterval),
 				EtcdElectionTimeout:            viper.GetUint(flagEtcdElectionTimeout),
 				EtcdLogLevel:                   viper.GetString(flagEtcdLogLevel),
+				EtcdClientLogLevel:             viper.GetString(flagEtcdClientLogLevel),
 				EtcdClientUsername:             viper.GetString(envEtcdClientUsername),
 				EtcdClientPassword:             viper.GetString(envEtcdClientPassword),
 				NoEmbedEtcd:                    viper.GetBool(flagNoEmbedEtcd),
@@ -438,6 +440,7 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 	viper.SetDefault(flagEtcdMaxRequestBytes, etcd.DefaultMaxRequestBytes)
 	viper.SetDefault(flagEtcdHeartbeatInterval, etcd.DefaultTickMs)
 	viper.SetDefault(flagEtcdElectionTimeout, etcd.DefaultElectionMs)
+	viper.SetDefault(flagEtcdClientLogLevel, "error")
 
 	if server {
 		viper.SetDefault(flagNoEmbedEtcd, false)
@@ -490,6 +493,8 @@ func flagSet(server bool) *pflag.FlagSet {
 	// Etcd client/server flags
 	flagSet.StringSlice(flagEtcdCipherSuites, nil, "list of ciphers to use for etcd TLS configuration")
 	_ = flagSet.SetAnnotation(flagEtcdCipherSuites, "categories", []string{"store"})
+	flagSet.String(flagEtcdClientLogLevel, viper.GetString(flagEtcdClientLogLevel), "etcd client logging level [panic, fatal, error, warn, info, debug]")
+	_ = flagSet.SetAnnotation(flagEtcdClientLogLevel, "categories", []string{"store"})
 
 	// This one is really only a server flag, but because we lacked
 	// --etcd-client-urls until recently, it's used as a fallback.
@@ -535,7 +540,6 @@ func flagSet(server bool) *pflag.FlagSet {
 		flagSet.Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
 		flagSet.Bool(flagDebug, false, "enable debugging and profiling features")
 		flagSet.String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug, trace]")
-		flagSet.String(flagEtcdLogLevel, viper.GetString(flagEtcdLogLevel), "etcd logging level [panic, fatal, error, warn, info, debug]")
 		flagSet.Int(backend.FlagEventdWorkers, viper.GetInt(backend.FlagEventdWorkers), "number of workers spawned for processing incoming events")
 		flagSet.Int(backend.FlagEventdBufferSize, viper.GetInt(backend.FlagEventdBufferSize), "number of incoming events that can be buffered")
 		flagSet.Int(backend.FlagKeepalivedWorkers, viper.GetInt(backend.FlagKeepalivedWorkers), "number of workers spawned for processing incoming keepalives")
@@ -576,6 +580,8 @@ func flagSet(server bool) *pflag.FlagSet {
 		_ = flagSet.SetAnnotation(flagEtcdHeartbeatInterval, "categories", []string{"store"})
 		flagSet.Uint(flagEtcdElectionTimeout, viper.GetUint(flagEtcdElectionTimeout), "time in ms a follower node will go without hearing a heartbeat before attempting to become leader itself")
 		_ = flagSet.SetAnnotation(flagEtcdElectionTimeout, "categories", []string{"store"})
+		flagSet.String(flagEtcdLogLevel, viper.GetString(flagEtcdLogLevel), "etcd server logging level [panic, fatal, error, warn, info, debug]")
+		_ = flagSet.SetAnnotation(flagEtcdLogLevel, "categories", []string{"store"})
 
 		// Etcd server TLS flags
 		flagSet.String(flagEtcdPeerCertFile, viper.GetString(flagEtcdPeerCertFile), "path to the peer server TLS cert file")

--- a/backend/config.go
+++ b/backend/config.go
@@ -112,8 +112,9 @@ type Config struct {
 
 	TLS *corev2.TLSOptions
 
-	LogLevel     string
-	EtcdLogLevel string
+	LogLevel           string
+	EtcdLogLevel       string
+	EtcdClientLogLevel string
 
 	LicenseGetter licensing.Getter
 

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -54,6 +54,12 @@ const (
 	// attempting to become leader itself.
 	// See: https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters
 	DefaultElectionMs = 1000
+
+	// DefaultLogLevel is the default log level for the embedded etcd server.
+	DefaultLogLevel = "warn"
+
+	// DefaultClientLogLevel is the default log level for the etcd client.
+	DefaultClientLogLevel = "error"
 )
 
 func init() {
@@ -111,6 +117,8 @@ func NewConfig() *Config {
 	c.QuotaBackendBytes = DefaultQuotaBackendBytes
 	c.TickMs = DefaultTickMs
 	c.ElectionMs = DefaultElectionMs
+	c.LogLevel = DefaultLogLevel
+	c.ClientLogLevel = DefaultClientLogLevel
 
 	return c
 }
@@ -410,6 +418,6 @@ func LogLevelToZap(level string) zapcore.Level {
 	case "fatal":
 		return zapcore.FatalLevel
 	default:
-		panic("invalid etcd log level")
+		panic(fmt.Sprintf("invalid etcd log level: %s", level))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds a `etcd-client-log-level` flag for setting the log level of the internal etcd client we use within sensu-backend. The default value is set to `error` as `warning` is overly verbose and doesn't typically add value when troubleshooting.

## Why is this change necessary?

The logs are currently flooded with unhelpful log lines generated by the etcd client (e.g. `retrying of unary invoker failed`). We already log errors returned by the etcd client.

## Does your change need a Changelog entry?

Yes.

## Were there any complications while making this change?

Setting the log level differs between the client we create for embedded vs. external etcd clusters.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required.

https://github.com/sensu/sensu-docs/issues/3552

## How did you verify this change?

I tested that the logs shown for etcd client are at error by default for both embedded & external etcd. I then tested that setting the log level to debug produces debug logs for both embedded & external etcd.

## Is this change a patch?

Yes. We consider the fact that `--etcd-log-level` does not control the etcd client log level, and the fact there's no way to set the etcd client log level, to be a bug.
