### PR TITLE
Correcting arm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Log agent IP address for connections with faulty TLS configurations.
+- ARM Version detection
 
 ### Changed
 - The default embedded etcd heartbeat interval has been increased from 100 to 300.

--- a/system/cpu_arm.go
+++ b/system/cpu_arm.go
@@ -6,8 +6,8 @@ package system
 import _ "unsafe"
 
 //go:linkname goarm runtime.goarm
-var goarm int32
+var goarm uint8
 
 func getARMVersion() int32 {
-	return goarm
+	return int32(goarm)
 }


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->
Correcting the detection of the arm version


## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->
At the present time the value retrieved for the arm version is invalid. Looking at some other code on internet ([here](https://gist.github.com/lucab/f7162ca2d95191c692edc12ea8ccaaef) or [here](https://github.com/creativeprojects/resticprofile/blob/master/arm.go) ) doing the same manipulation, it appears that the goarm needs to be define as a uint8.
Since int8/uint8 is not a valid type for protobuf exchange, the getARMVersion still return an int32. I'm just casting goarm to int32.

This is solving #4636

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->
Yes and I updated the changelog

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

Nothing I can think off

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

Not really. I just realised that protobuf doesn't support int8/uint8 as a type so I had to refrain myself from updating the .proto file.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

I don't think this change has any impact on the documentation.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

I build the sensu-agent with GOARM 6 and 7. Then I executed the program on a raspberry pi. Then I checked that the version displayed in the webUI and also with sensuctl.
As I do not have any other ARM device I was unable to perform some more complete testing.

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->

Not sure. the change is very small, so it might bee seen as a patch.
