### PR TITLE
Background keepalive reconstruction

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Agent websocket connection logging includes backend entity name.
 
+### Changed
+- Keepalive reconstruction no longer blocks backend startup. Instead runs
+gradually in the background.
+
 ## [6.8.0] - 2022-08-24
 
 ### Changed

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -277,7 +277,7 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 		tctx, cancel = context.WithTimeout(entityCtx, k.storeTimeout)
 		defer cancel()
 		if err := switches.Dead(tctx, id, ttl); err != nil {
-			return fmt.Errorf("error initializing keepalive %q: %s", id, err)
+			logger.WithFields(logrus.Fields{"event": event}).WithError(err).Warn("could not bury keepalive switch")
 		}
 	}
 	logger.Info("keepalived reconstruction complete")

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -91,6 +91,7 @@ type Keepalived struct {
 	ctx                   context.Context
 	cancel                context.CancelFunc
 	storeTimeout          time.Duration
+	reconstructionPeriod  time.Duration
 }
 
 // Option is a functional option.
@@ -142,6 +143,7 @@ func New(c Config, opts ...Option) (*Keepalived, error) {
 		ctx:                   ctx,
 		cancel:                cancel,
 		storeTimeout:          c.StoreTimeout,
+		reconstructionPeriod:  time.Second * 120,
 	}
 	for _, o := range opts {
 		if err := o(k); err != nil {
@@ -165,12 +167,10 @@ func (k *Keepalived) Start() error {
 	}
 
 	k.subscription = sub
-	if err := k.initFromStore(context.Background()); err != nil {
-		_ = sub.Cancel()
-		return err
-	}
 
+	k.wg = &sync.WaitGroup{}
 	k.startWorkers()
+	k.startReconstruction(context.Background())
 
 	return nil
 }
@@ -197,6 +197,25 @@ func (k *Keepalived) Name() string {
 	return "keepalived"
 }
 
+func (k *Keepalived) startReconstruction(ctx context.Context) {
+	k.wg.Add(1)
+	go func() {
+		defer k.wg.Done()
+		err := k.initFromStore(ctx)
+		if err != nil {
+			if _, ok := err.(*store.ErrInternal); ok {
+				// Fatal error
+				select {
+				case k.errChan <- err:
+				case <-ctx.Done():
+				}
+				return
+			}
+			logger.WithError(err).Error("failed to recover failing keepalives")
+		}
+	}()
+}
+
 func (k *Keepalived) initFromStore(ctx context.Context) error {
 	// For which clients were we previously alerting?
 	tctx, cancel := context.WithTimeout(ctx, k.storeTimeout)
@@ -208,7 +227,22 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 
 	switches := k.livenessFactory(k.Name(), k.dead, k.alive, logger)
 
-	for _, keepalive := range keepalives {
+	potentialKeepalives := len(keepalives)
+	recustructionInterval := float64(k.reconstructionPeriod) / float64(potentialKeepalives)
+	logger.Infof("recovering %d failing keepalives over %d seconds",
+		potentialKeepalives,
+		k.reconstructionPeriod/time.Second,
+	)
+
+	for i, keepalive := range keepalives {
+		if i > 0 {
+			select {
+			case <-time.After(time.Duration(recustructionInterval)):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
 		entityCtx := context.WithValue(ctx, corev2.NamespaceKey, keepalive.Namespace)
 		tctx, cancel := context.WithTimeout(entityCtx, k.storeTimeout)
 		defer cancel()
@@ -246,12 +280,12 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 			return fmt.Errorf("error initializing keepalive %q: %s", id, err)
 		}
 	}
+	logger.Info("keepalived reconstruction complete")
 
 	return nil
 }
 
 func (k *Keepalived) startWorkers() {
-	k.wg = &sync.WaitGroup{}
 	k.wg.Add(k.workerCount)
 
 	for i := 0; i < k.workerCount; i++ {

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -258,7 +258,7 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 			tctx, cancel := context.WithTimeout(entityCtx, k.storeTimeout)
 			defer cancel()
 			if err := switches.BuryAndRevokeLease(tctx, id); err != nil {
-				return err
+				logger.WithError(err).WithField("keepalive", id).Error("error burying switch")
 			}
 			continue
 		}
@@ -277,7 +277,8 @@ func (k *Keepalived) initFromStore(ctx context.Context) error {
 		tctx, cancel = context.WithTimeout(entityCtx, k.storeTimeout)
 		defer cancel()
 		if err := switches.Dead(tctx, id, ttl); err != nil {
-			logger.WithFields(logrus.Fields{"event": event}).WithError(err).Warn("could not bury keepalive switch")
+			logger.WithError(err).WithField("keepalive", id).Error("error initializing keepalive")
+			continue
 		}
 	}
 	logger.Info("keepalived reconstruction complete")

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -296,7 +296,7 @@ func (k *Keepalived) startWorkers() {
 func (k *Keepalived) processKeepalives(ctx context.Context) {
 	defer k.wg.Done()
 
-	switches := k.livenessFactory(k.Name(), k.alive, k.dead, logger)
+	switches := k.livenessFactory(k.Name(), k.dead, k.alive, logger)
 
 	for {
 		select {

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -80,6 +80,7 @@ func newKeepalivedTest(t *testing.T) *keepalivedTest {
 		StoreTimeout:    time.Second,
 	})
 	require.NoError(t, err)
+	k.reconstructionPeriod = 0
 	test := &keepalivedTest{
 		MessageBus:   bus,
 		Store:        store,


### PR DESCRIPTION
Partial solution for https://github.com/sensu/sensu-enterprise-go/issues/2373

Closes: https://github.com/sensu/sensu-go/issues/4828

## What is this change?

Instead of calling keepalived's initFromStore function to reconstruct failing keepalive switchset state in a blocking manner on backend startup, start it as a background goroutine and spread out the load across the default keepalive warning timeout of 120 seconds.

## Why is this change necessary?

When many failing keepalives are present in an environment, this approach can put a heavy load on the etcd database immediately, and tends to flood the pipeline with keepalive events when they expire at the same time later.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?
N/A

## How did you verify this change?
Performed a series of performance test comparing this strategy to the existing as well as others: https://docs.google.com/document/d/1s3xiZ4Dd_8UVZjUzpGGgjuH5aOfZu5dU1keq1ywXmS4/edit?usp=sharing

## Is this change a patch?

N