### PR TITLE
Add support for silencing deregistration events

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -1,5 +1,3 @@
-
-
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -7,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [Unreleased]
 
 ### Added
 - Automatically create system namespace and backend entities.

--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Breaking
 - Embedded etcd is no longer supported, all related configuration has been
@@ -19,8 +19,5 @@ software is upgraded when there are active keepalive failures.
 
 ### Changed
 - Changed parameters for `sensuctl cluster-role create` to be plural
-## [Unreleased]
-
-### Changed
 - Deregistration events are now silenced if a silenced entry exists matching the
 entity subscriptions and/or a check named `deregistration`.

--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -19,3 +19,8 @@ software is upgraded when there are active keepalive failures.
 
 ### Changed
 - Changed parameters for `sensuctl cluster-role create` to be plural
+## [Unreleased]
+
+### Changed
+- Deregistration events are now silenced if a silenced entry exists matching the
+entity subscriptions and/or a check named `deregistration`.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -486,6 +486,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
+		Client:                b.Client,
 		DeregistrationHandler: config.DeregistrationHandler,
 		Bus:                   bus,
 		Store:                 b.Store,

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -89,6 +89,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 		BufferSize:      1,
 		WorkerCount:     1,
 		StoreTimeout:    time.Minute,
+		Client:          store.Client,
 	})
 	require.NoError(t, err)
 

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -17,8 +17,10 @@ import (
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/cache"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sirupsen/logrus"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 const (
@@ -75,6 +77,7 @@ const deletedEventSentinel = -1
 // Keepalived is responsible for monitoring keepalive events and recording
 // keepalives for entities.
 type Keepalived struct {
+	client                *clientv3.Client
 	bus                   messaging.MessageBus
 	workerCount           int
 	store                 store.Store
@@ -91,6 +94,7 @@ type Keepalived struct {
 	ctx                   context.Context
 	cancel                context.CancelFunc
 	storeTimeout          time.Duration
+	silencedCache         cache.Cache
 }
 
 // Option is a functional option.
@@ -98,6 +102,7 @@ type Option func(*Keepalived) error
 
 // Config configures Keepalived.
 type Config struct {
+	Client                *clientv3.Client
 	Store                 store.Store
 	StoreV2               storev2.Interface
 	EventStore            store.EventStore
@@ -128,6 +133,7 @@ func New(c Config, opts ...Option) (*Keepalived, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	k := &Keepalived{
+		client:                c.Client,
 		store:                 c.Store,
 		storev2:               c.StoreV2,
 		eventStore:            c.EventStore,
@@ -603,11 +609,16 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 	}
 
 	if entityConfig.Deregister {
+		cache, err := cache.New(ctx, k.client, &corev2.Silenced{}, false)
+		if err != nil {
+			return false
+		}
 		deregisterer := &Deregistration{
-			EntityStore:  k.store,
-			EventStore:   k.eventStore,
-			MessageBus:   k.bus,
-			StoreTimeout: k.storeTimeout,
+			EntityStore:   k.store,
+			EventStore:    k.eventStore,
+			MessageBus:    k.bus,
+			SilencedCache: cache,
+			StoreTimeout:  k.storeTimeout,
 		}
 		if err := deregisterer.Deregister(currentEvent.Entity); err != nil {
 			lager.WithError(err).Error("error deregistering entity")

--- a/backend/silenced/silenced.go
+++ b/backend/silenced/silenced.go
@@ -1,26 +1,27 @@
-package eventd
+package silenced
 
 import (
 	"context"
 	"time"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/store/cache"
 	stringsutil "github.com/sensu/sensu-go/util/strings"
 )
 
-// addToSilencedBy takes a silenced entry ID and adds it to a silence of IDs if
+// AddToSilencedBy takes a silenced entry ID and adds it to a silence of IDs if
 // it's not already present in order to avoid duplicated elements
-func addToSilencedBy(id string, ids []string) []string {
+func AddToSilencedBy(id string, ids []string) []string {
 	if !stringsutil.InArray(id, ids) {
 		ids = append(ids, id)
 	}
 	return ids
 }
 
-// getSilenced retrieves all silenced entries for a given event, using the
+// GetSilenced retrieves all silenced entries for a given event, using the
 // entity subscription, the check subscription and the check name while
 // supporting wildcard silenced entries (e.g. subscription:*)
-func getSilenced(ctx context.Context, event *corev2.Event, cache Cache) {
+func GetSilenced(ctx context.Context, event *corev2.Event, cache cache.Cache) {
 	if !event.HasCheck() {
 		return
 	}
@@ -37,19 +38,19 @@ func getSilenced(ctx context.Context, event *corev2.Event, cache Cache) {
 	}
 
 	// Determine which entries silence this event
-	silencedIDs := silencedBy(event, entries)
+	silencedIDs := SilencedBy(event, entries)
 
 	// Add to the event all silenced entries ID that actually silence it
 	event.Check.Silenced = silencedIDs
 }
 
-// silencedBy determines which of the given silenced entries silenced a given
+// SilencedBy determines which of the given silenced entries silenced a given
 // event and return a list of silenced entry IDs
-func silencedBy(event *corev2.Event, silencedEntries []*corev2.Silenced) []string {
+func SilencedBy(event *corev2.Event, silencedEntries []*corev2.Silenced) []string {
 	silencedBy := event.SilencedBy(silencedEntries)
 	names := make([]string, 0, len(silencedBy))
 	for _, entry := range silencedBy {
-		names = addToSilencedBy(entry.Name, names)
+		names = AddToSilencedBy(entry.Name, names)
 	}
 	return names
 }

--- a/backend/silenced/silenced_test.go
+++ b/backend/silenced/silenced_test.go
@@ -1,22 +1,21 @@
-package eventd
+package silenced
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	corev3 "github.com/sensu/sensu-go/api/core/v3"
-	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/store/cache"
-	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	"github.com/sensu/sensu-go/backend/store/v2/storetest"
-	"github.com/sensu/sensu-go/testing/mockbus"
-	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
+
+func newFakeFactory(f liveness.Interface) liveness.Factory {
+	return func(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
+		return f
+	}
+}
 
 func TestGetSilenced(t *testing.T) {
 	testCases := []struct {
@@ -40,7 +39,7 @@ func TestGetSilenced(t *testing.T) {
 			ctx := context.WithValue(context.Background(), corev2.NamespaceKey, "default")
 			c := cache.NewFromResources(tc.silencedEntries, false)
 
-			getSilenced(ctx, tc.event, c)
+			GetSilenced(ctx, tc.event, c)
 			assert.Equal(t, tc.expectedEntries, tc.event.Check.Silenced)
 		})
 	}
@@ -174,134 +173,8 @@ func TestSilencedBy(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := silencedBy(tc.event, tc.entries)
+			result := SilencedBy(tc.event, tc.entries)
 			assert.Equal(t, tc.expectedEntries, result)
-		})
-	}
-}
-
-type mockCache struct {
-	mock.Mock
-}
-
-func (m *mockCache) Get(namespace string) []cache.Value {
-	args := m.Called(namespace)
-	return args.Get(0).([]cache.Value)
-}
-
-func TestEventd_handleMessage(t *testing.T) {
-	type busFunc func(*mockbus.MockBus)
-	type cacheFunc func(*mockCache)
-	type eventStoreFunc func(*mockstore.MockStore)
-	type storeFunc func(*storetest.Store)
-
-	var nilEvent *corev2.Event
-
-	newEntityConfig := func() storev2.Wrapper {
-		entity := corev3.FixtureEntityConfig("foo")
-		e, err := storev2.WrapResource(entity)
-		require.NoError(t, err)
-		return e
-	}
-	newEntityState := func() storev2.Wrapper {
-		state := corev3.FixtureEntityState("foo")
-		e, err := storev2.WrapResource(state)
-		require.NoError(t, err)
-		return e
-	}
-
-	tests := []struct {
-		name           string
-		event          corev2.Event
-		busFunc        busFunc
-		cacheFunc      cacheFunc
-		eventStoreFunc eventStoreFunc
-		storeFunc      storeFunc
-		wantErr        bool
-	}{
-		{
-			name: "metrics events are published without being stored",
-			event: corev2.Event{
-				Entity:  corev2.FixtureEntity("foo"),
-				Metrics: &corev2.Metrics{},
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.On("Publish", messaging.TopicEvent, mock.Anything).Once().Return(nil)
-			},
-		},
-		{
-			name: "silenced events are properly identified",
-			event: corev2.Event{
-				Check:  corev2.FixtureCheck("check-cpu"),
-				Entity: corev2.FixtureEntity("foo"),
-			},
-			busFunc: func(bus *mockbus.MockBus) {
-				bus.On("Publish", messaging.TopicEvent, mock.Anything).Once().Return(nil)
-			},
-			cacheFunc: func(c *mockCache) {
-				c.On("Get", "default").Once().Return(
-					[]cache.Value{
-						{Resource: corev2.FixtureSilenced("linux:check-cpu")},
-					},
-				)
-			},
-			eventStoreFunc: func(store *mockstore.MockStore) {
-				store.On("UpdateEvent", mock.AnythingOfType("*v2.Event")).
-					Run(func(args mock.Arguments) {
-						event := args[0].(*corev2.Event)
-
-						// The event we receive should be identified as silenced and contain
-						// the list of silenced entries that apply to it
-						if !event.Check.IsSilenced || len(event.Check.Silenced) == 0 {
-							t.Fatal("the check should be silenced")
-						}
-					}).Return(
-					corev2.FixtureEvent("foo", "check-cpu"), nilEvent, nil,
-				)
-			},
-			storeFunc: func(store *storetest.Store) {
-				store.On("Get", mock.Anything).Once().Return(
-					newEntityConfig(), nil,
-				)
-				store.On("Get", mock.Anything).Once().Return(
-					newEntityState(), nil,
-				)
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bus := &mockbus.MockBus{}
-			if tt.busFunc != nil {
-				tt.busFunc(bus)
-			}
-			cache := &mockCache{}
-			if tt.cacheFunc != nil {
-				tt.cacheFunc(cache)
-			}
-			eventStore := &mockstore.MockStore{}
-			if tt.eventStoreFunc != nil {
-				tt.eventStoreFunc(eventStore)
-			}
-			store := &storetest.Store{}
-			if tt.storeFunc != nil {
-				tt.storeFunc(store)
-			}
-			switches := &mockSwitchSet{}
-
-			e := &Eventd{
-				bus:             bus,
-				store:           store,
-				eventStore:      eventStore,
-				livenessFactory: newFakeFactory(switches),
-				workerCount:     1,
-				wg:              &sync.WaitGroup{},
-				Logger:          NoopLogger{},
-				silencedCache:   cache,
-			}
-			if _, err := e.handleMessage(&tt.event); (err != nil) != tt.wantErr {
-				t.Errorf("Eventd.handleMessage() error = %v, wantErr %v", err, tt.wantErr)
-			}
 		})
 	}
 }

--- a/backend/silenced/silenced_test.go
+++ b/backend/silenced/silenced_test.go
@@ -5,17 +5,9 @@ import (
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/store/cache"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
-
-func newFakeFactory(f liveness.Interface) liveness.Factory {
-	return func(name string, dead, alive liveness.EventFunc, logger logrus.FieldLogger) liveness.Interface {
-		return f
-	}
-}
 
 func TestGetSilenced(t *testing.T) {
 	testCases := []struct {

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -103,11 +103,11 @@ type Resource struct {
 	watchersMu sync.Mutex
 	synthesize bool
 	resourceT  corev2.Resource
-	client     *clientv3.Client
+	client     clientv3.KV
 }
 
 // getResources retrieves the resources from the store
-func getResources(ctx context.Context, client *clientv3.Client, resource corev2.Resource) ([]corev2.Resource, error) {
+func getResources(ctx context.Context, client clientv3.KV, resource corev2.Resource) ([]corev2.Resource, error) {
 	// Get the type of the resource and create a slice type of []type
 	typeOfResource := reflect.TypeOf(resource)
 	sliceOfResource := reflect.SliceOf(typeOfResource)
@@ -140,7 +140,7 @@ func getResources(ctx context.Context, client *clientv3.Client, resource corev2.
 
 // New creates a new resource cache. It retrieves all resources from the
 // store on creation.
-func New(ctx context.Context, client *clientv3.Client, resource corev2.Resource, synthesize bool) (*Resource, error) {
+func New(ctx context.Context, client clientv3.KV, resource corev2.Resource, synthesize bool) (*Resource, error) {
 	resources, err := getResources(ctx, client, resource)
 	if err != nil {
 		return nil, err

--- a/backend/store/cache/cache.go
+++ b/backend/store/cache/cache.go
@@ -13,8 +13,13 @@ import (
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/etcd"
 	"github.com/sensu/sensu-go/types/dynamic"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
+
+// Cache interfaces the cache.Resource struct for easier testing
+type Cache interface {
+	Get(namespace string) []Value
+}
 
 // Value contains a cached value, and its synthesized companion.
 type Value struct {

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -123,7 +123,7 @@ type KeyBuilderFn func(context.Context, string) string
 
 // List retrieves all keys from storage under the provided prefix key, while
 // supporting all namespaces, and deserialize it into objsPtr.
-func List(ctx context.Context, client *clientv3.Client, keyBuilder KeyBuilderFn, objsPtr interface{}, pred *store.SelectionPredicate) error {
+func List(ctx context.Context, client clientv3.KV, keyBuilder KeyBuilderFn, objsPtr interface{}, pred *store.SelectionPredicate) error {
 	// Make sure the interface is a pointer, and that the element at this address
 	// is a slice.
 	v := reflect.ValueOf(objsPtr)

--- a/testing/mockcache/mockcache.go
+++ b/testing/mockcache/mockcache.go
@@ -1,0 +1,15 @@
+package mockcache
+
+import (
+	"github.com/sensu/sensu-go/backend/store/cache"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockCache struct {
+	mock.Mock
+}
+
+func (m *MockCache) Get(namespace string) []cache.Value {
+	args := m.Called(namespace)
+	return args.Get(0).([]cache.Value)
+}

--- a/testing/mockclientv3/mockclientv3.go
+++ b/testing/mockclientv3/mockclientv3.go
@@ -1,0 +1,52 @@
+package mockclientv3
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// MockClientV3 is a V3 Etcd Client used for testing. When using the MockStore in unit
+// tests, stub out the behavior you wish to test against by assigning the
+// appropriate function to the appropriate Func field. If you have forgotten
+// to stub a particular function, the program will panic.
+type MockClientV3 struct {
+	mock.Mock
+}
+
+// Compact ...
+func (m MockClientV3) Compact(ctx context.Context, rev int64, opts ...clientv3.CompactOption) (*clientv3.CompactResponse, error) {
+	args := m.Called(ctx, rev, opts)
+	return args.Get(0).(*clientv3.CompactResponse), args.Error(1)
+}
+
+// Delete ...
+func (m MockClientV3) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	args := m.Called(ctx, key, opts)
+	return args.Get(0).(*clientv3.DeleteResponse), args.Error(1)
+}
+
+// Do ...
+func (m MockClientV3) Do(ctx context.Context, op clientv3.Op) (clientv3.OpResponse, error) {
+	args := m.Called(ctx, op)
+	return args.Get(0).(clientv3.OpResponse), args.Error(1)
+}
+
+// Get ...
+func (m MockClientV3) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	args := m.Called(ctx, key, opts)
+	return args.Get(0).(*clientv3.GetResponse), args.Error(1)
+}
+
+// Put ...
+func (m MockClientV3) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	args := m.Called(ctx, key, val, opts)
+	return args.Get(0).(*clientv3.PutResponse), args.Error(1)
+}
+
+// Txn ...
+func (m MockClientV3) Txn(ctx context.Context) clientv3.Txn {
+	args := m.Called(ctx)
+	return args.Get(0).(clientv3.Txn)
+}


### PR DESCRIPTION
## What is this change?

Adds support for silencing deregistration events. This may be seen as a breaking change so I've target the `main` branch meaning this will be shipped with the first 7.x release.

## Why is this change necessary?

Closes #4627.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation updates are required.

## How did you verify this change?

I reproduced the bug locally and confirmed the bug is fixed by confirming deregistration handlers are not fired when a subscription or check, matching the entity being registered, is silenced.

## Is this change a patch?

No.
