### PR TITLE
[GraphQL] Bump events max fetch size to 50k

### DIFF
--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -16,7 +16,7 @@ const (
 	// into memory; things likely won't work well if the upper bound is hit but
 	// at least we aren't breaking the existing behaviour. Eventually this
 	// interface will be deprecated in lieu of one that can be performant.
-	maxSizeNamespaceListEvents = 25_000
+	maxSizeNamespaceListEvents = 50_000
 
 	// When this number is exceeded the resolver will cease to count the total
 	// number of entities. This should reduce the instances where we scan the


### PR DESCRIPTION
Bumps the maximum number of events that will be read into memory when fetching events from the store. This will increase response time and memory usage for very large namespaces, but is less likely to leave events out of the response.

Note: No limitation is applied when using the postgresql store; only applicable for etcd store.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>