### PR TITLE
Backport addition of corev3.ValidateGlobalMetadata

### DIFF
--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -22,3 +22,18 @@ func ValidateMetadata(meta *corev2.ObjectMeta) error {
 	}
 	return nil
 }
+
+// ValidateGlobalMetadata validates ObjectMeta for global (unnamespaced)
+// resources. To be used on Resources implementing GlobalResource
+func ValidateGlobalMetadata(meta *corev2.ObjectMeta) error {
+	if meta == nil {
+		return errors.New("nil metadata")
+	}
+	if meta.Namespace != "" {
+		return fmt.Errorf(
+			"global resources must have empty namesapce: got %s",
+			meta.Namespace,
+		)
+	}
+	return nil
+}

--- a/api/core/v3/validation.go
+++ b/api/core/v3/validation.go
@@ -31,7 +31,7 @@ func ValidateGlobalMetadata(meta *corev2.ObjectMeta) error {
 	}
 	if meta.Namespace != "" {
 		return fmt.Errorf(
-			"global resources must have empty namesapce: got %s",
+			"global resources must have empty namespace: got %s",
 			meta.Namespace,
 		)
 	}


### PR DESCRIPTION
Signed-off-by: Christian Kruse <ctkruse99@gmail.com>

## What is this change?

#4766 added a corev3 utility for validating ObjectMeta for global resources. This backports the relevant part of that change, as I want to use it in https://github.com/sensu/sensu-enterprise-go/pull/2386

## Why is this change necessary?

Without a api/core/v3 function for this, it will need duplicated by the enterprise version's code generation scripts.

Alternatively we could just copy+paste, like I've done here: https://github.com/sensu/sensu-enterprise-go/pull/2386/files#diff-8f69bc9581a1a0baf76dbe3e61271df802806a13792c710e2d45a10da84ba691R48
