### PR TITLE
Retry Etcd Requests in BackendIDGetter

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -15,6 +15,10 @@ be marked as global resources.
 ### Changed
 - Upgraded CI Go version to 1.17.12
 
+### Fixed
+- Fixed a bug where sensu-backend could crash if the BackendIDGetter
+encounters etcd client unavailability.
+
 ## [6.7.3] - 2022-07-07
 
 ### Changed


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/4812

## What is this change?

It looks like we intend to have retry logic in the BackendIDGetter's getLease function, but in practice it currently never retries. 

## Why is this change necessary?

In a large environment we noticed that when the etcd cluster is overwhelmed, this tends to be a weak spot for sensu-go, triggering a restart due to an "etcdserver: too many requests" error returned from an etcd client. We intentionally include retry logic for this case in most of our store access logic, and should be consistent here.

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N. Although I've found our retry util very difficult to reason about and easy to use incorrectly, as it appears was the case here.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

Unit tests

## Is this change a patch?

N
