### PR TITLE
Request backend entity deletion in tessend

### DIFF
--- a/backend/ringv2/ringv2.go
+++ b/backend/ringv2/ringv2.go
@@ -25,6 +25,20 @@ var logger = logrus.WithFields(logrus.Fields{
 	"component": "ring",
 })
 
+type deleteEntityContextKeyT struct{}
+
+// DeleteEntityContextKey can be set to tell the ring implementation to delete
+// the entity as well as the entity's ring association. Does not currently apply
+// to the etcd-based ring.
+var DeleteEntityContextKey = deleteEntityContextKeyT{}
+
+// DeleteEntityContext modifies a context with a value that can inform ring
+// implementations that deleting the entity is desired as well as deleting
+// the ring association. Does not currently apply to the etcd-based ring.
+func DeleteEntityContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, DeleteEntityContextKey, struct{}{})
+}
+
 // EventType is an enum that describes the type of event received by watchers.
 type EventType int
 

--- a/backend/tessend/tessend.go
+++ b/backend/tessend/tessend.go
@@ -24,7 +24,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store/provider"
 	"github.com/sensu/sensu-go/version"
 	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 const (
@@ -193,6 +193,7 @@ func (t *Tessend) Stop() error {
 		defer cancel()
 		key := ringv2.Path("global", "backends")
 		ring := t.ringPool.Get(key)
+		ctx = ringv2.DeleteEntityContext(ctx)
 		if err := ring.Remove(ctx, t.backendID); err != nil {
 			logger.WithField("key", t.backendID).WithError(err).Error("error removing key from the ring")
 		} else {


### PR DESCRIPTION
## What is this change?

This commit adds a context value that indicates to ring implementations
that associated entities should be deleted when removed from a ring.
This only applies to the postgresql ring implementation, which is not
implemented in sensu-go directly.

## Why is this change necessary?

Part of an issue being worked on in the enterprise product.

## Does your change need a Changelog entry?

No, this is not a user facing change.

## Is this change a patch?

Yes