### PR TITLE
Add node resolver for Pipeline resources 

### DIFF
--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -326,3 +326,87 @@ func (m *MockClusterMetricStore) EntityCount(ctx context.Context, kind string) (
 	args := m.Called(ctx, kind)
 	return args.Get(0).(int), args.Error(1)
 }
+
+type MockRBACClient struct {
+	mock.Mock
+}
+
+func (m *MockRBACClient) ListRoleBindings(ctx context.Context) ([]*corev2.RoleBinding, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*corev2.RoleBinding), args.Error(1)
+}
+
+func (m *MockRBACClient) FetchRoleBinding(ctx context.Context, name string) (*corev2.RoleBinding, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*corev2.RoleBinding), args.Error(1)
+}
+
+func (m *MockRBACClient) CreateRoleBinding(ctx context.Context, rb *corev2.RoleBinding) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) UpdateRoleBinding(ctx context.Context, rb *corev2.RoleBinding) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) ListRoles(ctx context.Context) ([]*corev2.Role, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*corev2.Role), args.Error(1)
+}
+
+func (m *MockRBACClient) FetchRole(ctx context.Context, name string) (*corev2.Role, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*corev2.Role), args.Error(1)
+}
+
+func (m *MockRBACClient) CreateRole(ctx context.Context, rb *corev2.Role) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) UpdateRole(ctx context.Context, rb *corev2.Role) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) ListClusterRoleBindings(ctx context.Context) ([]*corev2.ClusterRoleBinding, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*corev2.ClusterRoleBinding), args.Error(1)
+}
+
+func (m *MockRBACClient) FetchClusterRoleBinding(ctx context.Context, name string) (*corev2.ClusterRoleBinding, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*corev2.ClusterRoleBinding), args.Error(1)
+}
+
+func (m *MockRBACClient) CreateClusterRoleBinding(ctx context.Context, rb *corev2.ClusterRoleBinding) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) UpdateClusterRoleBinding(ctx context.Context, rb *corev2.ClusterRoleBinding) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) ListClusterRoles(ctx context.Context) ([]*corev2.ClusterRole, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*corev2.ClusterRole), args.Error(1)
+}
+
+func (m *MockRBACClient) FetchClusterRole(ctx context.Context, name string) (*corev2.ClusterRole, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(*corev2.ClusterRole), args.Error(1)
+}
+
+func (m *MockRBACClient) CreateClusterRole(ctx context.Context, rb *corev2.ClusterRole) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}
+
+func (m *MockRBACClient) UpdateClusterRole(ctx context.Context, rb *corev2.ClusterRole) error {
+	args := m.Called(ctx, rb)
+	return args.Error(0)
+}

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -352,8 +352,8 @@ func (f *silencedNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, e
 
 func registerPipelineNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
-		ObjectType: schema.SilencedType,
-		Translator: globalid.SilenceTranslator,
+		ObjectType: schema.CoreV2PipelineType,
+		Translator: globalid.PipelineTranslator,
 		Resolve: util_relay.MakeNodeResolver(
 			client,
 			corev2.TypeMeta{Type: "Pipeline", APIVersion: "core/v2"}),

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -11,16 +11,16 @@ import (
 )
 
 func registerNodeResolvers(register relay.NodeRegister, cfg ServiceConfig) {
-	registerAssetNodeResolver(register, cfg.AssetClient)
-	registerCheckNodeResolver(register, cfg.CheckClient)
+	registerAssetNodeResolver(register, cfg.GenericClient)
+	registerCheckNodeResolver(register, cfg.GenericClient)
 	registerClusterRoleNodeResolver(register, cfg.RBACClient)
 	registerClusterRoleBindingNodeResolver(register, cfg.RBACClient)
-	registerEntityNodeResolver(register, cfg.EntityClient)
+	registerEntityNodeResolver(register, cfg.GenericClient)
 	registerEventNodeResolver(register, cfg.EventClient)
-	registerEventFilterNodeResolver(register, cfg.EventFilterClient)
-	registerHandlerNodeResolver(register, cfg.HandlerClient)
-	registerHookNodeResolver(register, cfg.HookClient)
-	registerMutatorNodeResolver(register, cfg.MutatorClient)
+	registerEventFilterNodeResolver(register, cfg.GenericClient)
+	registerHandlerNodeResolver(register, cfg.GenericClient)
+	registerHookNodeResolver(register, cfg.GenericClient)
+	registerMutatorNodeResolver(register, cfg.GenericClient)
 	registerNamespaceNodeResolver(register, cfg.NamespaceClient)
 	registerPipelineNodeResolver(register, cfg.GenericClient)
 	registerRoleNodeResolver(register, cfg.RBACClient)
@@ -31,233 +31,142 @@ func registerNodeResolvers(register relay.NodeRegister, cfg ServiceConfig) {
 
 // assets
 
-type assetNodeResolver struct {
-	client AssetClient
-}
-
-func registerAssetNodeResolver(register relay.NodeRegister, client AssetClient) {
-	resolver := &assetNodeResolver{client: client}
+func registerAssetNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.AssetType,
 		Translator: globalid.AssetTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "Asset", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *assetNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchAsset(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // checks
 
-type checkNodeResolver struct {
-	client CheckClient
-}
-
-func registerCheckNodeResolver(register relay.NodeRegister, client CheckClient) {
-	resolver := &checkNodeResolver{client: client}
+func registerCheckNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.CheckConfigType,
 		Translator: globalid.CheckTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "CheckConfig", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *checkNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchCheck(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // entities
 
-type entityNodeResolver struct {
-	client EntityClient
-}
-
-func registerEntityNodeResolver(register relay.NodeRegister, client EntityClient) {
-	resolver := &entityNodeResolver{client: client}
+func registerEntityNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.EntityType,
 		Translator: globalid.EntityTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "Entity", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *entityNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchEntity(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // event filters
 
-type eventFilterNodeResolver struct {
-	client EventFilterClient
-}
-
-func registerEventFilterNodeResolver(register relay.NodeRegister, client EventFilterClient) {
-	resolver := &eventFilterNodeResolver{client: client}
+func registerEventFilterNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.EventFilterType,
 		Translator: globalid.EventFilterTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "EventFilter", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *eventFilterNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchEventFilter(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // handlers
 
-type handlerNodeResolver struct {
-	client HandlerClient
-}
-
-func registerHandlerNodeResolver(register relay.NodeRegister, client HandlerClient) {
-	resolver := &handlerNodeResolver{client: client}
+func registerHandlerNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.HandlerType,
 		Translator: globalid.HandlerTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "Handler", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *handlerNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchHandler(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // hooks
 
-type hookNodeResolver struct {
-	client HookClient
-}
-
-func registerHookNodeResolver(register relay.NodeRegister, client HookClient) {
-	resolver := &hookNodeResolver{client: client}
+func registerHookNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.HookConfigType,
 		Translator: globalid.HookTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "HookConfig", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *hookNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchHookConfig(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // mutators
 
-type mutatorNodeResolver struct {
-	client MutatorClient
-}
-
-func registerMutatorNodeResolver(register relay.NodeRegister, client MutatorClient) {
-	resolver := &mutatorNodeResolver{client: client}
+func registerMutatorNodeResolver(register relay.NodeRegister, client GenericClient) {
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.MutatorType,
 		Translator: globalid.MutatorTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "Mutator", APIVersion: "core/v2"}),
 	})
-}
-
-func (f *mutatorNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchMutator(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // cluster roles
 
-type clusterRoleNodeResolver struct {
-	client RBACClient
-}
-
 func registerClusterRoleNodeResolver(register relay.NodeRegister, client RBACClient) {
-	resolver := &clusterRoleNodeResolver{client: client}
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.ClusterRoleType,
 		Translator: globalid.ClusterRoleTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: func(p relay.NodeResolverParams) (interface{}, error) {
+			ctx := setContextFromComponents(p.Context, p.IDComponents)
+			record, err := client.FetchClusterRole(ctx, p.IDComponents.UniqueComponent())
+			return handleFetchResult(record, err)
+		},
 	})
-}
-
-func (f *clusterRoleNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchClusterRole(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // cluster role bindings
 
-type clusterRoleBindingNodeResolver struct {
-	client RBACClient
-}
-
 func registerClusterRoleBindingNodeResolver(register relay.NodeRegister, client RBACClient) {
-	resolver := &clusterRoleBindingNodeResolver{client: client}
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.ClusterRoleBindingType,
 		Translator: globalid.ClusterRoleBindingTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: func(p relay.NodeResolverParams) (interface{}, error) {
+			ctx := setContextFromComponents(p.Context, p.IDComponents)
+			record, err := client.FetchClusterRoleBinding(ctx, p.IDComponents.UniqueComponent())
+			return handleFetchResult(record, err)
+		},
 	})
-}
-
-func (f *clusterRoleBindingNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchClusterRoleBinding(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // roles
 
-type roleNodeResolver struct {
-	client RBACClient
-}
-
 func registerRoleNodeResolver(register relay.NodeRegister, client RBACClient) {
-	resolver := &roleNodeResolver{client: client}
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.RoleType,
 		Translator: globalid.RoleTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: func(p relay.NodeResolverParams) (interface{}, error) {
+			ctx := setContextFromComponents(p.Context, p.IDComponents)
+			record, err := client.FetchRole(ctx, p.IDComponents.UniqueComponent())
+			return handleFetchResult(record, err)
+		},
 	})
-}
-
-func (f *roleNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchRole(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // role bindings
 
-type roleBindingNodeResolver struct {
-	client RBACClient
-}
-
 func registerRoleBindingNodeResolver(register relay.NodeRegister, client RBACClient) {
-	resolver := &roleBindingNodeResolver{client: client}
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.RoleBindingType,
 		Translator: globalid.RoleBindingTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: func(p relay.NodeResolverParams) (interface{}, error) {
+			ctx := setContextFromComponents(p.Context, p.IDComponents)
+			record, err := client.FetchRoleBinding(ctx, p.IDComponents.UniqueComponent())
+			return handleFetchResult(record, err)
+		},
 	})
-}
-
-func (f *roleBindingNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.FetchRoleBinding(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // user
@@ -329,23 +238,16 @@ func (f *namespaceNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, 
 
 // silences
 
-type silencedNodeResolver struct {
-	client SilencedClient
-}
-
 func registerSilencedNodeResolver(register relay.NodeRegister, client SilencedClient) {
-	resolver := &silencedNodeResolver{client: client}
 	register.RegisterResolver(relay.NodeResolver{
 		ObjectType: schema.SilencedType,
 		Translator: globalid.SilenceTranslator,
-		Resolve:    resolver.fetch,
+		Resolve: func(p relay.NodeResolverParams) (interface{}, error) {
+			ctx := setContextFromComponents(p.Context, p.IDComponents)
+			record, err := client.GetSilencedByName(ctx, p.IDComponents.UniqueComponent())
+			return handleFetchResult(record, err)
+		},
 	})
-}
-
-func (f *silencedNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, error) {
-	ctx := setContextFromComponents(p.Context, p.IDComponents)
-	record, err := f.client.GetSilencedByName(ctx, p.IDComponents.UniqueComponent())
-	return handleFetchResult(record, err)
 }
 
 // pipelines

--- a/backend/apid/graphql/node.go
+++ b/backend/apid/graphql/node.go
@@ -3,26 +3,29 @@ package graphql
 import (
 	"errors"
 
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
 	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
 	"github.com/sensu/sensu-go/backend/apid/graphql/schema"
+	util_relay "github.com/sensu/sensu-go/backend/apid/graphql/util/relay"
 )
 
 func registerNodeResolvers(register relay.NodeRegister, cfg ServiceConfig) {
 	registerAssetNodeResolver(register, cfg.AssetClient)
 	registerCheckNodeResolver(register, cfg.CheckClient)
+	registerClusterRoleNodeResolver(register, cfg.RBACClient)
+	registerClusterRoleBindingNodeResolver(register, cfg.RBACClient)
 	registerEntityNodeResolver(register, cfg.EntityClient)
+	registerEventNodeResolver(register, cfg.EventClient)
 	registerEventFilterNodeResolver(register, cfg.EventFilterClient)
 	registerHandlerNodeResolver(register, cfg.HandlerClient)
 	registerHookNodeResolver(register, cfg.HookClient)
 	registerMutatorNodeResolver(register, cfg.MutatorClient)
-	registerClusterRoleNodeResolver(register, cfg.RBACClient)
-	registerClusterRoleBindingNodeResolver(register, cfg.RBACClient)
+	registerNamespaceNodeResolver(register, cfg.NamespaceClient)
+	registerPipelineNodeResolver(register, cfg.GenericClient)
 	registerRoleNodeResolver(register, cfg.RBACClient)
 	registerRoleBindingNodeResolver(register, cfg.RBACClient)
 	registerUserNodeResolver(register, cfg.UserClient)
-	registerEventNodeResolver(register, cfg.EventClient)
-	registerNamespaceNodeResolver(register, cfg.NamespaceClient)
 	registerSilencedNodeResolver(register, cfg.SilencedClient)
 }
 
@@ -343,4 +346,16 @@ func (f *silencedNodeResolver) fetch(p relay.NodeResolverParams) (interface{}, e
 	ctx := setContextFromComponents(p.Context, p.IDComponents)
 	record, err := f.client.GetSilencedByName(ctx, p.IDComponents.UniqueComponent())
 	return handleFetchResult(record, err)
+}
+
+// pipelines
+
+func registerPipelineNodeResolver(register relay.NodeRegister, client GenericClient) {
+	register.RegisterResolver(relay.NodeResolver{
+		ObjectType: schema.SilencedType,
+		Translator: globalid.SilenceTranslator,
+		Resolve: util_relay.MakeNodeResolver(
+			client,
+			corev2.TypeMeta{Type: "Pipeline", APIVersion: "core/v2"}),
+	})
 }

--- a/backend/apid/graphql/node_test.go
+++ b/backend/apid/graphql/node_test.go
@@ -86,17 +86,13 @@ func TestNodeResolvers(t *testing.T) {
 		{
 			name: "entities",
 			setupNode: func() interface{} {
-				return corev2.FixtureEntity("name")
+				return corev2.FixtureEntity("sensu")
 			},
 			setupID: func(r interface{}) string {
 				return globalid.EntityTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
-				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
-					arg := args.Get(2).(*corev2.Entity)
-					*arg = *r.(*corev2.Entity)
-				}).Return(nil).Once()
+				cfg.EntityClient.(onner).On("FetchEntity", mock.Anything, "sensu").Return(r, nil).Once()
 			},
 		},
 		{

--- a/backend/apid/graphql/node_test.go
+++ b/backend/apid/graphql/node_test.go
@@ -30,17 +30,18 @@ type onner interface {
 	On(string, ...interface{}) *mock.Call
 }
 
-func TestAssetNodeResolver(t *testing.T) {
+func TestNodeResolvers(t *testing.T) {
 	cfg := ServiceConfig{
-		AssetClient:       new(MockAssetClient),
-		CheckClient:       new(MockCheckClient),
 		EntityClient:      new(MockEntityClient),
 		EventClient:       new(MockEventClient),
 		EventFilterClient: new(MockEventFilterClient),
+		GenericClient:     new(MockGenericClient),
 		HandlerClient:     new(MockHandlerClient),
 		MutatorClient:     new(MockMutatorClient),
-		UserClient:        new(MockUserClient),
 		NamespaceClient:   new(MockNamespaceClient),
+		RBACClient:        new(MockRBACClient),
+		SilencedClient:    new(MockSilencedClient),
+		UserClient:        new(MockUserClient),
 	}
 	find := setupNodeResolver(cfg)
 
@@ -59,7 +60,11 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.AssetTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.AssetClient.(onner).On("FetchAsset", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Asset)
+					*arg = *r.(*corev2.Asset)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -71,7 +76,11 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.CheckTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.CheckClient.(onner).On("FetchCheck", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.CheckConfig)
+					*arg = *r.(*corev2.CheckConfig)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -83,7 +92,11 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.EntityTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.EntityClient.(onner).On("FetchEntity", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Entity)
+					*arg = *r.(*corev2.Entity)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -95,7 +108,11 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.EventFilterTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.EventFilterClient.(onner).On("FetchEventFilter", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.EventFilter)
+					*arg = *r.(*corev2.EventFilter)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -107,7 +124,27 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.HandlerTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.HandlerClient.(onner).On("FetchHandler", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Handler)
+					*arg = *r.(*corev2.Handler)
+				}).Return(nil).Once()
+			},
+		},
+		{
+			name: "hooks",
+			setupNode: func() interface{} {
+				return corev2.FixtureHookConfig("name")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.HookTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.HookConfig)
+					*arg = *r.(*corev2.HookConfig)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -119,7 +156,11 @@ func TestAssetNodeResolver(t *testing.T) {
 				return globalid.MutatorTranslator.EncodeToString(context.Background(), r)
 			},
 			setup: func(r interface{}) {
-				cfg.MutatorClient.(onner).On("FetchMutator", mock.Anything, "name").Return(r, nil).Once()
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Mutator)
+					*arg = *r.(*corev2.Mutator)
+				}).Return(nil).Once()
 			},
 		},
 		{
@@ -158,6 +199,82 @@ func TestAssetNodeResolver(t *testing.T) {
 				cfg.NamespaceClient.(onner).On("FetchNamespace", mock.Anything, "sensu").Return(r, nil).Once()
 			},
 		},
+		{
+			name: "cluster-role",
+			setupNode: func() interface{} {
+				return corev2.FixtureClusterRole("sensu")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.ClusterRoleTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.RBACClient.(onner).On("FetchClusterRole", mock.Anything, "sensu").Return(r, nil).Once()
+			},
+		},
+		{
+			name: "cluster-role-binding",
+			setupNode: func() interface{} {
+				return corev2.FixtureClusterRoleBinding("sensu")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.ClusterRoleBindingTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.RBACClient.(onner).On("FetchClusterRoleBinding", mock.Anything, "sensu").Return(r, nil).Once()
+			},
+		},
+		{
+			name: "role",
+			setupNode: func() interface{} {
+				return corev2.FixtureRole("sensu", "default")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.RoleTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.RBACClient.(onner).On("FetchRole", mock.Anything, "sensu").Return(r, nil).Once()
+			},
+		},
+		{
+			name: "role-binding",
+			setupNode: func() interface{} {
+				return corev2.FixtureRoleBinding("sensu", "default")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.RoleBindingTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.RBACClient.(onner).On("FetchRoleBinding", mock.Anything, "sensu").Return(r, nil).Once()
+			},
+		},
+		{
+			name: "silenced",
+			setupNode: func() interface{} {
+				return corev2.FixtureSilenced("sub:check")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.SilenceTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.SilencedClient.(onner).On("GetSilencedByName", mock.Anything, "sub:check").Return(r, nil).Once()
+			},
+		},
+		{
+			name: "pipeline",
+			setupNode: func() interface{} {
+				return corev2.FixturePipeline("name", "default")
+			},
+			setupID: func(r interface{}) string {
+				return globalid.PipelineTranslator.EncodeToString(context.Background(), r)
+			},
+			setup: func(r interface{}) {
+				cfg.GenericClient.(onner).On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				cfg.GenericClient.(onner).On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Pipeline)
+					*arg = *r.(*corev2.Pipeline)
+				}).Return(nil).Once()
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -167,7 +284,7 @@ func TestAssetNodeResolver(t *testing.T) {
 			tc.setup(in)
 
 			res, err := find(id)
-			assert.Equal(t, res, in)
+			assert.Equal(t, in, res)
 			assert.NoError(t, err)
 		})
 	}

--- a/backend/apid/graphql/util/api/api.go
+++ b/backend/apid/graphql/util/api/api.go
@@ -71,27 +71,6 @@ func HandleGetResult(res interface{}, err error) (interface{}, error) {
 	return UnwrapResource(res), err
 }
 
-// HandleConnectionResult helps format the result of a list operation for
-// selection.
-func HandleConnectionResult(res interface{}, pa, pb *store.SelectionPredicate, err error) (interface{}, error) {
-	fe := ToFetchErr(err)
-	if fe == nil && err != nil {
-		return nil, err
-	}
-	return map[string]interface{}{
-		"nodes": UnwrapList(res),
-		"pageInfo": map[string]interface{}{
-			"hasNextPage": pb.Continue != "",
-			"endCursor":   pb.Continue,
-			// TODO: future enhancement; support for backward pagination
-			"hasPreviousPage": false,
-			"startCursor":     "",
-		},
-		"error":      fe,
-		"totalCount": nil, // TODO: future enhancement; always nil for now
-	}, nil
-}
-
 // Unwraps the results returned by the api client.
 func UnwrapList(ws interface{}) interface{} {
 	if wrapped, ok := ws.([]*types.Wrapper); ok {

--- a/backend/apid/graphql/util/api/api.go
+++ b/backend/apid/graphql/util/api/api.go
@@ -1,0 +1,168 @@
+package util_api
+
+import (
+	"fmt"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+)
+
+// UnwrapListResult from API client, helpful when resolving a field as GraphQL
+// does not consider the absence of a value an error; as such we omit the error
+// if the API client returns Permission denied.
+func UnwrapListResult(res interface{}, err error) (interface{}, error) {
+	// legacy resolvers returned empty results when encountering request errs
+	if fe := ToFetchErr(err); fe != nil {
+		logger.WithField("type", fmt.Sprintf("%T", res)).WithError(err).Info("couldn't access resource")
+		return []interface{}{}, nil
+	}
+	if err != nil {
+		return []interface{}{}, err
+	}
+	return UnwrapList(res), err
+}
+
+// UnwrapGetResult from API client, helpful when resolving a field as GraphQL
+// does not consider the absence of a value an error; as such we omit the
+// error when the API client returns NotFound or Permission denied.
+func UnwrapGetResult(res interface{}, err error) (interface{}, error) {
+	// legacy resolvers returned empty results when encountering request errs
+	if fe := ToFetchErr(err); fe != nil {
+		logger.WithField("type", fmt.Sprintf("%T", res)).WithError(err).Info("couldn't access resource")
+		return nil, nil
+	}
+	if _, ok := err.(*store.ErrNotFound); ok {
+		logger.WithField("type", fmt.Sprintf("%T", res)).WithError(err).Info("couldn't find resource")
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return UnwrapResource(res), err
+}
+
+// HandleListResult helps format the result of a list operation for selection.
+func HandleListResult(res interface{}, err error) (interface{}, error) {
+	if fe := ToFetchErr(err); fe != nil {
+		return fe, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"nodes": UnwrapList(res),
+	}, nil
+}
+
+// HandleGetResult helps format the result of a get operation for selection.
+func HandleGetResult(res interface{}, err error) (interface{}, error) {
+	if fe := ToFetchErr(err); fe != nil {
+		return fe, nil
+	}
+	if _, ok := err.(*store.ErrNotFound); ok {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return UnwrapResource(res), err
+}
+
+// HandleConnectionResult helps format the result of a list operation for
+// selection.
+func HandleConnectionResult(res interface{}, pa, pb *store.SelectionPredicate, err error) (interface{}, error) {
+	fe := ToFetchErr(err)
+	if fe == nil && err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"nodes": UnwrapList(res),
+		"pageInfo": map[string]interface{}{
+			"hasNextPage": pb.Continue != "",
+			"endCursor":   pb.Continue,
+			// TODO: future enhancement; support for backward pagination
+			"hasPreviousPage": false,
+			"startCursor":     "",
+		},
+		"error":      fe,
+		"totalCount": nil, // TODO: future enhancement; always nil for now
+	}, nil
+}
+
+// Unwraps the results returned by the api client.
+func UnwrapList(ws interface{}) interface{} {
+	if wrapped, ok := ws.([]*types.Wrapper); ok {
+		rs := make([]interface{}, len(wrapped))
+		for i, w := range wrapped {
+			rs[i] = w.Value
+		}
+		return rs
+	}
+	if wrapped, ok := ws.([]*corev3.V2ResourceProxy); ok {
+		rs := make([]interface{}, len(wrapped))
+		for i, w := range wrapped {
+			rs[i] = w.Resource
+		}
+		return rs
+	}
+	if ws == nil {
+		return []interface{}{}
+	}
+	return ws
+}
+
+// UnwrapResource unwrap the proxy or wrapper type from a given resource.
+func UnwrapResource(r interface{}) interface{} {
+	switch r := r.(type) {
+	case *corev3.V2ResourceProxy:
+		return r.Resource
+	case *types.Wrapper:
+		return r.Value
+	}
+	return r
+}
+
+// WrapResource safely wraps the given resource in a type wrapper
+func WrapResource(r interface{}) types.Wrapper {
+	switch r := r.(type) {
+	case corev3.Resource: // maybe we move this into the compat package
+		var tm types.TypeMeta
+		if getter, ok := r.(interface{ GetTypeMeta() types.TypeMeta }); ok {
+			tm = getter.GetTypeMeta()
+		}
+		var meta corev2.ObjectMeta
+		if r.GetMetadata() != nil {
+			meta = *r.GetMetadata()
+		}
+		return types.Wrapper{
+			TypeMeta:   tm,
+			ObjectMeta: meta,
+			Value:      r,
+		}
+	case corev2.Resource:
+		return types.WrapResource(r)
+	case *types.Wrapper:
+		if r == nil {
+			return types.Wrapper{}
+		}
+		return *r
+	case types.Wrapper:
+		return r
+	}
+	panic("wrap error: unknown type")
+}
+
+// ToFetchErr produces a FetchErr from the given err; may return nil if the err
+// does not have a relavant err code.
+func ToFetchErr(err error) map[string]interface{} {
+	if err == authorization.ErrUnauthorized || err == authorization.ErrNoClaims {
+		return map[string]interface{}{
+			"code":    "ERR_PERMISSION_DENIED",
+			"message": err.Error(),
+		}
+	}
+	return nil
+}

--- a/backend/apid/graphql/util/api/api_test.go
+++ b/backend/apid/graphql/util/api/api_test.go
@@ -1,0 +1,208 @@
+package util_api
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/authorization"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnwrapListResult(t *testing.T) {
+	type args struct {
+		res interface{}
+		err error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "wrapped results",
+			args: args{
+				res: []*types.Wrapper{{Value: corev2.FixtureHandler("")}},
+				err: nil,
+			},
+			want:    []interface{}{corev2.FixtureHandler("")},
+			wantErr: false,
+		},
+		{
+			name: "unauthorized",
+			args: args{
+				res: []*types.Wrapper{{Value: corev2.FixtureHandler("")}},
+				err: authorization.ErrUnauthorized,
+			},
+			want:    []interface{}{},
+			wantErr: false,
+		},
+		{
+			name: "no claims",
+			args: args{
+				res: []*types.Wrapper{{Value: corev2.FixtureHandler("")}},
+				err: authorization.ErrNoClaims,
+			},
+			want:    []interface{}{},
+			wantErr: false,
+		},
+		{
+			name: "err",
+			args: args{
+				res: []*types.Wrapper{{Value: corev2.FixtureHandler("")}},
+				err: fmt.Errorf("something bad"),
+			},
+			want:    []interface{}{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnwrapListResult(tt.args.res, tt.args.err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnwrapListResult() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UnwrapListResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnwrapGetResult(t *testing.T) {
+	type args struct {
+		res interface{}
+		err error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "standard",
+			args: args{
+				res: corev2.FixtureHandler(""),
+				err: nil,
+			},
+			want:    corev2.FixtureHandler(""),
+			wantErr: false,
+		},
+		{
+			name: "wrapped results",
+			args: args{
+				res: &types.Wrapper{Value: corev2.FixtureHandler("")},
+				err: nil,
+			},
+			want:    corev2.FixtureHandler(""),
+			wantErr: false,
+		},
+		{
+			name: "unauthorized",
+			args: args{
+				res: &types.Wrapper{Value: corev2.FixtureHandler("")},
+				err: authorization.ErrUnauthorized,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "no claims",
+			args: args{
+				res: &types.Wrapper{Value: corev2.FixtureHandler("")},
+				err: authorization.ErrNoClaims,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "store err",
+			args: args{
+				res: &types.Wrapper{Value: corev2.FixtureHandler("")},
+				err: &store.ErrNotFound{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "err",
+			args: args{
+				res: &types.Wrapper{Value: corev2.FixtureHandler("")},
+				err: fmt.Errorf("something bad"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnwrapGetResult(tt.args.res, tt.args.err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnwrapGetResult() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UnwrapGetResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapResource(t *testing.T) {
+	v3resource := corev3.FixtureEntityConfig("name")
+	v2resource := corev2.FixtureAsset("name")
+	v2wrapped := types.WrapResource(v2resource)
+
+	tests := []struct {
+		name string
+		args interface{}
+		want types.Wrapper
+	}{
+		{
+			name: "corev3",
+			args: v3resource,
+			want: types.Wrapper{
+				TypeMeta:   types.TypeMeta{APIVersion: "core/v3", Type: "EntityConfig"},
+				ObjectMeta: *v3resource.Metadata,
+				Value:      v3resource,
+			},
+		},
+		{
+			name: "corev2",
+			args: v2resource,
+			want: types.Wrapper{
+				TypeMeta:   types.TypeMeta{APIVersion: "core/v2", Type: "Asset"},
+				ObjectMeta: v2resource.ObjectMeta,
+				Value:      v2resource,
+			},
+		},
+		{
+			name: "wrapped",
+			args: types.WrapResource(v2resource),
+			want: types.WrapResource(v2resource),
+		},
+		{
+			name: "pointer",
+			args: &v2wrapped,
+			want: types.WrapResource(v2resource),
+		},
+		{
+			name: "nil",
+			args: (*types.Wrapper)(nil),
+			want: types.Wrapper{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WrapResource(tt.args)
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}

--- a/backend/apid/graphql/util/api/logger.go
+++ b/backend/apid/graphql/util/api/logger.go
@@ -1,0 +1,7 @@
+package util_api
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "apid.graphql.util.api",
+})

--- a/backend/apid/graphql/util/relay/logger.go
+++ b/backend/apid/graphql/util/relay/logger.go
@@ -1,0 +1,7 @@
+package util_relay
+
+import "github.com/sirupsen/logrus"
+
+var logger = logrus.WithFields(logrus.Fields{
+	"component": "apid.graphql.util.relay",
+})

--- a/backend/apid/graphql/util/relay/node.go
+++ b/backend/apid/graphql/util/relay/node.go
@@ -29,7 +29,7 @@ func MakeNodeResolver(client Fetcher, tm corev2.TypeMeta) func(relay.NodeResolve
 		}
 		r := compat.V2Resource(raw)
 		err = client.Get(p.Context, p.IDComponents.UniqueComponent(), r)
-		return util_api.HandleGetResult(util_api.UnwrapResource(r), err)
+		return util_api.UnwrapGetResult(util_api.UnwrapResource(r), err)
 	}
 }
 

--- a/backend/apid/graphql/util/relay/node.go
+++ b/backend/apid/graphql/util/relay/node.go
@@ -1,0 +1,46 @@
+package util_relay
+
+import (
+	"context"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
+	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
+	util_api "github.com/sensu/sensu-go/backend/apid/graphql/util/api"
+	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/types/compat"
+)
+
+type Fetcher interface {
+	SetTypeMeta(corev2.TypeMeta) error
+	Get(context.Context, string, corev2.Resource) error
+}
+
+// MakeNodeResolver instatiates a new node resolver given a generic client and
+// typemeta.
+func MakeNodeResolver(client Fetcher, tm corev2.TypeMeta) func(relay.NodeResolverParams) (interface{}, error) {
+	return func(p relay.NodeResolverParams) (interface{}, error) {
+		if err := client.SetTypeMeta(tm); err != nil {
+			return nil, err
+		}
+		raw, err := types.ResolveRaw(tm.APIVersion, tm.Type)
+		if err != nil {
+			return nil, err
+		}
+		r := compat.V2Resource(raw)
+		err = client.Get(p.Context, p.IDComponents.UniqueComponent(), r)
+		return util_api.HandleGetResult(util_api.UnwrapResource(r), err)
+	}
+}
+
+// ToGID produces a globalid for the given resource; an empty string is
+// returned if the reverse lookup failed. Use ReverseLookup if you need to
+// handle the error.
+func ToGID(ctx context.Context, r interface{}) string {
+	e, err := globalid.ReverseLookup(r)
+	if err != nil {
+		logger.WithError(err).Warn("toGID: unable to find type")
+		return ""
+	}
+	return e.Encode(ctx, util_api.UnwrapResource(r)).String()
+}

--- a/backend/apid/graphql/util/relay/node_test.go
+++ b/backend/apid/graphql/util/relay/node_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	v2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
 	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
 	"github.com/stretchr/testify/mock"
@@ -39,7 +38,7 @@ func TestToGID(t *testing.T) {
 			name: "check",
 			args: args{
 				ctx: context.Background(),
-				r:   v2.FixtureCheckConfig("name"),
+				r:   corev2.FixtureCheckConfig("name"),
 			},
 			want: "srn:checks:default:name",
 		},

--- a/backend/apid/graphql/util/relay/node_test.go
+++ b/backend/apid/graphql/util/relay/node_test.go
@@ -1,0 +1,155 @@
+package util_relay
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	v2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/apid/graphql/globalid"
+	"github.com/sensu/sensu-go/backend/apid/graphql/relay"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFetcher struct {
+	mock.Mock
+}
+
+func (c *MockFetcher) SetTypeMeta(meta corev2.TypeMeta) error {
+	return c.Called(meta).Error(0)
+}
+
+func (c *MockFetcher) Get(ctx context.Context, name string, val corev2.Resource) error {
+	return c.Called(ctx, name, val).Error(0)
+}
+
+func TestToGID(t *testing.T) {
+	type args struct {
+		ctx context.Context
+		r   interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "check",
+			args: args{
+				ctx: context.Background(),
+				r:   v2.FixtureCheckConfig("name"),
+			},
+			want: "srn:checks:default:name",
+		},
+		{
+			name: "unknown",
+			args: args{
+				ctx: context.Background(),
+				r:   struct{}{},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToGID(tt.args.ctx, tt.args.r); got != tt.want {
+				t.Errorf("ToGID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeNodeResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     corev2.TypeMeta
+		setup    func() Fetcher
+		globalid string
+		want     interface{}
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			meta: corev2.TypeMeta{
+				APIVersion: "core/v2",
+				Type:       "pipeline",
+			},
+			globalid: "srn:corev2/pipeline:default:name",
+			setup: func() Fetcher {
+				fetcher := &MockFetcher{}
+				fetcher.On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				fetcher.On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Pipeline)
+					*arg = *corev2.FixturePipeline("name", "default")
+				}).Return(nil).Once()
+				return fetcher
+			},
+			want:    corev2.FixturePipeline("name", "default"),
+			wantErr: false,
+		},
+		{
+			name: "bad type meta",
+			meta: corev2.TypeMeta{
+				APIVersion: "core/v2",
+				Type:       "pipeline",
+			},
+			globalid: "srn:corev2/pipeline:default:name",
+			setup: func() Fetcher {
+				fetcher := &MockFetcher{}
+				fetcher.On("SetTypeMeta", mock.Anything).Return(errors.New("test")).Once()
+				fetcher.On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Pipeline)
+					*arg = *corev2.FixturePipeline("name", "default")
+				}).Return(nil).Once()
+				return fetcher
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "cannot resolve type",
+			meta: corev2.TypeMeta{
+				APIVersion: "tm/v1",
+				Type:       "spoof",
+			},
+			globalid: "srn:corev2/pipeline:default:name",
+			setup: func() Fetcher {
+				fetcher := &MockFetcher{}
+				fetcher.On("SetTypeMeta", mock.Anything).Return(nil).Once()
+				fetcher.On("Get", mock.Anything, "name", mock.Anything).Run(func(args mock.Arguments) {
+					arg := args.Get(2).(*corev2.Pipeline)
+					*arg = *corev2.FixturePipeline("name", "default")
+				}).Return(nil).Once()
+				return fetcher
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := MakeNodeResolver(tt.setup(), tt.meta)
+			if resolver == nil {
+				t.Fatalf("MakeNodeResolver() = nil")
+			}
+
+			g, err := globalid.Decode(tt.globalid)
+			if err != nil {
+				t.Fatalf("unable to decode globalid: %s", err)
+			}
+
+			got, err := resolver(relay.NodeResolverParams{
+				Context:      context.Background(),
+				IDComponents: g,
+			})
+			if err != nil && !tt.wantErr {
+				t.Errorf("didn't expect err but got: %s", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("expect %v, got: %v", got, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Brings over the GraphQL util packages from enterprise and adds additional unit tests,
* Uses said packages to implement a node resolver for the Pipeline type.
* Switches some of the existing node resolvers over to using the newer machinery and adds more units tests 

Closes https://github.com/sensu/sensu-enterprise-go/issues/2114

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
