### PR TITLE
Agent TLS errors don't surface which agent is responsible for the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Automatically create system namespace and backend entities.
 - Generate backend events on secret provider access errors.
 
+### Fixed
+- Log agent IP address for connections with faulty TLS configurations.
+
 ## [6.6.5] - 2022-02-03
 
 ### Fixed

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -184,7 +184,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 			if cs != http.StateClosed {
 				var msg []byte
 				if _, err := c.Read(msg); err != nil {
-					logger.WithError(err).Error("websocket connection error")
+					logger.WithField("source", c.RemoteAddr().String()).WithError(err).Error("websocket connection error")
 				}
 			}
 		},


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

Adds the agent IP address:port on connection/TLS error log entries. The new property is named `source`.

## Why is this change necessary?

To help troubleshoot issues with misconfigured agents.

Closes #4574 

## Does your change need a Changelog entry?

Of course!

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

One of the comment mentioned it would be easy to get the agent name, however since the WSS connection is never established I'm not sure how we would get that information. However getting the remote IP address is fairly trivial.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No doc changes required.

## How did you verify this change?

Manual testing. New entry: 

```
{"component":"agentd","error":"tls: first record does not look like a TLS handshake","level":"error","msg":"websocket connection error","source":"192.168.7.160:35870","time":"2022-02-11T13:00:12-05:00"}
```

## Is this change a patch?

No