### PR TITLE
Add CheckConfig pipelines to Check on NewCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where pipelines in check configuration were not represented in
+the check object of events that were produced with the check configuration.
+
 ## [6.6.6] - 2022-02-16
 
 ### Fixed

--- a/api/core/v2/check.go
+++ b/api/core/v2/check.go
@@ -125,6 +125,7 @@ func NewCheck(c *CheckConfig) *Check {
 		DiscardOutput:        c.DiscardOutput,
 		MaxOutputSize:        c.MaxOutputSize,
 		Scheduler:            c.Scheduler,
+		Pipelines:            c.Pipelines,
 	}
 	if check.Labels == nil {
 		check.Labels = make(map[string]string)


### PR DESCRIPTION
## What is this change?

This commit fixes a bug where check pipelines aren't represented in event.check objects.

## Why is this change necessary?

The full check configuration should be represented in events.

## Does your change need a Changelog entry?

Yes

## Is this change a patch?

Yes