### PR TITLE
Author: Michael Kennedy <michael_l_kennedy@me.com>

### DIFF
--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -25,6 +25,7 @@ software is upgraded when there are active keepalive failures.
 entity subscriptions and/or a check named `deregistration`.
 - Upgraded Go version from 1.17.1 to 1.18.1.
 - Changed sensu-backend etcd configuration options.
+- Added VMware as a value return in `GetCloudProvider` function.
 
 ### Removed
 - Removed sensu-backend upgrade command. May make an appearance again in later versions.

--- a/system/system.go
+++ b/system/system.go
@@ -148,6 +148,10 @@ func GetCloudProvider(ctx context.Context) string {
 			logger.Debug("Running on Azure")
 			return "Azure"
 		}
+		if strings.Contains(text, "vmware") {
+			logger.Debug("Running on VMware")
+			return "VMware"
+		}
 	case "windows":
 		return cloudMetadataFallback(ctx)
 	}


### PR DESCRIPTION
Committer: Michael Kennedy <michael_l_kennedy@me.com>

Signed-off-by: Michael Kennedy <michael_l_kennedy@me.com>

  Adding support for VMware as a Cloud Provider returned by GetCloudProvider(ctx).

## What is this change?

Add VMware as a Cloud Provider applied to entity metadata through agent discovery.


## Why is this change necessary?

The agent is capable of platform discovery and supports AWS and GCP. This same approach is capable and should detect VMware as a platform cloud provider.

## Does your change need a Changelog entry?

Yes and the Changelog entry has been added as specified in the contribution guidelines.

## Do you need clarification on anything?


## Were there any complications while making this change?

The change is rather trivial and does not introduce error conditions, but rather simply detects a possible output returned from an existing exec command.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

There did not appear to be documentation pertaining to this agent behavior, so no updates have been made.

## How did you verify this change?

This change was verified on a Linux host running on a VMware vSphere 6.7 hypervisor, and the output was verified from the exec command and then validated using the existing function.

## Is this change a patch?

No it is not.
