### PR TITLE
Update github workflow to run golangci-lint on patch PRs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 env:
   GO_VERSION: 1.17.1


### PR DESCRIPTION
## What is this change?

It not clear to me if this was intentional, but patch pull requests against the release/x branch was not triggering the golangci-lint github action.

## Why is this change necessary?

Would be cool to not be surprised by a failing workflow in main after merging the release branch.

Github Workflow syntax: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags

**tl;dr**
>The * wildcard matches any character, but does not match slash (/)
The ** wildcard matches any character including slash (/) in branch and tag names.
