### PR TITLE
[GraphQL] Collect error types in metrics

### DIFF
--- a/backend/apid/graphql/service.go
+++ b/backend/apid/graphql/service.go
@@ -201,6 +201,12 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 
 	// Configure tracing
 	tracer := tracing.NewPrometheusTracer()
+	tracer.AllowList = []string{
+		tracing.KeyParse,
+		tracing.KeyValidate,
+		tracing.KeyExecuteQuery,
+		tracing.KeyExecuteField,
+	}
 	svc.RegisterMiddleware(tracer)
 
 	err := svc.Regenerate()


### PR DESCRIPTION
Adds an additional label with the type of error that occurred. Specifically it should help capture which errors are occurring, how frequently, and time elapsed before the resolver encountered an err.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
