### PR TITLE
Parametrize go version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,14 @@ version: 2.1
 orbs:
   go: circleci/go@1.1.2
 
+parameters:
+  go_version:
+    type: string
+    default: "1.17.6"
+
 sensu_go_build_env: &sensu_go_build_env
   docker:
-    - image: cimg/go:1.17.6
+    - image: cimg/go:<< pipeline.parameters.go_version >>
       auth:
         username: $DOCKER_USERNAME
         password: $DOCKER_PASSWORD


### PR DESCRIPTION
The goal is to have a format that's similar to the one in sensu-go-enterprise
and make certain operations, like grepping for the go version, easier across
both repositories.

If approved, this should also be applied to any other branch we work with during
releases, e.g. develop/6 and release/6.7

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No changes required.

## How did you verify this change?

I confirmed that I can achieve a step in the release checklist with a single,
simpler `grep` command.

## Is this change a patch?

No.