### PR TITLE
Check for nil handler in legacy pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add `sensu_go_event_metric_points_processed` counter metric and
 included it in tessen reporting.
 
+### Fixed
+- Referencing a non-existent handler in a pipeline no longer results in a crash.
+
 ## [6.6.3] - 2021-12-15
 
 ### Added

--- a/backend/pipeline/handler/legacy.go
+++ b/backend/pipeline/handler/legacy.go
@@ -59,12 +59,18 @@ func (l *LegacyAdapter) Handle(ctx context.Context, ref *corev2.ResourceReferenc
 	fields := utillogging.EventFields(event, false)
 	fields["pipeline"] = corev2.ContextPipeline(ctx)
 	fields["pipeline_workflow"] = corev2.ContextPipelineWorkflow(ctx)
+	fields["handler"] = ref.Name
 
 	tctx, cancel := context.WithTimeout(ctx, l.StoreTimeout)
 	handler, err := l.Store.GetHandlerByName(tctx, ref.Name)
 	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to fetch handler from store: %v", err)
+	}
+	if handler == nil {
+		logger.WithFields(fields).
+			Error("handler not found, skipping handler execution")
+		return nil
 	}
 
 	switch handler.Type {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds a conditional to the legacy pipeline to ensure that a handler isn't nil after attempting to fetch the handler from the store.

## Why is this change necessary?

A backend will currently crash if the handler does not exist.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Only unit/integration tests.

## Is this change a patch?

Yes.
