### PR TITLE
Fix an issue with non-dev event store

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -202,6 +202,8 @@ func initPGStateStore(ctx context.Context, b *Backend, client *clientv3.Client, 
 	if err != nil {
 		return err
 	}
+	b.EventStore = eventStore
+
 	entityStore := postgres.NewEntityStore(db, client)
 
 	pgStore := postgres.Store{


### PR DESCRIPTION
The store was never assigned to the backend, and so non-dev mode is broken.