### PR TITLE
change default embedded etcd heartbeat to 300 and election timeout to 3000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Automatically create system namespace and backend entities.
 - Generate backend events on secret provider access errors.
-## Unreleased
-
-### Added
 - Added `keepalive-pipelines` configuration flag to the sensu-agent
 
 ### Fixed
 - Log agent IP address for connections with faulty TLS configurations.
+
+### Changed
+- The default embedded etcd heartbeat interval has been increased from 100 to 300.
+- The default embedded etcd election timeout has been increased from 1000 to 3000.
+
 ## [6.6.6] - 2022-02-16
 
 ### Fixed

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -47,13 +47,13 @@ const (
 	// For best practices, the parameter should be set around round-trip time
 	// between members.
 	// See: https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters
-	DefaultTickMs = 100
+	DefaultTickMs = 300
 
 	// DefaultElectionMs is the default Election Timeout. This timeout is how
 	// long a follower node will go without hearing a heartbeat before
 	// attempting to become leader itself.
 	// See: https://github.com/etcd-io/etcd/blob/master/Documentation/tuning.md#time-parameters
-	DefaultElectionMs = 1000
+	DefaultElectionMs = 3000
 
 	// DefaultLogLevel is the default log level for the embedded etcd server.
 	DefaultLogLevel = "warn"


### PR DESCRIPTION
Increased the embedded etcd heatbeat interval and election timeout defaults.

Closes https://github.com/sensu/sensu-go/issues/4368

Values based on this discovery https://github.com/sensu/sensu-go/pull/4369#pullrequestreview-837806968

## What is this change?

Increased the embedded etc heartbeat interval and election timeout defaults, making etcd more latency tolerant for our use-case.

## Why is this change necessary?

Quality network an more importantly storage is harder to come by then expected. The etcd default values for the heartbeat interval and election timeout are too low, too sensitive to network and storage latency. etcd elections are expensive and destructive, increasing the default values helps avoid them while still not being too high that leader failover takes too long.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Local build.

## Is this change a patch?

No.

