### PR TITLE
fix: correct the spelling of requests in Help of sensu_go_handler_requests metric

### DIFF
--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -53,7 +53,7 @@ var (
 	handlerRequestsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: HandlerRequests,
-			Help: "The number of processed handler requets",
+			Help: "The number of processed handler requests",
 		},
 		[]string{"status", "type"},
 	)


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

## What is this change?
correct the spelling of requests in Help of sensu_go_handler_requests metric

## Why is this change necessary?
It's not, I just noticed it when reviewing the CHANGELOG for upgrade and figured I'd fix it. Feel free to close if deemed overly trivial.

## Does your change need a Changelog entry?
No

## Do you need clarification on anything?
No

## Were there any complications while making this change?
No

## Have you reviewed and updated the documentation for this change? Is new documentation required?
No

## How did you verify this change?
With my eyes

## Is this change a patch?
No
