### PR TITLE
Ensure that agent burial events happen before keepalive refresh

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -362,20 +362,21 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := SessionConfig{
-		AgentAddr:     r.RemoteAddr,
-		AgentName:     r.Header.Get(transport.HeaderKeyAgentName),
-		Namespace:     r.Header.Get(transport.HeaderKeyNamespace),
-		User:          r.Header.Get(transport.HeaderKeyUser),
-		Subscriptions: strings.Split(r.Header.Get(transport.HeaderKeySubscriptions), ","),
-		RingPool:      a.ringPool,
-		ContentType:   contentType,
-		WriteTimeout:  a.writeTimeout,
-		Bus:           a.bus,
-		Conn:          transport.NewTransport(conn),
-		Store:         a.store,
-		Storev2:       a.storev2,
-		Marshal:       marshal,
-		Unmarshal:     unmarshal,
+		AgentAddr:      r.RemoteAddr,
+		AgentName:      r.Header.Get(transport.HeaderKeyAgentName),
+		Namespace:      r.Header.Get(transport.HeaderKeyNamespace),
+		User:           r.Header.Get(transport.HeaderKeyUser),
+		Subscriptions:  strings.Split(r.Header.Get(transport.HeaderKeySubscriptions), ","),
+		RingPool:       a.ringPool,
+		ContentType:    contentType,
+		WriteTimeout:   a.writeTimeout,
+		Bus:            a.bus,
+		Conn:           transport.NewTransport(conn),
+		Store:          a.store,
+		Storev2:        a.storev2,
+		Marshal:        marshal,
+		Unmarshal:      unmarshal,
+		BurialReceiver: NewBurialReceiver(),
 	}
 
 	cfg.Subscriptions = corev2.AddEntitySubscription(cfg.AgentName, cfg.Subscriptions)

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -307,6 +307,8 @@ func (k *Keepalived) processKeepalives(ctx context.Context) {
 					}
 					logger.WithError(err).Error("error deleting keepalive")
 				}
+				// ignore error as this message is advisory
+				_ = k.bus.Publish(messaging.BurialTopic(event.Entity.Namespace, event.Entity.Name), nil)
 				continue
 			}
 

--- a/backend/liveness/liveness.go
+++ b/backend/liveness/liveness.go
@@ -259,7 +259,8 @@ func (t *SwitchSet) ping(ctx context.Context, id string, ttl int64, alive bool) 
 		resp, err := t.client.Put(ctx, key, val, clientv3.WithIgnoreLease(), clientv3.WithPrevKV())
 		if err != nil {
 			// The existing lease wasn't found, it must have expired or
-			// been revoked. This isn't strictly an error as it can occur
+			// been revoked. Or, the key associated with the lease was already deleted.
+			// This isn't strictly an error as it can occur
 			// in the course of normal operation. As such, we won't track
 			// metrics for it.
 			leaseID, err := t.newLease(ctx, ttl)
@@ -435,6 +436,11 @@ func (t *SwitchSet) handleEvent(ctx context.Context, event *clientv3.Event) {
 		if err != nil {
 			t.logger.WithError(err).Errorf("error commiting keepalive tx for %s", key)
 			return
+		}
+		if !resp.Succeeded {
+			if _, err := t.client.Revoke(ctx, leaseID); err != nil {
+				t.logger.WithError(err).Error("error revoking lease on keepalive follower")
+			}
 		}
 		t.events <- func() (string, bool) {
 			return key, t.notifyDead(strings.TrimPrefix(key, t.prefix+"/"), prevState, resp.Succeeded)

--- a/backend/messaging/message_bus.go
+++ b/backend/messaging/message_bus.go
@@ -109,3 +109,9 @@ func EntityConfigTopic(namespace, name string) string {
 func SubscriptionTopic(namespace, sub string) string {
 	return fmt.Sprintf("%s:%s:%s", TopicSubscriptions, namespace, sub)
 }
+
+// BurialTopic is used to signal to agentd sessions that a keepalive burial
+// has been processed.
+func BurialTopic(namespace, entity string) string {
+	return fmt.Sprintf("sensu:burial:%s:%s", namespace, entity)
+}


### PR DESCRIPTION
## What is this change?

This commit adds synchronization to agentd's sessions so that we can be
sure burial events are fully processed before setting a keepalive switch
to the "alive" state.

Also, a situation where leases are created but never used has been
resolved.

## Why is this change necessary?

This commit fixes a regression caused by a previous unreleased change, and also further reduces the possibility of dangling leases.

## Does your change need a Changelog entry?

No.

## Is this change a patch?

Yes.