### PR TITLE
Postgres entityconfig watcher

### DIFF
--- a/backend/store/postgres/counter_integration_test.go
+++ b/backend/store/postgres/counter_integration_test.go
@@ -18,9 +18,9 @@ func TestCounterWatcherIntegration(t *testing.T) {
 	// Set ExpectedTxnJitter to a very high percentile of expected transaction latency.
 	// This test case runs ~15k transactions - so p99 would mean on average 150 transactions
 	// that could fall out of the watcher's transaction window and cause a failure.
-	ExpectedTxnJitter := time.Millisecond * 1000
+	ExpectedTxnJitter := time.Millisecond * 1200
 	// additional transaction commit delay
-	SyntheticTxnJitter := time.Millisecond * 50
+	SyntheticTxnJitter := time.Millisecond * 25
 	TxnWindow := ExpectedTxnJitter + SyntheticTxnJitter
 
 	withPostgres(t, func(ctx context.Context, pool *pgxpool.Pool, dsn string) {

--- a/backend/store/postgres/counter_integration_test.go
+++ b/backend/store/postgres/counter_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package postgres
 
 import (
@@ -18,7 +20,7 @@ func TestCounterWatcherIntegration(t *testing.T) {
 	// Set ExpectedTxnJitter to a very high percentile of expected transaction latency.
 	// This test case runs ~15k transactions - so p99 would mean on average 150 transactions
 	// that could fall out of the watcher's transaction window and cause a failure.
-	ExpectedTxnJitter := time.Millisecond * 1200
+	ExpectedTxnJitter := time.Millisecond * 1500
 	// additional transaction commit delay
 	SyntheticTxnJitter := time.Millisecond * 25
 	TxnWindow := ExpectedTxnJitter + SyntheticTxnJitter

--- a/backend/store/postgres/counter_test.go
+++ b/backend/store/postgres/counter_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // test resources for integration testing watcher correctness.
 // defines a Counter store resource compatible with sensu-go/backend/poll
 package postgres

--- a/backend/store/postgres/entity_configs_schema.go
+++ b/backend/store/postgres/entity_configs_schema.go
@@ -320,3 +320,55 @@ WHERE
 	name = $2 AND
 	deleted_at IS NULL;
 `
+
+const pollEntityConfigQuery = `
+-- Looks for updates to the entiy_config table
+-- since a specified timestamp
+--
+WITH ignored AS (
+	SELECT
+		$3::text,
+		$4::text,
+		$5::text,
+		$6::text,
+		$7::text,
+		$8::text[],
+		$9::boolean,
+		$10::text,
+		$11::text[],
+		$12::text[],
+		$13::bigint,
+		$14::bigint,
+		$15::timestamptz,
+		$17::timestamptz
+)
+SELECT
+	namespaces.name,
+	entity_configs.name,
+	entity_configs.selectors,
+	entity_configs.annotations,
+	entity_configs.created_by,
+	entity_configs.entity_class,
+	entity_configs.sensu_user,
+	entity_configs.subscriptions,
+	entity_configs.deregister,
+	entity_configs.deregistration,
+	entity_configs.keepalive_handlers,
+	entity_configs.redact,
+	entity_configs.id,
+	entity_configs.namespace_id,
+	entity_configs.created_at,
+	entity_configs.updated_at,
+	entity_configs.deleted_at
+FROM entity_configs
+LEFT OUTER JOIN namespaces ON entity_configs.namespace_id = namespaces.id
+WHERE entity_configs.updated_at >= $16
+AND CASE
+		WHEN $1 <> '' THEN namespaces.name = $1
+		ELSE true
+	END
+AND CASE
+		WHEN $2 <> '' THEN entity_configs.name = $2
+		ELSE TRUE
+	END
+`

--- a/backend/store/postgres/watcher.go
+++ b/backend/store/postgres/watcher.go
@@ -1,9 +1,7 @@
 package postgres
 
 import (
-	"database/sql"
 	"sync"
-	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sensu/sensu-go/backend/poll"
@@ -27,25 +25,4 @@ func getWatchStoreOverride(storeName string) (factory watchStoreFactory, ok bool
 	defer watchStoreOverridesMu.Unlock()
 	factory, ok = watchStoreOverrides[storeName]
 	return
-}
-
-// recordStatus used by postgres stores implementing poll.Table
-type recordStatus struct {
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt sql.NullTime
-}
-
-// Row builds a poll.Row from a scanned row
-func (rs recordStatus) Row(id string, resource storev2.Wrapper) poll.Row {
-	row := poll.Row{
-		Id:        id,
-		Resource:  resource,
-		CreatedAt: rs.CreatedAt,
-		UpdatedAt: rs.UpdatedAt,
-	}
-	if rs.DeletedAt.Valid {
-		row.DeletedAt = &rs.DeletedAt.Time
-	}
-	return row
 }


### PR DESCRIPTION
## What

Follow up to https://github.com/sensu/sensu-go/issues/4738

* Adds the polling implementation for the EntityConfig table
* Disables the counter integration test by default now that a real implementation is present. Was not sure what to do about that one, could be convinced to delete it, but it does the best job of simulating multiple random writers - a worst case for our polling implementation.