### PR TITLE
Pipelines for agent keepalives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Automatically create system namespace and backend entities.
 - Generate backend events on secret provider access errors.
+## Unreleased
+
+### Added
+- Added `keepalive-pipelines` configuration flag to the sensu-agent
 
 ## [6.6.5] - 2022-02-03
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -136,34 +136,35 @@ func GetDefaultAgentName() string {
 
 // An Agent receives and acts on messages from a Sensu Backend.
 type Agent struct {
-	allowList         []allowList
-	api               *http.Server
-	assetGetter       asset.Getter
-	backendSelector   BackendSelector
-	config            *Config
-	connected         bool
-	connectedMu       sync.RWMutex
-	contentType       string
-	entityConfig      *corev3.EntityConfig
-	entityConfigCh    chan struct{}
-	entityMu          sync.Mutex
-	executor          command.Executor
-	handler           *handler.MessageHandler
-	header            http.Header
-	inProgress        map[string]*corev2.CheckConfig
-	inProgressMu      *sync.Mutex
-	localEntityConfig *corev3.EntityConfig
-	statsdServer      StatsdServer
-	sendq             chan *transport.Message
-	systemInfo        *corev2.System
-	systemInfoMu      sync.RWMutex
-	wg                sync.WaitGroup
-	apiQueue          queue
-	marshal           MarshalFunc
-	unmarshal         UnmarshalFunc
-	sequencesMu       sync.Mutex
-	sequences         map[string]int64
-	maxSessionLength  time.Duration
+	allowList          []allowList
+	api                *http.Server
+	assetGetter        asset.Getter
+	backendSelector    BackendSelector
+	config             *Config
+	connected          bool
+	connectedMu        sync.RWMutex
+	contentType        string
+	entityConfig       *corev3.EntityConfig
+	entityConfigCh     chan struct{}
+	entityMu           sync.Mutex
+	executor           command.Executor
+	handler            *handler.MessageHandler
+	header             http.Header
+	inProgress         map[string]*corev2.CheckConfig
+	inProgressMu       *sync.Mutex
+	localEntityConfig  *corev3.EntityConfig
+	statsdServer       StatsdServer
+	sendq              chan *transport.Message
+	systemInfo         *corev2.System
+	systemInfoMu       sync.RWMutex
+	wg                 sync.WaitGroup
+	apiQueue           queue
+	marshal            MarshalFunc
+	unmarshal          UnmarshalFunc
+	sequencesMu        sync.Mutex
+	sequences          map[string]int64
+	maxSessionLength   time.Duration
+	keepalivePipelines []*corev2.ResourceReference
 
 	// ProcessGetter gets information about local agent processes.
 	ProcessGetter process.Getter
@@ -357,6 +358,15 @@ func (a *Agent) Run(ctx context.Context) error {
 			if u.Scheme != "ws" && u.Scheme != "wss" {
 				return fmt.Errorf("backend URL (%s) must have ws:// or wss:// scheme", burl)
 			}
+		}
+	}
+
+	logger.Debug("validating keepalive pipelines: ", a.config.KeepalivePipelines)
+	for _, p := range a.config.KeepalivePipelines {
+		if ref, err := corev2.FromStringRef(p); err != nil {
+			logger.WithError(err).Warnf("error parsing keepalive pipeline resource reference: %s", p)
+		} else {
+			a.keepalivePipelines = append(a.keepalivePipelines, ref)
 		}
 	}
 
@@ -630,6 +640,7 @@ func (a *Agent) newKeepalive() *transport.Message {
 		ObjectMeta: corev2.NewObjectMeta("", entity.Namespace),
 		ID:         uid[:],
 		Sequence:   a.nextSequence("keepalive"),
+		Pipelines:  a.keepalivePipelines,
 	}
 
 	keepalive.Check = &corev2.Check{

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -55,6 +55,7 @@ const (
 	flagKeepaliveCriticalTimeout  = "keepalive-critical-timeout"
 	flagKeepaliveCheckLabels      = "keepalive-check-labels"
 	flagKeepaliveCheckAnnotations = "keepalive-check-annotations"
+	flagKeepalivePipelines        = "keepalive-pipelines"
 	flagNamespace                 = "namespace"
 	flagPassword                  = "password"
 	flagRedact                    = "redact"
@@ -128,6 +129,7 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.KeepaliveCriticalTimeout = uint32(viper.GetInt(flagKeepaliveCriticalTimeout))
 	cfg.KeepaliveCheckLabels = viper.GetStringMapString(flagKeepaliveCheckLabels)
 	cfg.KeepaliveCheckAnnotations = viper.GetStringMapString(flagKeepaliveCheckAnnotations)
+	cfg.KeepalivePipelines = viper.GetStringSlice(flagKeepalivePipelines)
 	cfg.Namespace = viper.GetString(flagNamespace)
 	cfg.Password = viper.GetString(flagPassword)
 	cfg.Socket.Host = viper.GetString(flagSocketHost)
@@ -434,6 +436,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Uint32(flagKeepaliveCriticalTimeout, uint32(viper.GetInt(flagKeepaliveCriticalTimeout)), "number of seconds until agent is considered dead by backend to create a critical event")
 	flagSet.StringToStringVar(&keepaliveCheckLabels, flagKeepaliveCheckLabels, nil, "keepalive labels map to add to keepalive events")
 	flagSet.StringToStringVar(&keepaliveCheckAnnotations, flagKeepaliveCheckAnnotations, nil, "keepalive annotations map to add to keepalive events")
+	flagSet.StringSlice(flagKeepalivePipelines, viper.GetStringSlice(flagKeepalivePipelines), "comma-delimited list of pipeline references for keepalive event")
 	flagSet.Bool(flagDisableAPI, viper.GetBool(flagDisableAPI), "disable the Agent HTTP API")
 	flagSet.Bool(flagDisableAssets, viper.GetBool(flagDisableAssets), "disable check assets on this agent")
 	flagSet.Bool(flagDisableSockets, viper.GetBool(flagDisableSockets), "disable the Agent TCP and UDP event sockets")

--- a/agent/cmd/start_test.go
+++ b/agent/cmd/start_test.go
@@ -89,6 +89,25 @@ func TestNewAgentConfigKeepaliveAnnotationsFlags(t *testing.T) {
 	}
 }
 
+func TestNewAgentConfigKeepalivePipelinesFlag(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+	if err := handleConfig(cmd, []string{}); err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+	_ = cmd.Flags().Set(flagKeepalivePipelines, "core/v2.Pipeline.a,core/v2.Pipeline b,kazoo")
+
+	cfg, err := NewAgentConfig(cmd)
+	if err != nil {
+		t.Fatal("unexpected error while calling handleConfig: ", err)
+	}
+
+	if !reflect.DeepEqual(cfg.KeepalivePipelines, []string{"core/v2.Pipeline.a", "core/v2.Pipeline b", "kazoo"}) {
+		t.Fatalf("TestNewAgentConfigFlags() labels = %v, want %v", cfg.KeepalivePipelines, `[core/v2.Pipeline.a core/v2.Pipeline b kazoo]`)
+	}
+}
+
 func TestNewAgentConfig_AgentManagedEntityFlag(t *testing.T) {
 	cmd := &cobra.Command{
 		Use: "test",

--- a/agent/config.go
+++ b/agent/config.go
@@ -148,6 +148,9 @@ type Config struct {
 	// KeepaliveCheckAnnotations are key-value pairs that users can provide to keepalive events
 	KeepaliveCheckAnnotations map[string]string
 
+	// KeepalivePipelines contain pipelines for agent's keepalive events
+	KeepalivePipelines []string
+
 	// Labels are key-value pairs that users can provide to agent entities
 	Labels map[string]string
 

--- a/api/core/v2/resource_reference.go
+++ b/api/core/v2/resource_reference.go
@@ -35,7 +35,7 @@ func (r *ResourceReference) StringRef() string {
 	return fmt.Sprintf("%s.%s.%s", r.APIVersion, r.Type, r.Name)
 }
 
-var resourceRefRE = regexp.MustCompile(`(\w+\/v\d+)\.(\w+)(?:\.|\s+)(\w+)`)
+var resourceRefRE = regexp.MustCompile(`(\w+\/v\d+)\.(\w+)(?:\.|\s+)([\w\.\-\:]+)`)
 
 func FromStringRef(s string) (*ResourceReference, error) {
 	var ref ResourceReference

--- a/api/core/v2/resource_reference.go
+++ b/api/core/v2/resource_reference.go
@@ -3,7 +3,10 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"regexp"
 )
+
+var errResourceRefFmt = errors.New("resource reference string must be in format api_version.type.name")
 
 // Validate checks if a resource reference resource passes validation rules.
 func (r *ResourceReference) Validate() error {
@@ -26,6 +29,24 @@ func (r *ResourceReference) Validate() error {
 // in the format: APIVersion.Type(Name=%s)
 func (r *ResourceReference) ResourceID() string {
 	return fmt.Sprintf("%s.%s(Name=%s)", r.APIVersion, r.Type, r.Name)
+}
+
+func (r *ResourceReference) StringRef() string {
+	return fmt.Sprintf("%s.%s.%s", r.APIVersion, r.Type, r.Name)
+}
+
+var resourceRefRE = regexp.MustCompile(`(\w+\/v\d+)\.(\w+)(?:\.|\s+)(\w+)`)
+
+func FromStringRef(s string) (*ResourceReference, error) {
+	var ref ResourceReference
+	groups := resourceRefRE.FindStringSubmatch(s)
+	if len(groups) != 4 {
+		return nil, errResourceRefFmt
+	}
+	ref.APIVersion = groups[1]
+	ref.Type = groups[2]
+	ref.Name = groups[3]
+	return &ref, nil
 }
 
 // LogFields returns a map of field names to values which represent a

--- a/api/core/v2/resource_reference_test.go
+++ b/api/core/v2/resource_reference_test.go
@@ -26,6 +26,11 @@ func TestStringRef(t *testing.T) {
 			ExpectedType:    "X",
 			ExpectedName:    "testcase",
 		}, {
+			Input:           "core/v2.X  test-case_123:A.b.C",
+			ExpectedVersion: "core/v2",
+			ExpectedType:    "X",
+			ExpectedName:    "test-case_123:A.b.C",
+		}, {
 			Input:           "api_version/v0.type.testcase",
 			ExpectedVersion: "api_version/v0",
 			ExpectedType:    "type",

--- a/api/core/v2/resource_reference_test.go
+++ b/api/core/v2/resource_reference_test.go
@@ -1,0 +1,70 @@
+package v2
+
+import testing "testing"
+
+func TestStringRef(t *testing.T) {
+	testCases := []struct {
+		Input           string
+		ExpectError     bool
+		ExpectedVersion string
+		ExpectedType    string
+		ExpectedName    string
+	}{
+		{
+			Input:           "core/v2.Pipeline.testcase",
+			ExpectedVersion: "core/v2",
+			ExpectedType:    "Pipeline",
+			ExpectedName:    "testcase",
+		}, {
+			Input:           "core/v2.Pipeline  testcase",
+			ExpectedVersion: "core/v2",
+			ExpectedType:    "Pipeline",
+			ExpectedName:    "testcase",
+		}, {
+			Input:           "core/v2000.X  testcase",
+			ExpectedVersion: "core/v2000",
+			ExpectedType:    "X",
+			ExpectedName:    "testcase",
+		}, {
+			Input:           "api_version/v0.type.testcase",
+			ExpectedVersion: "api_version/v0",
+			ExpectedType:    "type",
+			ExpectedName:    "testcase",
+		}, {
+			Input:       "api_version.type.testcase",
+			ExpectError: true,
+		}, {
+			Input:       "a/v1..",
+			ExpectError: true,
+		}, {
+			Input:       "a/v1..",
+			ExpectError: true,
+		}, {
+			Input:       "foo",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual, err := FromStringRef(tc.Input)
+		if err != nil {
+			if !tc.ExpectError {
+				t.Errorf("unexpected error for input %v: %v", tc.Input, err)
+			}
+			continue
+		} else if tc.ExpectError {
+			t.Errorf("expected error for input %v", tc.Input)
+			continue
+		}
+
+		if actual.GetAPIVersion() != tc.ExpectedVersion {
+			t.Errorf("expected %v, got %v", tc.ExpectedVersion, actual.GetAPIVersion())
+		}
+		if actual.GetType() != tc.ExpectedType {
+			t.Errorf("expected %v, got %v", tc.ExpectedType, actual.GetType())
+		}
+		if actual.GetName() != tc.ExpectedName {
+			t.Errorf("expected %v, got %v", tc.ExpectedName, actual.GetName())
+		}
+	}
+}

--- a/api/core/v2/resource_reference_test.go
+++ b/api/core/v2/resource_reference_test.go
@@ -42,9 +42,6 @@ func TestStringRef(t *testing.T) {
 			Input:       "a/v1..",
 			ExpectError: true,
 		}, {
-			Input:       "a/v1..",
-			ExpectError: true,
-		}, {
 			Input:       "foo",
 			ExpectError: true,
 		},

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -472,7 +472,6 @@ func createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
 		Timeout:   check.Timeout,
 		Ttl:       check.Ttl,
 		Handlers:  handlers,
-		Pipelines: rawEvent.Pipelines,
 		Executed:  time.Now().Unix(),
 		Issued:    time.Now().Unix(),
 		Scheduler: corev2.EtcdScheduler,
@@ -482,6 +481,7 @@ func createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
 		Timestamp:  time.Now().Unix(),
 		Entity:     rawEvent.Entity,
 		Check:      keepaliveCheck,
+		Pipelines:  rawEvent.Pipelines,
 	}
 
 	uid, _ := uuid.NewRandom()

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -472,6 +472,7 @@ func createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
 		Timeout:   check.Timeout,
 		Ttl:       check.Ttl,
 		Handlers:  handlers,
+		Pipelines: rawEvent.Pipelines,
 		Executed:  time.Now().Unix(),
 		Issued:    time.Now().Unix(),
 		Scheduler: corev2.EtcdScheduler,


### PR DESCRIPTION
## What is this change?

https://github.com/sensu/sensu-go/issues/4589

Adds a keepalive-pipelines flag to the sensu agent in order to allow operators to target pipelines for agent keepalive events.

## Why is this change necessary?

Adds flexibility (pipeline support) that is not currently supported using the special keepalive handler.

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

No

Spoke in #sensu-product slack and agreed on adopting the already familiar syntax from sensuctl edit. Ended up with regex that matches both `api_version.type.name` (dot) and `api_version.type name` (space).

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

New flag, so I assume so. @hillaryfraley 

Although I'd caution you to not get started until we land on the convention we want to use above.

## How did you verify this change?

Minimal unit testing + manual verification.

WIP:  https://github.com/sensu/sensu-go-qa-crucible/pull/217 and https://github.com/sensu/sensu-staging/pull/300

## Is this change a patch?

N