### PR TITLE
[GraphQL] Correctly reference event filter in suggestions API

### DIFF
--- a/backend/apid/graphql/suggest.go
+++ b/backend/apid/graphql/suggest.go
@@ -145,7 +145,7 @@ func DefaultSuggestSchema() suggest.Register {
 		},
 		&suggest.Resource{
 			Group:      "core/v2",
-			Name:       "filter",
+			Name:       "event_filter",
 			FilterFunc: corev2.EventFilterFields,
 			Fields: []suggest.Field{
 				&suggest.ObjectField{


### PR DESCRIPTION
The `suggest.Resource` name must match a resource type name. In this case the event filter's type name isn't `filter` but `event_filter` and as such suggestions were never returned. https://github.com/sensu/sensu-go/blob/e679f27a5918ed1547d0ae1b5643c68b2996f772/api/core/v2/typemap.go#L49