### PR TITLE
Prevent executing old or duplicate check requests

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -10,6 +10,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - GlobalResource interface in core/v3 allows core/v3 resources to
 be marked as global resources.
+
+### Changed
+- Agents will no longer execute check requests with equal or older issued
+timestamps than the issued timestamp for the last executed check request with
+the same check name.
+
 ## [6.7.2] - 2022-05-12
 
 ### Added

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -564,7 +564,7 @@ func (a *Agent) receiveLoop(ctx context.Context, cancel context.CancelFunc, conn
 			err := a.handler.Handle(ctx, msg.Type, msg.Payload)
 			if err != nil {
 				switch err {
-				case dupCheckRequestErr:
+				case errDupCheckRequest:
 					logger.WithError(err).Warn("error handling message")
 				default:
 					logger.WithError(err).Error("error handling message")

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -136,12 +136,6 @@ func (a *Agent) getLastIssued(request *corev2.CheckRequest) int64 {
 	return issued
 }
 
-func (a *Agent) removeLastIssued(request *corev2.CheckRequest) {
-	a.lastIssuedMu.Lock()
-	defer a.lastIssuedMu.Unlock()
-	delete(a.lastIssued, checkKey(request))
-}
-
 func (a *Agent) setLastIssued(request *corev2.CheckRequest) {
 	a.lastIssuedMu.Lock()
 	defer a.lastIssuedMu.Unlock()

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	dupCheckRequestErr = errors.New("check request has already been received - agent & check may have multiple matching subscriptions")
+	dupCheckRequestErr = errors.New("check request has already been received - agent and check may have multiple matching subscriptions")
 	oldCheckRequestErr = errors.New("check request is older than a previously received check request")
 )
 

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,61 +18,134 @@ import (
 )
 
 func TestHandleCheck(t *testing.T) {
-	assert := assert.New(t)
-
-	checkConfig := corev2.FixtureCheckConfig("check")
-
-	request := &corev2.CheckRequest{Config: checkConfig, Issued: time.Now().Unix()}
-	payload, err := json.Marshal(request)
-	if err != nil {
-		assert.FailNow("error marshaling check request")
+	newCheckRequest := func(t *testing.T, issued int64) []byte {
+		checkConfig := corev2.FixtureCheckConfig("check")
+		checkRequest := &corev2.CheckRequest{
+			Config: checkConfig,
+			Issued: issued,
+		}
+		payload, err := json.Marshal(checkRequest)
+		require.NoError(t, err)
+		return payload
 	}
-
-	config, cleanup := FixtureConfig()
-	defer cleanup()
-	agent, err := NewAgent(config)
-	if err != nil {
-		t.Fatal(err)
+	type fields struct {
+		inProgress map[string]*corev2.CheckConfig
+		lastIssued map[string]int64
+		sequences  map[string]int64
 	}
-	ex := &mockexecutor.MockExecutor{}
-	agent.executor = ex
-	execution := command.FixtureExecutionResponse(0, "")
-	ex.Return(execution, nil)
-	ch := make(chan *transport.Message, 5)
-	agent.sendq = ch
-
-	// check request issued timestamp is older than last issued
-	agent.lastIssuedMu.Lock()
-	agent.lastIssued[checkKey(request)] = time.Now().Unix() + 100
-	agent.lastIssuedMu.Unlock()
-	assert.ErrorIs(agent.handleCheck(context.TODO(), payload), oldCheckRequestErr)
-
-	// check request issued timestamp is the same as last issued
-	agent.lastIssuedMu.Lock()
-	agent.lastIssued[checkKey(request)] = request.Issued
-	agent.lastIssuedMu.Unlock()
-	assert.ErrorIs(agent.handleCheck(context.TODO(), payload), dupCheckRequestErr)
-
-	// check request issued timestamp is newer than last issued
-	agent.lastIssuedMu.Lock()
-	agent.lastIssued[checkKey(request)] = time.Now().Unix() - 100
-	agent.lastIssuedMu.Unlock()
-	assert.NoError(agent.handleCheck(context.TODO(), payload))
-
-	// check is already in progress, it shouldn't execute
-	agent.inProgressMu.Lock()
-	delete(agent.lastIssued, checkKey(request))
-	agent.inProgress[checkKey(request)] = request.Config
-	agent.inProgressMu.Unlock()
-	assert.EqualError(
-		agent.handleCheck(context.TODO(), payload),
-		fmt.Sprintf("check execution still in progress: %s", request.Config.Name))
-
-	// check is not in progress, it should execute
-	agent.inProgressMu.Lock()
-	delete(agent.inProgress, checkKey(request))
-	agent.inProgressMu.Unlock()
-	assert.NoError(agent.handleCheck(context.TODO(), payload))
+	type args struct {
+		ctx     context.Context
+		payload []byte
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "errors when issued timestamp is older than the previous",
+			fields: fields{
+				lastIssued: map[string]int64{
+					"check": time.Now().Unix() + 1000,
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				payload: newCheckRequest(t, time.Now().Unix()),
+			},
+			wantErr:    true,
+			wantErrMsg: errOldCheckRequest.Error(),
+		},
+		{
+			name: "errors when issued timestamp is the same as the previous",
+			fields: fields{
+				lastIssued: map[string]int64{
+					"check": 1234,
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				payload: newCheckRequest(t, 1234),
+			},
+			wantErr:    true,
+			wantErrMsg: errDupCheckRequest.Error(),
+		},
+		{
+			name: "errors when check execution is already in progress",
+			fields: fields{
+				inProgress: map[string]*corev2.CheckConfig{
+					"check": corev2.FixtureCheckConfig("check"),
+				},
+				lastIssued: map[string]int64{
+					"check": 1234,
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				payload: newCheckRequest(t, 1235),
+			},
+			wantErr:    true,
+			wantErrMsg: "check execution still in progress: check",
+		},
+		{
+			name: "executes the first time a request for a check is received",
+			fields: fields{
+				inProgress: make(map[string]*corev2.CheckConfig),
+				lastIssued: make(map[string]int64),
+				sequences:  make(map[string]int64),
+			},
+			args: args{
+				ctx:     context.Background(),
+				payload: newCheckRequest(t, 1235),
+			},
+			wantErr: false,
+		},
+		{
+			name: "executes the second time a request for a check is received",
+			fields: fields{
+				inProgress: make(map[string]*corev2.CheckConfig),
+				lastIssued: map[string]int64{
+					"check": 1234,
+				},
+				sequences: map[string]int64{
+					"check": 1,
+				},
+			},
+			args: args{
+				ctx:     context.Background(),
+				payload: newCheckRequest(t, 1235),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agentConfig := &Config{}
+			ex := &mockexecutor.MockExecutor{}
+			execution := command.FixtureExecutionResponse(0, "")
+			ex.Return(execution, nil)
+			agent := &Agent{
+				config:       agentConfig,
+				executor:     ex,
+				inProgress:   tt.fields.inProgress,
+				inProgressMu: &sync.Mutex{},
+				lastIssued:   tt.fields.lastIssued,
+				lastIssuedMu: &sync.Mutex{},
+				marshal:      MarshalJSON,
+				sequences:    tt.fields.sequences,
+				unmarshal:    UnmarshalJSON,
+			}
+			err := agent.handleCheck(tt.args.ctx, tt.args.payload)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Agent.handleCheck() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && err.Error() != tt.wantErrMsg {
+				t.Errorf("Agent.handleCheck() error msg = %v, wantErrMsg %v", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
 }
 
 func TestCheckInProgress_GH2704(t *testing.T) {


### PR DESCRIPTION
## What is this change?

Adds a new map of check keys -> issued timestamps that is used to determine if received check requests are older than or duplicates of the last executed check request.

## Why is this change necessary?

Sensu backends currently send a check request to all matching subscriptions. If an agent and check have multiple matching subscriptions then the agent will receive the check request for every matching subscription. This can result in one of two undesirable behaviours:
1. If one of the check requests are still being executed when another is received it will result in the `check execution still in progress` error being logged.
2. If the check requests are executed quickly enough to avoid the `check execution still in progress` error then check history & features that rely on it (e.g. flap detection) may behave strangely.

## Does your change need a Changelog entry?

Yes.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required unless we want to document that agents and checks should only share one subscription.

## How did you verify this change?

I've added new test coverage.

## Is this change a patch?

No.
