### PR TITLE
Update agent prometheus transformer to map prometheus help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Agent now persists prometheus HELP messages as a metric tag.
+
 ## [6.6.3] - 2021-12-15
 
 ### Added

--- a/agent/transformers/prometheus.go
+++ b/agent/transformers/prometheus.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	PromTypeTagName = "prom_type"
+	PromHelpTagName = "prom_help"
+)
+
 // PromList contains Prometheus vector (samples)
 type PromList model.Vector
 
@@ -73,7 +78,10 @@ func ParseProm(event *types.Event) PromList {
 		familySamples, _ := expfmt.ExtractSamples(decodeOptions, family)
 		for _, prom := range familySamples {
 			lv := model.LabelValue(strings.ToLower(family.Type.String()))
-			prom.Metric[model.LabelName("prom_type")] = lv
+			prom.Metric[model.LabelName(PromTypeTagName)] = lv
+			if help := family.GetHelp(); help != "" {
+				prom.Metric[model.LabelName(PromHelpTagName)] = model.LabelValue(help)
+			}
 		}
 		p = append(p, familySamples...)
 	}

--- a/agent/transformers/prometheus_test.go
+++ b/agent/transformers/prometheus_test.go
@@ -80,6 +80,7 @@ func TestParseProm(t *testing.T) {
 					Metric: model.Metric{
 						model.MetricNameLabel: "go_memstats_alloc_bytes_total",
 						"prom_type":           "counter",
+						"prom_help":           "Total number of bytes allocated, even if freed.",
 					},
 					Value:     4.095146016e+09,
 					Timestamp: model.TimeFromUnix(ts),


### PR DESCRIPTION
## What is this change?

Tooling around mapping sensu corev2 metrics back to prometheus is being built in the plugin sdk. This solidifies some of the conventions these tools will rely on.


## Why is this change necessary?

Per https://github.com/sensu/sensu-plugin-sdk/issues/65 - it is going to be valuable for sensu handlers to marshal sensu corev2 metrics back to the prometheus exposition format.

Without this change, HELP info in prometheus formatted check output will be discarded by the sensu agent.

This change also hopes to make it clearer that the `prom_type` and `prom_help` tag names are special and likely depended on outside the system.
 
## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

**Q:** Persisting HELP info on each metric point is pretty inefficient. I can imagine sensu with the plain ole etcd event storage might be noticeably impacted by this if folks had lots of metrics. Anyone have a better feeling on what the impact of this may be?

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

Manual verification. Some steps described https://github.com/sensu/sensu-plugin-sdk/pull/67

## Is this change a patch?

N