### PR TITLE
Use typecasted nil for empty maps in dynamic pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Agent now persists prometheus HELP messages as a metric tag.
 
+### Fixed
+- Empty map fields (e.g. an entity with no labels) are no longer treated as nil
+when used with token substitution.
+
 ## [6.6.3] - 2021-12-15
 
 ### Added

--- a/types/dynamic/dynamic.go
+++ b/types/dynamic/dynamic.go
@@ -217,6 +217,10 @@ func synthesizeStruct(value reflect.Value) map[string]interface{} {
 		// Don't add empty/nil fields to the map if omitempty is specified
 		empty := isEmpty(fieldValue)
 		if empty && omitEmpty {
+			// If value is a map, set field to nil with map type
+			if fieldValue.Kind() == reflect.Map {
+				out[fieldName] = (map[string]interface{})(nil)
+			}
 			continue
 		}
 

--- a/types/dynamic/dynamic.go
+++ b/types/dynamic/dynamic.go
@@ -211,18 +211,8 @@ func synthesizeStruct(value reflect.Value) map[string]interface{} {
 			continue
 		}
 		s := structField{Field: field}
-		fieldName, omitEmpty := s.jsonFieldName()
+		fieldName, _ := s.jsonFieldName()
 		fieldValue := value.Field(i)
-
-		// Don't add empty/nil fields to the map if omitempty is specified
-		empty := isEmpty(fieldValue)
-		if empty && omitEmpty {
-			// If value is a map, set field to nil with map type
-			if fieldValue.Kind() == reflect.Map {
-				out[fieldName] = (map[string]interface{})(nil)
-			}
-			continue
-		}
 
 		switch fieldValue.Kind() {
 		case reflect.Struct:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Updates the dynamic pkg to set fields (with omitempty) to a map-typed nil value instead of not setting the field at all.

## Why is this change necessary?

It fixes a bug where token substitution can result in an unexpected error when attempting to use a key that doesn't exist in labels.

Closes https://github.com/sensu/sensu-go/issues/4236.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I wrote new specs to confirm the bug in the issue linked above. After adding the changes the new specs (& old specs) pass.

## Is this change a patch?

It can be if we'd like it to be but I've targeted main for now.
