### PR TITLE
Add corev3 namespace and store methods

### DIFF
--- a/api/core/v3/namespace.go
+++ b/api/core/v3/namespace.go
@@ -1,0 +1,19 @@
+package v3
+
+import (
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+)
+
+// Namespace resource contains standard resource object metadata for
+// a given namespace.
+type Namespace struct {
+	Metadata *corev2.ObjectMeta `json:"metadata"`
+}
+
+func (n *Namespace) IsGlobalResource() bool {
+	return true
+}
+
+func (n *Namespace) GetMetadata() *corev2.ObjectMeta {
+	return n.Metadata
+}

--- a/api/core/v3/resource_generated.tmpl
+++ b/api/core/v3/resource_generated.tmpl
@@ -106,8 +106,14 @@ func ({{ receiver $typename }}) Validate() error {
 	}
 	var iface interface{} = {{ rvar $typename }}
 	if resource, ok := iface.(Resource); ok {
-		if err := ValidateMetadata(resource.GetMetadata()); err != nil {
+		meta := resource.GetMetadata()
+		if err := ValidateMetadata(meta); err != nil {
 			return fmt.Errorf("invalid {{ $typename }}: %s", err)
+		}
+		if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+			if err := ValidateGlobalMetadata(meta); err != nil {
+			    return fmt.Errorf("invalid {{ $typename }}: %s", err)
+			}
 		}
 	}
 	if validator, ok := iface.(validator); ok {

--- a/api/core/v3/resource_generated_test.go
+++ b/api/core/v3/resource_generated_test.go
@@ -90,7 +90,17 @@ func TestEntityConfigValidate(t *testing.T) {
 		t.Errorf("expected non-nil error for invalid metadata name")
 	}
 	value.Metadata.Name = "foo"
+
 	var iface interface{} = &value
+
+	if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+		value.Metadata.Namespace = "fizz"
+		if err := value.Validate(); err == nil {
+			t.Errorf("expected non-nill error for global resource with namespace set")
+		}
+		value.Metadata.Namespace = ""
+	}
+
 	if validator, ok := iface.(validator); ok {
 		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
 			t.Errorf("validator error: got %s, want %s", got, want)
@@ -245,7 +255,17 @@ func TestEntityStateValidate(t *testing.T) {
 		t.Errorf("expected non-nil error for invalid metadata name")
 	}
 	value.Metadata.Name = "foo"
+
 	var iface interface{} = &value
+
+	if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+		value.Metadata.Namespace = "fizz"
+		if err := value.Validate(); err == nil {
+			t.Errorf("expected non-nill error for global resource with namespace set")
+		}
+		value.Metadata.Namespace = ""
+	}
+
 	if validator, ok := iface.(validator); ok {
 		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
 			t.Errorf("validator error: got %s, want %s", got, want)
@@ -317,6 +337,171 @@ func TestEntityStateGetTypeMeta(t *testing.T) {
 		t.Errorf("bad api version: got %s, want %s", got, want)
 	}
 	if got, want := meta.Type, "EntityState"; got != want {
+		t.Errorf("bad type: got %s, want %s", got, want)
+	}
+}
+
+func TestNamespaceSetMetadata(t *testing.T) {
+	value := new(Namespace)
+	var iface interface{} = value
+	metaer, ok := iface.(getMetadataer)
+	if !ok {
+		return
+	}
+	meta := &corev2.ObjectMeta{
+		Name:        "snoopdogg",
+		Namespace:   "lbc",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	value.SetMetadata(meta)
+	if got, want := metaer.GetMetadata(), meta; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad metadata: got %v, want %v", got, want)
+	}
+}
+
+func TestNamespaceStoreName(t *testing.T) {
+	var value Namespace
+	got := value.StoreName()
+	if len(got) == 0 {
+		t.Error("undefined store suffix")
+	}
+	var iface interface{} = value
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
+			t.Errorf("bad store suffix: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestNamespaceRBACName(t *testing.T) {
+	var value Namespace
+	got := value.RBACName()
+	if len(got) == 0 {
+		t.Error("undefined rbac name")
+	}
+	var iface interface{} = value
+	if namer, ok := iface.(rbacNamer); ok {
+		if got, want := value.RBACName(), namer.rbacName(); got != want {
+			t.Errorf("bad rbac name: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestNamespaceURIPath(t *testing.T) {
+	var value Namespace
+	value.Metadata = &corev2.ObjectMeta{
+		Namespace: "default",
+		Name:      "foo",
+	}
+	got := value.URIPath()
+	if _, err := url.Parse(got); err != nil {
+		t.Error(err)
+	}
+	var iface interface{} = value
+	if pather, ok := iface.(uriPather); ok {
+		if got, want := value.URIPath(), pather.uriPath(); got != want {
+			t.Errorf("bad uri path: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestNamespaceValidate(t *testing.T) {
+	var value Namespace
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for nil metadata")
+	}
+	value.Metadata = &corev2.ObjectMeta{
+		Name:        "#@$@#%@#%@#%",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for invalid metadata name")
+	}
+	value.Metadata.Name = "foo"
+
+	var iface interface{} = &value
+
+	if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+		value.Metadata.Namespace = "fizz"
+		if err := value.Validate(); err == nil {
+			t.Errorf("expected non-nill error for global resource with namespace set")
+		}
+		value.Metadata.Namespace = ""
+	}
+
+	if validator, ok := iface.(validator); ok {
+		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
+			t.Errorf("validator error: got %s, want %s", got, want)
+		}
+		return
+	}
+	if err := value.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNamespaceUnmarshalJSON(t *testing.T) {
+	msg := []byte(`{"metadata": {"namespace": "default", "name": "foo"}}`)
+	var value Namespace
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+	var iface interface{} = &value
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if got, want := meta.Namespace, "default"; got != want {
+			t.Errorf("bad namespace: got %s, want %s", got, want)
+		}
+		if got, want := meta.Name, "foo"; got != want {
+			t.Errorf("bad name: got %s, want %s", got, want)
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+	}
+
+	// make sure labels are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "labels": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Labels), 1; got != want {
+			t.Error("expected one label")
+		}
+	}
+
+	// make sure annotations are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "annotations": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Annotations), 1; got != want {
+			t.Error("expected one annotation")
+		}
+	}
+}
+
+func TestNamespaceGetTypeMeta(t *testing.T) {
+	var value Namespace
+	meta := value.GetTypeMeta()
+	if got, want := meta.APIVersion, "core/v3"; got != want {
+		t.Errorf("bad api version: got %s, want %s", got, want)
+	}
+	if got, want := meta.Type, "Namespace"; got != want {
 		t.Errorf("bad type: got %s, want %s", got, want)
 	}
 }
@@ -400,7 +585,17 @@ func TestResourceTemplateValidate(t *testing.T) {
 		t.Errorf("expected non-nil error for invalid metadata name")
 	}
 	value.Metadata.Name = "foo"
+
 	var iface interface{} = &value
+
+	if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+		value.Metadata.Namespace = "fizz"
+		if err := value.Validate(); err == nil {
+			t.Errorf("expected non-nill error for global resource with namespace set")
+		}
+		value.Metadata.Namespace = ""
+	}
+
 	if validator, ok := iface.(validator); ok {
 		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
 			t.Errorf("validator error: got %s, want %s", got, want)

--- a/api/core/v3/resource_generated_test.tmpl
+++ b/api/core/v3/resource_generated_test.tmpl
@@ -91,7 +91,17 @@ func Test{{ $typename}}Validate(t *testing.T) {
 		t.Errorf("expected non-nil error for invalid metadata name")
 	}
 	value.Metadata.Name = "foo"
+
 	var iface interface{} = &value
+
+    if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+        value.Metadata.Namespace = "fizz"
+        if err := value.Validate(); err == nil {
+            t.Errorf("expected non-nill error for global resource with namespace set")
+        }
+        value.Metadata.Namespace = ""
+    }
+
 	if validator, ok := iface.(validator); ok {
 		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
 			t.Errorf("validator error: got %s, want %s", got, want)

--- a/api/core/v3/typemap.go
+++ b/api/core/v3/typemap.go
@@ -29,6 +29,8 @@ var typeMap = map[string]interface{}{
 	"entity_config":     &EntityConfig{},
 	"EntityState":       &EntityState{},
 	"entity_state":      &EntityState{},
+	"Namespace":         &Namespace{},
+	"namespace":         &Namespace{},
 	"ResourceTemplate":  &ResourceTemplate{},
 	"resource_template": &ResourceTemplate{},
 }

--- a/api/core/v3/typemap_test.go
+++ b/api/core/v3/typemap_test.go
@@ -191,6 +191,98 @@ func TestResolveV2ResourceEntityState(t *testing.T) {
 	}
 }
 
+func TestResolveNamespace(t *testing.T) {
+	var value interface{} = new(Namespace)
+	if _, ok := value.(Resource); ok {
+		resource, err := ResolveResource("Namespace")
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil metadata")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+		return
+	}
+	_, err := ResolveResource("Namespace")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if got, want := err.Error(), `"Namespace" is not a Resource`; got != want {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestResolveNamespaceByRBACName(t *testing.T) {
+	value := new(Namespace)
+	var iface interface{} = value
+	resource, err := ResolveResourceByRBACName(value.RBACName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveNamespaceByStoreName(t *testing.T) {
+	value := new(Namespace)
+	var iface interface{} = value
+	resource, err := ResolveResourceByStoreName(value.StoreName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveV2ResourceNamespace(t *testing.T) {
+	v2Resource, err := ResolveV2Resource("Namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3Resource, err := ResolveResource("Namespace")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := v2Resource.(*V2ResourceProxy).Resource, v3Resource; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad resource: got %v, want %v", got, want)
+	}
+}
+
 func TestResolveResourceTemplate(t *testing.T) {
 	var value interface{} = new(ResourceTemplate)
 	if _, ok := value.(Resource); ok {

--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -20,5 +20,19 @@ func ValidateMetadata(meta *corev2.ObjectMeta) error {
 	if meta.Annotations == nil {
 		return errors.New("nil annotations")
 	}
+
+	return nil
+}
+
+func ValidateGlobalMetadata(meta *corev2.ObjectMeta) error {
+	if meta == nil {
+		return errors.New("nil metadata")
+	}
+	if meta.Namespace != "" {
+		return fmt.Errorf(
+			"global resources must have empty namesapce: got %s",
+			meta.Namespace,
+		)
+	}
 	return nil
 }

--- a/backend/store/v2/etcdstore/store.go
+++ b/backend/store/v2/etcdstore/store.go
@@ -22,6 +22,8 @@ var (
 	_ storev2.Interface = new(Store)
 )
 
+const namespaceIndexStoreName = "internal/storev2/namespaces"
+
 // ComputeContinueToken calculates a continue token based on the given resource.
 // The resource can be a core/v2 or a core/v3 resource.
 func ComputeContinueToken(namespace string, r interface{}) string {
@@ -107,9 +109,15 @@ func (s *Store) CreateOrUpdate(req storev2.ResourceRequest, wrapper storev2.Wrap
 	comparator := kvc.Comparisons(
 		kvc.NamespaceExists(req.Namespace),
 	)
-	op := clientv3.OpPut(key, string(msg))
+	ops := []clientv3.Op{
+		clientv3.OpPut(key, string(msg)),
+	}
+	if req.Namespace != "" {
+		namespaceOp := clientv3.OpPut(namespaceIndexKey(req.Namespace, key), "")
+		ops = append(ops, namespaceOp)
+	}
 
-	return kvc.Txn(req.Context, s.client, comparator, op)
+	return kvc.Txn(req.Context, s.client, comparator, ops...)
 }
 
 func (s *Store) Patch(req storev2.ResourceRequest, wrapper storev2.Wrapper, patcher patch.Patcher, conditions *store.ETagCondition) error {
@@ -253,9 +261,15 @@ func (s *Store) CreateIfNotExists(req storev2.ResourceRequest, wrapper storev2.W
 		kvc.NamespaceExists(req.Namespace),
 		kvc.KeyIsNotFound(key),
 	)
-	op := clientv3.OpPut(key, string(msg))
+	ops := []clientv3.Op{
+		clientv3.OpPut(key, string(msg)),
+	}
+	if req.Namespace != "" {
+		namespaceOp := clientv3.OpPut(namespaceIndexKey(req.Namespace, key), "")
+		ops = append(ops, namespaceOp)
+	}
 
-	return kvc.Txn(req.Context, s.client, comparator, op)
+	return kvc.Txn(req.Context, s.client, comparator, ops...)
 }
 
 func (s *Store) Get(req storev2.ResourceRequest) (storev2.Wrapper, error) {
@@ -302,9 +316,15 @@ func (s *Store) Delete(req storev2.ResourceRequest) error {
 	comparator := kvc.Comparisons(
 		kvc.KeyIsFound(key),
 	)
-	op := clientv3.OpDelete(key)
+	ops := []clientv3.Op{
+		clientv3.OpDelete(key),
+	}
+	if req.Namespace != "" {
+		namespaceOp := clientv3.OpDelete(namespaceIndexKey(req.Namespace, key))
+		ops = append(ops, namespaceOp)
+	}
 
-	return kvc.Txn(req.Context, s.client, comparator, op)
+	return kvc.Txn(req.Context, s.client, comparator, ops...)
 }
 
 func (s *Store) List(req storev2.ResourceRequest, pred *store.SelectionPredicate) (storev2.WrapList, error) {
@@ -400,6 +420,7 @@ func (s *Store) CreateNamespace(ctx context.Context, namespace *corev3.Namespace
 
 	comparator := kvc.Comparisons(
 		kvc.KeyIsNotFound(key),
+		kvc.NamespaceExists(""),
 	)
 	op := clientv3.OpPut(key, string(msg))
 
@@ -407,6 +428,18 @@ func (s *Store) CreateNamespace(ctx context.Context, namespace *corev3.Namespace
 }
 
 func (s *Store) DeleteNamespace(ctx context.Context, namespace string) error {
+	key := store.NewKeyBuilder(namespaceIndexStoreName).Build(namespace)
+	var resp *clientv3.GetResponse
+	err := kvc.Backoff(ctx).Retry(func(n int) (done bool, err error) {
+		resp, err = s.client.Get(ctx, key, clientv3.WithPrefix(), clientv3.WithCountOnly())
+		return kvc.RetryRequest(n, err)
+	})
+	if err != nil {
+		return err
+	}
+	if resp.Count > 0 {
+		return fmt.Errorf("cannot delete namespace %s: namespace not empty", namespace)
+	}
 	req := storev2.NewResourceRequest(ctx, "", namespace, "namespaces")
 	return s.Delete(req)
 }
@@ -419,4 +452,8 @@ func getSortOrder(order storev2.SortOrder) clientv3.SortOrder {
 		return clientv3.SortDescend
 	}
 	return clientv3.SortNone
+}
+
+func namespaceIndexKey(namespace, key string) string {
+	return store.NewKeyBuilder(namespaceIndexStoreName).WithNamespace(namespace).Build(key)
 }

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"context"
+
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/patch"
@@ -21,6 +23,9 @@ type WrapList interface {
 
 // Interface specifies the interface of a v2 store.
 type Interface interface {
+	// todo: uncomment after #4765 implements namespacestore on postgres store
+	// NamespaceStore
+
 	// CreateOrUpdate creates or updates the wrapped resource.
 	CreateOrUpdate(ResourceRequest, Wrapper) error
 
@@ -69,4 +74,12 @@ type WatchEvent struct {
 	PreviousValue Wrapper
 	Revision      int64
 	Err           error
+}
+
+type NamespaceStore interface {
+	// CreateNamespace persists a corev3.Namespace resource
+	CreateNamespace(context.Context, *corev3.Namespace) error
+	// DeleteNamespace deletes the corresponding corev3.Namespace resource and
+	// cleans up any store resources from that namespace.
+	DeleteNamespace(context.Context, string) error
 }

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.15.0-alpha1
-	github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2
+	github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha2
 	github.com/sensu/sensu-go/types v0.11.0-alpha1
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.15.0-alpha1
-	github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha1
+	github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2
 	github.com/sensu/sensu-go/types v0.11.0-alpha1
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2 h1:hENCTTmVlypxMeNmy1BNAc81g
 github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2/go.mod h1:X0mcDXOt2LCjuu0sCzXNdeeYbLq9QLtxKSpnsDybclg=
 github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha1 h1:PJ7gvN1uPvIotdCswfOBiOREJM4kX1NaLY8iR8T6jsQ=
 github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha1/go.mod h1:X0mcDXOt2LCjuu0sCzXNdeeYbLq9QLtxKSpnsDybclg=
+github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha2 h1:in2zff4g7eGEgRpqYgrsaa7DOOHdj+WeYkFipU7RbEE=
+github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha2/go.mod h1:X0mcDXOt2LCjuu0sCzXNdeeYbLq9QLtxKSpnsDybclg=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/sensu/sensu-go/types v0.11.0-alpha1 h1:cjxVdmR6qPBkM7e7znLUR79/rGnG0lIXBgdY605EJDU=
 github.com/sensu/sensu-go/types v0.11.0-alpha1/go.mod h1:fhgW3xlvkPFMZiT0IppHySeyN61ZTIKevgSPFSoaQEk=

--- a/go.sum
+++ b/go.sum
@@ -488,6 +488,8 @@ github.com/sensu/sensu-go/api/core/v2 v2.15.0-alpha1 h1:ULlSbeut2CXtFYQDamEZaqUP
 github.com/sensu/sensu-go/api/core/v2 v2.15.0-alpha1/go.mod h1:QxGKxqQv4rpweFrR4Jkp1tas3amGzAy0wO0fUwq0suU=
 github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2 h1:hENCTTmVlypxMeNmy1BNAc81gMPdhfSXWNWl8f3kCs8=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-alpha2/go.mod h1:X0mcDXOt2LCjuu0sCzXNdeeYbLq9QLtxKSpnsDybclg=
 github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha1 h1:PJ7gvN1uPvIotdCswfOBiOREJM4kX1NaLY8iR8T6jsQ=
 github.com/sensu/sensu-go/api/core/v3 v3.7.0-alpha1/go.mod h1:X0mcDXOt2LCjuu0sCzXNdeeYbLq9QLtxKSpnsDybclg=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/4764
Closes https://github.com/sensu/sensu-go/issues/4771

## What
* Adds a corev3 namespace type - like the regular core/v2 one but with the standard Metadata field.
* Adds namespace-specific store methods
* Implements an "index" as described in https://github.com/sensu/sensu-go/issues/4771 in store/v2 in order to keep track of whether a namespace is empty or not.


