### PR TITLE
Fix wording in sensu-backend upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixed interactive wording for `sensu-backend upgrade`. The wording no longer
+refers to Sensu 5.x.
+
 ## [6.6.4] - 2022-01-13
 
 ### Added

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 const (
@@ -26,7 +26,7 @@ func UpgradeCommand() *cobra.Command {
 	var setupErr error
 	cmd := &cobra.Command{
 		Use:           "upgrade",
-		Short:         "upgrade a sensu installation from 5.x to 6.x",
+		Short:         "upgrade a sensu etcd database to the current version",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -97,7 +97,7 @@ func UpgradeCommand() *cobra.Command {
 			if !skipConfirm {
 				var confirm bool
 				prompt := &survey.Confirm{
-					Message: "Do you really want to upgrade your Sensu 5.x database to 6.x? This operation cannot be undone; make sure you back up your database!",
+					Message: "Are you sure you want to upgrade your Sensu database? This operation cannot be undone; make sure you back up your database!",
 				}
 				if err := survey.AskOne(prompt, &confirm, nil); err != nil {
 					return err


### PR DESCRIPTION
## What is this change?

Fixes the wording when a user runs `sensu-backend upgrade` in interactive mode.

## Why is this change necessary?

Closes #4528 

## Does your change need a Changelog entry?

Yes

## Is this change a patch?

Yes