### PR TITLE
[backend/api] Allow consumer to test if authorized to perform action

### DIFF
--- a/backend/api/generic.go
+++ b/backend/api/generic.go
@@ -14,6 +14,16 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+type RBACVerb string
+
+const (
+	VerbGet    RBACVerb = "get"
+	VerbList   RBACVerb = "list"
+	VerbCreate RBACVerb = "create"
+	VerbUpdate RBACVerb = "update"
+	VerbDetete RBACVerb = "delete"
+)
+
 // GenericClient is a generic API client that uses the ResourceStore.
 type GenericClient struct {
 	Kind       corev2.Resource
@@ -217,14 +227,14 @@ func (g *GenericClient) List(ctx context.Context, resources interface{}, pred *s
 
 // Authorize tests whether or not the current user can perform an action.
 // Returns nil if action is allow and otherwise an auth error.
-func (g *GenericClient) Authorize(ctx context.Context, verb, name string) error {
+func (g *GenericClient) Authorize(ctx context.Context, verb RBACVerb, name string) error {
 	attrs := &authorization.Attributes{
 		APIGroup:     g.APIGroup,
 		APIVersion:   g.APIVersion,
 		Namespace:    corev2.ContextNamespace(ctx),
 		Resource:     g.Kind.RBACName(),
 		ResourceName: name,
-		Verb:         verb,
+		Verb:         string(verb),
 	}
 	if err := authorize(ctx, g.Auth, attrs); err != nil {
 		return err

--- a/backend/api/generic.go
+++ b/backend/api/generic.go
@@ -21,7 +21,7 @@ const (
 	VerbList   RBACVerb = "list"
 	VerbCreate RBACVerb = "create"
 	VerbUpdate RBACVerb = "update"
-	VerbDetete RBACVerb = "delete"
+	VerbDelete RBACVerb = "delete"
 )
 
 // GenericClient is a generic API client that uses the ResourceStore.

--- a/backend/api/generic_test.go
+++ b/backend/api/generic_test.go
@@ -118,6 +118,9 @@ func TestGenericClient(t *testing.T) {
 		ListErr   bool
 		DelName   string
 		DelErr    bool
+		AuthVerb  string
+		AuthName  string
+		AuthErr   bool
 		Ctx       context.Context
 	}{
 		{
@@ -133,6 +136,9 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "todelete",
 			DelErr:    true,
 			ListErr:   true,
+			AuthVerb:  "get",
+			AuthName:  "todelete",
+			AuthErr:   true,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),
 		},
 		{
@@ -168,6 +174,9 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "default",
 			DelErr:    true,
 			ListErr:   false,
+			AuthVerb:  "delete",
+			AuthName:  "default",
+			AuthErr:   true,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),
 		},
 		{
@@ -230,6 +239,9 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "default",
 			DelErr:    false,
 			ListErr:   false,
+			AuthVerb:  "get",
+			AuthName:  "default",
+			AuthErr:   false,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),
 		},
 	}
@@ -286,6 +298,15 @@ func TestGenericClient(t *testing.T) {
 				if err == nil && val.Validate() != nil {
 					t.Fatal(val.Validate())
 				}
+			}
+		})
+		t.Run(test.Name+"_authorize", func(t *testing.T) {
+			err := test.Client.Authorize(test.Ctx, test.AuthVerb, test.AuthName)
+			if err != nil && !test.AuthErr {
+				t.Fatal(err)
+			}
+			if err == nil && test.AuthErr {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/backend/api/generic_test.go
+++ b/backend/api/generic_test.go
@@ -174,7 +174,7 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "default",
 			DelErr:    true,
 			ListErr:   false,
-			AuthVerb:  VerbDetete,
+			AuthVerb:  VerbDelete,
 			AuthName:  "default",
 			AuthErr:   true,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),

--- a/backend/api/generic_test.go
+++ b/backend/api/generic_test.go
@@ -118,7 +118,7 @@ func TestGenericClient(t *testing.T) {
 		ListErr   bool
 		DelName   string
 		DelErr    bool
-		AuthVerb  string
+		AuthVerb  RBACVerb
 		AuthName  string
 		AuthErr   bool
 		Ctx       context.Context
@@ -136,7 +136,7 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "todelete",
 			DelErr:    true,
 			ListErr:   true,
-			AuthVerb:  "get",
+			AuthVerb:  VerbGet,
 			AuthName:  "todelete",
 			AuthErr:   true,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),
@@ -174,7 +174,7 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "default",
 			DelErr:    true,
 			ListErr:   false,
-			AuthVerb:  "delete",
+			AuthVerb:  VerbDetete,
 			AuthName:  "default",
 			AuthErr:   true,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),
@@ -239,7 +239,7 @@ func TestGenericClient(t *testing.T) {
 			DelName:   "default",
 			DelErr:    false,
 			ListErr:   false,
-			AuthVerb:  "get",
+			AuthVerb:  VerbGet,
 			AuthName:  "default",
 			AuthErr:   false,
 			Ctx:       contextWithUser(defaultContext(), "tom", nil),

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -5,6 +5,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/api"
 	"github.com/sensu/sensu-go/backend/store"
 )
 
@@ -126,7 +127,7 @@ type GenericClient interface {
 	Delete(ctx context.Context, name string) error
 	Get(ctx context.Context, name string, val corev2.Resource) error
 	List(ctx context.Context, resources interface{}, pred *store.SelectionPredicate) error
-	Authorize(ctx context.Context, verb, name string) error
+	Authorize(ctx context.Context, verb api.RBACVerb, name string) error
 }
 
 type EtcdHealthController interface {

--- a/backend/apid/graphql/interfaces.go
+++ b/backend/apid/graphql/interfaces.go
@@ -126,6 +126,7 @@ type GenericClient interface {
 	Delete(ctx context.Context, name string) error
 	Get(ctx context.Context, name string, val corev2.Resource) error
 	List(ctx context.Context, resources interface{}, pred *store.SelectionPredicate) error
+	Authorize(ctx context.Context, verb, name string) error
 }
 
 type EtcdHealthController interface {

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -230,6 +230,10 @@ func (c *MockGenericClient) List(ctx context.Context, resources interface{}, pre
 	return c.Called(ctx, resources, pred).Error(0)
 }
 
+func (c *MockGenericClient) Authorize(ctx context.Context, verb, name string) error {
+	return c.Called(ctx, verb, name).Error(0)
+}
+
 type MockEventFilterClient struct {
 	mock.Mock
 }

--- a/backend/apid/graphql/mock_test.go
+++ b/backend/apid/graphql/mock_test.go
@@ -5,6 +5,7 @@ import (
 
 	dto "github.com/prometheus/client_model/go"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/api"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/stretchr/testify/mock"
 )
@@ -230,7 +231,7 @@ func (c *MockGenericClient) List(ctx context.Context, resources interface{}, pre
 	return c.Called(ctx, resources, pred).Error(0)
 }
 
-func (c *MockGenericClient) Authorize(ctx context.Context, verb, name string) error {
+func (c *MockGenericClient) Authorize(ctx context.Context, verb api.RBACVerb, name string) error {
 	return c.Called(ctx, verb, name).Error(0)
 }
 


### PR DESCRIPTION
Adds method to api package allowing the consumer to test if they are able to perform an action.

Required by https://github.com/sensu/sensu-enterprise-go/pull/2150.
Replaces https://github.com/sensu/sensu-go/pull/4666

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>