### PR TITLE
CI: Use xlarge resource class Executor for Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
   go-with-postgres:
+    resource_class: xlarge
     docker:
       - image: cimg/go:<< pipeline.parameters.go_version >>
         auth:


### PR DESCRIPTION
Using a larger circleci executor should cut our CI tests time nearly in
half from ~4 minutes to ~2.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>


## What

If you look at our previous `run_the_tests` workflow durations in circleci, they hover around 4 minutes: https://app.circleci.com/pipelines/github/sensu/sensu-go?branch=main&filter=all

Every once in a while I end up needing to wait around for these tests to pass. This looks like it will cut down test time to the 2-2:30 minute range.

## Open Questions

Can we afford such nice things?