### PR TITLE
Add procedure for updating updated_at

### DIFF
--- a/backend/store/postgres/common_schema.go
+++ b/backend/store/postgres/common_schema.go
@@ -1,0 +1,15 @@
+package postgres
+
+const migrateRefreshUpdatedAtProcedure = `
+-- This is a procedure that can be used to set the "updated_at" column to the
+-- current time on a given table. It is intended to be used with update triggers
+-- to ensure that the "updated_at" column represents the last time a row was
+-- updated.
+CREATE OR REPLACE FUNCTION refresh_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+   NEW.updated_at = now();
+   RETURN NEW;
+END;
+$$ language 'plpgsql';
+`

--- a/backend/store/postgres/common_schema_test.go
+++ b/backend/store/postgres/common_schema_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+const testRefreshUpdatedAtTable = `
+CREATE TABLE IF NOT EXISTS test_updated_at (
+    name               text NOT NULL,
+    updated_at         timestamptz
+);
+`
+
+const testRefreshUpdatedAtTrigger = `
+CREATE TRIGGER test_refresh_updated_at BEFORE UPDATE
+    ON test_updated_at FOR EACH ROW
+    EXECUTE PROCEDURE refresh_updated_at_column();
+`
+
+func TestRefreshUpdatedAtProcedure(t *testing.T) {
+	withPostgres(t, func(ctx context.Context, db *pgxpool.Pool, dsn string) {
+		// create a table & trigger to test the procedure
+		if _, err := db.Exec(ctx, testRefreshUpdatedAtTable); err != nil {
+			t.Fatalf("error creating table: %v", err)
+		}
+		if _, err := db.Exec(ctx, testRefreshUpdatedAtTrigger); err != nil {
+			t.Fatalf("error creating trigger: %v", err)
+		}
+
+		var updatedAt *time.Time
+
+		// insert two rows with no value for updated_at
+		names := []string{"foo", "bar"}
+		insertQuery := "INSERT INTO test_updated_at (name) VALUES($1)"
+		for _, name := range names {
+			if _, err := db.Exec(ctx, insertQuery, name); err != nil {
+				t.Fatalf("error inserting row: %v", err)
+			}
+		}
+
+		// ensure the updated_at value is null for both rows
+		for _, name := range names {
+			query := "SELECT updated_at FROM test_updated_at WHERE name = $1"
+			row := db.QueryRow(ctx, query, name)
+			if err := row.Scan(&updatedAt); err != nil {
+				t.Fatal(err)
+			}
+			if got, want := updatedAt, (*time.Time)(nil); got != want {
+				t.Errorf("updated_at = %v, want %v", got, want)
+			}
+		}
+
+		// update row
+		now := time.Now()
+		if _, err := db.Exec(ctx, "UPDATE test_updated_at SET name = 'baz' WHERE name = 'foo'"); err != nil {
+			t.Fatalf("error updating row: %v", err)
+		}
+
+		// ensure the updated_at value for foo is set
+		row := db.QueryRow(ctx, "SELECT updated_at FROM test_updated_at WHERE name = 'baz'")
+		if err := row.Scan(&updatedAt); err != nil {
+			t.Fatal(err)
+		}
+		if got, after := updatedAt, now.Add(-1*time.Second); !got.After(after) {
+			t.Errorf("updated_at = %v, want >= %v", got, after)
+		}
+		if got, before := updatedAt, now.Add(1*time.Second); !got.Before(before) {
+			t.Errorf("updated_at = %v, want <= %v", got, before)
+		}
+
+		// ensure the updated_at value for bar is null
+		row = db.QueryRow(ctx, "SELECT updated_at FROM test_updated_at WHERE name = 'bar'")
+		if err := row.Scan(&updatedAt); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := updatedAt, (*time.Time)(nil); got != want {
+			t.Errorf("updated_at = %v, want %v", got, want)
+		}
+	})
+}

--- a/backend/store/postgres/migrations.go
+++ b/backend/store/postgres/migrations.go
@@ -55,6 +55,10 @@ var migrations = []migration.Migrator{
 		_, err := tx.Exec(context.Background(), migrateEntityState)
 		return err
 	},
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), migrateRefreshUpdatedAtProcedure)
+		return err
+	},
 }
 
 type eventRecord struct {


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Adds a PostgreSQL procedure for setting the `updated_at` column to the current time when used with a trigger.

## Why is this change necessary?

This is required for #4744 and any other ongoing work that will be using triggers to set `updated_at`.

## Does your change need a Changelog entry?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

I added new tests to ensure that everything works.

## Is this change a patch?

No.
