### PR TITLE
Add develop/ and release/ to AppVeyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ clone_folder: c:\gopath\src\github.com\sensu\sensu-go
 branches:
   only:
     - main
+    - /develop\/[0-9.]+/
+    - /release\/[0-9.]+/
 
 image:
   - Visual Studio 2015


### PR DESCRIPTION
Updates the AppVeyor configuration so that it triggers on `develop/[0-9.]+` and
`release/[0-9.]+` branches.