### PR TITLE
Bump Go version to 1.17.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ cache:
 environment:
   GOPATH: c:\gopath
   GOROOT: c:\Program Files\Go
-  GOVERSION: 1.17.1
+  GOVERSION: 1.17.6
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 sensu_go_build_env: &sensu_go_build_env
   docker:
-    - image: cimg/go:1.17.1
+    - image: cimg/go:1.17.6
       auth:
         username: $DOCKER_USERNAME
         password: $DOCKER_PASSWORD

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ on:
       - '**'
 
 env:
-  GO_VERSION: 1.17.1
+  GO_VERSION: 1.17.6
   GOLANGCI_LINT_VERSION: v1.42.1
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Bump Go version to 1.17.6.

## Does your change need a Changelog entry?

No as we do not produce binaries from this repository.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## Is this change a patch?

No.
