### PR TITLE
Upgrade Go to 1.17.12

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ cache:
 environment:
   GOPATH: c:\gopath
   GOROOT: c:\Program Files\Go
-  GOVERSION: 1.17.6
+  GOVERSION: 1.17.12
   GO111MODULE: 'on'
   GOPROXY: 'https://proxy.golang.org'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.1.2
+  go: circleci/go@1.7.1
 
 parameters:
   go_version:
     type: string
-    default: "1.17.6"
+    default: "1.17.12"
 
 sensu_go_build_env: &sensu_go_build_env
   docker:

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [6.7.4] - 2022-07-12
+
+### Changed
+- Upgraded CI Go version to 1.17.12
+
 ## [6.7.3] - 2022-07-07
 
 ### Changed


### PR DESCRIPTION
Mitigates several CVEs. https://github.com/golang/go/issues?q=milestone%3AGo1.17.12+label%3ACherryPickApproved for details.

Signed-off-by: Eric Chlebek <eric@sensu.io>