### PR TITLE
sensuctl cluster-role create flags should be plural

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -27,6 +27,7 @@ mid-write.
 - The default embedded etcd heartbeat interval has been increased from 100 to 300.
 - The default embedded etcd election timeout has been increased from 1000 to 3000.
 - Upgraded etcd version from 3.5.0 to 3.5.2.
+- Changing parameters for `sensuctl cluster-role create` to use plurals
 
 ## [6.6.6] - 2022-02-16
 

--- a/cli/commands/clusterrole/create_test.go
+++ b/cli/commands/clusterrole/create_test.go
@@ -35,7 +35,7 @@ func TestCreateCommandRunEClosureMissingArgs(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestCreateCommandRunEClosureWithDeps(t *testing.T) {
+func TestCreateCommandDeprecatedRunEClosureWithDeps(t *testing.T) {
 	assert := assert.New(t)
 	cli := test.NewMockCLI()
 	client := cli.Client.(*client.MockClient)
@@ -44,6 +44,21 @@ func TestCreateCommandRunEClosureWithDeps(t *testing.T) {
 	cmd := CreateCommand(cli)
 	require.NoError(t, cmd.Flags().Set("verb", "list"))
 	require.NoError(t, cmd.Flags().Set("resource", "events"))
+	out, err := test.RunCmd(cmd, []string{"my-role"})
+
+	assert.NoError(err)
+	assert.Regexp("Created", out)
+}
+
+func TestCreateCommandRunEClosureWithDeps(t *testing.T) {
+	assert := assert.New(t)
+	cli := test.NewMockCLI()
+	client := cli.Client.(*client.MockClient)
+	client.On("CreateClusterRole", mock.Anything).Return(nil)
+
+	cmd := CreateCommand(cli)
+	require.NoError(t, cmd.Flags().Set("verbs", "list"))
+	require.NoError(t, cmd.Flags().Set("resources", "events"))
 	out, err := test.RunCmd(cmd, []string{"my-role"})
 
 	assert.NoError(err)


### PR DESCRIPTION

## What is this change?

adding two new flags, "verbs" and "resources" to replace "verb" and "resource".
In order not to break things, old flags are markes as deprecated and will "map" to the new flags transparently for the user.


## Why is this change necessary?

Solving #4141 

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

Changelog has been updated.

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

nope

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->
none for now :)

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
Some examples are to be updated. A PR is going to be opened for this
## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->
Running integration test plus manual creation of cluster-resource and mixing old & new flags.
## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->

No
