### PR TITLE
[GraphQL] Use a sliding chunk size

### DIFF
--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -254,10 +254,8 @@ func (r *namespaceImpl) Entities(p schema.NamespaceEntitiesFieldResolverParams) 
 	ctx := store.NamespaceContext(p.Context, p.Source.(*corev2.Namespace).Name)
 
 	chunkSize := p.Args.Limit
-	if len(p.Args.Filters) != 0 {
-		chunkSize = maxInt(chunkSize, minChunkSizeNamespaceListEntities)
-		chunkSize = minInt(chunkSize, maxChunkSizeNamespaceListEntities)
-	}
+	chunkSize = maxInt(chunkSize, minChunkSizeNamespaceListEntities)
+	chunkSize = minInt(chunkSize, maxChunkSizeNamespaceListEntities)
 
 	ordering, desc := listEntitiesOrdering(p.Args.OrderBy)
 	pred := &store.SelectionPredicate{


### PR DESCRIPTION
Switches to using a chunk size of between 250 and 500 records. In cases where the page size is small (eg. 25 items) this will lead to a bit more memory usage but it greatly reduce the amount to round trips. As I/O is likely a bigger bottleneck than CPU or memory, this should greatly reduce resolver execution time.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
