### PR TITLE
Fix a panic in socket handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Fixed a bug where pipelines in check configuration were not represented in
 the check object of events that were produced with the check configuration.
+- Socket handlers will no longer cause sensu-backend to panic when interrupted
+mid-write.
 
 ## [6.6.6] - 2022-02-16
 

--- a/backend/pipeline/handler/legacy.go
+++ b/backend/pipeline/handler/legacy.go
@@ -188,6 +188,7 @@ func (l *LegacyAdapter) socketHandler(ctx context.Context, handler *corev2.Handl
 
 	logger.WithFields(fields).Debug("sending event to socket handler")
 
+	deadline := time.Now().Add(timeoutDuration)
 	conn, err = net.DialTimeout(protocol, address, timeoutDuration)
 	if err != nil {
 		return nil, err
@@ -198,6 +199,10 @@ func (l *LegacyAdapter) socketHandler(ctx context.Context, handler *corev2.Handl
 			err = e
 		}
 	}()
+
+	if err := conn.SetWriteDeadline(deadline); err != nil {
+		return conn, err
+	}
 
 	bytes, err := conn.Write(mutatedData)
 	if err != nil {

--- a/backend/pipeline/handler/legacy_test.go
+++ b/backend/pipeline/handler/legacy_test.go
@@ -492,7 +492,7 @@ func TestLegacyAdapter_socketHandlerTCP(t *testing.T) {
 		close(done)
 	}()
 
-	if _, err := l.socketHandler(ctx, handler, event, mutatedData); err != nil {
+	if err := l.socketHandler(ctx, handler, event, mutatedData); err != nil {
 		t.Fatal(err)
 	}
 
@@ -536,12 +536,8 @@ func TestLegacyAdapter_GH4675(t *testing.T) {
 		close(done)
 	}()
 
-	conn, err := l.socketHandler(ctx, handler, event, mutatedData)
-	if err == nil {
+	if err := l.socketHandler(ctx, handler, event, mutatedData); err == nil {
 		t.Error("expected non-nil error")
-	}
-	if conn == nil {
-		t.Fatal("nil conn")
 	}
 	<-done
 }
@@ -594,7 +590,7 @@ func TestLegacyAdapter_socketHandlerUDP(t *testing.T) {
 		assert.Equal(t, mutatedData, buffer[0:rlen])
 	}()
 
-	if _, err := l.socketHandler(ctx, handler, event, mutatedData); err != nil {
+	if err := l.socketHandler(ctx, handler, event, mutatedData); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## What is this change?

This changelog fixes a panic in sensu-backend when a socket handler gets an error mid-write. It also fixes another bug where socket handlers will stop respecting their timeout after the initial connection is established.

## Why is this change necessary?

Closes #4675 

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

It was tricky to reproduce the bug with a test but I eventually succeeded.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Docs changes not required.

## How did you verify this change?

Fully verified with automated testing.

## Is this change a patch?

Yes.