### PR TITLE
types: Fix ResolveType/ResolveRaw deadlock

### DIFF
--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -293,11 +293,12 @@ func RegisterResolver(key string, resolver func(string) (interface{}, error)) {
 
 // ResolveType returns the Resource associated with the given package and type.
 func ResolveType(apiVersion string, typename string) (Resource, error) {
+	availableModules := APIModuleVersions()
+
 	// Guard read access to packageMap
 	packageMapMu.RLock()
 	defer packageMapMu.RUnlock()
 	apiGroup, reqVer := ParseAPIVersion(apiVersion)
-	availableModules := APIModuleVersions()
 	foundVer, ok := availableModules[apiGroup]
 	if ok {
 		if semverGreater(reqVer, foundVer) {
@@ -333,11 +334,12 @@ func semverGreater(s1, s2 string) bool {
 
 // ResolveRaw resolves the raw type for the requested type.
 func ResolveRaw(apiVersion string, typename string) (interface{}, error) {
+	availableModules := APIModuleVersions()
+
 	// Guard read access to packageMap
 	packageMapMu.RLock()
 	defer packageMapMu.RUnlock()
 	apiGroup, reqVer := ParseAPIVersion(apiVersion)
-	availableModules := APIModuleVersions()
 	foundVer, ok := availableModules[apiGroup]
 	if ok {
 		if semverGreater(reqVer, foundVer) {


### PR DESCRIPTION
## What is this change?

Fix bug #4610 by calling `APIModuleVersions()` before read-locking `packageMapMu`.

## Why is this change necessary?
Required to be able to start the backend node.

## Does your change need a Changelog entry?

Perhaps yes?

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Yes, after that backend works again.

## Is this change a patch?

Yes.