### PR TITLE
[GraphQL] Continue paging until requested slice has been satisfied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.6.6] - ???
+
+### Fixed
+
+- [GraphQL] Fixed issue where one could not use an offset >= 500 when paging
+through entities.
+
 ## [6.6.5] - 2022-02-03
 
 ### Fixed

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -289,13 +289,13 @@ CONTINUE:
 	}
 
 	// in the case where there are still more entities to scan through,
-	// continue scanning if...
+	// continue scanning...
 	if pred.Continue != "" {
 		// ...if the user's requested slice is not yet satisfied
 		if (matches - p.Args.Offset) < p.Args.Limit {
 			goto CONTINUE
 		}
-		// ...or, we are still determining the total count.
+		// ...or, if we are still determining the total count.
 		if matches < maxCountNamespaceListEntities {
 			goto CONTINUE
 		}


### PR DESCRIPTION
Continues to scan through entities until the requested slice (offset + limit) has been satisfied.

Previously if the current matches had exceeded the `maxCountNamespaceListEntities` constant, the resolver would stop the scan and return whatever it had collected up to that point. This didn't really match the intent of `maxCountNamespaceListEntities` constant which had only been meant to signify when we give up on determining the total count<sup>[1](https://github.com/sensu/sensu-go/blob/4086938e0e61e99e175c2120bf80fbc34ccdca53/backend/apid/graphql/namespace.go#L21-L24)</sup>.

Closes https://github.com/sensu/sensu-enterprise-go/issues/2026

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>