### PR TITLE
[GraphQL] Partial count field

### DIFF
--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -96,6 +96,10 @@ type UserClient interface {
 	UpdateUser(ctx context.Context, user *corev2.User) error
 }
 
+type ClusterMetricStore interface {
+	EntityCount(ctx context.Context, kind string) (int, error)
+}
+
 type RBACClient interface {
 	ListRoleBindings(ctx context.Context) ([]*corev2.RoleBinding, error)
 	FetchRoleBinding(ctx context.Context, name string) (*corev2.RoleBinding, error)

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -317,3 +317,12 @@ func (m *MockEtcdHealthController) GetClusterHealth(ctx context.Context) *corev2
 	args := m.Called(ctx)
 	return args.Get(0).(*corev2.HealthResponse)
 }
+
+type MockClusterMetricStore struct {
+	mock.Mock
+}
+
+func (m *MockClusterMetricStore) EntityCount(ctx context.Context, kind string) (int, error) {
+	args := m.Called(ctx, kind)
+	return args.Get(0).(int), args.Error(1)
+}

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -295,7 +295,7 @@ CONTINUE:
 	// if no filter was applied, use the cluster metrics service to get the total
 	// count
 	var hasTotalCount bool
-	if len(p.Args.Filter) == 0 && metricStore != nil {
+	if len(p.Args.Filters) == 0 && metricStore != nil {
 		if count, err := metricStore.EntityCount(ctx, "total"); err != nil {
 			logger.WithError(err).Warn("Namespace.Entities: unable to retrieve total entity count")
 		} else if count > 0 {

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -286,6 +286,12 @@ CONTINUE:
 		goto CONTINUE
 	}
 
+	// if the count was abandoned due to reaching the count limit, set the
+	// partialCount flag so that clients are aware
+	if matches >= maxCountNamespaceListEntities {
+		res.PageInfo.partialCount = true
+	}
+
 	res.Nodes = records
 	res.PageInfo.totalCount = matches
 	return res, nil

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -63,7 +63,7 @@ func TestNamespaceTypeEntitiesField(t *testing.T) {
 	// Metrics
 	metricsStore := new(MockClusterMetricStore)
 	metricsStore.On("EntityCount", mock.Anything, "total").Return(10, nil)
-	resolver.metricsStore = metricsStore
+	resolver.serviceConfig = &ServiceConfig{ClusterMetricStore: metricsStore}
 	got, err = resolver.Entities(params)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, got.(offsetContainer).Nodes)

--- a/backend/apid/graphql/namespace_test.go
+++ b/backend/apid/graphql/namespace_test.go
@@ -47,7 +47,7 @@ func TestNamespaceTypeEntitiesField(t *testing.T) {
 		corev2.FixtureEntity("a"),
 		corev2.FixtureEntity("b"),
 		corev2.FixtureEntity("c"),
-	}, nil).Once()
+	}, nil).Times(2)
 
 	params := schema.NamespaceEntitiesFieldResolverParams{ResolveParams: graphql.ResolveParams{Context: context.Background()}}
 	params.Context = context.Background()
@@ -59,6 +59,16 @@ func TestNamespaceTypeEntitiesField(t *testing.T) {
 	got, err := resolver.Entities(params)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, got.(offsetContainer).Nodes)
+
+	// Metrics
+	metricsStore := new(MockClusterMetricStore)
+	metricsStore.On("EntityCount", mock.Anything, "total").Return(10, nil)
+	resolver.metricsStore = metricsStore
+	got, err = resolver.Entities(params)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, got.(offsetContainer).Nodes)
+	assert.Equal(t, got.(offsetContainer).PageInfo.totalCount, 10)
+	assert.False(t, got.(offsetContainer).PageInfo.partialCount)
 
 	// Store err
 	client.On("ListEntities", mock.Anything, mock.Anything).Return([]*corev2.Entity{}, errors.New("abc")).Once()

--- a/backend/apid/graphql/pagination.go
+++ b/backend/apid/graphql/pagination.go
@@ -15,9 +15,10 @@ type offsetContainer struct {
 }
 
 type offsetPageInfo struct {
-	offset     int
-	limit      int
-	totalCount int
+	offset       int
+	limit        int
+	totalCount   int
+	partialCount bool
 }
 
 func newOffsetContainer(offset, limit int) offsetContainer {
@@ -70,4 +71,10 @@ func (*offsetPageInfoImpl) PreviousOffset(p graphql.ResolveParams) (int, error) 
 func (*offsetPageInfoImpl) TotalCount(p graphql.ResolveParams) (int, error) {
 	page := p.Source.(offsetPageInfo)
 	return page.totalCount, nil
+}
+
+// PartialCount implements response to request for 'totalCount' field.
+func (*offsetPageInfoImpl) PartialCount(p graphql.ResolveParams) (bool, error) {
+	page := p.Source.(offsetPageInfo)
+	return page.partialCount, nil
 }

--- a/backend/apid/graphql/schema/pagination.gql.go
+++ b/backend/apid/graphql/schema/pagination.gql.go
@@ -26,6 +26,9 @@ type OffsetPageInfoFieldResolvers interface {
 
 	// TotalCount implements response to request for 'totalCount' field.
 	TotalCount(p graphql.ResolveParams) (int, error)
+
+	// PartialCount implements response to request for 'partialCount' field.
+	PartialCount(p graphql.ResolveParams) (bool, error)
 }
 
 // OffsetPageInfoAliases implements all methods on OffsetPageInfoFieldResolvers interface by using reflection to
@@ -99,6 +102,19 @@ func (_ OffsetPageInfoAliases) TotalCount(p graphql.ResolveParams) (int, error) 
 	return ret, err
 }
 
+// PartialCount implements response to request for 'partialCount' field.
+func (_ OffsetPageInfoAliases) PartialCount(p graphql.ResolveParams) (bool, error) {
+	val, err := graphql.DefaultResolver(p.Source, p.Info.FieldName)
+	ret, ok := val.(bool)
+	if err != nil {
+		return ret, err
+	}
+	if !ok {
+		return ret, errors.New("unable to coerce value for field 'partialCount'")
+	}
+	return ret, err
+}
+
 // OffsetPageInfoType Information about the current page.
 var OffsetPageInfoType = graphql.NewType("OffsetPageInfo", graphql.ObjectKind)
 
@@ -151,6 +167,15 @@ func _ObjTypeOffsetPageInfoTotalCountHandler(impl interface{}) graphql1.FieldRes
 	}
 }
 
+func _ObjTypeOffsetPageInfoPartialCountHandler(impl interface{}) graphql1.FieldResolveFn {
+	resolver := impl.(interface {
+		PartialCount(p graphql.ResolveParams) (bool, error)
+	})
+	return func(frp graphql1.ResolveParams) (interface{}, error) {
+		return resolver.PartialCount(frp)
+	}
+}
+
 func _ObjectTypeOffsetPageInfoConfigFn() graphql1.ObjectConfig {
 	return graphql1.ObjectConfig{
 		Description: "Information about the current page.",
@@ -175,6 +200,13 @@ func _ObjectTypeOffsetPageInfoConfigFn() graphql1.ObjectConfig {
 				Description:       "Next offset to use when paginating forward; null if there are no more items.",
 				Name:              "nextOffset",
 				Type:              graphql1.Int,
+			},
+			"partialCount": &graphql1.Field{
+				Args:              graphql1.FieldConfigArgument{},
+				DeprecationReason: "",
+				Description:       "When true the total count does not represent the entire data set",
+				Name:              "partialCount",
+				Type:              graphql1.NewNonNull(graphql1.Boolean),
 			},
 			"previousOffset": &graphql1.Field{
 				Args:              graphql1.FieldConfigArgument{},
@@ -211,6 +243,7 @@ var _ObjectTypeOffsetPageInfoDesc = graphql.ObjectDesc{
 		"hasNextPage":     _ObjTypeOffsetPageInfoHasNextPageHandler,
 		"hasPreviousPage": _ObjTypeOffsetPageInfoHasPreviousPageHandler,
 		"nextOffset":      _ObjTypeOffsetPageInfoNextOffsetHandler,
+		"partialCount":    _ObjTypeOffsetPageInfoPartialCountHandler,
 		"previousOffset":  _ObjTypeOffsetPageInfoPreviousOffsetHandler,
 		"totalCount":      _ObjTypeOffsetPageInfoTotalCountHandler,
 	},

--- a/backend/apid/graphql/schema/pagination.graphql
+++ b/backend/apid/graphql/schema/pagination.graphql
@@ -16,4 +16,7 @@ type OffsetPageInfo {
 
   "Total count of records in relationship."
   totalCount: Int!
+
+  "When true the total count does not represent the entire data set"
+  partialCount: Boolean!
 }

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -67,7 +67,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	// Register types
 	schema.RegisterAsset(svc, &assetImpl{})
 	schema.RegisterCoreV2Secret(svc, &schema.CoreV2SecretAliases{})
-	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient, entityClient: cfg.EntityClient, eventClient: cfg.EventClient, metricsStore: cfg.ClusterMetricStore})
+	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient, entityClient: cfg.EntityClient, eventClient: cfg.EventClient, serviceConfig: &cfg})
 	schema.RegisterErrCode(svc)
 	schema.RegisterEvent(svc, &eventImpl{})
 	schema.RegisterEventsListOrder(svc)

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -23,22 +23,23 @@ type ClientFactory interface {
 
 // ServiceConfig describes values required to instantiate service.
 type ServiceConfig struct {
-	AssetClient       AssetClient
-	CheckClient       CheckClient
-	EntityClient      EntityClient
-	EventClient       EventClient
-	EventFilterClient EventFilterClient
-	HandlerClient     HandlerClient
-	HealthController  EtcdHealthController
-	MutatorClient     MutatorClient
-	SilencedClient    SilencedClient
-	NamespaceClient   NamespaceClient
-	HookClient        HookClient
-	UserClient        UserClient
-	RBACClient        RBACClient
-	VersionController VersionController
-	GenericClient     GenericClient
-	MetricGatherer    MetricGatherer
+	AssetClient        AssetClient
+	CheckClient        CheckClient
+	EntityClient       EntityClient
+	EventClient        EventClient
+	EventFilterClient  EventFilterClient
+	HandlerClient      HandlerClient
+	HealthController   EtcdHealthController
+	MutatorClient      MutatorClient
+	SilencedClient     SilencedClient
+	NamespaceClient    NamespaceClient
+	HookClient         HookClient
+	UserClient         UserClient
+	RBACClient         RBACClient
+	VersionController  VersionController
+	GenericClient      GenericClient
+	MetricGatherer     MetricGatherer
+	ClusterMetricStore ClusterMetricStore
 }
 
 // Service describes the Sensu GraphQL service capable of handling queries.
@@ -66,7 +67,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	// Register types
 	schema.RegisterAsset(svc, &assetImpl{})
 	schema.RegisterCoreV2Secret(svc, &schema.CoreV2SecretAliases{})
-	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient, entityClient: cfg.EntityClient, eventClient: cfg.EventClient})
+	schema.RegisterNamespace(svc, &namespaceImpl{client: cfg.NamespaceClient, entityClient: cfg.EntityClient, eventClient: cfg.EventClient, metricsStore: cfg.ClusterMetricStore})
 	schema.RegisterErrCode(svc)
 	schema.RegisterEvent(svc, &eventImpl{})
 	schema.RegisterEventsListOrder(svc)

--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -45,7 +45,7 @@ type ServiceConfig struct {
 // Service describes the Sensu GraphQL service capable of handling queries.
 type Service struct {
 	Target       *graphql.Service
-	Config       ServiceConfig
+	Config       *ServiceConfig
 	NodeRegister *relay.NodeRegister
 }
 
@@ -57,7 +57,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	nodeResolver := relay.Resolver{Register: &nodeRegister}
 	wrapper := Service{
 		Target:       svc,
-		Config:       cfg,
+		Config:       &cfg,
 		NodeRegister: &nodeRegister,
 	}
 
@@ -210,7 +210,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 // Do executes given query string and variables
 func (svc *Service) Do(ctx context.Context, p graphql.QueryParams) *graphql.Result {
 	// Instantiate loaders and lift them into the context
-	qryCtx := contextWithLoaders(ctx, svc.Config)
+	qryCtx := contextWithLoaders(ctx, *svc.Config)
 
 	// Execute query inside context
 	return svc.Target.Do(qryCtx, p)


### PR DESCRIPTION
* Adds a `partialCount` flag to pagination that communicates whether or not the `totalCount` in fact represents the total count of entities or if the count was abandoned.
* When queries entities, in the case where no filter was given, the total count of entities is retrieved from the metrics daemon to avoid having to scan the entire keyspace for determine the count.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>