### PR TITLE
Remove support for embedded etcd

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,8 +21,6 @@ environment:
   matrix:
     - GOARCH: amd64
       TEST_SUITE: unit
-    - GOARCH: amd64
-      TEST_SUITE: integration
 
 install:
   - rmdir c:\go /s /q

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
 
       # Run tests
       - run: ./build.sh unit
-      - run: ./build.sh integration
 
   test-module:
     parameters:
@@ -422,5 +421,3 @@ workflows:
       - build:
           name: sensuctl-windows-amd64
           binary: sensuctl
-          os: windows
-          arch: amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,3 +421,5 @@ workflows:
       - build:
           name: sensuctl-windows-amd64
           binary: sensuctl
+          os: windows
+          arch: amd64

--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -6,3 +6,13 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Breaking
+- Embedded etcd is no longer supported, all related configuration has been
+removed.
+- The prefix that keepalives are stored under has now changed. This could lead
+to dangling references when using an older Sensu database with 7.x, if the
+software is upgraded when there are active keepalive failures.
+
+### Added
+- Developer mode can now be enabled with the --dev flag.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package agent
 
 import (

--- a/agent/statsd_server_test.go
+++ b/agent/statsd_server_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !solaris
-// +build integration,!solaris
-
 package agent
 
 import (

--- a/backend/agentd/agentd_test.go
+++ b/backend/agentd/agentd_test.go
@@ -175,7 +175,7 @@ func TestHealthHandler(t *testing.T) {
 	client := e.NewEmbeddedClient()
 	defer func() { _ = client.Close() }()
 
-	stor := etcdstore.NewStore(client, "test")
+	stor := etcdstore.NewStore(client)
 	agent, err := New(Config{
 		Store:  stor,
 		Client: client,
@@ -207,7 +207,7 @@ func TestReplaceHealthController(t *testing.T) {
 	client := e.NewEmbeddedClient()
 	defer func() { _ = client.Close() }()
 
-	stor := etcdstore.NewStore(client, "test")
+	stor := etcdstore.NewStore(client)
 	agent, err := New(Config{
 		Store:  stor,
 		Client: client,

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -577,6 +577,8 @@ func (s *Session) stop() {
 			logger.WithError(err).Error("error closing session")
 		}
 	}()
+	defer close(s.entityConfig.updatesChannel)
+	defer close(s.checkChannel)
 
 	sessionCounter.WithLabelValues(s.cfg.Namespace).Dec()
 
@@ -592,9 +594,6 @@ func (s *Session) stop() {
 	case <-time.After(closeGracePeriod):
 		sessionErrorCounter.WithLabelValues("GracePeriodExpired").Inc()
 	}
-
-	close(s.entityConfig.updatesChannel)
-	close(s.checkChannel)
 
 	// Remove the entity config subscriptions
 	for sub := range s.entityConfig.subscriptions {

--- a/backend/apid/handlers/patch_integration_test.go
+++ b/backend/apid/handlers/patch_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package handlers
 
 import (
@@ -34,7 +31,7 @@ func testWithEtcdStores(t *testing.T, f func(*etcdstore.Store, *etcdstorev2.Stor
 
 	client := e.NewEmbeddedClient()
 
-	s1 := etcdstore.NewStore(client, e.Name())
+	s1 := etcdstore.NewStore(client)
 	s2 := etcdstorev2.NewStore(client)
 
 	if err := seeds.SeedInitialData(s1); err != nil {

--- a/backend/apid/handlers/patch_integration_test.go
+++ b/backend/apid/handlers/patch_integration_test.go
@@ -34,7 +34,7 @@ func testWithEtcdStores(t *testing.T, f func(*etcdstore.Store, *etcdstorev2.Stor
 	s1 := etcdstore.NewStore(client)
 	s2 := etcdstorev2.NewStore(client)
 
-	if err := seeds.SeedInitialData(s1); err != nil {
+	if err := seeds.SeedInitialDataWithContext(context.Background(), s1); err != nil {
 		t.Fatalf("failed to seed initial etcd data: %v", err)
 	}
 

--- a/backend/apid/middlewares/authorization_test.go
+++ b/backend/apid/middlewares/authorization_test.go
@@ -25,7 +25,7 @@ import (
 func seedStore(t *testing.T, store store.Store) {
 	t.Helper()
 
-	if err := seeds.SeedInitialData(store); err != nil {
+	if err := seeds.SeedInitialDataWithContext(context.Background(), store); err != nil {
 		t.Fatalf("Could not seed the backend: %s", err)
 	}
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -192,7 +192,7 @@ func devModeClient(ctx context.Context, config *Config, backend *Backend) (*clie
 	cfg.InitialAdvertisePeerURLs = cfg.ListenPeerURLs
 	cfg.AdvertiseClientURLs = config.EtcdClientURLs
 	cfg.Name = "dev"
-	cfg.LogLevel = "warn"
+	cfg.LogLevel = config.LogLevel
 	cfg.ClientLogLevel = config.EtcdClientLogLevel
 
 	// Start etcd

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -524,6 +524,13 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 			clusterVersion = status.Version
 			break
 		}
+	} else {
+		status, err := b.Client.Status(ctx, config.EtcdClientURLs[0])
+		if err != nil {
+			logger.WithError(err).Error("error getting etcd cluster info")
+		} else {
+			clusterVersion = status.Version
+		}
 	}
 
 	// Load the JWT key pair

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -95,7 +95,7 @@ func TestBackendHTTPListener(t *testing.T) {
 			}
 
 			store := etcdstore.NewStore(b.Client)
-			if err := seeds.SeedInitialData(store); err != nil {
+			if err := seeds.SeedInitialDataWithContext(context.Background(), store); err != nil {
 				t.Fatal(err)
 			}
 

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package backend
 
 import (
@@ -63,11 +60,10 @@ func TestBackendHTTPListener(t *testing.T) {
 			cachePath, cleanup := testutil.TempDir(t)
 			defer cleanup()
 
-			clURL := fmt.Sprintf("%s://127.0.0.1:0", tc.httpScheme)
-			apURL := fmt.Sprintf("%s://127.0.0.1:0", tc.httpScheme)
+			clURL := "http://127.0.0.1:0"
+
 			agentPort := 8081
 			apiPort := 8080
-			initCluster := fmt.Sprintf("default=%s", apURL)
 
 			var tlsInfo etcd.TLSInfo
 			if tc.tls != nil {
@@ -80,25 +76,17 @@ func TestBackendHTTPListener(t *testing.T) {
 			}
 
 			cfg := &Config{
-				AgentHost:                    "127.0.0.1",
-				AgentPort:                    agentPort,
-				APIListenAddress:             fmt.Sprintf("127.0.0.1:%d", apiPort),
-				StateDir:                     dataPath,
-				CacheDir:                     cachePath,
-				TLS:                          tc.tls,
-				EtcdAdvertiseClientURLs:      []string{clURL},
-				EtcdListenClientURLs:         []string{clURL},
-				EtcdListenPeerURLs:           []string{apURL},
-				EtcdInitialCluster:           initCluster,
-				EtcdInitialClusterState:      etcd.ClusterStateNew,
-				EtcdInitialAdvertisePeerURLs: []string{apURL},
-				EtcdName:                     "default",
-				EtcdClientTLSInfo:            tlsInfo,
-				EtcdPeerTLSInfo:              tlsInfo,
-				EtcdUseEmbeddedClient:        true,
-				EtcdLogLevel:                 "info",
-				EtcdClientLogLevel:           "error",
-				DisablePlatformMetrics:       true,
+				AgentHost:              "127.0.0.1",
+				AgentPort:              agentPort,
+				APIListenAddress:       fmt.Sprintf("127.0.0.1:%d", apiPort),
+				StateDir:               dataPath,
+				CacheDir:               cachePath,
+				TLS:                    tc.tls,
+				EtcdClientURLs:         []string{clURL},
+				EtcdClientTLSInfo:      tlsInfo,
+				DevMode:                true,
+				EtcdClientLogLevel:     "error",
+				DisablePlatformMetrics: true,
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			b, err := Initialize(ctx, cfg)
@@ -106,7 +94,7 @@ func TestBackendHTTPListener(t *testing.T) {
 				t.Fatalf("failed to start backend: %s", err)
 			}
 
-			store := etcdstore.NewStore(b.Client, cfg.EtcdName)
+			store := etcdstore.NewStore(b.Client)
 			if err := seeds.SeedInitialData(store); err != nil {
 				t.Fatal(err)
 			}

--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -103,10 +103,7 @@ func InitCommand() *cobra.Command {
 			}
 
 			cfg := &backend.Config{
-				EtcdClientURLs:      fallbackStringSlice(flagEtcdClientURLs, flagEtcdAdvertiseClientURLs),
-				EtcdCipherSuites:    viper.GetStringSlice(flagEtcdCipherSuites),
-				EtcdMaxRequestBytes: viper.GetUint(flagEtcdMaxRequestBytes),
-				NoEmbedEtcd:         true,
+				EtcdClientURLs: viper.GetStringSlice(flagEtcdClientURLs),
 			}
 
 			// Sensu APIs TLS config
@@ -148,9 +145,6 @@ func InitCommand() *cobra.Command {
 			}
 
 			clientURLs := viper.GetStringSlice(flagEtcdClientURLs)
-			if len(clientURLs) == 0 {
-				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
-			}
 
 			timeout := viper.GetDuration(flagTimeout)
 			if timeout < 1*time.Second {
@@ -270,7 +264,7 @@ func initializeStore(clientConfig clientv3.Config, initConfig initConfig, endpoi
 	}
 
 	// The endpoint did not return any error, therefore we can proceed
-	store := etcdstore.NewStore(client, "")
+	store := etcdstore.NewStore(client)
 	if err := seeds.SeedCluster(ctx, store, client, initConfig.SeedConfig); err != nil {
 		if errors.Is(err, seeds.ErrAlreadyInitialized) {
 			return err

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -103,19 +103,6 @@ const (
 
 	// Default values
 
-	// defaultEtcdClientURL is the default URL to listen for Etcd clients
-	defaultEtcdClientURL = "http://127.0.0.1:2379"
-	// defaultEtcdName is the default etcd member node name (single-node cluster
-	// only)
-	defaultEtcdName = "default"
-	// defaultEtcdPeerURL is the default URL to listen for Etcd peers (single-node
-	// cluster only)
-	defaultEtcdPeerURL = "http://127.0.0.1:2380"
-
-	// defaultEtcdAdvertiseClientURL is the default list of this member's client
-	// URLs to advertise to the rest of the cluster
-	defaultEtcdAdvertiseClientURL = "http://localhost:2379"
-
 	// Start command usage template
 	startUsageTemplate = `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
@@ -156,14 +143,6 @@ var (
 // InitializeFunc represents the signature of an initialization function, used
 // to initialize the backend
 type InitializeFunc func(context.Context, *backend.Config) (*backend.Backend, error)
-
-func fallbackStringSlice(newFlag, oldFlag string) []string {
-	slice := viper.GetStringSlice(newFlag)
-	if len(slice) == 0 {
-		slice = viper.GetStringSlice(oldFlag)
-	}
-	return slice
-}
 
 // StartCommand ...
 func StartCommand(initialize InitializeFunc) *cobra.Command {

--- a/backend/cmd/upgrade.go
+++ b/backend/cmd/upgrade.go
@@ -36,10 +36,7 @@ func UpgradeCommand() *cobra.Command {
 			}
 
 			cfg := &backend.Config{
-				EtcdClientURLs:      fallbackStringSlice(flagEtcdClientURLs, flagEtcdAdvertiseClientURLs),
-				EtcdCipherSuites:    viper.GetStringSlice(flagEtcdCipherSuites),
-				EtcdMaxRequestBytes: viper.GetUint(flagEtcdMaxRequestBytes),
-				NoEmbedEtcd:         true,
+				EtcdClientURLs: viper.GetStringSlice(flagEtcdClientURLs),
 			}
 
 			// Sensu APIs TLS config
@@ -77,10 +74,6 @@ func UpgradeCommand() *cobra.Command {
 			}
 
 			clientURLs := viper.GetStringSlice(flagEtcdClientURLs)
-			if len(clientURLs) == 0 {
-				clientURLs = viper.GetStringSlice(flagEtcdAdvertiseClientURLs)
-			}
-
 			timeout := viper.GetDuration(flagTimeout)
 
 			client, err := clientv3.New(clientv3.Config{

--- a/backend/config.go
+++ b/backend/config.go
@@ -84,36 +84,20 @@ type Config struct {
 	// Annotations are key-value pairs that users can provide to backend entities
 	Annotations map[string]string
 
-	// Etcd configuration
-	EtcdAdvertiseClientURLs      []string
-	EtcdInitialAdvertisePeerURLs []string
-	EtcdInitialClusterToken      string
-	EtcdInitialClusterState      string
-	EtcdInitialCluster           string
-	EtcdClientURLs               []string
-	EtcdListenClientURLs         []string
-	EtcdListenPeerURLs           []string
-	EtcdName                     string
-	NoEmbedEtcd                  bool
-	EtcdHeartbeatInterval        uint
-	EtcdElectionTimeout          uint
-	EtcdDiscovery                string
-	EtcdDiscoverySrv             string
-	EtcdUseEmbeddedClient        bool
-	EtcdClientUsername           string
-	EtcdClientPassword           string
+	// DevMode starts up a single-node embedded etcd server when enabled.
+	DevMode bool
+
+	EtcdClientURLs        []string
+	EtcdClientUsername    string
+	EtcdClientPassword    string
+	EtcdUseEmbeddedClient bool
 
 	// Etcd TLS configuration
-	EtcdClientTLSInfo     etcd.TLSInfo
-	EtcdPeerTLSInfo       etcd.TLSInfo
-	EtcdCipherSuites      []string
-	EtcdMaxRequestBytes   uint
-	EtcdQuotaBackendBytes int64
+	EtcdClientTLSInfo etcd.TLSInfo
 
 	TLS *corev2.TLSOptions
 
 	LogLevel           string
-	EtcdLogLevel       string
 	EtcdClientLogLevel string
 
 	LicenseGetter licensing.Getter

--- a/backend/etcd/etcd_test.go
+++ b/backend/etcd/etcd_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/etcd/sequence_test.go
+++ b/backend/etcd/sequence_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package etcd
 
 import (

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package eventd
 
 import (

--- a/backend/eventd/integration_test.go
+++ b/backend/eventd/integration_test.go
@@ -55,7 +55,7 @@ func TestEventdMonitor(t *testing.T) {
 	}
 	storev2 := etcdstore.NewStore(store.Client)
 
-	if err := seeds.SeedInitialData(store); err != nil {
+	if err := seeds.SeedInitialDataWithContext(context.Background(), store); err != nil {
 		assert.FailNow(t, err.Error())
 	}
 

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package keepalived
 
 import (

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -52,7 +52,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 	}
 	storev2 := etcdstorev2.NewStore(store.Client)
 
-	if err := seeds.SeedInitialData(store); err != nil {
+	if err := seeds.SeedInitialDataWithContext(context.Background(), store); err != nil {
 		assert.FailNow(t, err.Error())
 	}
 

--- a/backend/liveness/liveness_test.go
+++ b/backend/liveness/liveness_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package liveness
 
 import (

--- a/backend/queue/queue_test.go
+++ b/backend/queue/queue_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package queue
 
 import (

--- a/backend/ringv2/pool_test.go
+++ b/backend/ringv2/pool_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package ringv2
 
 import (

--- a/backend/ringv2/ringv2_test.go
+++ b/backend/ringv2/ringv2_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 // These tests are unfortunately quite slow. This is somewhat mitigated by the
 // fact that they are parallelized, but still consume 30-45 seconds. This is
 // due to the fact that etcd lease expirations cannot be hurried. No, I don't

--- a/backend/schedulerd/check_watcher_test.go
+++ b/backend/schedulerd/check_watcher_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package schedulerd
 
 import (

--- a/backend/schedulerd/cron_scheduler.go
+++ b/backend/schedulerd/cron_scheduler.go
@@ -2,6 +2,7 @@ package schedulerd
 
 import (
 	"context"
+	"sync"
 
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/secrets"
@@ -24,6 +25,7 @@ type CronScheduler struct {
 	interrupt              chan *corev2.CheckConfig
 	entityCache            *cachev2.Resource
 	secretsProviderManager *secrets.ProviderManager
+	stopWg                 sync.WaitGroup
 }
 
 // NewCronScheduler initializes a CronScheduler
@@ -65,10 +67,12 @@ func (s *CronScheduler) schedule(timer *CronTimer, executor *CheckExecutor) {
 // Start starts the cron scheduler.
 func (s *CronScheduler) Start() {
 	cronCounter.WithLabelValues(s.check.Namespace).Inc()
+	s.stopWg.Add(1)
 	go s.start()
 }
 
 func (s *CronScheduler) start() {
+	defer s.stopWg.Done()
 	s.logger.Info("starting new cron scheduler")
 	timer := NewCronTimer(s.check.Name, s.check.Cron)
 	executor := NewCheckExecutor(s.bus, s.check.Namespace, s.store, s.entityCache, s.secretsProviderManager)
@@ -101,9 +105,10 @@ func (s *CronScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the cron scheduler.
 func (s *CronScheduler) Stop() error {
+	s.cancel()
+	s.stopWg.Wait()
 	cronCounter.WithLabelValues(s.check.Namespace).Dec()
 	logger.Info("stopping cron scheduler")
-	s.cancel()
 
 	return nil
 }

--- a/backend/schedulerd/cron_scheduler.go
+++ b/backend/schedulerd/cron_scheduler.go
@@ -105,10 +105,10 @@ func (s *CronScheduler) Interrupt(check *corev2.CheckConfig) {
 
 // Stop stops the cron scheduler.
 func (s *CronScheduler) Stop() error {
+	logger.Info("stopping cron scheduler")
 	s.cancel()
 	s.stopWg.Wait()
 	cronCounter.WithLabelValues(s.check.Namespace).Dec()
-	logger.Info("stopping cron scheduler")
 
 	return nil
 }

--- a/backend/schedulerd/executor_test.go
+++ b/backend/schedulerd/executor_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package schedulerd
 
 import (

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package schedulerd
 
 import (

--- a/backend/seeds/seeds.go
+++ b/backend/seeds/seeds.go
@@ -138,12 +138,6 @@ func SeedCluster(ctx context.Context, store storev1.Store, client *clientv3.Clie
 	return initializer.FlagAsInitialized(ctx)
 }
 
-// SeedInitialData will seed a store with initial data. This method is
-// idempotent and can be safely run every time the backend starts.
-func SeedInitialData(store storev1.Store) (err error) {
-	return SeedInitialDataWithContext(context.Background(), store)
-}
-
 // SeedInitialDataWithContext is like SeedInitialData except it takes an existing
 // context.
 func SeedInitialDataWithContext(ctx context.Context, store storev1.Store) (err error) {
@@ -151,8 +145,6 @@ func SeedInitialDataWithContext(ctx context.Context, store storev1.Store) (err e
 		AdminUsername: "admin",
 		AdminPassword: "P@ssw0rd!",
 	}
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
 	return SeedCluster(ctx, store, nil, config)
 }
 

--- a/backend/seeds/seeds_test.go
+++ b/backend/seeds/seeds_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSeedInitialData(t *testing.T) {
+func TestSeedInitialDataWithContext(t *testing.T) {
 	// Setup store
 	ctx := context.Background()
 	st, serr := testutil.NewStoreInstance()
@@ -18,10 +18,10 @@ func TestSeedInitialData(t *testing.T) {
 	}
 	defer st.Teardown()
 
-	err := SeedInitialData(st)
+	err := SeedInitialDataWithContext(ctx, st)
 	require.NoError(t, err, "seeding process should not raise an error")
 
-	err = SeedInitialData(st)
+	err = SeedInitialDataWithContext(ctx, st)
 	if err != ErrAlreadyInitialized {
 		require.NoError(t, err, "seeding process should be able to be run more than once without error")
 	}

--- a/backend/store/cache/cache_integration_test.go
+++ b/backend/store/cache/cache_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package cache
 
 import (
@@ -32,7 +29,7 @@ func TestResourceCacheIntegration(t *testing.T) {
 
 	client := e.NewEmbeddedClient()
 
-	store := store.NewStore(client, e.Name())
+	store := store.NewStore(client)
 
 	if err := store.CreateNamespace(context.Background(), types.FixtureNamespace("default")); err != nil {
 		t.Fatal(err)

--- a/backend/store/cache/cache_test.go
+++ b/backend/store/cache/cache_test.go
@@ -114,7 +114,7 @@ func TestResourceRebuild(t *testing.T) {
 	c := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer c.Terminate(t)
 	client := c.RandClient()
-	s := etcd.NewStore(client, "store")
+	s := etcd.NewStore(client)
 	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
 	ctx := store.NamespaceContext(context.Background(), "default")
 

--- a/backend/store/cache/v2/cache_integration_test.go
+++ b/backend/store/cache/v2/cache_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package v2
 
 import (

--- a/backend/store/etcd/asset_store_test.go
+++ b/backend/store/etcd/asset_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/authentication_test.go
+++ b/backend/store/etcd/authentication_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/check_store_test.go
+++ b/backend/store/etcd/check_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/cluster_id_store_test.go
+++ b/backend/store/etcd/cluster_id_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/entity_store_test.go
+++ b/backend/store/etcd/entity_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/event_store_integration_test.go
+++ b/backend/store/etcd/event_store_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/event_store_test.go
+++ b/backend/store/etcd/event_store_test.go
@@ -145,6 +145,6 @@ func Test_updateEventHistory(t *testing.T) {
 }
 
 func TestEventStoreSupportsFilteringUnsupported(t *testing.T) {
-	store := NewStore(nil, "")
+	store := NewStore(nil)
 	assert.Equal(t, false, store.EventStoreSupportsFiltering(context.Background()), "etcd event store not expected to support filtering")
 }

--- a/backend/store/etcd/filter_store_test.go
+++ b/backend/store/etcd/filter_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/handler_store_test.go
+++ b/backend/store/etcd/handler_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/health_store_test.go
+++ b/backend/store/etcd/health_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (
@@ -11,7 +8,7 @@ import (
 
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/stretchr/testify/assert"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestGetClusterHealth(t *testing.T) {

--- a/backend/store/etcd/hook_store_test.go
+++ b/backend/store/etcd/hook_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/keepalive_store_test.go
+++ b/backend/store/etcd/keepalive_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/migrations.go
+++ b/backend/store/etcd/migrations.go
@@ -7,7 +7,7 @@ import (
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // A migration is a function that receives a context and an etcd client, and
@@ -33,7 +33,7 @@ func Base(ctx context.Context, client *clientv3.Client) error {
 
 // In Sensu 6.0, we migrate v2 entities to v3.
 func MigrateV2EntityToV3(ctx context.Context, client *clientv3.Client) error {
-	s := NewStore(client, "")
+	s := NewStore(client)
 	responses := readPagedV2Entities(ctx, client)
 	for response := range responses {
 		if response.Err != nil {

--- a/backend/store/etcd/migrations_test.go
+++ b/backend/store/etcd/migrations_test.go
@@ -1,6 +1,3 @@
-//go:build !race && integration
-// +build !race,integration
-
 package etcd
 
 import (
@@ -12,7 +9,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func testMigration(ctx context.Context, client *clientv3.Client) error {

--- a/backend/store/etcd/mutator_store_test.go
+++ b/backend/store/etcd/mutator_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/namespace_store_test.go
+++ b/backend/store/etcd/namespace_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/resource_integration_test.go
+++ b/backend/store/etcd/resource_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (
@@ -11,7 +8,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/patch"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestStore_PatchResource(t *testing.T) {

--- a/backend/store/etcd/silenced_store_test.go
+++ b/backend/store/etcd/silenced_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -29,10 +29,10 @@ type Store struct {
 }
 
 // NewStore creates a new Store.
-func NewStore(client *clientv3.Client, name string) *Store {
+func NewStore(client *clientv3.Client) *Store {
 	store := &Store{
 		client:         client,
-		keepalivesPath: path.Join(EtcdRoot, keepalivesPathPrefix, name),
+		keepalivesPath: path.Join(EtcdRoot, keepalivesPathPrefix),
 	}
 
 	return store

--- a/backend/store/etcd/store_test.go
+++ b/backend/store/etcd/store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (
@@ -17,7 +14,7 @@ import (
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func testWithEtcd(t *testing.T, f func(store.Store)) {
@@ -26,7 +23,7 @@ func testWithEtcd(t *testing.T, f func(store.Store)) {
 
 	client := e.NewEmbeddedClient()
 
-	s := NewStore(client, e.Name())
+	s := NewStore(client)
 
 	// Mock a default namespace
 	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
@@ -40,7 +37,7 @@ func testWithEtcdStore(t *testing.T, f func(*Store)) {
 
 	client := e.NewEmbeddedClient()
 
-	s := NewStore(client, e.Name())
+	s := NewStore(client)
 
 	// Mock a default namespace
 	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))
@@ -54,7 +51,7 @@ func testWithEtcdClient(t *testing.T, f func(store.Store, *clientv3.Client)) {
 
 	client := e.NewEmbeddedClient()
 
-	s := NewStore(client, e.Name())
+	s := NewStore(client)
 
 	// Mock a default namespace
 	require.NoError(t, s.CreateNamespace(context.Background(), types.FixtureNamespace("default")))

--- a/backend/store/etcd/tessen_store_test.go
+++ b/backend/store/etcd/tessen_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/testutil/store.go
+++ b/backend/store/etcd/testutil/store.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sensu/sensu-go/backend/etcd"
 	"github.com/sensu/sensu-go/backend/store"
 	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // IntegrationTestStore wrapper for etcd & store
@@ -59,7 +59,7 @@ func NewStoreInstance() (*IntegrationTestStore, error) {
 
 	client := e.NewEmbeddedClient()
 
-	st := etcdstore.NewStore(client, e.Name())
+	st := etcdstore.NewStore(client)
 
 	return &IntegrationTestStore{
 		Store:        st,

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (

--- a/backend/store/etcd/version_test.go
+++ b/backend/store/etcd/version_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (
@@ -8,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/store"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestGetSetDatabaseVersion(t *testing.T) {

--- a/backend/store/etcd/watcher_test.go
+++ b/backend/store/etcd/watcher_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcd
 
 import (
@@ -13,7 +10,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/testing/fixture"
 	"github.com/sirupsen/logrus/hooks/test"
-	"go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/integration"
 )
 
@@ -166,7 +163,7 @@ func TestWatchRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	client := c.Client(0)
-	s := NewStore(client, "store0")
+	s := NewStore(client)
 	w := Watch(ctx, client, "/sensu.io", true)
 
 	// Create resource
@@ -202,7 +199,7 @@ func TestWatchCompactedRevision(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	client := c.Client(0)
-	s := NewStore(client, "store")
+	s := NewStore(client)
 
 	// Create the 'foo' resource to generate a new revision (revision=2)
 	foo := &fixture.Resource{ObjectMeta: corev2.ObjectMeta{Name: "foo"}}
@@ -255,7 +252,7 @@ func TestWatchRevisions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	client := c.Client(0)
-	s := NewStore(client, "store")
+	s := NewStore(client)
 
 	// Create the 'foo' resource to generate a new revision (revision=2)
 	foo := &fixture.Resource{ObjectMeta: corev2.ObjectMeta{Name: "foo"}}

--- a/backend/store/v2/etcdstore/fixtures_test.go
+++ b/backend/store/v2/etcdstore/fixtures_test.go
@@ -77,7 +77,7 @@ func testWithV1Store(t testing.TB, f func(store.Store)) {
 	defer cleanup()
 
 	client := e.NewEmbeddedClient()
-	s := etcdstore.NewStore(client, "default")
+	s := etcdstore.NewStore(client)
 
 	f(s)
 }

--- a/backend/store/v2/etcdstore/store_test.go
+++ b/backend/store/v2/etcdstore/store_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package etcdstore_test
 
 import (

--- a/backend/tessend/tessend_test.go
+++ b/backend/tessend/tessend_test.go
@@ -1,6 +1,3 @@
-//go:build integration && !race
-// +build integration,!race
-
 package tessend
 
 import (

--- a/build.ps1
+++ b/build.ps1
@@ -164,7 +164,7 @@ function unit_test_commands
 {
     echo "Running unit tests..."
 
-	go test $RACE ./...
+    go test $RACE ./agent/... ./asset/... ./bonsai/... ./cli/... ./command/...
     If ($LASTEXITCODE -ne 0) {
         echo "Unit testing failed..."
         exit 1

--- a/build.ps1
+++ b/build.ps1
@@ -164,20 +164,9 @@ function unit_test_commands
 {
     echo "Running unit tests..."
 
-    go test -timeout=60s $(go list ./... | Select-String -pattern "scripts", "testing", "vendor", "backend" -notMatch)
+	go test $RACE ./...
     If ($LASTEXITCODE -ne 0) {
         echo "Unit testing failed..."
-        exit 1
-    }
-}
-
-function integration_test_commands
-{
-    echo "Running integration tests..."
-
-    go test -timeout=200s -tags=integration github.com/sensu/sensu-go/agent/...
-    If ($LASTEXITCODE -ne 0) {
-        echo "Integration testing failed..."
         exit 1
     }
 }
@@ -258,9 +247,6 @@ ElseIf ($cmd -eq "quality") {
 ElseIf ($cmd -eq "unit") {
     unit_test_commands
 }
-ElseIf ($cmd -eq "integration") {
-    integration_test_commands
-}
 ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
     If (($env:APPVEYOR_REPO_TAG -eq $true) -and ($env:MSI_BUILDER -eq $true)) {
         $env:GOARCH = "amd64"
@@ -273,6 +259,5 @@ ElseIf ($cmd -eq "wait_for_appveyor_jobs") {
 }
 Else {
     unit_test_commands
-    integration_test_commands
     build_commands
 }

--- a/build.sh
+++ b/build.sh
@@ -35,19 +35,9 @@ esac
 unit_test_commands () {
     echo "Running unit tests..."
 
-    go test -timeout=60s $RACE $(go list ./... | egrep -v '(testing|vendor|scripts)')
+    go test $RACE ./...
     if [ $? -ne 0 ]; then
         echo "Unit testing failed..."
-        exit 1
-    fi
-}
-
-integration_test_commands () {
-    echo "Running integration tests..."
-
-    go test -timeout=180s -tags=integration $(go list ./... | egrep -v '(testing|vendor|scripts)')
-    if [ $? -ne 0 ]; then
-        echo "Integration testing failed..."
         exit 1
     fi
 }
@@ -59,11 +49,7 @@ case "$cmd" in
     "unit")
         unit_test_commands
         ;;
-    "integration")
-        integration_test_commands
-        ;;
     *)
         unit_test_commands
-        integration_test_commands
         ;;
 esac


### PR DESCRIPTION
## What is this change?

    Remove embedded etcd clustering
    
    This is a substantial breaking commit. It removes several etcd
    configuration options for configuring embedded etcd clustering. At one
    time, this was the only way that sensu-go worked.
    
    We've learned that embedded etcd introduces a lot of operational
    fragility, and are now mandating that etcd be an external dependency.
    
    To improve hackability and developer velocity, there is now a
    zero-dependency developer mode for sensu-go. The developer mode makes
    use of a single-node etcd instance, but we reserve the right to change
    it to something else in the future of the 7 series releases.
    
    This is the first in a series of commits that will add full support for
    PostgreSQL to sensu-go. We have chosen to de-emphasize etcd in favour of
    PostgresQL, as we have found that it is far easier for users to deploy
    PostgresQL on cloud infrastructure (and possibly also on-prem
    infrastructure).
    
    In addition to these breaking changes, some routine gardening has been
    done. The concept of integration build tags has been removed.
    Integration test build tags are troublesome for static analysis tools
    and editors that compile on save. We introduced them at a time that Go
    didn't have test caching, and now it is time to de-introduce them. The
    whole senus-go test suite can run with the race detector enabled in just
    a few minutes.

## Why is this change necessary?

Part of #4616

## Does your change need a Changelog entry?

Yes

## Were there any complications while making this change?

I decided to pay down some technical debt and remove the `+built integration` tags from our integration tests.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Documentation updates will be needed, as embedded etcd is no longer supported for the 7.x series. cc @hillaryfraley 

## How did you verify this change?

I manually tested a few things under an external etcd including backend init. All is well, but we'll need to update our staging environment to not use embedded etcd.