### PR TITLE
etcd-unsafe-no-fsync pass-through etcd option flag

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added the `etcd-unsafe-no-fsync` backend configuration option,
+making it possible to run a sensu-backend with an embedded etcd node
+for testing and development without placing lots of load on the file
+system.
+
 ### Fixed
 - Print the correct round robin scheduler source (etcd or postgres).
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -275,6 +275,9 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 		cfg.MaxRequestBytes = config.EtcdMaxRequestBytes
 	}
 
+	// Unsafe config
+	cfg.UnsafeNoFsync = config.EtcdUnsafeNoFsync
+
 	// Start etcd
 	e, err := etcd.NewEtcd(cfg)
 	if err != nil {

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -104,6 +104,9 @@ const (
 	envEtcdClientUsername = "etcd-client-username"
 	envEtcdClientPassword = "etcd-client-password"
 
+	// Etcd unsafe constants
+	flagEtcdUnsafeNoFsync = "etcd-unsafe-no-fsync"
+
 	// Metric logging flags
 	flagDisablePlatformMetrics         = "disable-platform-metrics"
 	flagPlatformMetricsLoggingInterval = "platform-metrics-logging-interval"
@@ -255,6 +258,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				EtcdClientLogLevel:             viper.GetString(flagEtcdClientLogLevel),
 				EtcdClientUsername:             viper.GetString(envEtcdClientUsername),
 				EtcdClientPassword:             viper.GetString(envEtcdClientPassword),
+				EtcdUnsafeNoFsync:              viper.GetBool(flagEtcdUnsafeNoFsync),
 				NoEmbedEtcd:                    viper.GetBool(flagNoEmbedEtcd),
 				Labels:                         viper.GetStringMapString(flagLabels),
 				Annotations:                    viper.GetStringMapString(flagAnnotations),
@@ -597,6 +601,9 @@ func flagSet(server bool) *pflag.FlagSet {
 
 		_ = flagSet.String(flagEventLogFile, "", "path to the event log file")
 		_ = flagSet.Bool(flagEventLogParallelEncoders, false, "use parallel JSON encoding for the event log")
+
+		// Etcd server unsafe flags
+		_ = flagSet.Bool(flagEtcdUnsafeNoFsync, false, "disables fsync, unsafe, may cause data loss")
 
 		// Use a default value of 100,000 messages for the buffer. A serialized event
 		// takes a minimum of around 1300 bytes, so once full the buffer ring could

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -604,6 +604,7 @@ func flagSet(server bool) *pflag.FlagSet {
 
 		// Etcd server unsafe flags
 		_ = flagSet.Bool(flagEtcdUnsafeNoFsync, false, "disables fsync, unsafe, may cause data loss")
+		_ = flagSet.SetAnnotation(flagEtcdUnsafeNoFsync, "categories", []string{"store"})
 
 		// Use a default value of 100,000 messages for the buffer. A serialized event
 		// takes a minimum of around 1300 bytes, so once full the buffer ring could

--- a/backend/config.go
+++ b/backend/config.go
@@ -116,6 +116,9 @@ type Config struct {
 	EtcdLogLevel       string
 	EtcdClientLogLevel string
 
+	// Etcd unsafe configuration
+	EtcdUnsafeNoFsync bool
+
 	LicenseGetter licensing.Getter
 
 	DisablePlatformMetrics         bool

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -277,9 +277,7 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	}
 
 	// Unsafe options.
-	if config.UnsafeNoFsync == true {
-		cfg.UnsafeNoFsync = config.UnsafeNoFsync
-	}
+	cfg.UnsafeNoFsync = config.UnsafeNoFsync
 
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -104,6 +104,8 @@ type Config struct {
 
 	LogLevel       string
 	ClientLogLevel string
+
+	UnsafeNoFsync bool
 }
 
 // TLSInfo wraps etcd transport TLSInfo
@@ -272,6 +274,11 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	if config.LogLevel != "" {
 		cfg.LogLevel = config.LogLevel
 		logutil.DefaultZapLoggerConfig.Level.SetLevel(LogLevelToZap(config.LogLevel))
+	}
+
+	// Unsafe options.
+	if config.UnsafeNoFsync == true {
+		cfg.UnsafeNoFsync = config.UnsafeNoFsync
 	}
 
 	e, err := embed.StartEtcd(cfg)


### PR DESCRIPTION
## What is this change?

Adds the `etcd-unsafe-no-fsync` backend configuration option ("disables fsync, unsafe, may cause data loss").

This makes it possible to run a sensu-backend with an embedded etcd node for testing and development without placing lots of load on the file system.

## Why is this change necessary?

Local disk/storage may not perform well enough for etcd.

## Does your change need a Changelog entry?

YES

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No. Yes.

## How did you verify this change?

Tested on my local host. Will test on the SPDC.

## Is this change a patch?

Yes.
