### PR TITLE
Add Fields() methods to corev2 resources

### DIFF
--- a/api/core/v2/apikey.go
+++ b/api/core/v2/apikey.go
@@ -61,6 +61,11 @@ func APIKeyFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent the resource.
+func (a *APIKey) Fields() map[string]string {
+	return APIKeyFields(a)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (a *APIKey) SetNamespace(namespace string) {}
 

--- a/api/core/v2/apikey_test.go
+++ b/api/core/v2/apikey_test.go
@@ -44,7 +44,7 @@ func TestAPIKeyValidate(t *testing.T) {
 func TestAPIKeyFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -73,9 +73,9 @@ func TestAPIKeyFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := APIKeyFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("APIKeyFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("APIKey.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/asset.go
+++ b/api/core/v2/asset.go
@@ -147,6 +147,11 @@ func AssetFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (a *Asset) Fields() map[string]string {
+	return AssetFields(a)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (a *Asset) SetNamespace(namespace string) {
 	a.Namespace = namespace

--- a/api/core/v2/asset_test.go
+++ b/api/core/v2/asset_test.go
@@ -64,7 +64,7 @@ func TestValidateName_GH3344(t *testing.T) {
 func TestAssetFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -93,7 +93,7 @@ func TestAssetFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AssetFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
 				t.Errorf("AssetFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}

--- a/api/core/v2/check_config.go
+++ b/api/core/v2/check_config.go
@@ -251,3 +251,8 @@ func CheckConfigFields(r Resource) map[string]string {
 
 	return fields
 }
+
+// CheckConfigFields returns a set of fields that represent that resource
+func (c *CheckConfig) Fields() map[string]string {
+	return CheckConfigFields(c)
+}

--- a/api/core/v2/check_config_test.go
+++ b/api/core/v2/check_config_test.go
@@ -144,7 +144,7 @@ func TestSortCheckConfigsByName(t *testing.T) {
 func TestCheckConfigFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -167,6 +167,18 @@ func TestCheckConfigFields(t *testing.T) {
 			want:    "true",
 		},
 		{
+			name: "exposes pipelines",
+			args: &CheckConfig{
+				Pipelines: []*ResourceReference{{
+					Name:       "xxx",
+					Type:       "yyy",
+					APIVersion: "zzz",
+				}},
+			},
+			wantKey: "check.pipelines",
+			want:    "zzz.yyy(Name=xxx)",
+		},
+		{
 			name: "exposes labels",
 			args: &CheckConfig{
 				ObjectMeta: ObjectMeta{
@@ -179,9 +191,9 @@ func TestCheckConfigFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CheckConfigFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("CheckConfigFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("CheckConfig.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/entity.go
+++ b/api/core/v2/entity.go
@@ -180,6 +180,11 @@ func EntityFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (e *Entity) Fields() map[string]string {
+	return EntityFields(e)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (e *Entity) SetNamespace(namespace string) {
 	e.Namespace = namespace

--- a/api/core/v2/entity_test.go
+++ b/api/core/v2/entity_test.go
@@ -56,7 +56,7 @@ func TestEntityMarshal(t *testing.T) {
 func TestEntityFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -85,9 +85,9 @@ func TestEntityFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := EntityFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("EntityFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Entity.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/event.go
+++ b/api/core/v2/event.go
@@ -332,6 +332,11 @@ func EventFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (e *Event) Fields() map[string]string {
+	return EventFields(e)
+}
+
 func isSilenced(e *Event) string {
 	if len(e.Check.Silenced) > 0 {
 		return "true"

--- a/api/core/v2/event_test.go
+++ b/api/core/v2/event_test.go
@@ -764,7 +764,7 @@ func TestUnmarshalID(t *testing.T) {
 func TestEventFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -816,9 +816,9 @@ func TestEventFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := EventFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("EventFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Event.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/extension.go
+++ b/api/core/v2/extension.go
@@ -61,6 +61,11 @@ func ExtensionFields(r Resource) map[string]string {
 	return fields
 }
 
+// ExtensionFields returns a set of fields that represent that resource
+func (e *Extension) Fields() map[string]string {
+	return ExtensionFields(e)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (e *Extension) SetNamespace(namespace string) {
 	e.Namespace = namespace

--- a/api/core/v2/extension_test.go
+++ b/api/core/v2/extension_test.go
@@ -8,7 +8,7 @@ import (
 func TestExtensionFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -31,9 +31,9 @@ func TestExtensionFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtensionFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("ExtensionFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Extension.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/fielder.go
+++ b/api/core/v2/fielder.go
@@ -1,0 +1,7 @@
+package v2
+
+// Fielder includes a set of fields that represent a resource.
+type Fielder interface {
+	// Fields returns a set of fields that represent the resource.
+	Fields() map[string]string
+}

--- a/api/core/v2/filter.go
+++ b/api/core/v2/filter.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/sensu/sensu-go/api/core/v2/internal/js"
-	stringsutil "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 	utilstrings "github.com/sensu/sensu-go/api/core/v2/internal/stringutil"
 )
 
@@ -173,8 +172,13 @@ func EventFilterFields(r Resource) map[string]string {
 		"filter.action":         resource.Action,
 		"filter.runtime_assets": strings.Join(resource.RuntimeAssets, ","),
 	}
-	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "filter.labels.")
+	utilstrings.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "filter.labels.")
 	return fields
+}
+
+// Fields returns a set of fields that represent that resource
+func (e *EventFilter) Fields() map[string]string {
+	return EventFilterFields(e)
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/filter_test.go
+++ b/api/core/v2/filter_test.go
@@ -49,7 +49,7 @@ func TestEventFilterValidate(t *testing.T) {
 func TestEventFilterFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -78,9 +78,9 @@ func TestEventFilterFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := EventFilterFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("EventFilterFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("EventFilter.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/handler.go
+++ b/api/core/v2/handler.go
@@ -195,6 +195,11 @@ func HandlerFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (h *Handler) Fields() map[string]string {
+	return HandlerFields(h)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (h *Handler) SetNamespace(namespace string) {
 	h.Namespace = namespace

--- a/api/core/v2/handler_test.go
+++ b/api/core/v2/handler_test.go
@@ -238,7 +238,7 @@ func TestSortHandlersByName(t *testing.T) {
 func TestHandlerFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -267,7 +267,7 @@ func TestHandlerFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := HandlerFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
 				t.Errorf("HandlerFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}

--- a/api/core/v2/hook.go
+++ b/api/core/v2/hook.go
@@ -177,6 +177,11 @@ func HookConfigFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (h *HookConfig) Fields() map[string]string {
+	return HookConfigFields(h)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (c *HookConfig) SetNamespace(namespace string) {
 	c.Namespace = namespace

--- a/api/core/v2/hook_test.go
+++ b/api/core/v2/hook_test.go
@@ -112,7 +112,7 @@ func TestHookUnmarshal_GH1520(t *testing.T) {
 func TestHookConfigFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -135,9 +135,9 @@ func TestHookConfigFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := HookConfigFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("HookConfigFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("HookConfig.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/mutator.go
+++ b/api/core/v2/mutator.go
@@ -160,6 +160,11 @@ func MutatorFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (m *Mutator) Fields() map[string]string {
+	return MutatorFields(m)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (m *Mutator) SetNamespace(namespace string) {
 	m.Namespace = namespace

--- a/api/core/v2/mutator_test.go
+++ b/api/core/v2/mutator_test.go
@@ -70,7 +70,7 @@ func TestSortMutatorsByName(t *testing.T) {
 func TestMutatorFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -93,9 +93,9 @@ func TestMutatorFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MutatorFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("MutatorFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Mutator.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/namespace.go
+++ b/api/core/v2/namespace.go
@@ -54,6 +54,11 @@ func NamespaceFields(r Resource) map[string]string {
 	}
 }
 
+// Fields returns a set of fields that represent that resource
+func (n *Namespace) Fields() map[string]string {
+	return NamespaceFields(n)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (n *Namespace) SetNamespace(namespace string) {
 }

--- a/api/core/v2/namespace_test.go
+++ b/api/core/v2/namespace_test.go
@@ -8,7 +8,7 @@ import (
 func TestNamespaceFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -21,9 +21,9 @@ func TestNamespaceFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NamespaceFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("NamespaceFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Namespace.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/pipeline.go
+++ b/api/core/v2/pipeline.go
@@ -77,6 +77,11 @@ func PipelineFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource.
+func (p *Pipeline) Fields() map[string]string {
+	return PipelineFields(p)
+}
+
 // FixturePipeline returns a testing fixture for a Pipeline object.
 func FixturePipeline(name, namespace string) *Pipeline {
 	return &Pipeline{

--- a/api/core/v2/pipeline_test.go
+++ b/api/core/v2/pipeline_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -282,6 +283,36 @@ func TestResourceReference_validate(t *testing.T) {
 			}
 			if err != nil && err.Error() != tt.wantMsg {
 				t.Errorf("ResourceReference.validate() error = %v, wantMsg %v", err.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestPipelineFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Fielder
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixturePipeline("contoso", "default"),
+			wantKey: "pipeline.name",
+			want:    "contoso",
+		},
+		{
+			name:    "exposes namespace",
+			args:    FixturePipeline("contoso", "default"),
+			wantKey: "pipeline.namespace",
+			want:    "default",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Fields()
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("Pipeline.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/rbac.go
+++ b/api/core/v2/rbac.go
@@ -380,6 +380,11 @@ func ClusterRoleFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (c *ClusterRole) Fields() map[string]string {
+	return ClusterRoleFields(c)
+}
+
 // ClusterRoleBindingFields returns a set of fields that represent that resource
 func ClusterRoleBindingFields(r Resource) map[string]string {
 	resource := r.(*ClusterRoleBinding)
@@ -390,6 +395,11 @@ func ClusterRoleBindingFields(r Resource) map[string]string {
 	}
 	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "clusterrolebinding.labels.")
 	return fields
+}
+
+// Fields returns a set of fields that represent that resource
+func (c *ClusterRoleBinding) Fields() map[string]string {
+	return ClusterRoleBindingFields(c)
 }
 
 // RoleFields returns a set of fields that represent that resource
@@ -403,6 +413,11 @@ func RoleFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (c *Role) Fields() map[string]string {
+	return RoleFields(c)
+}
+
 // RoleBindingFields returns a set of fields that represent that resource
 func RoleBindingFields(r Resource) map[string]string {
 	resource := r.(*RoleBinding)
@@ -414,6 +429,11 @@ func RoleBindingFields(r Resource) map[string]string {
 	}
 	stringsutil.MergeMapWithPrefix(fields, resource.ObjectMeta.Labels, "rolebinding.labels.")
 	return fields
+}
+
+// Fields returns a set of fields that represent that resource
+func (c *RoleBinding) Fields() map[string]string {
+	return RoleBindingFields(c)
 }
 
 // SetNamespace sets the namespace of the resource.

--- a/api/core/v2/rbac_test.go
+++ b/api/core/v2/rbac_test.go
@@ -360,3 +360,99 @@ func TestValidateRoleRef(t *testing.T) {
 		})
 	}
 }
+
+func TestRoleFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Fielder
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureRole("contoso", "default"),
+			wantKey: "role.name",
+			want:    "contoso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Fields()
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("Role.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoleBindingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Fielder
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureRoleBinding("contoso", "default"),
+			wantKey: "rolebinding.name",
+			want:    "contoso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Fields()
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("RoleBinding.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterRoleFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Fielder
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureClusterRole("contoso"),
+			wantKey: "clusterrole.name",
+			want:    "contoso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Fields()
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("ClusterRole.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    Fielder
+		wantKey string
+		want    string
+	}{
+		{
+			name:    "exposes name",
+			args:    FixtureClusterRoleBinding("contoso"),
+			wantKey: "clusterrolebinding.name",
+			want:    "contoso",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.args.Fields()
+			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
+				t.Errorf("ClusterRoleBinding.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+			}
+		})
+	}
+}

--- a/api/core/v2/silenced.go
+++ b/api/core/v2/silenced.go
@@ -201,6 +201,11 @@ func SilencedFields(r Resource) map[string]string {
 	return fields
 }
 
+// Fields returns a set of fields that represent that resource
+func (s *Silenced) Fields() map[string]string {
+	return SilencedFields(s)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (s *Silenced) SetNamespace(namespace string) {
 	s.Namespace = namespace

--- a/api/core/v2/silenced_test.go
+++ b/api/core/v2/silenced_test.go
@@ -165,7 +165,7 @@ func TestSilencedMatches(t *testing.T) {
 func TestSilencedFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -194,9 +194,9 @@ func TestSilencedFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SilencedFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
-				t.Errorf("SilencedFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
+				t.Errorf("Silenced.Fields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}
 		})
 	}

--- a/api/core/v2/user.go
+++ b/api/core/v2/user.go
@@ -70,6 +70,11 @@ func UserFields(r Resource) map[string]string {
 	}
 }
 
+// Fields returns a set of fields that represent that resource
+func (u *User) Fields() map[string]string {
+	return UserFields(u)
+}
+
 // SetNamespace sets the namespace of the resource.
 func (u *User) SetNamespace(namespace string) {
 }

--- a/api/core/v2/user_test.go
+++ b/api/core/v2/user_test.go
@@ -43,7 +43,7 @@ func TestUserValidatePassword(t *testing.T) {
 func TestUserFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		args    Resource
+		args    Fielder
 		wantKey string
 		want    string
 	}{
@@ -62,7 +62,7 @@ func TestUserFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := UserFields(tt.args)
+			got := tt.args.Fields()
 			if !reflect.DeepEqual(got[tt.wantKey], tt.want) {
 				t.Errorf("UserFields() = got[%s] %v, want[%s] %v", tt.wantKey, got[tt.wantKey], tt.wantKey, tt.want)
 			}


### PR DESCRIPTION
## Summary

Adds a new `Fields()` method to each resource with a corresponding fieldset function. This will allow consumers of the package to retrieve the fieldset from the resource without having to know the requisite function before hand.

Continuation of: https://github.com/sensu/sensu-go/pull/4772
Required for: https://github.com/sensu/sensu-enterprise-go/pull/2280

## Usage

```go
check := corev2.FixtureCheckConfig("disk-check")

selector, ok := selector.ParseFieldSelector(q)
selector.Matches(check.Fields())
```
