### PR TITLE
Fix Changelog Merge

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- GlobalResource interface in core/v3 allows core/v3 resources to
+be marked as global resources.
+
 ## [6.7.1] - 2022-04-28
 
 ### Changed
@@ -16,9 +20,6 @@ stopping.
 ### Fixed
 - Fixed several data races in schedulerd.
 - Mitigate a data race in agentd sessions.
-### Added
-- GlobalResource interface in core/v3 allows core/v3 resources to
-be marked as global resources.
 
 ## [6.7.0] - 2022-04-21
 


### PR DESCRIPTION
ac3387abab was merged with its changelog entry under the 6.7.1 release.
This moves it back to unreleased.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>
