### PR TITLE
Update Postgres CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.18.1"
+    default: "1.18.3"
 
 executors:
   go:
@@ -23,7 +23,7 @@ executors:
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
-      - image: circleci/postgres:9.5.20-alpine
+      - image: cimg/postgres:9.6
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD

--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -16,6 +16,7 @@ software is upgraded when there are active keepalive failures.
 - Etcd client configuration options have changed.
 - Entity configuration can now be stored in PostgreSQL. Existing entity
 configuration will not be migrated from Etcd.
+- PostgreSQL >= 9.6 is now required.
 
 ### Added
 - Developer mode can now be enabled with the --dev flag.


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

It updates the Docker image & PostgreSQL version (from 9.5 to 9.6) that we use for testing in CI.

## Why is this change necessary?

The `circleci/*` Docker images are deprecated and the new `cimg/postgres` Docker image does not support Postgres 9.5.

## Does your change need a Changelog entry?

Yes; it is a breaking change as PostgreSQL >= 9.6 will be required for 7.0.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We may need to update the minimum version requirement for PostgreSQL if it is listed anywhere in the docs. cc @hillaryfraley 

## How did you verify this change?

CI functions. :)

## Is this change a patch?

No.
