### PR TITLE
Round Robin Postgres Scheduler

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Print the correct round robin scheduler source (etcd or postgres).
+
 ## [6.7.1] - 2022-04-28
 
 ### Changed

--- a/backend/ringv2/ringv2.go
+++ b/backend/ringv2/ringv2.go
@@ -101,6 +101,9 @@ type Event struct {
 
 	// Err is any error that occurred while processing the event.
 	Err error
+
+	// Source is the notification source
+	Source string
 }
 
 // Ring is a circular queue of items that are cooperatively iterated over by one
@@ -534,7 +537,7 @@ func (r *Ring) startWatchers(ctx context.Context, ch chan Event, name string, va
 
 func notifyClosing(ctx context.Context, ch chan<- Event) {
 	select {
-	case ch <- Event{Type: EventClosing}:
+	case ch <- Event{Type: EventClosing, Source: "etcd"}:
 	case <-ctx.Done():
 	}
 	close(ch)
@@ -680,6 +683,7 @@ func notifyAddRemove(ch chan<- Event, response clientv3.WatchResponse) {
 		ch <- Event{
 			Type:   eventType,
 			Values: []string{path.Base(string(event.Kv.Key))},
+			Source: "etcd",
 		}
 	}
 }
@@ -699,6 +703,7 @@ func notifyTrigger(ch chan<- Event, items []*mvccpb.KeyValue) {
 	event := Event{
 		Type:   EventTrigger,
 		Values: values,
+		Source: "etcd",
 	}
 	ch <- event
 }

--- a/backend/ringv2/ringv2_test.go
+++ b/backend/ringv2/ringv2_test.go
@@ -85,6 +85,7 @@ func TestWatchAddRemove(t *testing.T) {
 	want := Event{
 		Type:   EventAdd,
 		Values: []string{"foo"},
+		Source: "etcd",
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -100,6 +101,7 @@ func TestWatchAddRemove(t *testing.T) {
 	want = Event{
 		Type:   EventRemove,
 		Values: []string{"foo"},
+		Source: "etcd",
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -140,6 +142,7 @@ func TestWatchTrigger(t *testing.T) {
 		want := Event{
 			Type:   EventTrigger,
 			Values: []string{"foo"},
+			Source: "etcd",
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("bad event: got %v, want %v", got, want)
@@ -188,6 +191,7 @@ func TestRingOrdering(t *testing.T) {
 		want := Event{
 			Type:   EventTrigger,
 			Values: []string{items[i%len(items)]},
+			Source: "etcd",
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("bad event: got %v, want %v", got, want)
@@ -237,6 +241,7 @@ func TestConcurrentRingOrdering(t *testing.T) {
 			want := Event{
 				Type:   EventAdd,
 				Values: []string{items[i]},
+				Source: "etcd",
 			}
 
 			if !reflect.DeepEqual(got, want) {
@@ -261,11 +266,11 @@ func TestConcurrentRingOrdering(t *testing.T) {
 	wg.Wait()
 
 	exp := []Event{
-		{Type: EventTrigger, Values: []string{"mulder"}},
-		{Type: EventTrigger, Values: []string{"scully"}},
-		{Type: EventTrigger, Values: []string{"skinner"}},
-		{Type: EventTrigger, Values: []string{"mulder"}},
-		{Type: EventTrigger, Values: []string{"scully"}},
+		{Type: EventTrigger, Values: []string{"mulder"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"scully"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"skinner"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"mulder"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"scully"}, Source: "etcd"},
 	}
 
 	for i := range events {
@@ -323,25 +328,25 @@ func eventTest(t *testing.T, want []Event) {
 
 func TestRemoveNextTrigger(t *testing.T) {
 	eventTest(t, []Event{
-		{Type: EventAdd, Values: []string{"mulder"}},
-		{Type: EventAdd, Values: []string{"scully"}},
-		{Type: EventAdd, Values: []string{"skinner"}},
-		{Type: EventTrigger, Values: []string{"mulder"}},
-		{Type: EventTrigger, Values: []string{"scully"}},
-		{Type: EventRemove, Values: []string{"skinner"}},
-		{Type: EventTrigger, Values: []string{"mulder"}},
+		{Type: EventAdd, Values: []string{"mulder"}, Source: "etcd"},
+		{Type: EventAdd, Values: []string{"scully"}, Source: "etcd"},
+		{Type: EventAdd, Values: []string{"skinner"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"mulder"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"scully"}, Source: "etcd"},
+		{Type: EventRemove, Values: []string{"skinner"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"mulder"}, Source: "etcd"},
 	})
 }
 
 func TestWatchAndAddAfter(t *testing.T) {
 	eventTest(t, []Event{
-		{Type: EventAdd, Values: []string{"byers"}},
-		{Type: EventAdd, Values: []string{"frohike"}},
-		{Type: EventTrigger, Values: []string{"byers"}},
-		{Type: EventAdd, Values: []string{"langly"}},
-		{Type: EventTrigger, Values: []string{"frohike"}},
-		{Type: EventTrigger, Values: []string{"langly"}},
-		{Type: EventTrigger, Values: []string{"byers"}},
+		{Type: EventAdd, Values: []string{"byers"}, Source: "etcd"},
+		{Type: EventAdd, Values: []string{"frohike"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"byers"}, Source: "etcd"},
+		{Type: EventAdd, Values: []string{"langly"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"frohike"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"langly"}, Source: "etcd"},
+		{Type: EventTrigger, Values: []string{"byers"}, Source: "etcd"},
 	})
 }
 
@@ -366,7 +371,7 @@ func TestWatchAfterAdd(t *testing.T) {
 	wc := ring.Watch(ctx, "test", 1, 5, "")
 
 	got := <-wc
-	want := Event{Type: EventTrigger, Values: []string{"fowley"}}
+	want := Event{Type: EventTrigger, Values: []string{"fowley"}, Source: "etcd"}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("bad event: got %v, want %v", got, want)


### PR DESCRIPTION
Signed-off-by: Francis Guimond <francis@sensu.io>

## What is this change?

This pull request fixes the information printed indicating which round robin scheduler is used (etcd or postgres). The actual fix that implements active polling for PostgresConfig changes will be created in sensu-enterprise-go.

This is related to https://github.com/sensu/sensu-enterprise-go/issues/2113.

## Why is this change necessary?

The information was not accurate, etcd was always printed instead of postgres.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Not required.

## How did you verify this change?

Manual testing.

## Is this change a patch?

Yes.