### PR TITLE
Move agentd to storev2

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/backend/apid/actions"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/middlewares"
 	"github.com/sensu/sensu-go/backend/apid/routers"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
@@ -29,12 +29,10 @@ import (
 	"github.com/sensu/sensu-go/backend/metrics"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/backend/store/cache"
+	cachev2 "github.com/sensu/sensu-go/backend/store/cache/v2"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	"github.com/sensu/sensu-go/backend/store/v2/etcdstore"
 	"github.com/sensu/sensu-go/transport"
 	"github.com/sirupsen/logrus"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var (
@@ -89,33 +87,32 @@ type Agentd struct {
 	wg                  *sync.WaitGroup
 	errChan             chan error
 	httpServer          *http.Server
-	store               store.Store
-	storev2             storev2.Interface
+	store               storev2.Interface
 	bus                 messaging.MessageBus
 	tls                 *corev2.TLSOptions
 	ringPool            *ringv2.RingPool
 	ctx                 context.Context
 	cancel              context.CancelFunc
 	writeTimeout        int
-	namespaceCache      *cache.Resource
-	watcher             <-chan store.WatchEventEntityConfig
-	client              *clientv3.Client
+	namespaceCache      *cachev2.Resource
+	watcher             <-chan []storev2.WatchEvent
 	etcdClientTLSConfig *tls.Config
-	healthRouter        *routers.HealthRouter
+	healthRouter        routers.Router
+	authenticator       Authenticator
 }
 
 // Config configures an Agentd.
 type Config struct {
-	Host                string
-	Port                int
-	Bus                 messaging.MessageBus
-	Store               store.Store
-	TLS                 *corev2.TLSOptions
-	RingPool            *ringv2.RingPool
-	WriteTimeout        int
-	Client              *clientv3.Client
-	EtcdClientTLSConfig *tls.Config
-	Watcher             <-chan store.WatchEventEntityConfig
+	Host          string
+	Port          int
+	Bus           messaging.MessageBus
+	Store         storev2.Interface
+	TLS           *corev2.TLSOptions
+	RingPool      *ringv2.RingPool
+	WriteTimeout  int
+	Watcher       <-chan []storev2.WatchEvent
+	HealthRouter  routers.Router
+	Authenticator Authenticator
 }
 
 // Option is a functional option.
@@ -125,23 +122,21 @@ type Option func(*Agentd) error
 func New(c Config, opts ...Option) (*Agentd, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	a := &Agentd{
-		Host:                c.Host,
-		Port:                c.Port,
-		bus:                 c.Bus,
-		store:               c.Store,
-		tls:                 c.TLS,
-		stopping:            make(chan struct{}, 1),
-		running:             &atomic.Value{},
-		wg:                  &sync.WaitGroup{},
-		errChan:             make(chan error, 1),
-		ringPool:            c.RingPool,
-		ctx:                 ctx,
-		cancel:              cancel,
-		writeTimeout:        c.WriteTimeout,
-		storev2:             etcdstore.NewStore(c.Client),
-		watcher:             c.Watcher,
-		client:              c.Client,
-		etcdClientTLSConfig: c.EtcdClientTLSConfig,
+		Host:          c.Host,
+		Port:          c.Port,
+		bus:           c.Bus,
+		tls:           c.TLS,
+		stopping:      make(chan struct{}, 1),
+		running:       &atomic.Value{},
+		wg:            &sync.WaitGroup{},
+		errChan:       make(chan error, 1),
+		ringPool:      c.RingPool,
+		ctx:           ctx,
+		cancel:        cancel,
+		writeTimeout:  c.WriteTimeout,
+		store:         c.Store,
+		watcher:       c.Watcher,
+		authenticator: c.Authenticator,
 	}
 
 	// prepare server TLS config
@@ -163,9 +158,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	// runtime, so we need this workaround
 	router := mux.NewRouter()
 
-	a.healthRouter = routers.NewHealthRouter(
-		actions.NewHealthController(a.store, a.client.Cluster, a.etcdClientTLSConfig),
-	)
+	a.healthRouter = c.HealthRouter
 	a.healthRouter.Mount(router)
 
 	route := router.NewRoute().Subrouter()
@@ -195,7 +188,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		}
 	}
 
-	a.namespaceCache, err = cache.New(ctx, c.Client, &corev2.Namespace{}, false)
+	a.namespaceCache, err = cachev2.New(ctx, c.Store, &corev3.Namespace{}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -247,24 +240,35 @@ func (a *Agentd) runWatcher() {
 		select {
 		case <-a.ctx.Done():
 			return
-		case event, ok := <-a.watcher:
+		case events, ok := <-a.watcher:
 			if !ok {
 				return
 			}
-			if err := a.handleEvent(event); err != nil {
-				logger.WithError(err).Error("error handling entity config watch event")
+			for _, event := range events {
+				if err := a.handleEvent(event); err != nil {
+					logger.WithError(err).Error("error handling entity config watch event")
+				}
 			}
 		}
 	}
 }
 
-func (a *Agentd) handleEvent(event store.WatchEventEntityConfig) error {
-	if event.Entity == nil {
+func (a *Agentd) handleEvent(event storev2.WatchEvent) error {
+	changeEvent := entityChange{
+		Type:         event.Type,
+		EntityConfig: new(corev3.EntityConfig),
+	}
+
+	if event.Value == nil {
 		return errors.New("nil entity received from entity config watcher")
 	}
 
-	topic := messaging.EntityConfigTopic(event.Entity.Metadata.Namespace, event.Entity.Metadata.Name)
-	if err := a.bus.Publish(topic, &event); err != nil {
+	if err := event.Value.UnwrapInto(changeEvent.EntityConfig); err != nil {
+		return err
+	}
+
+	topic := messaging.EntityConfigTopic(event.Key.Namespace, event.Key.Name)
+	if err := a.bus.Publish(topic, &changeEvent); err != nil {
 		logger.WithField("topic", topic).WithError(err).
 			Error("unable to publish an entity config update to the bus")
 		return err
@@ -343,7 +347,8 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	var found bool
 	values := a.namespaceCache.Get("")
 	for _, value := range values {
-		if namespace == value.Resource.GetObjectMeta().Name {
+		objectMeta := value.Resource.GetMetadata()
+		if objectMeta != nil && objectMeta.Name == namespace {
 			found = true
 			break
 		}
@@ -372,8 +377,7 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 		WriteTimeout:   a.writeTimeout,
 		Bus:            a.bus,
 		Conn:           transport.NewTransport(conn),
-		Store:          a.store,
-		Storev2:        a.storev2,
+		Storev2:        a.store,
 		Marshal:        marshal,
 		Unmarshal:      unmarshal,
 		BurialReceiver: NewBurialReceiver(),
@@ -420,7 +424,7 @@ func (a *Agentd) AuthenticationMiddleware(next http.Handler) http.Handler {
 		}
 
 		// Authenticate against the provider
-		user, err := a.store.AuthenticateUser(r.Context(), username, password)
+		claims, err := a.authenticator.Authenticate(r.Context(), username, password)
 		if err != nil {
 			if r.Context().Err() != nil {
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -448,11 +452,10 @@ func (a *Agentd) AuthenticationMiddleware(next http.Handler) http.Handler {
 
 		// The user was authenticated against the local store, therefore add the
 		// system:user group so it can view itself and change its password
-		user.Groups = append(user.Groups, "system:user")
+		claims.Groups = append(claims.Groups, "system:user")
 
 		// TODO: eventually break out authorization details in context from jwt
 		// claims; in this method they are too tightly bound
-		claims, _ := jwt.NewClaims(user)
 		ctx := jwt.SetClaimsIntoContext(r, claims)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -524,8 +527,6 @@ func (a *Agentd) EntityLimiterMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// ReplaceHealthController replaces the default health controller. It
-// can be replaced by an enterprise controller to include more information.
-func (a *Agentd) ReplaceHealthController(controller routers.HealthController) {
-	a.healthRouter.Swap(controller)
+type Authenticator interface {
+	Authenticate(ctx context.Context, username, password string) (*corev2.Claims, error)
 }

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -1,11 +1,9 @@
 package agentd
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/gorilla/mux"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
 // AuthenticationMiddleware represents the middleware used for authentication
@@ -38,17 +36,4 @@ func authorize(next http.Handler) http.Handler {
 // runtime the actual function assigned to AgentLimiterMiddleware above.
 func agentLimit(next http.Handler) http.Handler {
 	return AgentLimiterMiddleware(next)
-}
-
-// AuthStore specifies the storage requirements for authentication and
-// authorization.
-type AuthStore interface {
-	// AuthenticateUser attempts to authenticate a user with the given username
-	// and hashed password. An error is returned if the user does not exist, is
-	// disabled or the given password does not match.
-	AuthenticateUser(ctx context.Context, user, pass string) (*corev2.User, error)
-
-	// GetUser directly retrieves a user with the given username. An error is
-	// returned if the user does not exist or is disabled
-	GetUser(ctx context.Context, username string) (*corev2.User, error)
 }

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -82,7 +82,6 @@ var (
 type Session struct {
 	cfg              SessionConfig
 	conn             transport.Transport
-	store            store.EntityStore
 	storev2          storev2.Interface
 	handler          *handler.MessageHandler
 	wg               *sync.WaitGroup
@@ -139,7 +138,6 @@ type SessionConfig struct {
 	Bus      messaging.MessageBus
 	Conn     transport.Transport
 	RingPool *ringv2.RingPool
-	Store    store.Store
 	Storev2  storev2.Interface
 
 	Marshal   agent.MarshalFunc
@@ -184,7 +182,6 @@ func NewSession(ctx context.Context, cfg SessionConfig) (*Session, error) {
 		cfg:              cfg,
 		wg:               &sync.WaitGroup{},
 		checkChannel:     make(chan interface{}, 100),
-		store:            cfg.Store,
 		storev2:          cfg.Storev2,
 		bus:              cfg.Bus,
 		subscriptionsMap: map[string]subscription{},
@@ -322,52 +319,53 @@ func (s *Session) sender() {
 		var msg *transport.Message
 		select {
 		case e := <-s.entityConfig.updatesChannel:
-			watchEvent, ok := e.(*store.WatchEventEntityConfig)
+			watchEvent, ok := e.(*entityChange)
 			if !ok {
 				logger.Errorf("session received unexpected struct: %T", e)
 				continue
 			}
 
 			// Handle the delete and unknown watch events
-			switch watchEvent.Action {
-			case store.WatchDelete:
+			switch watchEvent.Type {
+			case storev2.WatchDelete:
 				// stop session
 				return
-			case store.WatchUnknown:
+			case storev2.WatchUnknown:
 				logger.Error("session received unknown watch event")
 				continue
 			}
 
-			if watchEvent.Entity == nil {
+			if watchEvent.EntityConfig == nil {
 				logger.Error("session received nil entity in watch event")
 				continue
 			}
 
+			entity := watchEvent.EntityConfig
 			lager := logger.WithFields(logrus.Fields{
-				"action":    watchEvent.Action.String(),
-				"entity":    watchEvent.Entity.Metadata.Name,
-				"namespace": watchEvent.Entity.Metadata.Namespace,
+				"action":    watchEvent.Type.String(),
+				"entity":    entity.Metadata.Name,
+				"namespace": entity.Metadata.Namespace,
 			})
 			lager.Debug("entity update received")
 
 			// Enforce the entity class to agent
-			if watchEvent.Entity.EntityClass != corev2.EntityAgentClass {
-				watchEvent.Entity.EntityClass = corev2.EntityAgentClass
+			if entity.EntityClass != corev2.EntityAgentClass {
+				entity.EntityClass = corev2.EntityAgentClass
 				lager.Warningf(
 					"misconfigured entity class %q, updating entity to be a %s",
-					watchEvent.Entity.EntityClass,
+					entity.EntityClass,
 					corev2.EntityAgentClass,
 				)
 
 				// Update the entity in the store
-				configReq := storev2.NewResourceRequestFromResource(s.ctx, watchEvent.Entity)
-				wrapper, err := storev2.WrapResource(watchEvent.Entity)
+				configReq := storev2.NewResourceRequestFromResource(entity)
+				wrapper, err := storev2.WrapResource(entity)
 				if err != nil {
 					lager.WithError(err).Error("could not wrap the entity config")
 					continue
 				}
 
-				if err := s.storev2.CreateOrUpdate(configReq, wrapper); err != nil {
+				if err := s.storev2.CreateOrUpdate(s.ctx, configReq, wrapper); err != nil {
 					sessionErrorCounter.WithLabelValues(err.Error()).Inc()
 					lager.WithError(err).Error("could not update the entity config")
 				}
@@ -377,7 +375,7 @@ func (s *Session) sender() {
 				continue
 			}
 
-			bytes, err := s.marshal(watchEvent.Entity)
+			bytes, err := s.marshal(entity)
 			if err != nil {
 				lager.WithError(err).Error("session failed to serialize entity config")
 				continue
@@ -387,7 +385,7 @@ func (s *Session) sender() {
 			// sorting the subscriptions and then comparing those
 			s.mu.Lock()
 			oldSubscriptions := sortSubscriptions(s.cfg.Subscriptions)
-			newSubscriptions := sortSubscriptions(watchEvent.Entity.Subscriptions)
+			newSubscriptions := sortSubscriptions(entity.Subscriptions)
 			added, removed := diff(oldSubscriptions, newSubscriptions)
 			s.cfg.Subscriptions = newSubscriptions
 			s.mu.Unlock()
@@ -402,7 +400,7 @@ func (s *Session) sender() {
 				s.unsubscribe(removed)
 			}
 
-			if watchEvent.Entity.Metadata.Labels[corev2.ManagedByLabel] == "sensu-agent" {
+			if entity.Metadata.Labels[corev2.ManagedByLabel] == "sensu-agent" {
 				lager.Debug("not sending entity update because entity is managed by its agent")
 			}
 
@@ -487,8 +485,10 @@ func (s *Session) Start() (err error) {
 	s.entityConfig.subscriptions <- subscription
 
 	// Determine if the entity already exists
-	req := storev2.NewResourceRequest(s.ctx, s.cfg.Namespace, s.cfg.AgentName, (&corev3.EntityConfig{}).StoreName())
-	wrapper, err := s.storev2.Get(req)
+	tmp := &corev3.EntityConfig{}
+
+	req := storev2.NewResourceRequest(tmp.GetTypeMeta(), s.cfg.Namespace, s.cfg.AgentName, tmp.StoreName())
+	wrapper, err := s.storev2.Get(s.ctx, req)
 	if err != nil {
 		// We do not want to send an error if the entity config does not exist
 		if _, ok := err.(*store.ErrNotFound); !ok {
@@ -530,11 +530,17 @@ func (s *Session) Start() (err error) {
 			delete(storedEntityConfig.Metadata.Labels, corev2.ManagedByLabel)
 		}
 
+		wrapper, err := storev2.WrapResource(&storedEntityConfig)
+		if err != nil {
+			lager.WithError(err).Error("error wrapping entity config")
+			return err
+		}
+
 		// Send back this entity config to the agent so it uses that rather than
 		// its local config for its events
-		watchEvent := &store.WatchEventEntityConfig{
-			Action: store.WatchUpdate,
-			Entity: &storedEntityConfig,
+		watchEvent := &storev2.WatchEvent{
+			Type:  storev2.WatchUpdate,
+			Value: wrapper,
 		}
 		err = s.bus.Publish(messaging.EntityConfigTopic(s.cfg.Namespace, s.cfg.AgentName), watchEvent)
 		if err != nil {
@@ -812,4 +818,9 @@ func sortSubscriptions(subscriptions []string) []string {
 	sortedSubscriptions := append(subscriptions[:0:0], subscriptions...)
 	sort.Strings(sortedSubscriptions)
 	return sortedSubscriptions
+}
+
+type entityChange struct {
+	Type         storev2.WatchActionType
+	EntityConfig *corev3.EntityConfig
 }

--- a/backend/agentd/watcher.go
+++ b/backend/agentd/watcher.go
@@ -2,71 +2,13 @@ package agentd
 
 import (
 	"context"
-	"errors"
 
-	"github.com/gogo/protobuf/proto"
-	corev2 "github.com/sensu/sensu-go/api/core/v2"
 	corev3 "github.com/sensu/sensu-go/api/core/v3"
-	"github.com/sensu/sensu-go/backend/store"
-	etcdstore "github.com/sensu/sensu-go/backend/store/etcd"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	etcdstorev2 "github.com/sensu/sensu-go/backend/store/v2/etcdstore"
-	"github.com/sensu/sensu-go/backend/store/v2/wrap"
-	"go.etcd.io/etcd/client/v3"
 )
 
-// GetEntityConfigWatcher watches changes to EntityConfig in etcd and publish them
-// over the bus as store.WatchEventEntityConfig
-func GetEntityConfigWatcher(ctx context.Context, client *clientv3.Client) <-chan store.WatchEventEntityConfig {
-	key := etcdstorev2.StoreKey(storev2.ResourceRequest{
-		Context:   ctx,
-		StoreName: new(corev3.EntityConfig).StoreName(),
-	})
-	w := etcdstore.Watch(ctx, client, key, true)
-	ch := make(chan store.WatchEventEntityConfig, 1)
-
-	go func() {
-		defer close(ch)
-		for response := range w.Result() {
-			if response.Type == store.WatchError {
-				logger.
-					WithError(errors.New(string(response.Object))).
-					Error("unexpected error while watching for entity config updates")
-				ch <- store.WatchEventEntityConfig{
-					Action: response.Type,
-				}
-				continue
-			}
-
-			var (
-				configWrapper wrap.Wrapper
-				entityConfig  corev3.EntityConfig
-			)
-
-			// Decode and unwrap the entity config
-			if err := proto.Unmarshal(response.Object, &configWrapper); err != nil {
-				logger.WithField("key", response.Key).WithError(err).
-					Error("unable to unmarshal entity config from key")
-				continue
-			}
-			if err := configWrapper.UnwrapInto(&entityConfig); err != nil {
-				logger.WithField("key", response.Key).WithError(err).
-					Error("unable to unwrap entity config from key")
-				continue
-			}
-
-			// Remove the managed_by label if the value is sensu-agent, in case the
-			// entity is no longer managed by its agent
-			if entityConfig.Metadata.Labels[corev2.ManagedByLabel] == "sensu-agent" {
-				delete(entityConfig.Metadata.Labels, corev2.ManagedByLabel)
-			}
-
-			ch <- store.WatchEventEntityConfig{
-				Action: response.Type,
-				Entity: &entityConfig,
-			}
-		}
-	}()
-
-	return ch
+// GetEntityConfigWatcher uses the store to build a watcher for all EntityConfig resources
+func GetEntityConfigWatcher(ctx context.Context, store storev2.Interface) <-chan []storev2.WatchEvent {
+	tmp := new(corev3.EntityConfig)
+	return store.Watch(ctx, storev2.NewResourceRequest(tmp.GetTypeMeta(), "", "", tmp.StoreName()))
 }

--- a/backend/agentd/watcher_test.go
+++ b/backend/agentd/watcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/sensu/sensu-go/backend/etcd"
+	"github.com/sensu/sensu-go/backend/store/v2/etcdstore"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +14,8 @@ func TestGetEntityConfigWatcher(t *testing.T) {
 	defer cleanup()
 	client := e.NewEmbeddedClient()
 	defer client.Close()
+	store := etcdstore.NewStore(client)
 
-	ch := GetEntityConfigWatcher(context.Background(), client)
+	ch := GetEntityConfigWatcher(context.Background(), store)
 	assert.NotNil(t, ch)
 }

--- a/backend/api/entity.go
+++ b/backend/api/entity.go
@@ -105,14 +105,14 @@ func (e *EntityClient) UpdateEntity(ctx context.Context, entity *corev2.Entity) 
 		config, _ := corev3.V2EntityToV3(entity)
 		// Ensure per-entity subscription does not get removed
 		config.Subscriptions = corev2.AddEntitySubscription(config.Metadata.Name, config.Subscriptions)
-		req := storev2.NewResourceRequestFromResource(ctx, config)
+		req := storev2.NewResourceRequestFromResource(config)
 
 		wConfig, err := storev2.WrapResource(config)
 		if err != nil {
 			return err
 		}
 
-		if err := e.storev2.CreateOrUpdate(req, wConfig); err != nil {
+		if err := e.storev2.CreateOrUpdate(ctx, req, wConfig); err != nil {
 			return err
 		}
 	}

--- a/backend/api/generic.go
+++ b/backend/api/generic.go
@@ -54,13 +54,13 @@ func (g GenericClient) validateConfig() error {
 func (g *GenericClient) createResource(ctx context.Context, value corev2.Resource) error {
 	if value, ok := value.(*corev3.V2ResourceProxy); ok {
 		resource := value.Resource
-		req := storev2.NewResourceRequestFromResource(ctx, resource)
+		req := storev2.NewResourceRequestFromResource(resource)
 		req.Namespace = corev2.ContextNamespace(ctx)
 		wrapper, err := storev2.WrapResource(resource)
 		if err != nil {
 			return err
 		}
-		return g.StoreV2.CreateIfNotExists(req, wrapper)
+		return g.StoreV2.CreateIfNotExists(ctx, req, wrapper)
 	}
 	return g.Store.CreateResource(ctx, value)
 }
@@ -107,13 +107,13 @@ func (g *GenericClient) SetTypeMeta(meta corev2.TypeMeta) error {
 func (g *GenericClient) updateResource(ctx context.Context, value corev2.Resource) error {
 	if value, ok := value.(*corev3.V2ResourceProxy); ok {
 		resource := value.Resource
-		req := storev2.NewResourceRequestFromResource(ctx, resource)
+		req := storev2.NewResourceRequestFromResource(resource)
 		req.Namespace = corev2.ContextNamespace(ctx)
 		wrapper, err := storev2.WrapResource(resource)
 		if err != nil {
 			return err
 		}
-		return g.StoreV2.CreateOrUpdate(req, wrapper)
+		return g.StoreV2.CreateOrUpdate(ctx, req, wrapper)
 	}
 	return g.Store.CreateOrUpdateResource(ctx, value)
 }
@@ -139,9 +139,8 @@ func (g *GenericClient) deleteResource(ctx context.Context, name string) error {
 			Namespace: corev2.ContextNamespace(ctx),
 			Name:      name,
 			StoreName: g.Kind.StorePrefix(),
-			Context:   ctx,
 		}
-		return g.StoreV2.Delete(req)
+		return g.StoreV2.Delete(ctx, req)
 	}
 	return g.Store.DeleteResource(ctx, g.Kind.StorePrefix(), name)
 }
@@ -163,9 +162,8 @@ func (g *GenericClient) getResource(ctx context.Context, name string, value core
 			Namespace: corev2.ContextNamespace(ctx),
 			Name:      name,
 			StoreName: value.StorePrefix(),
-			Context:   ctx,
 		}
-		wrapper, err := g.StoreV2.Get(req)
+		wrapper, err := g.StoreV2.Get(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -190,9 +188,8 @@ func (g *GenericClient) list(ctx context.Context, resources interface{}, pred *s
 		req := storev2.ResourceRequest{
 			Namespace: corev2.ContextNamespace(ctx),
 			StoreName: g.Kind.StorePrefix(),
-			Context:   ctx,
 		}
-		list, err := g.StoreV2.List(req, pred)
+		list, err := g.StoreV2.List(ctx, req, pred)
 		if err != nil {
 			return err
 		}

--- a/backend/api/namespace.go
+++ b/backend/api/namespace.go
@@ -329,8 +329,8 @@ func (a *NamespaceClient) CreateNamespace(ctx context.Context, namespace *corev2
 }
 
 func (a *NamespaceClient) createResourceTemplates(ctx context.Context, namespace string) error {
-	req := storev2.NewResourceRequestFromResource(ctx, new(corev3.ResourceTemplate))
-	list, err := a.storev2.List(req, nil)
+	req := storev2.NewResourceRequestFromResource(new(corev3.ResourceTemplate))
+	list, err := a.storev2.List(ctx, req, nil)
 	if err != nil {
 		return err
 	}
@@ -346,12 +346,12 @@ func (a *NamespaceClient) createResourceTemplates(ctx context.Context, namespace
 		if err != nil {
 			return err
 		}
-		req := storev2.NewResourceRequestFromResource(ctx, resource)
+		req := storev2.NewResourceRequestFromResource(resource)
 		wrapper, err := storev2.WrapResource(resource)
 		if err != nil {
 			return err
 		}
-		if err := a.storev2.CreateOrUpdate(req, wrapper); err != nil {
+		if err := a.storev2.CreateOrUpdate(ctx, req, wrapper); err != nil {
 			return err
 		}
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -423,7 +423,7 @@ func Initialize(ctx context.Context, client *clientv3.Client, db *pgxpool.Pool, 
 	}
 
 	// Start the entity config watcher, so agentd sessions are notified of updates
-	entityConfigWatcher := agentd.GetEntityConfigWatcher(ctx, client)
+	entityConfigWatcher := agentd.GetEntityConfigWatcher(ctx, b.StoreV2)
 
 	// Prepare the etcd client TLS config
 	etcdClientTLSInfo := (transport.TLSInfo)(config.Store.EtcdConfigurationStore.ClientTLSInfo)
@@ -556,16 +556,15 @@ func Initialize(ctx context.Context, client *clientv3.Client, db *pgxpool.Pool, 
 
 	// Initialize agentd
 	agent, err := agentd.New(agentd.Config{
-		Host:                config.AgentHost,
-		Port:                config.AgentPort,
-		Bus:                 bus,
-		Store:               b.Store,
-		TLS:                 config.AgentTLSOptions,
-		RingPool:            b.RingPool,
-		WriteTimeout:        config.AgentWriteTimeout,
-		Client:              client,
-		Watcher:             entityConfigWatcher,
-		EtcdClientTLSConfig: b.EtcdClientTLSConfig,
+		Host:         config.AgentHost,
+		Port:         config.AgentPort,
+		Bus:          bus,
+		Store:        b.StoreV2,
+		TLS:          config.AgentTLSOptions,
+		RingPool:     b.RingPool,
+		WriteTimeout: config.AgentWriteTimeout,
+		Watcher:      entityConfigWatcher,
+		HealthRouter: b.HealthRouter,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", agent.Name(), err)

--- a/backend/store/cache/v2/cache_integration_test.go
+++ b/backend/store/cache/v2/cache_integration_test.go
@@ -94,7 +94,7 @@ func TestEntityCacheIntegration(t *testing.T) {
 	cacheCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cache, err := New(cacheCtx, client, &corev3.EntityConfig{}, true)
+	cache, err := New(cacheCtx, store, &corev3.EntityConfig{}, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/store/cache/v2/cache_test.go
+++ b/backend/store/cache/v2/cache_test.go
@@ -129,7 +129,7 @@ func TestResourceRebuild(t *testing.T) {
 
 	cacher := Resource{
 		cache:     make(map[string][]Value),
-		client:    client,
+		store:     store,
 		resourceT: &corev3.EntityConfig{},
 	}
 


### PR DESCRIPTION
Moves agentd to the store/v2 package.

Updates the backend/store/cache/v2 package to remove dependency on etcd.
Migrates agentd to store/v2 by:
  * Moving from cache to cache/v2 package
  * Adding Config for HealthRouter instead of constructing it on creation to match apid and remove etcd dep.
  * Using new storev2 WatchEvent
  * Adding Config/dependency for an Authenticator to matche apid and remove dependency on UserStore.
* Updates usage of the store/v2 interface in session.go to use new calling convention (ctx, req).
* Update some backend/api package compile errors for now store/v2 interface calling conventions.


## Dear Cyril,
Haha, don't want to @ you to disrupt your rest. I suspect my changes to cache/v2 may step on your toes if you've already made some progress on the schedulerd task. I hope we've taken similar steps if you have 🤞.