### PR TITLE
Add Generic store

### DIFF
--- a/backend/store/v2/generic.go
+++ b/backend/store/v2/generic.go
@@ -1,0 +1,135 @@
+package v2
+
+import (
+	"context"
+	"reflect"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/patch"
+)
+
+type ID = corev2.ObjectMeta
+
+type Resource[T any] interface {
+	corev3.Resource
+	*T
+}
+
+// Generic is a generic store that sits on top of an Interface and provides
+// a type safe set of methods for dealing with resource CRUD operations.
+// It allows users to avoid dealing with the Wrapper abstraction, and handles
+// list allocations optimally.
+type Generic[R Resource[T], T any] struct {
+	Interface Interface
+}
+
+func NewGenericStore[R Resource[T], T any](face Interface) Generic[R, T] {
+	return Generic[R, T]{Interface: face}
+}
+
+func makeResource[R Resource[T], T any]() *T {
+	var t T
+	return &t
+}
+
+func prepare(resource corev3.Resource) (ResourceRequest, Wrapper, error) {
+	req := NewResourceRequestFromResource(resource)
+	wrapper, err := WrapResource(resource)
+	return req, wrapper, err
+}
+
+func (g Generic[R, T]) CreateOrUpdate(ctx context.Context, resource R) error {
+	req, wrapper, err := prepare(resource)
+	if err != nil {
+		return err
+	}
+	return g.Interface.CreateOrUpdate(ctx, req, wrapper)
+}
+
+func (g Generic[R, T]) UpdateIfExists(ctx context.Context, resource R) error {
+	req, wrapper, err := prepare(resource)
+	if err != nil {
+		return err
+	}
+	return g.Interface.UpdateIfExists(ctx, req, wrapper)
+}
+
+func (g Generic[R, T]) CreateIfNotExists(ctx context.Context, resource R) error {
+	req, wrapper, err := prepare(resource)
+	if err != nil {
+		return err
+	}
+	return g.Interface.CreateIfNotExists(ctx, req, wrapper)
+}
+
+func (g Generic[R, T]) Get(ctx context.Context, id ID) (R, error) {
+	result := makeResource[R, T]()
+	tm := getGenericTypeMeta[R, T]()
+	var r R
+	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
+	wrapper, err := g.Interface.Get(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := wrapper.UnwrapInto(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (g Generic[R, T]) Delete(ctx context.Context, id ID) error {
+	var r R
+	tm := getGenericTypeMeta[R, T]()
+	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
+	req.Namespace = id.Namespace
+	req.Name = id.Name
+	return g.Interface.Delete(ctx, req)
+}
+
+func (g Generic[R, T]) List(ctx context.Context, id ID, pred *store.SelectionPredicate) ([]T, error) {
+	var r R
+	tm := getGenericTypeMeta[R, T]()
+	req := NewResourceRequest(tm, id.Namespace, "", r.StoreName())
+	wrapper, err := g.Interface.List(ctx, req, pred)
+	if err != nil {
+		return nil, err
+	}
+	wlen := wrapper.Len()
+	result := make([]T, wlen, wlen)
+	if err := wrapper.UnwrapInto(&result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (g Generic[R, T]) Exists(ctx context.Context, id ID) (bool, error) {
+	tm := getGenericTypeMeta[R, T]()
+	var r R
+	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
+	return g.Interface.Exists(ctx, req)
+}
+
+func (g Generic[R, T]) Patch(ctx context.Context, resource R, patcher patch.Patcher, etag *store.ETagCondition) error {
+	req, wrapper, err := prepare(resource)
+	if err != nil {
+		return err
+	}
+	return g.Interface.Patch(ctx, req, wrapper, patcher, etag)
+}
+
+func getGenericTypeMeta[R Resource[T], T any]() corev2.TypeMeta {
+	var t T
+	var tm corev2.TypeMeta
+	if getter, ok := (interface{}(&t)).(tmGetter); ok {
+		tm = getter.GetTypeMeta()
+	} else {
+		typ := reflect.TypeOf(t)
+		tm = corev2.TypeMeta{
+			Type:       typ.Name(),
+			APIVersion: apiVersion(typ.PkgPath()),
+		}
+	}
+	return tm
+}

--- a/backend/store/v2/generic_test.go
+++ b/backend/store/v2/generic_test.go
@@ -1,0 +1,140 @@
+package v2_test
+
+import (
+	"context"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/backend/store/v2/wrap"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGenericStoreCreateOrUpdate(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "foo",
+		StoreName:  "check_configs",
+	}
+	sv2.On("CreateOrUpdate", mock.Anything, req, mock.Anything).Return(nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	if err := store.CreateOrUpdate(context.Background(), corev2.FixtureCheckConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	sv2.AssertCalled(t, "CreateOrUpdate", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStoreUpdateIfExists(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "foo",
+		StoreName:  "check_configs",
+	}
+	sv2.On("UpdateIfExists", mock.Anything, req, mock.Anything).Return(nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	if err := store.UpdateIfExists(context.Background(), corev2.FixtureCheckConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	sv2.AssertCalled(t, "UpdateIfExists", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStoreCreateIfNotExists(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "foo",
+		StoreName:  "check_configs",
+	}
+	sv2.On("CreateIfNotExists", mock.Anything, req, mock.Anything).Return(nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	if err := store.CreateIfNotExists(context.Background(), corev2.FixtureCheckConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	sv2.AssertCalled(t, "CreateIfNotExists", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStoreGet(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "foo",
+		StoreName:  "check_configs",
+	}
+	sv2.On("Get", mock.Anything, req).Return(mockstore.Wrapper[*corev2.CheckConfig]{Value: corev2.FixtureCheckConfig("foo")}, nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	check, err := store.Get(context.Background(), storev2.ID{Namespace: "default", Name: "foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := check.Name, "foo"; got != want {
+		t.Fatalf("wrong check name: got %q, want %q", got, want)
+	}
+	if got, want := check.Interval, uint32(60); got != want {
+		t.Fatalf("wrong check interval: got %d, want %d", got, want)
+	}
+	sv2.AssertCalled(t, "Get", mock.Anything, req)
+}
+
+func TestGenericStoreDelete(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "foo",
+		StoreName:  "check_configs",
+	}
+	sv2.On("Delete", mock.Anything, req).Return(nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	if err := store.Delete(context.Background(), storev2.ID{Namespace: "default", Name: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+	sv2.AssertCalled(t, "Delete", mock.Anything, req)
+}
+
+func TestGenericStoreList(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	req := storev2.ResourceRequest{
+		APIVersion: "core/v2",
+		Type:       "CheckConfig",
+		Namespace:  "default",
+		Name:       "",
+		StoreName:  "check_configs",
+	}
+	wrapper, _ := wrap.Resource(corev2.FixtureCheckConfig("foo"))
+	wrapList := wrap.List{wrapper}
+	sv2.On("List", mock.Anything, req, mock.Anything).Return(wrapList, nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	checks, err := store.List(context.Background(), storev2.ID{Namespace: "default", Name: "foo"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := checks[0].Name, "foo"; got != want {
+		t.Fatalf("wrong check name: got %q, want %q", got, want)
+	}
+	if got, want := checks[0].Interval, uint32(60); got != want {
+		t.Fatalf("wrong check interval: got %d, want %d", got, want)
+	}
+	sv2.AssertCalled(t, "List", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStorePatch(t *testing.T) {
+	sv2 := new(mockstore.V2MockStore)
+	sv2.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store := storev2.NewGenericStore[*corev2.CheckConfig](sv2)
+	if err := store.Patch(context.Background(), corev2.FixtureCheckConfig("foo"), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	sv2.AssertCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -262,10 +262,8 @@ type tmGetter interface {
 func WrapResource(r Resource) Wrapper {
 	var tm TypeMeta
 	if getter, ok := r.(tmGetter); ok {
-		fmt.Println("tmGetter")
 		tm = getter.GetTypeMeta()
 	} else {
-		fmt.Println("not tmGetter")
 		typ := reflect.Indirect(reflect.ValueOf(r)).Type()
 		tm = TypeMeta{
 			Type:       typ.Name(),


### PR DESCRIPTION
The Generic store sits on top of any store/v2.Interface implementation
and provides a type-safe API for dealing with corev3.Resource CRUD,
while allowing the user to avoid dealing with the storev2.Wrapper
abstraction.