### PR TITLE
Clarify Install Sensu in the docs is for supported packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Sensu Go installer packages are available for a number of computing
 platforms (e.g. Debian/Ubuntu, RHEL/Centos, etc), but the easiest way
 to get started is with the official Docker image, sensu/sensu.
 
-See the [installation documentation](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/) to get started with one of Sensu's [supported packages](https://docs.sensu.io/sensu-go/latest/platforms/).
+See the [installation documentation](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/)
+to get started with one of Sensu's [supported packages](https://docs.sensu.io/sensu-go/latest/platforms/).
 
 **NOTE**: Starting with Sensu Go version 6.0, for instances built from source, the web UI is now a [standalone product](https://github.com/sensu/web) — it is no longer included with the Sensu backend. To build the web UI from source, use the [installation instructions](https://github.com/sensu/web/blob/master/INSTALL.md) in the Sensu Go Web repository.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sensu Go installer packages are available for a number of computing
 platforms (e.g. Debian/Ubuntu, RHEL/Centos, etc), but the easiest way
 to get started is with the official Docker image, sensu/sensu.
 
-See the [installation documentation](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/) to get started.
+See the [installation documentation](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/) to get started with one of Sensu's [supported packages](https://docs.sensu.io/sensu-go/latest/platforms/).
 
 **NOTE**: Starting with Sensu Go version 6.0, for instances built from source, the web UI is now a [standalone product](https://github.com/sensu/web) — it is no longer included with the Sensu backend. To build the web UI from source, use the [installation instructions](https://github.com/sensu/web/blob/master/INSTALL.md) in the Sensu Go Web repository.
 


### PR DESCRIPTION
## What is this change?

I'm updating the Install Sensu page in the docs to clarify that the installation instructions are specific to our supported packages and sending readers to this readme for binary/OSS instructions.


## Why is this change necessary?

This suggestion would make sure we are providing this clarification in both spots (here and in the docs).

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I am updating https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/install-sensu/ to provide clarification about what the page covers as well. This is the only docs update required.

## How did you verify this change?

n/a

## Is this change a patch?

No