### PR TITLE
Remove go mod replace usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,21 @@ go_test_env: &sensu_go_test_env
       GOPROXY: 'https://proxy.golang.org'
 
 jobs:
+  assert-no-replace:
+    <<: *sensu_go_build_env
+    <<: *sensu_go_test_env
+    steps:
+      - checkout
+      - run:
+          name: Check For Replace Directives
+          command: |
+            replaces=$(grep -R --include="go.mod" "^replace " || :)
+            if [ -n "$replaces" ]
+            then
+              echo "replace directives not allowed"
+              echo "$replaces"
+              exit 1
+            fi
   test:
     <<: *sensu_go_build_env
     <<: *sensu_go_test_env
@@ -90,6 +105,7 @@ workflows:
       - test-module:
           name: types
           path: types
+      - assert-no-replace
   build:
     jobs:
       # darwin/amd64

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ sensu-backend
 sensuctl
 loadit
 *.exe
+
+# multi-module workspaces
+go.work
+go.work.sum

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,30 @@ Once you make a change to any `*.proto` file within the **types** package, you w
 Sensu uses [Go modules](https://github.com/golang/go/wiki/Modules) for managing
 its dependencies.
 
+The sensu-go repository contains multiple go modules. `github.com/sensu/sensu-go` is the main module containing the bulk of sensu's logic, and has dependencies on the other sensu-go modules.
+`github.com/sensu/sensu-go/types`, `github.com/sensu/sensu-go/api/core/v2` and `github.com/sensu/sensu-go/api/core/v3` are supporting modules that define sensu's API resources.
+
+#### Working with local dependencies
+
+When developing changes across multiple modules in the sensu-go repository it can be helpful to use [workspaces](https://go.dev/ref/mod#workspaces) (go 1.18+) locally.
+
+Example:
+```
+$ go work init && go work use . ./types ./api/core/v2 ./api/core/v3
+```
+
+#### Staging PRs changing multiple modules
+
+If it is most convenient to review changes to multiple modules in the sensu-go repository in a single PR, we recommend that you organize commits by module.
+You may then `go get` a dependency by either commit sha or pushed `-dev` tag in a subsequent commit to the dependent module.
+
+Example CL for a PR:
+```
+bad91f2 (HEAD -> razzle-dazzle-feat) Add RazzleDazzle HTTP Routes to sensu-go
+8171511 Bump sensu-go /api/core/v3 dependency to v1.0.1-dev
+76e86d0 (tag: v1.0.1-dev) Add /api/core/v3/RazzleDazzle Resource
+```
+
 ## Testing
 
 Run test suites:

--- a/api/core/v3/go.mod
+++ b/api/core/v3/go.mod
@@ -2,11 +2,6 @@ module github.com/sensu/sensu-go/api/core/v3
 
 go 1.16
 
-replace (
-	github.com/sensu/sensu-go/api/core/v2 => ../v2
-	github.com/sensu/sensu-go/types => ../../../types
-)
-
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2

--- a/api/core/v3/go.sum
+++ b/api/core/v3/go.sum
@@ -64,7 +64,11 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspo
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
-github.com/sensu/sensu-go/api/core/v3 v3.6.1-alpha/go.mod h1:xnd6gfPu21bESxlI9Zd6VLaVhuz/ly2P9suwMux2TDU=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0 h1:z4JVqy7z6iFgMDUH0uc1Ns0bqLFKTpc5bi4Iw7qweks=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU17L/E5BexeZHkGDdTls=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
+github.com/sensu/sensu-go/types v0.10.0 h1:sm+dLuqEEECVxjW5EfXkU5weGPwrg/Jymbm28HdQpl8=
+github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,6 @@ module github.com/sensu/sensu-go
 
 go 1.13
 
-replace (
-	github.com/sensu/sensu-go/api/core/v2 => ./api/core/v2
-	github.com/sensu/sensu-go/api/core/v3 => ./api/core/v3
-	github.com/sensu/sensu-go/backend/store/v2 => ./backend/store/v2
-	github.com/sensu/sensu-go/types => ./types
-)
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go
 
-go 1.13
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14

--- a/go.sum
+++ b/go.sum
@@ -565,7 +565,6 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,13 @@ github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmR
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=
 github.com/sensu/lasr v1.2.1/go.mod h1:VIMtIK67Bcef6dTfctRCBg8EY9M9TtCY9NEFT6Zw5xQ=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0 h1:z4JVqy7z6iFgMDUH0uc1Ns0bqLFKTpc5bi4Iw7qweks=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU17L/E5BexeZHkGDdTls=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
+github.com/sensu/sensu-go/api/core/v3 v3.6.2 h1:NEkHcPxkaYwPlH4gG6kgvdvYLlwBBaswMHscA7X3V+4=
+github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
+github.com/sensu/sensu-go/types v0.10.0 h1:sm+dLuqEEECVxjW5EfXkU5weGPwrg/Jymbm28HdQpl8=
+github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/shirou/gopsutil/v3 v3.21.12 h1:VoGxEW2hpmz0Vt3wUvHIl9fquzYLNpVpgNNB7pGJimA=
 github.com/shirou/gopsutil/v3 v3.21.12/go.mod h1:BToYZVTlSVlfazpDDYFnsVZLaoRG+g8ufT6fPQLdJzA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/types/go.mod
+++ b/types/go.mod
@@ -2,12 +2,6 @@ module github.com/sensu/sensu-go/types
 
 go 1.13
 
-replace (
-	github.com/sensu/sensu-go => ../
-	github.com/sensu/sensu-go/api/core/v2 => ../api/core/v2
-	github.com/sensu/sensu-go/api/core/v3 => ../api/core/v3
-)
-
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/sensu/sensu-go/types
 
-go 1.13
+go 1.16
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/types/go.sum
+++ b/types/go.sum
@@ -64,6 +64,11 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspo
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0 h1:z4JVqy7z6iFgMDUH0uc1Ns0bqLFKTpc5bi4Iw7qweks=
+github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU17L/E5BexeZHkGDdTls=
+github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
+github.com/sensu/sensu-go/api/core/v3 v3.6.2 h1:NEkHcPxkaYwPlH4gG6kgvdvYLlwBBaswMHscA7X3V+4=
+github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=


### PR DESCRIPTION
## What is this change?

* Removes `replace` directives in our modules.
* bumps develop/6 minimum to go 1.16
* adds CI check to ensure nobody accidentally includes a replace directive.
* Updates CONTRIBUTING.md with suggestions on working across modules.

## Why is this change necessary?

To force us to keep sensu-go's internal dependencies updated.

## Does your change need a Changelog entry?

Probably not. Does not affect the product.

## Do you need clarification on anything?

N

## Were there any complications while making this change?

I was hopeful to fit the CI check for replace directives in semgrep but didn't see any obvious ways to do so.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

N/A

## Is this change a patch?

N
