### PR TITLE
Integrate PR 4357 (Metadata configuration for keepalive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added `--max-session-length` flag to agent to configure the maximum duration
   after which the agent will reconnect to one of its backends.
 - Added API group version information to the /version endpoint.
+- Added `keepalive-check-labels`and `keepalive-check-annotations` configuration flags to the sensu-agent
 
 ### Changed
 - Agent now persists prometheus HELP messages as a metric tag.
@@ -214,7 +215,6 @@ agent processed a particular event.
 - Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
 metrics to the `/metrics` endpoint.
 - Added support for environment variable arguments in `sensuctl`.
-- Added `keepalive-labels`and `keepalive-annotations` configuration flags to the sensu-agent
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ agent processed a particular event.
 - Added `sensu_go_agentd_event_bytes` & `sensu_go_store_event_bytes` summary
 metrics to the `/metrics` endpoint.
 - Added support for environment variable arguments in `sensuctl`.
+- Added `keepalive-labels`and `keepalive-annotations` configuration flags to the sensu-agent
 
 ### Changed
 - When deleting resource with sensuctl, the resource type will now be displayed

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -638,6 +638,10 @@ func (a *Agent) newKeepalive() *transport.Message {
 		Timeout:    a.config.KeepaliveWarningTimeout,
 		Ttl:        int64(a.config.KeepaliveCriticalTimeout),
 	}
+
+	keepalive.ObjectMeta.Labels = a.config.KeepaliveLabels
+	keepalive.ObjectMeta.Annotations = a.config.KeepaliveAnnotations
+
 	keepalive.Entity = entity
 	keepalive.Timestamp = time.Now().Unix()
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -639,8 +639,8 @@ func (a *Agent) newKeepalive() *transport.Message {
 		Ttl:        int64(a.config.KeepaliveCriticalTimeout),
 	}
 
-	keepalive.ObjectMeta.Labels = a.config.KeepaliveLabels
-	keepalive.ObjectMeta.Annotations = a.config.KeepaliveAnnotations
+	keepalive.Labels = a.config.KeepaliveCheckLabels
+	keepalive.Annotations = a.config.KeepaliveCheckAnnotations
 
 	keepalive.Entity = entity
 	keepalive.Timestamp = time.Now().Unix()

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -24,8 +24,8 @@ import (
 var (
 	annotations               map[string]string
 	labels                    map[string]string
-	keepaliveLabels           map[string]string
-	keepaliveAnnotations      map[string]string
+	keepaliveCheckLabels      map[string]string
+	keepaliveCheckAnnotations map[string]string
 	configFileDefaultLocation = filepath.Join(path.SystemConfigDir(), "agent.yml")
 )
 
@@ -36,52 +36,52 @@ const (
 
 	environmentPrefix = "sensu"
 
-	flagAgentName                = "name"
-	flagAPIHost                  = "api-host"
-	flagAPIPort                  = "api-port"
-	flagAssetsRateLimit          = "assets-rate-limit"
-	flagAssetsBurstLimit         = "assets-burst-limit"
-	flagBackendURL               = "backend-url"
-	flagCacheDir                 = "cache-dir"
-	flagConfigFile               = "config-file"
-	flagDeregister               = "deregister"
-	flagDeregistrationHandler    = "deregistration-handler"
-	flagDetectCloudProvider      = "detect-cloud-provider"
-	flagEventsRateLimit          = "events-rate-limit"
-	flagEventsBurstLimit         = "events-burst-limit"
-	flagKeepaliveHandlers        = "keepalive-handlers"
-	flagKeepaliveInterval        = "keepalive-interval"
-	flagKeepaliveWarningTimeout  = "keepalive-warning-timeout"
-	flagKeepaliveCriticalTimeout = "keepalive-critical-timeout"
-	flagKeepaliveLabels          = "keepalive-labels"
-	flagKeepaliveAnnotations     = "keepalive-annotations"
-	flagNamespace                = "namespace"
-	flagPassword                 = "password"
-	flagRedact                   = "redact"
-	flagSocketHost               = "socket-host"
-	flagSocketPort               = "socket-port"
-	flagStatsdDisable            = "statsd-disable"
-	flagStatsdEventHandlers      = "statsd-event-handlers"
-	flagStatsdFlushInterval      = "statsd-flush-interval"
-	flagStatsdMetricsHost        = "statsd-metrics-host"
-	flagStatsdMetricsPort        = "statsd-metrics-port"
-	flagSubscriptions            = "subscriptions"
-	flagUser                     = "user"
-	flagDisableAPI               = "disable-api"
-	flagDisableAssets            = "disable-assets"
-	flagDisableSockets           = "disable-sockets"
-	flagLogLevel                 = "log-level"
-	flagLabels                   = "labels"
-	flagAnnotations              = "annotations"
-	flagAllowList                = "allow-list"
-	flagBackendHandshakeTimeout  = "backend-handshake-timeout"
-	flagBackendHeartbeatInterval = "backend-heartbeat-interval"
-	flagBackendHeartbeatTimeout  = "backend-heartbeat-timeout"
-	flagAgentManagedEntity       = "agent-managed-entity"
-	flagRetryMin                 = "retry-min"
-	flagRetryMax                 = "retry-max"
-	flagRetryMultiplier          = "retry-multiplier"
-	flagMaxSessionLength         = "max-session-length"
+	flagAgentName                 = "name"
+	flagAPIHost                   = "api-host"
+	flagAPIPort                   = "api-port"
+	flagAssetsRateLimit           = "assets-rate-limit"
+	flagAssetsBurstLimit          = "assets-burst-limit"
+	flagBackendURL                = "backend-url"
+	flagCacheDir                  = "cache-dir"
+	flagConfigFile                = "config-file"
+	flagDeregister                = "deregister"
+	flagDeregistrationHandler     = "deregistration-handler"
+	flagDetectCloudProvider       = "detect-cloud-provider"
+	flagEventsRateLimit           = "events-rate-limit"
+	flagEventsBurstLimit          = "events-burst-limit"
+	flagKeepaliveHandlers         = "keepalive-handlers"
+	flagKeepaliveInterval         = "keepalive-interval"
+	flagKeepaliveWarningTimeout   = "keepalive-warning-timeout"
+	flagKeepaliveCriticalTimeout  = "keepalive-critical-timeout"
+	flagKeepaliveCheckLabels      = "keepalive-check-labels"
+	flagKeepaliveCheckAnnotations = "keepalive-check-annotations"
+	flagNamespace                 = "namespace"
+	flagPassword                  = "password"
+	flagRedact                    = "redact"
+	flagSocketHost                = "socket-host"
+	flagSocketPort                = "socket-port"
+	flagStatsdDisable             = "statsd-disable"
+	flagStatsdEventHandlers       = "statsd-event-handlers"
+	flagStatsdFlushInterval       = "statsd-flush-interval"
+	flagStatsdMetricsHost         = "statsd-metrics-host"
+	flagStatsdMetricsPort         = "statsd-metrics-port"
+	flagSubscriptions             = "subscriptions"
+	flagUser                      = "user"
+	flagDisableAPI                = "disable-api"
+	flagDisableAssets             = "disable-assets"
+	flagDisableSockets            = "disable-sockets"
+	flagLogLevel                  = "log-level"
+	flagLabels                    = "labels"
+	flagAnnotations               = "annotations"
+	flagAllowList                 = "allow-list"
+	flagBackendHandshakeTimeout   = "backend-handshake-timeout"
+	flagBackendHeartbeatInterval  = "backend-heartbeat-interval"
+	flagBackendHeartbeatTimeout   = "backend-heartbeat-timeout"
+	flagAgentManagedEntity        = "agent-managed-entity"
+	flagRetryMin                  = "retry-min"
+	flagRetryMax                  = "retry-max"
+	flagRetryMultiplier           = "retry-multiplier"
+	flagMaxSessionLength          = "max-session-length"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -126,8 +126,8 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
 	cfg.KeepaliveWarningTimeout = uint32(viper.GetInt(flagKeepaliveWarningTimeout))
 	cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
-	cfg.KeepaliveLabels = viper.GetStringMapString(flagKeepaliveLabels)
-	cfg.KeepaliveAnnotations = viper.GetStringMapString(flagKeepaliveAnnotations)
+	cfg.KeepaliveCheckLabels = viper.GetStringMapString(flagKeepaliveCheckLabels)
+	cfg.KeepaliveCheckAnnotations = viper.GetStringMapString(flagKeepaliveCheckAnnotations)
 	cfg.Namespace = viper.GetString(flagNamespace)
 	cfg.Password = viper.GetString(flagPassword)
 	cfg.Socket.Host = viper.GetString(flagSocketHost)
@@ -432,8 +432,8 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagKeepaliveInterval, viper.GetInt(flagKeepaliveInterval), "number of seconds to send between keepalive events")
 	flagSet.Uint32(flagKeepaliveWarningTimeout, uint32(viper.GetInt(flagKeepaliveWarningTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
 	flagSet.Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
-	flagSet.StringToStringVar(&keepaliveLabels, flagKeepaliveLabels, nil, "keepalive labels map")
-	flagSet.StringToStringVar(&keepaliveAnnotations, flagKeepaliveAnnotations, nil, "keepalive annotations map")
+	flagSet.StringToStringVar(&keepaliveCheckLabels, flagKeepaliveCheckLabels, nil, "keepalive labels map to add to keepalive events")
+	flagSet.StringToStringVar(&keepaliveCheckAnnotations, flagKeepaliveCheckAnnotations, nil, "keepalive annotations map to add to keepalive events")
 	flagSet.Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	flagSet.Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	flagSet.Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -24,6 +24,8 @@ import (
 var (
 	annotations               map[string]string
 	labels                    map[string]string
+	keepaliveLabels           map[string]string
+	keepaliveAnnotations      map[string]string
 	configFileDefaultLocation = filepath.Join(path.SystemConfigDir(), "agent.yml")
 )
 
@@ -51,6 +53,8 @@ const (
 	flagKeepaliveInterval        = "keepalive-interval"
 	flagKeepaliveWarningTimeout  = "keepalive-warning-timeout"
 	flagKeepaliveCriticalTimeout = "keepalive-critical-timeout"
+	flagKeepaliveLabels          = "keepalive-labels"
+	flagKeepaliveAnnotations     = "keepalive-annotations"
 	flagNamespace                = "namespace"
 	flagPassword                 = "password"
 	flagRedact                   = "redact"
@@ -122,6 +126,8 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.KeepaliveInterval = uint32(viper.GetInt(flagKeepaliveInterval))
 	cfg.KeepaliveWarningTimeout = uint32(viper.GetInt(flagKeepaliveWarningTimeout))
 	cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
+	cfg.KeepaliveLabels = viper.GetStringMapString(flagKeepaliveLabels)
+	cfg.KeepaliveAnnotations = viper.GetStringMapString(flagKeepaliveAnnotations)
 	cfg.Namespace = viper.GetString(flagNamespace)
 	cfg.Password = viper.GetString(flagPassword)
 	cfg.Socket.Host = viper.GetString(flagSocketHost)
@@ -426,6 +432,8 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Int(flagKeepaliveInterval, viper.GetInt(flagKeepaliveInterval), "number of seconds to send between keepalive events")
 	flagSet.Uint32(flagKeepaliveWarningTimeout, uint32(viper.GetInt(flagKeepaliveWarningTimeout)), "number of seconds until agent is considered dead by backend to create a warning event")
 	flagSet.Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
+	flagSet.StringToStringVar(&keepaliveLabels, flagKeepaliveLabels, nil, "keepalive labels map")
+	flagSet.StringToStringVar(&keepaliveAnnotations, flagKeepaliveAnnotations, nil, "keepalive annotations map")
 	flagSet.Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	flagSet.Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	flagSet.Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -58,15 +58,15 @@ func TestNewAgentConfigKeepaliveLabelsFlags(t *testing.T) {
 	if err := handleConfig(cmd, []string{}); err != nil {
 		t.Fatal("unexpected error while calling handleConfig: ", err)
 	}
-	_ = cmd.Flags().Set(flagKeepaliveLabels, "foo=bar")
+	_ = cmd.Flags().Set(flagKeepaliveCheckLabels, "foo=bar")
 
 	cfg, err := NewAgentConfig(cmd)
 	if err != nil {
 		t.Fatal("unexpected error while calling handleConfig: ", err)
 	}
 
-	if !reflect.DeepEqual(cfg.KeepaliveLabels, map[string]string{"foo": "bar"}) {
-		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveLabels, `{"foo":"bar"}`)
+	if !reflect.DeepEqual(cfg.KeepaliveCheckLabels, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveCheckLabels, `{"foo":"bar"}`)
 	}
 }
 
@@ -77,15 +77,15 @@ func TestNewAgentConfigKeepaliveAnnotationsFlags(t *testing.T) {
 	if err := handleConfig(cmd, []string{}); err != nil {
 		t.Fatal("unexpected error while calling handleConfig: ", err)
 	}
-	_ = cmd.Flags().Set(flagKeepaliveAnnotations, "foo=bar")
+	_ = cmd.Flags().Set(flagKeepaliveCheckAnnotations, "foo=bar")
 
 	cfg, err := NewAgentConfig(cmd)
 	if err != nil {
 		t.Fatal("unexpected error while calling handleConfig: ", err)
 	}
 
-	if !reflect.DeepEqual(cfg.KeepaliveAnnotations, map[string]string{"foo": "bar"}) {
-		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveAnnotations, `{"foo":"bar"}`)
+	if !reflect.DeepEqual(cfg.KeepaliveCheckAnnotations, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveCheckAnnotations, `{"foo":"bar"}`)
 	}
 }
 

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -51,6 +51,44 @@ func TestNewAgentConfigFlags(t *testing.T) {
 	}
 }
 
+func TestNewAgentConfigKeepaliveLabelsFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagKeepaliveLabels, "foo=bar")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.KeepaliveLabels, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveLabels, `{"foo":"bar"}`)
+	}
+}
+
+func TestNewAgentConfigKeepaliveAnnotationsFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagKeepaliveAnnotations, "foo=bar")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.KeepaliveAnnotations, map[string]string{"foo": "bar"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepaliveAnnotations, `{"foo":"bar"}`)
+	}
+}
+
 func TestNewAgentConfig_AgentManagedEntityFlag(t *testing.T) {
 	cmd := &cobra.Command{
 		Use: "test",

--- a/agent/config.go
+++ b/agent/config.go
@@ -142,6 +142,12 @@ type Config struct {
 	// by the backend to create a critical event.
 	KeepaliveCriticalTimeout uint32
 
+	// KeepaliveLabels are key-value pairs that users can provide to keepalive events
+	KeepaliveLabels map[string]string
+
+	// KeepaliveAnnotations are key-value pairs that users can provide to keepalive events
+	KeepaliveAnnotations map[string]string
+
 	// Labels are key-value pairs that users can provide to agent entities
 	Labels map[string]string
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -142,11 +142,11 @@ type Config struct {
 	// by the backend to create a critical event.
 	KeepaliveCriticalTimeout uint32
 
-	// KeepaliveLabels are key-value pairs that users can provide to keepalive events
-	KeepaliveLabels map[string]string
+	// KeepaliveCheckLabels are key-value pairs that users can provide to keepalive events
+	KeepaliveCheckLabels map[string]string
 
-	// KeepaliveAnnotations are key-value pairs that users can provide to keepalive events
-	KeepaliveAnnotations map[string]string
+	// KeepaliveCheckAnnotations are key-value pairs that users can provide to keepalive events
+	KeepaliveCheckAnnotations map[string]string
 
 	// Labels are key-value pairs that users can provide to agent entities
 	Labels map[string]string


### PR DESCRIPTION
## What is this change?

Add 2 new flags to the agent, `--keepalive-check-labels` and `--keepalive-check-annotations` to let the agent inject labels and annotations in the keepalive events produced by the backend.

## Why is this change necessary?

- Close #4042 
- Integrate @agm650's PR (#4357) after bringing it up to speed with current `main` and making a few alterations.

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

Can the reviewers share their opinion one last time on the new flag names?

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New documentation is required for the 2 new flags, `--keepalive-check-labels` and `--keepalive-check-annotations`.
@hillaryfraley 

## How did you verify this change?

- Unit tests for new configuration flags
- Manual testing to check that the configured labels/annotations appear in keepalive events
- Manual testing using the `curl` commands shared in #4042, to check that one can now retrieve keepalives based on labels (using `sensu-enterprise-go` as the backend)

## Is this change a patch?

No.
