### PR TITLE
Create proxy entity state when missing if entity config exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ when --event-log-file cannot be written to.
 - Fixed a crash that can occur when keepalive leases are revoked on another
 backend, or by an etcd operator.
 - Fixed an issue where sensu-backend would not terminate correctly.
+- Proxy entity state is now created when it is missing and a matching entity
+config already exists.
 
 ## [6.6.1, 6.6.2] - 2021-11-29
 

--- a/backend/eventd/entity.go
+++ b/backend/eventd/entity.go
@@ -89,7 +89,6 @@ func createProxyEntity(event *corev2.Event, s storev2.Interface) (fErr error) {
 			default:
 				return err
 			}
-			return err
 		}
 
 		if err := wState.UnwrapInto(state); err != nil {


### PR DESCRIPTION
## What is this change?

Proxy entity state is now created if it does not exist but matching proxy entity config does exist.

## Why is this change necessary?

There seems to be a race condition when switching the store from Etcd to Postgres where entity state is not migrated from Etcd to Postgres. This can cause events for proxy entities return an error when attempting to handle them.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I've only run the unit & integration tests.

## Is this change a patch?

Yes.
