### PR TITLE
Bump sensu-go and types api/core/v3 dependency to v3.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.14.0
-	github.com/sensu/sensu-go/api/core/v3 v3.6.1
+	github.com/sensu/sensu-go/api/core/v3 v3.6.2
 	github.com/sensu/sensu-go/types v0.10.0
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.7.0

--- a/types/go.mod
+++ b/types/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff
 	github.com/sensu/sensu-go/api/core/v2 v2.14.0
-	github.com/sensu/sensu-go/api/core/v3 v3.6.1
+	github.com/sensu/sensu-go/api/core/v3 v3.6.2
 	github.com/stretchr/testify v1.6.0
 )

--- a/types/go.sum
+++ b/types/go.sum
@@ -64,8 +64,6 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspo
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/sensu/sensu-go/api/core/v3 v3.6.1 h1:WJfIE8gIE9TlmkAI14FGALnOKO/O+D0BS68+HxmjmxY=
-github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
Signed-off-by: Christian Kruse <ctkruse99@gmail.com>


@echlebek looks like you might not usually PR these, but wanted to sanity check myself here.

Already pushed a api/core/v3.6.2 tag on the current head of develop/6.