### PR TITLE
Add core/v3 support for global resources

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -16,6 +16,9 @@ stopping.
 ### Fixed
 - Fixed several data races in schedulerd.
 - Mitigate a data race in agentd sessions.
+### Added
+- GlobalResource interface in core/v3 allows core/v3 resources to
+be marked as global resources.
 
 ## [6.7.0] - 2022-04-21
 

--- a/api/core/v3/resource.go
+++ b/api/core/v3/resource.go
@@ -37,6 +37,14 @@ type GeneratedType interface {
 	Validate() error
 }
 
+// GlobalResource  is an interface for indicating
+// a resource's namespace strategy
+type GlobalResource interface {
+	// IsGlobalResource returns true when the resource
+	// is not namespaced.
+	IsGlobalResource() bool
+}
+
 // V2ResourceProxy is a compatibility shim for converting from a v3 resource to
 // a v2 resource.
 //sensu:nogen
@@ -64,6 +72,14 @@ func (v *V2ResourceProxy) SetObjectMeta(meta corev2.ObjectMeta) {
 }
 
 func (v *V2ResourceProxy) SetNamespace(ns string) {
+	// SetNamespace expected to be a no-op for
+	// core/v2 Resources. sensu-go and sensu-go/types
+	// both depend on this property.
+	if gr, ok := v.Resource.(GlobalResource); ok {
+		if gr.IsGlobalResource() {
+			return
+		}
+	}
 	if v.GetMetadata() == nil {
 		v.SetMetadata(&corev2.ObjectMeta{
 			Labels:      make(map[string]string),

--- a/types/compat/compat.go
+++ b/types/compat/compat.go
@@ -39,7 +39,17 @@ func SetNamespace(value interface{}, namespace string) {
 	case corev2.Resource:
 		value.SetNamespace(namespace)
 	case corev3.Resource:
-		value.GetMetadata().Namespace = namespace
+		if gr, ok := value.(corev3.GlobalResource); ok && gr.IsGlobalResource() {
+			// replicate corev2.Resource behavior where SetNamespace is no-op
+			// for global resources
+			return
+		}
+		meta := value.GetMetadata()
+		if meta == nil {
+			meta = &corev2.ObjectMeta{}
+			value.SetMetadata(meta)
+		}
+		meta.Namespace = namespace
 	default:
 		// impossible unless the type resolver is broken. fatal error.
 		panic("got neither corev2 resource nor corev3 resource")

--- a/types/compat/compat_test.go
+++ b/types/compat/compat_test.go
@@ -1,0 +1,81 @@
+package compat
+
+import (
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+)
+
+func TestSetNamespace(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Resource  interface{}
+		Namespace string
+		Expected  string
+	}{
+		{
+			Name:      "namespaced corev2 resource",
+			Resource:  new(testCoreV2Resoruce),
+			Namespace: "test",
+			Expected:  "test",
+		}, {
+			Name:      "global corev2 resource",
+			Resource:  new(testCoreV2GlobalResoruce),
+			Namespace: "test",
+			Expected:  "",
+		}, {
+			Name:      "namespaced corev3 resource",
+			Resource:  new(testCoreV3Resoruce),
+			Namespace: "test",
+			Expected:  "test",
+		}, {
+			Name:      "global corev3 resource",
+			Resource:  new(testCoreV3GlobalResoruce),
+			Namespace: "test",
+			Expected:  "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			SetNamespace(tc.Resource, tc.Namespace)
+			var namespace string
+			if meta := GetObjectMeta(tc.Resource); meta != nil {
+				namespace = meta.Namespace
+			}
+			if got, want := namespace, tc.Expected; got != want {
+				t.Errorf("SetNamespace had incorrect effect. got: %s, want: %s", got, want)
+			}
+		})
+	}
+}
+
+type testCoreV3Resoruce struct {
+	corev3.EntityConfig
+}
+
+type testCoreV3GlobalResoruce struct {
+	corev3.EntityConfig
+}
+
+func (t *testCoreV3GlobalResoruce) IsGlobalResource() bool {
+	return true
+}
+
+type testCoreV2Resoruce struct {
+	corev2.Entity
+}
+
+type testCoreV2GlobalResoruce struct {
+	corev2.Entity
+}
+
+func (t *testCoreV2GlobalResoruce) SetNamespace(namespace string) {}
+
+// compile time assertions that test types
+// implement expected interfaces
+var _ corev3.Resource = new(testCoreV3Resoruce)
+var _ corev3.Resource = new(testCoreV3GlobalResoruce)
+var _ corev3.GlobalResource = new(testCoreV3GlobalResoruce)
+var _ corev2.Resource = new(testCoreV2Resoruce)
+var _ corev2.Resource = new(testCoreV2GlobalResoruce)

--- a/types/go.mod
+++ b/types/go.mod
@@ -5,6 +5,7 @@ go 1.13
 replace (
 	github.com/sensu/sensu-go => ../
 	github.com/sensu/sensu-go/api/core/v2 => ../api/core/v2
+	github.com/sensu/sensu-go/api/core/v3 => ../api/core/v3
 )
 
 require (


### PR DESCRIPTION
## What is this change?

Closes https://github.com/sensu/sensu-go/issues/4697

* Adds a GlobalResource interface that corev3 Resoruces
can optionally implement in order to indicate they are not namespaced.
* Also updates the V2ResourceProxy to honor the core/v2 behavior
of no-op SetNamespace implementations to indicate a resource
is global.
* Fixes some unit tests that were making poor assertions.
* Updates the types/compat package to check for GlobalResources.

## Why is this change necessary?

This will enable global resources to be implemented using the core/v3.Resource interface.

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

I am a bit iffy on the effects of adding api/core/v3 to the replace block of types/go.mod.

## Were there any complications while making this change?

Not really. May need a followup pr to bump the version number on the dependency from types on api/core/v3?

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

Using the enterprise SensuProvider api WIP.

Without this change sensuctl assumes all corev3 resources are namesapced so it defaults namespace to "default":
```
$ cat << EOF | sensuctl create
type: SensuProvider
api_version: secrets/v2
metadata:
  name: foo
spec:
...

Error: error putting resource #0 with name "foo" and namespace "default" (/api/enterprise/secrets/v2/sensu-providers/base64-encoded): namespace must be empty. sensu-providers are global resources
```

Including this change:
```
$ cat << EOF | sensuctl create
type: SensuProvider
api_version: secrets/v2
metadata:
  name: foo
spec:
...

$ sensuctl dump secrets/v2.SensuProvider
type: SensuProvider
api_version: secrets/v2
metadata:
  created_by: admin
  labels:
    sensu.io/managed_by: sensuctl
  name: foo
...
```

## Is this change a patch?

N