### PR TITLE
Add event metric points processed counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Removed unused rate limiting code in the liveness package.
 - Include new Go 1.17+ build constraint syntax by running gofmt
 
+### Added
+- Add `sensu_go_event_metric_points_processed` counter metric and
+included it in tessen reporting.
+
 ## [6.6.1, 6.6.2] - 2021-11-29
 
 ### Added

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -122,14 +122,6 @@ var (
 		},
 	)
 
-	eventsProcessed = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: EventsProcessedCounterVec,
-			Help: "The total number of processed events",
-		},
-		[]string{EventsProcessedLabelName, EventsProcessedTypeLabelName},
-	)
-
 	eventHandlerDuration = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       EventHandlerDuration,


### PR DESCRIPTION
## What is this change?

Adds a count of metric points processed.

## Why is this change necessary?

https://github.com/sensu/sensu-enterprise-go/issues/1872

This metric will help us better understand how much metric data is flowing through sensu.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N - ~~do we have "data we collect" sort docs around tessen?~~ We have some examples of tessen data but no exhaustive list: https://docs.sensu.io/sensu-go/latest/operations/monitor-sensu/tessen/#tessen-metrics-log-examples.

## How did you verify this change?

Manual/local validation running cluster_id = `d075d31d-cb38-4650-9c4f-41cabd43bf62` with a check with metric points scheduled.

`psql $TESSEN_DB_URL -c "SELECT name, value, time FROM metrics WHERE cluster_id='d075d31d-cb38-4650-9c4f-41cabd43bf62' AND name like 'sensu_go%'"`
```
                  name                  | value |          time
----------------------------------------+-------+------------------------
 sensu_go_event_metric_points_processed |  6612 | 2021-12-15 18:56:18+00
 sensu_go_event_metric_points_processed | 13452 | 2021-12-15 19:26:18+00
 sensu_go_event_metric_points_processed | 20292 | 2021-12-15 19:56:18+00
 sensu_go_events_processed              |    83 | 2021-12-15 17:21:49+00
 sensu_go_events_processed              |   233 | 2021-12-15 17:51:49+00
 sensu_go_events_processed              |   145 | 2021-12-15 18:56:18+00
 sensu_go_events_processed              |   295 | 2021-12-15 19:26:18+00
 sensu_go_events_processed              |   445 | 2021-12-15 19:56:18+00
(8 rows)
```



## Is this change a patch?

N