### PR TITLE
Route Keepalive Events to Eventd with High Priority

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,17 +7,23 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Eventd now prioritizes keepalive events over other events in order to
+mitigate the potential of keepalive event creation storms and mass agent
+disconnects.
+
 ### Added
 - GlobalResource interface in core/v3 allows core/v3 resources to
 be marked as global resources.
-## [6.7.4] - 2022-07-12
-
-### Changed
-- Upgraded CI Go version to 1.17.12
 
 ### Fixed
 - Fixed a bug where sensu-backend could crash if the BackendIDGetter
 encounters etcd client unavailability.
+
+## [6.7.4] - 2022-07-12
+
+### Changed
+- Upgraded CI Go version to 1.17.12
 
 ## [6.7.3] - 2022-07-07
 

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -650,11 +650,6 @@ func (s *Session) handleEvent(_ context.Context, payload []byte) error {
 		} else {
 			eventBytesSummary.WithLabelValues(metrics.EventTypeLabelCheck).Observe(float64(len(payload)))
 		}
-		// TODO (ck) Should these be going through keepalived (TopicKeepalive)
-		// or straight to eventd (TopicKeepaliveRaw)?
-		if event.Check.Name == corev2.KeepaliveCheckName {
-			return s.bus.Publish(messaging.TopicKeepaliveRaw, event)
-		}
 	} else if event.HasMetrics() {
 		eventBytesSummary.WithLabelValues(metrics.EventTypeLabelMetrics).Observe(float64(len(payload)))
 	}

--- a/backend/agentd/session.go
+++ b/backend/agentd/session.go
@@ -650,6 +650,8 @@ func (s *Session) handleEvent(_ context.Context, payload []byte) error {
 		} else {
 			eventBytesSummary.WithLabelValues(metrics.EventTypeLabelCheck).Observe(float64(len(payload)))
 		}
+		// TODO (ck) Should these be going through keepalived (TopicKeepalive)
+		// or straight to eventd (TopicKeepaliveRaw)?
 		if event.Check.Name == corev2.KeepaliveCheckName {
 			return s.bus.Publish(messaging.TopicKeepaliveRaw, event)
 		}

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -61,6 +61,7 @@ func newEventd(store storev2.Interface, eventStore store.Store, bus messaging.Me
 		errChan:         make(chan error, 1),
 		shutdownChan:    make(chan struct{}, 1),
 		eventChan:       make(chan interface{}, 100),
+		keepaliveChan:   make(chan interface{}, 100),
 		wg:              &sync.WaitGroup{},
 		mu:              &sync.Mutex{},
 		Logger:          NoopLogger{},

--- a/backend/keepalived/integration_test.go
+++ b/backend/keepalived/integration_test.go
@@ -38,7 +38,7 @@ func TestKeepaliveMonitor(t *testing.T) {
 	tsub := testSubscriber{
 		ch: eventChan,
 	}
-	subscription, err := bus.Subscribe(messaging.TopicEventRaw, "testSubscriber", tsub)
+	subscription, err := bus.Subscribe(messaging.TopicKeepaliveRaw, "testSubscriber", tsub)
 	if err != nil {
 		assert.FailNow(t, "failed to subscribe to message bus topic event raw")
 	}

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -634,7 +634,7 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 	}
 	event.Check.Output = fmt.Sprintf("No keepalive sent from %s for %v seconds (>= %v)", event.Entity.Name, timeSinceLastSeen, timeout)
 
-	if err := k.bus.Publish(messaging.TopicEventRaw, event); err != nil {
+	if err := k.bus.Publish(messaging.TopicKeepaliveRaw, event); err != nil {
 		lager.WithError(err).Error("error publishing event")
 		return false
 	}
@@ -737,5 +737,5 @@ func (k *Keepalived) handleUpdate(e *corev2.Event) error {
 		}
 	}
 
-	return k.bus.Publish(messaging.TopicEventRaw, event)
+	return k.bus.Publish(messaging.TopicKeepaliveRaw, event)
 }


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/4813

## What is this change?

Changes the flow of keepalive events from keepalived to eventd. Currently keepalive and other events are mixed together in the same topic going into eventd, so are handled at the same priority. This change uses the (until now) unused wizard bus topic "sensu:keepalive-raw" as a higher-priority topic between keepalived and eventd, allowing eventd to process time sensitive keepalive events ahead of regular events.

## Why is this change necessary?

Keepalive events are time sensitive. Under high event load today, keepalives can fall behind and cause a keepalive storm where the events are being generated faster than they can be processed. In order to mitigate this, we should prioritize the handling of keepalive events in eventd.

## Does your change need a Changelog entry?

Yes

## Do you need clarification on anything?

I could use a second set of eyes on the `// TODO`. Near as I can tell these events have been dropped for the past few minor releases. I'm unsure of the consequences of beginning to handle them again.

## Were there any complications while making this change?

Performance testing was... interesting. I'd like to revisit with someone more familiar with the perf test suite, but I observed a failure mode in the etcd only mode that appeared more severe than past releases.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

Integration tests, QA Crucible tests.

## Is this change a patch?

N