### PR TITLE
Run tests for all modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,18 @@ jobs:
           path: ~/sensu-go
       - go/mod-download-cached
       - run: go test ./...
+  test-types:
+    <<: *sensu_go_build_env
+    environment:
+      GO111MODULE: 'on'
+      GOPROXY: 'https://proxy.golang.org'
+    resource_class: large
+    working_directory: ~/sensu-go/types
+    steps:
+      - checkout:
+          path: ~/sensu-go
+      - go/mod-download-cached
+      - run: go test ./...
   build:
     <<: *sensu_go_build_env
     parameters:
@@ -72,6 +84,7 @@ workflows:
             tags:
               ignore: /.*/
       - test-core-v2
+      - test-types
   build:
     jobs:
       # darwin/amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,13 @@ workflows:
             tags:
               ignore: /.*/
       - test-module:
+          name: core/v2
           path: api/core/v2
       - test-module:
+          name: core/v3
           path: api/core/v3
       - test-module:
+          name: types
           path: types
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
       # Run tests
       - run: ./build.sh unit
       - run: ./build.sh integration
+  test-core-v2:
+    <<: *sensu_go_build_env
+    environment:
+      GO111MODULE: 'on'
+      GOPROXY: 'https://proxy.golang.org'
+    resource_class: large
+    working_directory: ~/sensu-go/api/core/v2
+    steps:
+      - checkout:
+          path: ~/sensu-go
+      - go/mod-download-cached
+      - run: go test ./...
   build:
     <<: *sensu_go_build_env
     parameters:
@@ -59,6 +71,7 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+      - test-core-v2
   build:
     jobs:
       # darwin/amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,16 @@ sensu_go_build_env: &sensu_go_build_env
         username: $DOCKER_USERNAME
         password: $DOCKER_PASSWORD
 
-jobs:
-  test:
-    <<: *sensu_go_build_env
+go_test_env: &sensu_go_test_env
+    resource_class: large
     environment:
       GO111MODULE: 'on'
       GOPROXY: 'https://proxy.golang.org'
-    resource_class: large
+
+jobs:
+  test:
+    <<: *sensu_go_build_env
+    <<: *sensu_go_test_env
     steps:
       - checkout
       - go/mod-download-cached
@@ -24,30 +27,20 @@ jobs:
       # Run tests
       - run: ./build.sh unit
       - run: ./build.sh integration
-  test-core-v2:
+
+  test-module:
+    parameters:
+      path:
+        type: string
+    working_directory: ~/sensu-go/<< parameters.path>>
     <<: *sensu_go_build_env
-    environment:
-      GO111MODULE: 'on'
-      GOPROXY: 'https://proxy.golang.org'
-    resource_class: large
-    working_directory: ~/sensu-go/api/core/v2
+    <<: *sensu_go_test_env
     steps:
       - checkout:
           path: ~/sensu-go
       - go/mod-download-cached
       - run: go test ./...
-  test-types:
-    <<: *sensu_go_build_env
-    environment:
-      GO111MODULE: 'on'
-      GOPROXY: 'https://proxy.golang.org'
-    resource_class: large
-    working_directory: ~/sensu-go/types
-    steps:
-      - checkout:
-          path: ~/sensu-go
-      - go/mod-download-cached
-      - run: go test ./...
+
   build:
     <<: *sensu_go_build_env
     parameters:
@@ -83,8 +76,12 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      - test-core-v2
-      - test-types
+      - test-module:
+          path: api/core/v2
+      - test-module:
+          path: api/core/v3
+      - test-module:
+          path: types
   build:
     jobs:
       # darwin/amd64

--- a/api/core/v2/metric_threshold_test.go
+++ b/api/core/v2/metric_threshold_test.go
@@ -13,10 +13,10 @@ var (
 	thresholdOneTag   = &MetricThreshold{Name: "metric-name", Thresholds: []*MetricThresholdRule{thresholdRuleAll}, Tags: []*MetricThresholdTag{tag1}}
 	thresholdTwoTags  = &MetricThreshold{Name: "metric-name", Thresholds: []*MetricThresholdRule{thresholdRuleAll}, Tags: []*MetricThresholdTag{tag1, tag2}}
 
-	thresholdRuleAll      = &MetricThresholdRule{Min: "3.4", Max: "10.2", Status: 2, NullStatus: 0}
-	thresholdRuleNoMin    = &MetricThresholdRule{Min: "", Max: "10.2", Status: 2, NullStatus: 0}
-	thresholdRuleNoMax    = &MetricThresholdRule{Min: "", Max: "10.2", Status: 2, NullStatus: 0}
-	thresholdRuleNoMinMax = &MetricThresholdRule{Min: "", Max: "", Status: 2, NullStatus: 0}
+	thresholdRuleAll      = &MetricThresholdRule{Min: "3.4", Max: "10.2", Status: 2}
+	thresholdRuleNoMin    = &MetricThresholdRule{Min: "", Max: "10.2", Status: 2}
+	thresholdRuleNoMax    = &MetricThresholdRule{Min: "", Max: "10.2", Status: 2}
+	thresholdRuleNoMinMax = &MetricThresholdRule{Min: "", Max: "", Status: 2}
 
 	tagValid       = &MetricThresholdTag{Name: "tag-name", Value: "tag-value"}
 	tagNoName      = &MetricThresholdTag{Name: "", Value: "tag-value"}

--- a/api/core/v3/go.sum
+++ b/api/core/v3/go.sum
@@ -23,7 +23,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
@@ -53,7 +52,6 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
@@ -66,7 +64,7 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspo
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/sensu/sensu-go/api/core/v3 v3.3.0/go.mod h1:qjzW//KOc1VnVwf3YUdvHFlVsVXBui3IpVNtedCzCPY=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1-alpha/go.mod h1:xnd6gfPu21bESxlI9Zd6VLaVhuz/ly2P9suwMux2TDU=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -128,7 +126,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/types/go.sum
+++ b/types/go.sum
@@ -54,6 +54,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -71,6 +72,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/sensu/sensu-go/api/core/v3 v3.3.0 h1:260rON3b4DQ1yX2bBH3zR7+9BWkyeV2S4OpEDezQ5Hk=
 github.com/sensu/sensu-go/api/core/v3 v3.3.0/go.mod h1:qjzW//KOc1VnVwf3YUdvHFlVsVXBui3IpVNtedCzCPY=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1-alpha h1:IYqWVLq03FEJTRYvH0pguwVBUu70/4r3Tpp6dATs0ZY=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1-alpha/go.mod h1:xnd6gfPu21bESxlI9Zd6VLaVhuz/ly2P9suwMux2TDU=
 github.com/sensu/sensu-go/types v0.3.0/go.mod h1:TyeO3h/82XE1KppZRFg+jKB4QYwY2hE5hbCzjnnGdRo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
## What is this change?

Add CircleCI job to test core/v2 and types modules


## Why is this change necessary?

No use in tests that aren't ran!

## Does your change need a Changelog entry?

Probs not.

## Do you need clarification on anything?

Would y'all prefer build.sh always run types and core/v2 unit tests? I'm on the fence. It'd probably mean no go module caching in CI for those modules. Also go 1.18 seems to have problems with the types tests (making running the types test suite locally if you've upgraded to 1.18 a hassle - have so far successfully avoided a goenv type tool)

## Were there any complications while making this change?

CircleCI is a mystery.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

CircleCI

## Is this change a patch?

N