### PR TITLE
Add module versions to /version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Added metric threshold service checks.
+- Added API group version information to the /version endpoint.
 
 ### Changed
 - Agent now persists prometheus HELP messages as a metric tag.

--- a/api/core/v2/version.go
+++ b/api/core/v2/version.go
@@ -8,6 +8,7 @@ import (
 type Version struct {
 	Etcd         *etcdVersion.Versions `json:"etcd"`
 	SensuBackend string                `json:"sensu_backend"`
+	APIGroups    map[string]string     `json:"api_groups"`
 }
 
 // FixtureVersion returns a Version fixture for testing.

--- a/backend/apid/actions/version.go
+++ b/backend/apid/actions/version.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
 	"github.com/sensu/sensu-go/version"
 	etcdVersion "go.etcd.io/etcd/api/v3/version"
 	"golang.org/x/net/context"
@@ -27,5 +28,6 @@ func (v VersionController) GetVersion(ctx context.Context) *corev2.Version {
 			Cluster: v.clusterVersion,
 		},
 		SensuBackend: version.Semver(),
+		APIGroups:    types.APIModuleVersions(),
 	}
 }

--- a/types/versions.go
+++ b/types/versions.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"path"
+	"runtime/debug"
+	"strings"
+)
+
+// APIModuleVersions returns a map of Sensu API modules that are compiled into
+// the product.
+func APIModuleVersions() map[string]string {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+	apiModuleVersions := make(map[string]string)
+	packageMapMu.Lock()
+	defer packageMapMu.Unlock()
+	for k := range packageMap {
+		for _, mod := range buildInfo.Deps {
+			if strings.HasSuffix(mod.Path, path.Join("api", k)) {
+				apiModuleVersions[k] = mod.Version
+				break
+			}
+		}
+	}
+	return apiModuleVersions
+}

--- a/types/versions_test.go
+++ b/types/versions_test.go
@@ -1,0 +1,26 @@
+package types_test
+
+import (
+	"testing"
+
+	"runtime/debug"
+
+	types "github.com/sensu/sensu-go/types"
+)
+
+// TODO(eric): This test doesn't work yet because of https://github.com/golang/go/issues/33976
+func TestAPIModuleVersions(t *testing.T) {
+	_, ok := debug.ReadBuildInfo()
+	if ok {
+		t.Fatal("remove this if block, the test works now")
+	} else {
+		t.Skip()
+	}
+	modVersions := types.APIModuleVersions()
+	if _, ok := modVersions["core/v2"]; !ok {
+		t.Errorf("missing core/v2 module version")
+	}
+	if _, ok := modVersions["core/v3"]; !ok {
+		t.Errorf("missing core/v3 module version")
+	}
+}


### PR DESCRIPTION
## What is this change?

This commit adds module version info to the /version endpoint. Due to an
open Go bug, the commit is not testable yet. A unit test has been added
anyways, with a canary that should die when Go fixes the bug on their
end.

## Why is this change necessary?

Closes #4590 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

While the change does work, as validated by starting up sensu-backend and querying the `/version` endpoint, it is not testable with `go test` yet, due to a Go bug. See https://github.com/golang/go/issues/33976

## How did you verify this change?

Manually.

## Is this change a patch?

No.