### PR TITLE
Use only storev2 for rbac package

### DIFF
--- a/api/core/v2/compat.go
+++ b/api/core/v2/compat.go
@@ -231,7 +231,7 @@ func (s *Silenced) SetMetadata(meta *ObjectMeta) {
 }
 
 func (u *User) StoreName() string {
-	return u.StorePrefix()
+	return "users"
 }
 
 func (u *User) GetMetadata() *ObjectMeta {

--- a/api/core/v2/compat.go
+++ b/api/core/v2/compat.go
@@ -229,3 +229,18 @@ func (s *Silenced) GetMetadata() *ObjectMeta {
 func (s *Silenced) SetMetadata(meta *ObjectMeta) {
 	s.ObjectMeta = *meta
 }
+
+func (u *User) StoreName() string {
+	return u.StorePrefix()
+}
+
+func (u *User) GetMetadata() *ObjectMeta {
+	return &ObjectMeta{
+		Namespace: "",
+		Name:      u.Username,
+	}
+}
+
+func (u *User) SetMetadata(meta *ObjectMeta) {
+	u.Username = meta.Name
+}

--- a/backend/authorization/rbac/rbac.go
+++ b/backend/authorization/rbac/rbac.go
@@ -7,6 +7,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,20 +27,10 @@ func (e ErrRoleNotFound) Error() string {
 	return fmt.Sprintf("%s not found: %s", e.Type(), e.Role)
 }
 
-// Store is the storage requirements for the Authorizer. If you find that you
-// need functionality that is not in here, add it method by method. The god
-// type in the store package will have it.
-type Store interface {
-	ListClusterRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.ClusterRoleBinding, error)
-	ListRoleBindings(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.RoleBinding, error)
-	GetRole(ctx context.Context, name string) (*corev2.Role, error)
-	GetClusterRole(ctx context.Context, name string) (*corev2.ClusterRole, error)
-}
-
 // Authorizer implements an authorizer interface using Role-Based Acccess
 // Control (RBAC)
 type Authorizer struct {
-	Store Store
+	Store storev2.Interface
 }
 
 // RoleBinding implements the RoleBinding interface.
@@ -59,9 +50,17 @@ type RuleVisitFunc func(RoleBinding, corev2.Rule, error) (terminate bool)
 // It is up to the visitor function to make a useful decision about the
 // information it is given. For an example, see the Authorize method.
 func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Attributes, visitor RuleVisitFunc) {
+	namespace := corev2.ContextNamespace(ctx)
 	var empty = corev2.Rule{}
-	clusterRoleBindings, err := a.Store.ListClusterRoleBindings(ctx, &store.SelectionPredicate{})
+	req := storev2.NewResourceRequest(ctx, namespace, "", new(corev2.ClusterRoleBinding).StoreName())
+	list, err := a.Store.List(req, nil)
 	if err != nil {
+		if !visitor(nil, empty, err) {
+			return
+		}
+	}
+	var clusterRoleBindings []*corev2.ClusterRoleBinding
+	if err := list.UnwrapInto(&clusterRoleBindings); err != nil {
 		if !visitor(nil, empty, err) {
 			return
 		}
@@ -73,7 +72,7 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 		}
 
 		// Get the RoleRef that matched our user
-		rules, err := a.getRoleReferenceRules(ctx, binding.RoleRef)
+		rules, err := a.getRoleReferenceRules(ctx, namespace, binding.RoleRef)
 		if err != nil {
 			if !visitor(binding, empty, err) {
 				return
@@ -90,8 +89,15 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 		return
 	}
 
-	roleBindings, err := a.Store.ListRoleBindings(ctx, &store.SelectionPredicate{})
+	req = storev2.NewResourceRequest(ctx, namespace, "", new(corev2.RoleBinding).StoreName())
+	list, err = a.Store.List(req, &store.SelectionPredicate{})
 	if err != nil {
+		if !visitor(nil, empty, err) {
+			return
+		}
+	}
+	var roleBindings []*corev2.RoleBinding
+	if err := list.UnwrapInto(&roleBindings); err != nil {
 		if !visitor(nil, empty, err) {
 			return
 		}
@@ -106,7 +112,7 @@ func (a *Authorizer) VisitRulesFor(ctx context.Context, attrs *authorization.Att
 		ctx = store.NamespaceContext(ctx, binding.Namespace)
 
 		// Get the RoleRef that matched our user
-		rules, err := a.getRoleReferenceRules(ctx, binding.RoleRef)
+		rules, err := a.getRoleReferenceRules(ctx, binding.Namespace, binding.RoleRef)
 		if err != nil {
 			if !visitor(nil, empty, err) {
 				return
@@ -183,23 +189,37 @@ func (a *Authorizer) Authorize(ctx context.Context, attrs *authorization.Attribu
 	return authorized, visitErr
 }
 
-func (a *Authorizer) getRoleReferenceRules(ctx context.Context, roleRef corev2.RoleRef) ([]corev2.Rule, error) {
+func (a *Authorizer) getRoleReferenceRules(ctx context.Context, namespace string, roleRef corev2.RoleRef) ([]corev2.Rule, error) {
 	switch roleRef.Type {
 	case "Role":
-		role, err := a.Store.GetRole(ctx, roleRef.Name)
-		if err != nil {
-			return nil, fmt.Errorf("could not retrieve the Role %s: %s", roleRef.Name, err.Error())
-		} else if role == nil {
+		req := storev2.NewResourceRequest(ctx, namespace, roleRef.Name, new(corev2.Role).StoreName())
+		wrapper, err := a.Store.Get(req)
+		if _, ok := err.(*store.ErrNotFound); ok {
 			return nil, ErrRoleNotFound{Role: roleRef.Name, Cluster: false}
+		} else if err != nil {
+			return nil, fmt.Errorf("could not retrieve the role %s: %s", roleRef.Name, err)
+		} else if wrapper == nil {
+			return nil, &store.ErrNotFound{Key: "?"}
+		}
+		var role corev2.Role
+		if err := wrapper.UnwrapInto(&role); err != nil {
+			return nil, err
 		}
 		return role.Rules, nil
 
 	case "ClusterRole":
-		clusterRole, err := a.Store.GetClusterRole(ctx, roleRef.Name)
-		if err != nil {
-			return nil, fmt.Errorf("could not retrieve the ClusterRole %s: %s", roleRef.Name, err.Error())
-		} else if clusterRole == nil {
+		req := storev2.NewResourceRequest(ctx, namespace, roleRef.Name, new(corev2.ClusterRole).StoreName())
+		wrapper, err := a.Store.Get(req)
+		if _, ok := err.(*store.ErrNotFound); ok {
 			return nil, ErrRoleNotFound{Role: roleRef.Name, Cluster: true}
+		} else if err != nil {
+			return nil, fmt.Errorf("could not retrieve the ClusterRole %s: %s", roleRef.Name, err.Error())
+		} else if wrapper == nil {
+			return nil, &store.ErrNotFound{Key: "?"}
+		}
+		var clusterRole corev2.ClusterRole
+		if err := wrapper.UnwrapInto(&clusterRole); err != nil {
+			return nil, err
 		}
 		return clusterRole.Rules, nil
 

--- a/backend/authorization/rbac/rbac_test.go
+++ b/backend/authorization/rbac/rbac_test.go
@@ -3,19 +3,63 @@ package rbac
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/authorization"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/mock"
 )
 
+type wrapList[T corev3.Resource] []T
+
+func (w wrapList[T]) Unwrap() ([]corev3.Resource, error) {
+	result := make([]corev3.Resource, 0)
+	for _, resource := range w {
+		result = append(result, resource)
+	}
+	return result, nil
+}
+
+func (w wrapList[T]) UnwrapInto(target interface{}) error {
+	list, ok := target.(*[]T)
+	if !ok {
+		return errors.New("bad target")
+	}
+	*list = w
+	return nil
+}
+
+func (w wrapList[T]) Len() int {
+	return len(w)
+}
+
+type wrapper[T corev3.Resource] struct {
+	Value T
+}
+
+func (w wrapper[T]) Unwrap() (corev3.Resource, error) {
+	return w.Value, nil
+}
+
+func (w wrapper[T]) UnwrapInto(target interface{}) error {
+	val, ok := target.(T)
+	if !ok {
+		panic("bad target")
+	}
+	reflect.ValueOf(val).Elem().Set(reflect.ValueOf(w.Value).Elem())
+	return nil
+}
+
 func TestAuthorize(t *testing.T) {
-	type storeFunc func(*mockstore.MockStore)
-	var nilClusterRoleBindings []*corev2.ClusterRoleBinding
-	var nilRoleBindings []*corev2.RoleBinding
+	type storeFunc func(*mockstore.V2MockStore)
+	ctx := store.NamespaceContext(context.Background(), "acme")
+	clusterRoleBindingListRequest := storev2.NewResourceRequest(ctx, "acme", "", new(corev2.ClusterRoleBinding).StoreName())
+	roleBindingListRequest := storev2.NewResourceRequest(ctx, "acme", "", new(corev2.RoleBinding).StoreName())
 	tests := []struct {
 		name      string
 		attrs     *authorization.Attributes
@@ -26,19 +70,19 @@ func TestAuthorize(t *testing.T) {
 		{
 			name:  "no bindings",
 			attrs: &authorization.Attributes{Namespace: "acme"},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilRoleBindings, nil)
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding](nil), nil)
 			},
 			want: false,
 		},
 		{
 			name: "ClusterRoleBindings store err",
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, errors.New("error"))
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", mock.Anything, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), errors.New("error"))
 			},
 			wantErr: true,
 		},
@@ -50,28 +94,29 @@ func TestAuthorize(t *testing.T) {
 					Username: "foo",
 				},
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.ClusterRoleBinding{{
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding]{{
 						Subjects: []corev2.Subject{
 							{Type: corev2.UserType, Name: "bar"},
 						},
 					}}, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilRoleBindings, nil)
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding](nil), nil)
 			},
 			want: false,
 		},
 		{
 			name: "GetClusterRole store err",
 			attrs: &authorization.Attributes{
+				Namespace: "acme",
 				User: corev2.User{
 					Username: "foo",
 				},
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.ClusterRoleBinding{{
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", mock.Anything, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
 							Name: "admin",
@@ -79,8 +124,8 @@ func TestAuthorize(t *testing.T) {
 						Subjects: []corev2.Subject{
 							{Type: corev2.UserType, Name: "foo"},
 						},
-					}}, nil)
-				s.On("GetClusterRole", mock.Anything, "admin").
+					}}, (error)(nil))
+				s.On("Get", mock.Anything).
 					Return(nil, errors.New("error"))
 			},
 			wantErr: true,
@@ -95,9 +140,9 @@ func TestAuthorize(t *testing.T) {
 					Username: "foo",
 				},
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.ClusterRoleBinding{{
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
 							Name: "admin",
@@ -106,25 +151,25 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetClusterRole", mock.Anything, "admin").
-					Return(&corev2.ClusterRole{Rules: []corev2.Rule{
+				s.On("Get", mock.Anything).
+					Return(wrapper[*corev2.ClusterRole](wrapper[*corev2.ClusterRole]{Value: &corev2.ClusterRole{Rules: []corev2.Rule{
 						{
 							Verbs:         []string{"create"},
 							Resources:     []string{"checks"},
 							ResourceNames: []string{"check-cpu"},
 						},
-					}}, nil)
+					}}}), nil)
 			},
 			want: true,
 		},
 		{
 			name:  "RoleBindings store err",
 			attrs: &authorization.Attributes{Namespace: "acme"},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilRoleBindings, errors.New("error"))
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding](nil), errors.New("error"))
 			},
 			wantErr: true,
 		},
@@ -136,11 +181,11 @@ func TestAuthorize(t *testing.T) {
 					Username: "foo",
 				},
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.RoleBinding{{
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
 							Name: "admin",
@@ -149,8 +194,8 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.Anything, "admin").
-					Return(nil, nil)
+				s.On("Get", mock.Anything).
+					Return(nil, &store.ErrNotFound{})
 			},
 			want:    false,
 			wantErr: true,
@@ -163,11 +208,11 @@ func TestAuthorize(t *testing.T) {
 					Username: "foo",
 				},
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.RoleBinding{{
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
 							Name: "admin",
@@ -176,8 +221,8 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.Anything, "admin").
-					Return(nil, errors.New("error"))
+				s.On("Get", mock.Anything).
+					Return(nil, &store.ErrNotFound{})
 			},
 			wantErr: true,
 		},
@@ -192,12 +237,12 @@ func TestAuthorize(t *testing.T) {
 				Resource:     "checks",
 				ResourceName: "check-cpu",
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.RoleBinding{{
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
 							Name: "admin",
@@ -206,14 +251,14 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.Anything, "admin").
-					Return(&corev2.Role{Rules: []corev2.Rule{
+				s.On("Get", mock.Anything).
+					Return(wrapper[*corev2.Role]{Value: &corev2.Role{Rules: []corev2.Rule{
 						{
 							Verbs:         []string{"create"},
 							Resources:     []string{"checks"},
 							ResourceNames: []string{"check-cpu"},
 						},
-					}}, nil)
+					}}}, nil)
 			},
 			want: true,
 		},
@@ -226,12 +271,12 @@ func TestAuthorize(t *testing.T) {
 				Verb:     "list",
 				Resource: "users",
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.RoleBinding{{
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
 							Name: "cluster-admin",
@@ -240,13 +285,13 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetClusterRole", mock.Anything, "cluster-admin").
-					Return(&corev2.ClusterRole{Rules: []corev2.Rule{
+				s.On("Get", mock.Anything).
+					Return(wrapper[*corev2.ClusterRole]{Value: &corev2.ClusterRole{Rules: []corev2.Rule{
 						{
 							Verbs:     []string{"*"},
 							Resources: []string{"*"},
 						},
-					}}, nil)
+					}}}, nil)
 			},
 			want: false,
 		},
@@ -261,12 +306,12 @@ func TestAuthorize(t *testing.T) {
 				Resource:     "checks",
 				ResourceName: "check-cpu",
 			},
-			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return(nilClusterRoleBindings, nil)
+			storeFunc: func(s *mockstore.V2MockStore) {
+				s.On("List", clusterRoleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.ClusterRoleBinding](nil), nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-					Return([]*corev2.RoleBinding{{
+				s.On("List", roleBindingListRequest, mock.Anything).
+					Return(wrapList[*corev2.RoleBinding]{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
 							Name: "admin",
@@ -275,8 +320,8 @@ func TestAuthorize(t *testing.T) {
 							{Type: corev2.UserType, Name: "foo"},
 						},
 					}}, nil)
-				s.On("GetRole", mock.Anything, "admin").
-					Return((*corev2.Role)(nil), nil)
+				s.On("Get", mock.Anything).
+					Return(wrapper[*corev2.Role]{Value: nil}, &store.ErrNotFound{})
 			},
 			want:    false,
 			wantErr: true,
@@ -284,13 +329,13 @@ func TestAuthorize(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			store := &mockstore.MockStore{}
+			store := &mockstore.V2MockStore{}
+			tc.storeFunc(store)
 			a := &Authorizer{
 				Store: store,
 			}
-			tc.storeFunc(store)
 
-			got, err := a.Authorize(context.Background(), tc.attrs)
+			got, err := a.Authorize(ctx, tc.attrs)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("Authorizer.Authorize() error = %v, wantErr %v", err, tc.wantErr)
 				return
@@ -438,12 +483,21 @@ func TestVisitRulesFor(t *testing.T) {
 		Resource:     "checks",
 		ResourceName: "check-cpu",
 	}
-	stor := &mockstore.MockStore{}
+	stor := &mockstore.V2MockStore{}
 	a := &Authorizer{
 		Store: stor,
 	}
-	stor.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-		Return([]*corev2.ClusterRoleBinding{{
+	ctx := store.NamespaceContext(context.Background(), "acme")
+	clusterRoleBindingListRequest := storev2.NewResourceRequest(ctx, "acme", "", new(corev2.ClusterRoleBinding).StoreName())
+	roleBindingListRequest := storev2.NewResourceRequest(ctx, "acme", "", new(corev2.RoleBinding).StoreName())
+	roleRequest := storev2.NewResourceRequest(store.NamespaceContext(ctx, "acme"), "acme", "admin", new(corev2.Role).StoreName())
+	clusterRoleRequest := storev2.NewResourceRequest(ctx, "acme", "admin", new(corev2.ClusterRole).StoreName())
+
+	stor.On("List", clusterRoleBindingListRequest, mock.Anything).
+		Return(wrapList[*corev2.ClusterRoleBinding]{{
+			ObjectMeta: corev2.ObjectMeta{
+				Namespace: "acme",
+			},
 			RoleRef: corev2.RoleRef{
 				Type: "ClusterRole",
 				Name: "admin",
@@ -453,8 +507,11 @@ func TestVisitRulesFor(t *testing.T) {
 			},
 		}}, nil)
 
-	stor.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
-		Return([]*corev2.RoleBinding{{
+	stor.On("List", roleBindingListRequest, mock.Anything).
+		Return(wrapList[*corev2.RoleBinding]{{
+			ObjectMeta: corev2.ObjectMeta{
+				Namespace: "acme",
+			},
 			RoleRef: corev2.RoleRef{
 				Type: "Role",
 				Name: "admin",
@@ -463,26 +520,26 @@ func TestVisitRulesFor(t *testing.T) {
 				{Type: corev2.UserType, Name: "foo"},
 			},
 		}}, nil)
-	stor.On("GetRole", mock.Anything, "admin").
-		Return(&corev2.Role{Rules: []corev2.Rule{
+	stor.On("Get", roleRequest).
+		Return(wrapper[*corev2.Role]{Value: &corev2.Role{Rules: []corev2.Rule{
 			{
 				Verbs:         []string{"create"},
 				Resources:     []string{"checks"},
 				ResourceNames: []string{"check-cpu"},
 			},
-		}}, nil)
-	stor.On("GetClusterRole", mock.Anything, "admin").
-		Return(&corev2.ClusterRole{Rules: []corev2.Rule{
+		}}}, nil)
+	stor.On("Get", clusterRoleRequest).
+		Return(wrapper[*corev2.ClusterRole]{Value: &corev2.ClusterRole{Rules: []corev2.Rule{
 			{
 				Verbs:         []string{"delete"},
 				Resources:     []string{"checks"},
 				ResourceNames: []string{"check-cpu"},
 			},
-		}}, nil)
+		}}}, nil)
 
 	var rules []corev2.Rule
 
-	a.VisitRulesFor(context.Background(), attrs, func(binding RoleBinding, rule corev2.Rule, err error) bool {
+	a.VisitRulesFor(ctx, attrs, func(binding RoleBinding, rule corev2.Rule, err error) bool {
 		if err != nil {
 			t.Fatal(err)
 			return false

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -23,8 +23,7 @@ type WrapList interface {
 
 // Interface specifies the interface of a v2 store.
 type Interface interface {
-	// todo: uncomment after #4765 implements namespacestore on postgres store
-	// NamespaceStore
+	NamespaceStore
 
 	// CreateOrUpdate creates or updates the wrapped resource.
 	CreateOrUpdate(ResourceRequest, Wrapper) error

--- a/backend/store/v2/proxy.go
+++ b/backend/store/v2/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/patch"
 )
@@ -87,4 +88,16 @@ func (p *Proxy) Watch(ctx context.Context, req ResourceRequest) <-chan []WatchEv
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.impl.Watch(ctx, req)
+}
+
+func (p *Proxy) CreateNamespace(ctx context.Context, ns *corev3.Namespace) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.impl.CreateNamespace(ctx, ns)
+}
+
+func (p *Proxy) DeleteNamespace(ctx context.Context, name string) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.impl.DeleteNamespace(ctx, name)
 }

--- a/backend/store/v2/storetest/mock.go
+++ b/backend/store/v2/storetest/mock.go
@@ -3,6 +3,7 @@ package storetest
 import (
 	"context"
 
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/patch"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
@@ -58,4 +59,12 @@ func (s *Store) Patch(req storev2.ResourceRequest, w storev2.Wrapper, patcher pa
 
 func (s *Store) Watch(ctx context.Context, req storev2.ResourceRequest) <-chan []storev2.WatchEvent {
 	return s.Called(ctx, req).Get(0).(<-chan []storev2.WatchEvent)
+}
+
+func (s *Store) CreateNamespace(ctx context.Context, ns *corev3.Namespace) error {
+	return s.Called(ctx, ns).Error(0)
+}
+
+func (s *Store) DeleteNamespace(ctx context.Context, name string) error {
+	return s.Called(ctx, name).Error(0)
 }

--- a/testing/mockstore/v2.go
+++ b/testing/mockstore/v2.go
@@ -3,10 +3,10 @@ package mockstore
 import (
 	"context"
 
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/store"
 	"github.com/sensu/sensu-go/backend/store/patch"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -38,7 +38,7 @@ func (v *V2MockStore) Delete(req storev2.ResourceRequest) error {
 
 func (v *V2MockStore) List(req storev2.ResourceRequest, pred *store.SelectionPredicate) (storev2.WrapList, error) {
 	args := v.Called(req, pred)
-	list, _ := args.Get(0).(wrap.List)
+	list, _ := args.Get(0).(storev2.WrapList)
 	return list, args.Error(1)
 }
 
@@ -54,4 +54,12 @@ func (v *V2MockStore) Patch(req storev2.ResourceRequest, w storev2.Wrapper, patc
 func (v *V2MockStore) Watch(ctx context.Context, req storev2.ResourceRequest) <-chan []storev2.WatchEvent {
 	args := v.Called(ctx, req)
 	return args.Get(0).(<-chan []storev2.WatchEvent)
+}
+
+func (v *V2MockStore) CreateNamespace(ctx context.Context, ns *corev3.Namespace) error {
+	return v.Called(ctx, ns).Error(0)
+}
+
+func (v *V2MockStore) DeleteNamespace(ctx context.Context, name string) error {
+	return v.Called(ctx, name).Error(0)
 }


### PR DESCRIPTION
You must use go.work in order for this to work, core/v2 isn't tagged yet