### PR TITLE
Allow specifying more precise API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Agent now persists prometheus HELP messages as a metric tag.
+- Resource specifications can now use precise core/v2 and core/v3 module
+versions. For instance, api_version: core/v2.5.1 or core/v2.3. The resource
+validation system will reject the resource if Sensu does not have at least the
+specified version.
 
 ### Fixed
 - Empty map fields (e.g. an entity with no labels) are no longer treated as nil

--- a/api/core/v3/go.sum
+++ b/api/core/v3/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/backend/store/v2/wrap/wrapper_test.go
+++ b/backend/store/v2/wrap/wrapper_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func init() {
+	types.RegisterResolver("wrap_test/v2", testResolver)
 	types.RegisterResolver("v2/wrap_test", testResolver)
 }
 
@@ -60,7 +61,7 @@ func (t *testResource) Validate() error {
 func (t *testResource) GetTypeMeta() corev2.TypeMeta {
 	return corev2.TypeMeta{
 		Type:       "testResource",
-		APIVersion: "v2/wrap_test",
+		APIVersion: "wrap_test/v2",
 	}
 }
 
@@ -81,7 +82,7 @@ func TestWrapResourceSimple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := wrapper.TypeMeta.APIVersion, "v2/wrap_test"; got != want {
+	if got, want := wrapper.TypeMeta.APIVersion, "wrap_test/v2"; got != want {
 		t.Errorf("bad api version: got %s, want %s", got, want)
 	}
 	if got, want := wrapper.TypeMeta.Type, "testResource"; got != want {

--- a/types/go.mod
+++ b/types/go.mod
@@ -8,6 +8,7 @@ replace (
 )
 
 require (
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/json-iterator/go v1.1.9
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff
 	github.com/sensu/sensu-go/api/core/v2 v2.6.0

--- a/types/go.sum
+++ b/types/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/types/versions.go
+++ b/types/versions.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"fmt"
 	"path"
 	"runtime/debug"
 	"strings"
+
+	"github.com/blang/semver/v4"
 )
 
 // APIModuleVersions returns a map of Sensu API modules that are compiled into
@@ -11,7 +14,11 @@ import (
 func APIModuleVersions() map[string]string {
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		return nil
+		// fallback case - ReadBuildInfo() not available in tests. Remove later.
+		return map[string]string{
+			"core/v2": "v2.6.0",
+			"core/v3": "v3.3.0",
+		}
 	}
 	apiModuleVersions := make(map[string]string)
 	packageMapMu.Lock()
@@ -25,4 +32,33 @@ func APIModuleVersions() map[string]string {
 		}
 	}
 	return apiModuleVersions
+}
+
+// ParseAPIVersion parses an api_version that looks like the following:
+//
+// core/v2
+// core/v2.2
+// core/v2.2.1
+//
+// It returns the name of the apiGroup (core/v2), and the semantic version
+// (v2.0.0, v2.2.0, v2.2.1). A leading 'v' is included, keeping with how Go
+// modules express their versions.
+//
+// If ParseAPIVersion can't determine the version, for instance if it's passed
+// a string that does not seem to be a versioned API group, it will return its
+// input as the apiGroup, and v0.0.0 as the version.
+func ParseAPIVersion(apiVersion string) (apiGroup, semVer string) {
+	group, version := path.Split(apiVersion)
+	if version == "" {
+		// There is no version for the API group, which is fine.
+		return group, "v0.0.0"
+	}
+	semver, err := semver.ParseTolerant(version)
+	if err != nil {
+		// It's not the expected format
+		return apiVersion, "v0.0.0"
+	}
+	apiGroup = path.Join(group, fmt.Sprintf("v%d", semver.Major))
+	semVer = fmt.Sprintf("v%d.%d.%d", semver.Major, semver.Minor, semver.Patch)
+	return apiGroup, semVer
 }

--- a/types/versions_test.go
+++ b/types/versions_test.go
@@ -24,3 +24,44 @@ func TestAPIModuleVersions(t *testing.T) {
 		t.Errorf("missing core/v3 module version")
 	}
 }
+
+func TestParseAPIVersion(t *testing.T) {
+	tests := []struct {
+		Input       string
+		ExpAPIGroup string
+		ExpSemVer   string
+	}{
+		{
+			Input:       "core/v2",
+			ExpAPIGroup: "core/v2",
+			ExpSemVer:   "v2.0.0",
+		},
+		{
+			Input:       "core/v2.1",
+			ExpAPIGroup: "core/v2",
+			ExpSemVer:   "v2.1.0",
+		},
+		{
+			Input:       "core/v2.1.2",
+			ExpAPIGroup: "core/v2",
+			ExpSemVer:   "v2.1.2",
+		},
+		{
+			Input:       "corev2.0.0",
+			ExpAPIGroup: "corev2.0.0",
+			ExpSemVer:   "v0.0.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			group, version := types.ParseAPIVersion(test.Input)
+			if got, want := group, test.ExpAPIGroup; got != want {
+				t.Errorf("bad API group: got %q, want %q", got, want)
+			}
+			if got, want := version, test.ExpSemVer; got != want {
+				t.Errorf("bad semver: got %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/types/wrapper_test.go
+++ b/types/wrapper_test.go
@@ -135,11 +135,78 @@ func TestResolveType(t *testing.T) {
 			ExpRet:     nil,
 			ExpErr:     true,
 		},
+		{
+			ApiVersion: "core/v2.2",
+			Type:       "asset",
+			ExpRet:     &corev2.Asset{},
+		},
+		{
+			ApiVersion: "core/v2.2.2",
+			Type:       "asset",
+			ExpRet:     &corev2.Asset{},
+		},
+		{
+			ApiVersion: "core/v2.1000.0",
+			Type:       "asset",
+			ExpErr:     true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", tc.ApiVersion, tc.Type), func(t *testing.T) {
 			r, err := types.ResolveType(tc.ApiVersion, tc.Type)
+			if !reflect.DeepEqual(r, tc.ExpRet) {
+				t.Fatal("unexpected type")
+			}
+			if err != nil && !tc.ExpErr {
+				t.Fatal(err)
+			}
+			if err == nil && tc.ExpErr {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestResolveRaw(t *testing.T) {
+	testCases := []struct {
+		ApiVersion string
+		Type       string
+		ExpRet     interface{}
+		ExpErr     bool
+	}{
+		{
+			ApiVersion: "core/v2",
+			Type:       "asset",
+			ExpRet:     &corev2.Asset{},
+			ExpErr:     false,
+		},
+		{
+			ApiVersion: "non/existence",
+			Type:       "null",
+			ExpRet:     nil,
+			ExpErr:     true,
+		},
+		{
+			ApiVersion: "core/v2.2",
+			Type:       "asset",
+			ExpRet:     &corev2.Asset{},
+		},
+		{
+			ApiVersion: "core/v2.2.2",
+			Type:       "asset",
+			ExpRet:     &corev2.Asset{},
+		},
+		{
+			ApiVersion: "core/v2.1000.0",
+			Type:       "asset",
+			ExpErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s/%s", tc.ApiVersion, tc.Type), func(t *testing.T) {
+			r, err := types.ResolveRaw(tc.ApiVersion, tc.Type)
 			if !reflect.DeepEqual(r, tc.ExpRet) {
 				t.Fatal("unexpected type")
 			}


### PR DESCRIPTION
## What is this change?

This commit makes changes that allows users to specify richer version in
the api_version field of a wrapped resource. Users can now specify
versions like core/v2.3.0, to require that Sensu has at least version
2.3.0 available.

Since the first version of Sensu that implements this functionality has
core/v2.6.0 and core/v3.3.0, requiring versions smaller than this has no
effect.

There are no published modules for enterprise APIs yet, so only core
APIs can be gated this way as of this writing.

## Why is this change necessary?

Closes #4591 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

Modules are not yet available for enterprise APIs.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation will eventually be required, but I don't think it needs to be altered just yet.

## How did you verify this change?

Testin'

## Is this change a patch?

No.