### PR TITLE
Bump Go version to 1.18.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ cache:
 environment:
   GOPATH: c:\gopath
   GOROOT: c:\Program Files\Go
-  GOVERSION: 1.17.6
+  GOVERSION: 1.18.1
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.17.6"
+    default: "1.18.1"
 
 sensu_go_build_env: &sensu_go_build_env
   docker:

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           version: "2021.1.1"
 env:
-  GO_VERSION: 1.17.1
+  GO_VERSION: 1.18.1

--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -21,3 +21,4 @@ software is upgraded when there are active keepalive failures.
 - Changed parameters for `sensuctl cluster-role create` to be plural
 - Deregistration events are now silenced if a silenced entry exists matching the
 entity subscriptions and/or a check named `deregistration`.
+- Upgraded Go version from 1.17.1 to 1.18.1.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to get started with one of Sensu's [supported packages](https://docs.sensu.io/se
 ### Building from source
 
 The various components of Sensu Go can be manually built from this repository.
-You will first need [Go >= 1.16](https://golang.org/doc/install#install)
+You will first need [Go >= 1.18](https://golang.org/doc/install#install)
 installed. Then, you should clone this repository **outside** of the GOPATH
 since Sensu Go uses [Go Modules](https://github.com/golang/go/wiki/Modules):
 ```

--- a/api/core/v2/go.mod
+++ b/api/core/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go/api/core/v2
 
-go 1.16
+go 1.18
 
 require (
 	github.com/echlebek/crock v1.0.1

--- a/api/core/v2/go.mod
+++ b/api/core/v2/go.mod
@@ -14,6 +14,20 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.0
 	go.etcd.io/etcd/api/v3 v3.5.0
+)
+
+require (
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/api/core/v3/go.mod
+++ b/api/core/v3/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go/api/core/v3
 
-go 1.16
+go 1.18
 
 replace (
 	github.com/sensu/sensu-go/api/core/v2 => ../v2

--- a/api/core/v3/go.mod
+++ b/api/core/v3/go.mod
@@ -13,3 +13,23 @@ require (
 	github.com/sensu/sensu-go/api/core/v2 v2.14.0
 	github.com/sensu/sensu-go/types v0.10.0
 )
+
+require (
+	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/echlebek/timeproxy v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.0 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+)

--- a/api/core/v3/go.sum
+++ b/api/core/v3/go.sum
@@ -64,7 +64,7 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspo
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/sensu/sensu-go/api/core/v3 v3.6.1-alpha/go.mod h1:xnd6gfPu21bESxlI9Zd6VLaVhuz/ly2P9suwMux2TDU=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -176,6 +176,7 @@ func TestCheckSubdueInterval(t *testing.T) {
 	scheduler := newIntervalScheduler(ctx, t, "check")
 
 	// Set interval to smallest valid value
+	mockTime.Set(time.Date(2022, time.April, 6, 1, 0, 0, 0, time.UTC))
 	check := scheduler.check
 	check.Subscriptions = []string{"subscription1"}
 	check.Subdues = []*corev2.TimeWindowRepeated{

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,6 @@ replace (
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4 // indirect
 	github.com/atlassian/gostatsd v0.0.0-20180514010436-af796620006e
 	github.com/blang/semver/v4 v4.0.0
 	github.com/dave/jennifer v0.0.0-20171207062344-d8bdbdbee4e1
@@ -22,7 +20,6 @@ require (
 	github.com/echlebek/timeproxy v1.0.0
 	github.com/emicklei/proto v1.1.0
 	github.com/evanphx/json-patch/v5 v5.1.0
-	github.com/frankban/quicktest v1.7.2 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-resty/resty/v2 v2.5.0
 	github.com/gogo/protobuf v1.3.2
@@ -32,19 +29,10 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c
 	github.com/graphql-go/graphql v0.7.10-0.20200426202700-116f19d099aa
-	github.com/gxed/GoEndian v0.0.0-20160916112711-0f5c6873267e // indirect
-	github.com/gxed/eventfd v0.0.0-20160916113412-80a92cca79a8 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097
-	github.com/ipfs/go-log v1.0.4 // indirect
-	github.com/jbenet/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/libp2p/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect
-	github.com/libp2p/go-sockaddr v0.1.0 // indirect
-	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 	github.com/mholt/archiver/v3 v3.3.1-0.20191129193105-44285f7ed244
 	github.com/mitchellh/go-homedir v1.1.0
@@ -65,9 +53,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/willf/pad v0.0.0-20160331131008-b3d780601022
 	go.etcd.io/bbolt v1.3.6
 	go.etcd.io/etcd/api/v3 v3.5.2
@@ -84,5 +70,93 @@ require (
 	google.golang.org/grpc v1.38.0
 	gopkg.in/h2non/filetype.v1 v1.0.3
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/andybalholm/brotli v1.0.0 // indirect
+	github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
+	github.com/frankban/quicktest v1.7.2 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/gxed/GoEndian v0.0.0-20160916112711-0f5c6873267e // indirect
+	github.com/gxed/eventfd v0.0.0-20160916113412-80a92cca79a8 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/ipfs/go-log v1.0.4 // indirect
+	github.com/ipfs/go-log/v2 v2.0.5 // indirect
+	github.com/jbenet/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.9.2 // indirect
+	github.com/klauspost/pgzip v1.2.1 // indirect
+	github.com/libp2p/go-reuseport v0.0.0-20180416043609-15a1cd37f050 // indirect
+	github.com/libp2p/go-sockaddr v0.1.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.8 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pierrec/lz4/v3 v3.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/soheilhy/cmux v0.1.5 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.9 // indirect
+	github.com/tklauser/numcpus v0.3.0 // indirect
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	go.etcd.io/etcd/client/v2 v2.305.2 // indirect
+	go.etcd.io/etcd/pkg/v3 v3.5.2 // indirect
+	go.etcd.io/etcd/raft/v3 v3.5.2 // indirect
+	go.opentelemetry.io/contrib v0.20.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0 // indirect
+	go.opentelemetry.io/otel v0.20.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp v0.20.0 // indirect
+	go.opentelemetry.io/otel/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/export/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
+	go.opentelemetry.io/otel/trace v0.20.0 // indirect
+	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/term v0.0.0-20210503060354-a79de5458b56 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	gotest.tools v2.2.0+incompatible // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go
 
-go 1.13
+go 1.18
 
 replace (
 	github.com/sensu/sensu-go/api/core/v2 => ./api/core/v2

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -71,7 +70,6 @@ github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkE
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
@@ -558,7 +556,6 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/types/versions.go
+++ b/types/versions.go
@@ -13,7 +13,7 @@ import (
 // the product.
 func APIModuleVersions() map[string]string {
 	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
+	if !ok || buildInfo.Deps == nil {
 		// fallback case - ReadBuildInfo() not available in tests. Remove later.
 		return map[string]string{
 			"core/v2": "v2.6.0",

--- a/types/versions_test.go
+++ b/types/versions_test.go
@@ -10,8 +10,8 @@ import (
 
 // TODO(eric): This test doesn't work yet because of https://github.com/golang/go/issues/33976
 func TestAPIModuleVersions(t *testing.T) {
-	_, ok := debug.ReadBuildInfo()
-	if ok {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok && buildInfo.Deps != nil {
 		t.Fatal("remove this if block, the test works now")
 	} else {
 		t.Skip()

--- a/types/wrapper_test.go
+++ b/types/wrapper_test.go
@@ -156,10 +156,10 @@ func TestResolveType(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/%s", tc.ApiVersion, tc.Type), func(t *testing.T) {
 			r, err := types.ResolveType(tc.ApiVersion, tc.Type)
 			if !reflect.DeepEqual(r, tc.ExpRet) {
-				t.Fatal("unexpected type")
+				t.Fatalf("unexpected type: got %T, want %T", r, tc.ExpRet)
 			}
 			if err != nil && !tc.ExpErr {
-				t.Fatal(err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if err == nil && tc.ExpErr {
 				t.Fatal("expected an error")


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Bumps the Go version to 1.18.1 and makes Go 1.18 the minimum version required to build the project.

## Why is this change necessary?

We need Go 1.18 for Sensu 7.0.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Only if we refer to the version of Go required to build Sensu. cc @hillaryfraley 

## How did you verify this change?

I confirmed that Sensu still builds.

## Is this change a patch?

No.
