### PR TITLE
Add metrics around sensu-backend startup

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -15,6 +15,8 @@ disconnects.
 ### Added
 - GlobalResource interface in core/v3 allows core/v3 resources to
 be marked as global resources.
+- `sensu_go_backend_restart_count` and `sensu_go_backend_daemon_start_seconds`
+metrics added to help diagnose startup issues.
 
 ### Fixed
 - Fixed a bug where sensu-backend could crash if the BackendIDGetter


### PR DESCRIPTION
Exposes new system metrics for `sensu_go_backend_restart_count`
and `sensu_go_backend_daemon_start_seconds`, exposing details
of our internal restart loop and the start times of individual daemons.
 
Signed-off-by: Christian Kruse <ctkruse99@gmail.com>


## Why is this change necessary?

It was noted in a discussion with CE that they would be interested in having this information available. It was also helpful in testing some in progress changes to keepalived start.

FWIW I could go either way on this one. sensu_go_backend_daemon_start_seconds turns out to be almost always super uninteresting as most daemom's Start function are procedural so complete in sub-10ms time.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?
## Is this change a patch?
N