### PR TITLE
Always Run Staticcheck workflow

### DIFF
--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -1,14 +1,12 @@
 name: static-check
 
 on:
+  pull_request:
   push:
     tags:
       - 'v*'
     branches:
       - main
-  pull_request:
-    branches:
-      - '*'
 
 jobs:
   staticcheck:


### PR DESCRIPTION
## What is this change?

The github workflows syntax for branch filtering is odd (glob-y not regex-y) so filtering to `branches: *` does not match target branches with a slash in them like `develop/6`

## Why is this change necessary?

See https://github.com/sensu/sensu-go/pull/4689 as an example of a PR where staticcheck was not ran due to this filter.

## Does your change need a Changelog entry?

No

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

See above

## Is this change a patch?

N