### PR TITLE
Add max-session-length flag and logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added metric threshold service checks.
+- Added `--max-session-length` flag to agent to configure the maximum duration
+  after which the agent will reconnect to one of its backends.
 
 ### Changed
 - Agent now persists prometheus HELP messages as a metric tag.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -508,11 +508,9 @@ func (a *Agent) enforceMaxSessionLength(connCancel context.CancelFunc) {
 		timeout := a.maxSessionLength + jitter
 
 		logger.Infof("Session will be terminated in %v", timeout)
-		select {
-		case <-time.After(timeout):
-			logger.Infof("Ending session after %v (max session length is %v)", timeout, a.maxSessionLength)
-			connCancel()
-		}
+		<-time.After(timeout)
+		logger.Infof("Ending session after %v (max session length is %v)", timeout, a.maxSessionLength)
+		connCancel()
 	} else {
 		logger.Debugf("maxSessionLength is %v, agent won't periodically disconnect", a.maxSessionLength)
 	}

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -77,6 +77,7 @@ const (
 	flagRetryMin                 = "retry-min"
 	flagRetryMax                 = "retry-max"
 	flagRetryMultiplier          = "retry-multiplier"
+	flagMaxSessionLength         = "max-session-length"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -138,6 +139,7 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.RetryMin = viper.GetDuration(flagRetryMin)
 	cfg.RetryMax = viper.GetDuration(flagRetryMax)
 	cfg.RetryMultiplier = viper.GetFloat64(flagRetryMultiplier)
+	cfg.MaxSessionLength = viper.GetDuration(flagMaxSessionLength)
 
 	// Set the labels & annotations using values defined configuration files
 	// and/or environment variables for now
@@ -320,6 +322,7 @@ func handleConfig(cmd *cobra.Command, arguments []string) error {
 	viper.SetDefault(flagRetryMin, time.Second)
 	viper.SetDefault(flagRetryMax, 120*time.Second)
 	viper.SetDefault(flagRetryMultiplier, 2.0)
+	viper.SetDefault(flagMaxSessionLength, 0*time.Second)
 
 	// Merge in flag set so that it appears in command usage
 	flags := flagSet()
@@ -441,6 +444,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Duration(flagRetryMin, viper.GetDuration(flagRetryMin), "minimum amount of time to wait before retrying an agent connection to the backend")
 	flagSet.Duration(flagRetryMax, viper.GetDuration(flagRetryMax), "maximum amount of time to wait before retrying an agent connection to the backend")
 	flagSet.Float64(flagRetryMultiplier, viper.GetFloat64(flagRetryMultiplier), "value multiplied with the current retry delay to produce a longer retry delay (bounded by --retry-max)")
+	flagSet.Duration(flagMaxSessionLength, viper.GetDuration(flagMaxSessionLength), "maximum amount of time after which the agent will reconnect to one of the configured backends")
 
 	flagSet.SetOutput(ioutil.Discard)
 

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -444,7 +444,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Duration(flagRetryMin, viper.GetDuration(flagRetryMin), "minimum amount of time to wait before retrying an agent connection to the backend")
 	flagSet.Duration(flagRetryMax, viper.GetDuration(flagRetryMax), "maximum amount of time to wait before retrying an agent connection to the backend")
 	flagSet.Float64(flagRetryMultiplier, viper.GetFloat64(flagRetryMultiplier), "value multiplied with the current retry delay to produce a longer retry delay (bounded by --retry-max)")
-	flagSet.Duration(flagMaxSessionLength, viper.GetDuration(flagMaxSessionLength), "maximum amount of time after which the agent will reconnect to one of the configured backends")
+	flagSet.Duration(flagMaxSessionLength, viper.GetDuration(flagMaxSessionLength), "maximum amount of time after which the agent will reconnect to one of the configured backends (no maximum by default)")
 
 	flagSet.SetOutput(ioutil.Discard)
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -210,6 +210,10 @@ type Config struct {
 	// RetryMultiplier is multiplied with the current retry delay to produce
 	// a longer retry delay. It is bounded by RetryMax.
 	RetryMultiplier float64
+
+	// MaxSessionLength is the maximum duration after which the agent will
+	// reconnect to one of the backends.
+	MaxSessionLength time.Duration
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -35,7 +35,7 @@ var (
 	flagUser              = flag.String("user", agent.DefaultUser, "user to authenticate with server")
 	flagPassword          = flag.String("password", agent.DefaultPassword, "password to authenticate with server")
 	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number")
-	flagMaxSessionLength  = flag.Duration("max-session-length", 0*time.Second, "maximum amount of time after which the agent will reconnect to one of the configure backends")
+	flagMaxSessionLength  = flag.Duration("max-session-length", 0*time.Second, "maximum amount of time after which the agent will reconnect to one of the configured backends (no maximum by default)")
 )
 
 func main() {

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -34,7 +34,8 @@ var (
 	flagHugeEvents        = flag.Bool("huge-events", false, "send 1 MB events to the backend")
 	flagUser              = flag.String("user", agent.DefaultUser, "user to authenticate with server")
 	flagPassword          = flag.String("password", agent.DefaultPassword, "password to authenticate with server")
-	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number.")
+	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number")
+	flagMaxSessionLength  = flag.Duration("max-session-length", 0*time.Second, "maximum amount of time after which the agent will reconnect to one of the configure backends")
 )
 
 func main() {
@@ -92,6 +93,7 @@ func main() {
 		cfg.BackendHeartbeatInterval = 30
 		cfg.BackendHeartbeatTimeout = 300
 		cfg.PrometheusBinding = *flagPromBinding
+		cfg.MaxSessionLength = *flagMaxSessionLength
 
 		agent, err := agent.NewAgent(cfg)
 		if err != nil {


### PR DESCRIPTION
## What is this change?
```
This makes the agent disconnect and reconnect after some configurable
amount of time (+ built-in jitter). The aim of this change is to have
agents organically rebalance their connections to the backends over
time.

Signed-off-by: Cyril Cressent <cyril@sensu.io>
```

## Why is this change necessary?

Close #3329.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

Yes: I am suggesting a different way to calculate the final session length (including jitter) such that `--max-session-length` feels more "natural". Let me know if it makes sense to go ahead with that.

```
maxSessionLength = x/2 + randFloat() * x
where x is the value given to the flag
```

Given that `randFloat()` gives a value in the range `[0, 1(`, it makes it so the maximum amount of time before a disconnect/reconnect is really bounded by the value given to the flag.

## Were there any complications while making this change?

Yes. The connection manager in the agent is quite crusty and I broke various things several times before arriving at my current solution.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I haven't. New documentation for the flag will be required.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

## Is this change a patch?

No.
