### PR TITLE
Adds API Serve Wait Time Backend Configuration

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -15,6 +15,10 @@ disconnects.
 ### Added
 - GlobalResource interface in core/v3 allows core/v3 resources to
 be marked as global resources.
+- Added `--api-serve-wait-time` backend flag to delay serving API requests
+for a period of time after startup.
+- Added `/ready` endpoint to the sensu-go API. Returns 200 when the API is ready
+to serve traffic.
 
 ### Fixed
 - Fixed a bug where sensu-backend could crash if the BackendIDGetter

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -27,6 +27,10 @@ import (
 	"github.com/sensu/sensu-go/types"
 )
 
+const apidStartupErrorMsg = `API unavailable during startup.
+See api-serve-wait-time settings.
+`
+
 // APId is the backend HTTP API.
 type APId struct {
 	Authenticator              *authentication.Authenticator
@@ -35,6 +39,7 @@ type APId struct {
 	EntityLimitedCoreSubrouter *mux.Router
 	GraphQLSubrouter           *mux.Router
 	RequestLimit               int64
+	ReadyMiddleware            middlewares.HTTPMiddleware
 
 	stopping            chan struct{}
 	running             *atomic.Value
@@ -49,6 +54,9 @@ type APId struct {
 	cluster             clientv3.Cluster
 	etcdClientTLSConfig *tls.Config
 	clusterVersion      string
+
+	serveWaitTime time.Duration
+	ready         func()
 }
 
 // Option is a functional option.
@@ -59,6 +67,7 @@ type Config struct {
 	ListenAddress       string
 	RequestLimit        int64
 	WriteTimeout        time.Duration
+	ServeWaitTime       time.Duration
 	URL                 string
 	Bus                 messaging.MessageBus
 	Store               store.Store
@@ -92,6 +101,7 @@ func New(c Config, opts ...Option) (*APId, error) {
 		Authenticator:       c.Authenticator,
 		clusterVersion:      c.ClusterVersion,
 		RequestLimit:        c.RequestLimit,
+		serveWaitTime:       c.ServeWaitTime,
 	}
 
 	// prepare TLS config
@@ -107,9 +117,21 @@ func New(c Config, opts ...Option) (*APId, error) {
 	router := NewRouter()
 	_ = PublicSubrouter(router, c)
 	a.GraphQLSubrouter = GraphQLSubrouter(router, c)
-	_ = AuthenticationSubrouter(router, c)
+	authSubrouter := AuthenticationSubrouter(router, c)
 	a.CoreSubrouter = CoreSubrouter(router, c)
 	a.EntityLimitedCoreSubrouter = EntityLimitedCoreSubrouter(router, c)
+
+	awaitMiddleware := &middlewares.AwaitStartupMiddleware{
+		RetryAfterSeconds: int(c.ServeWaitTime / time.Second),
+		ResponseText:      apidStartupErrorMsg,
+	}
+	a.ReadyMiddleware = awaitMiddleware
+	a.ready = awaitMiddleware.Ready
+
+	a.GraphQLSubrouter.Use(a.ReadyMiddleware.Then)
+	authSubrouter.Use(a.ReadyMiddleware.Then)
+	a.CoreSubrouter.Use(a.ReadyMiddleware.Then)
+	a.EntityLimitedCoreSubrouter.Use(a.ReadyMiddleware.Then)
 
 	a.HTTPServer = &http.Server{
 		Addr:         c.ListenAddress,
@@ -281,6 +303,21 @@ func notFoundHandler(w http.ResponseWriter, req *http.Request) {
 
 // Start APId.
 func (a *APId) Start() error {
+
+	if a.serveWaitTime <= 0 {
+		a.ready()
+	} else {
+		logger.Warnf("starting apid as temporarily unavailable for: %s", a.serveWaitTime)
+		go func() {
+			select {
+			case <-time.After(a.serveWaitTime):
+				a.ready()
+				logger.Warn("apid is now available")
+			case <-a.stopping:
+			}
+		}()
+	}
+
 	logger.Warn("starting apid on address: ", a.HTTPServer.Addr)
 	ln, err := net.Listen("tcp", a.HTTPServer.Addr)
 	if err != nil {

--- a/backend/apid/middlewares/awaitstartup.go
+++ b/backend/apid/middlewares/awaitstartup.go
@@ -1,0 +1,41 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type AwaitStartupMiddleware struct {
+	RetryAfterSeconds int
+	ResponseText      string
+	isReady           bool
+	mu                sync.RWMutex
+}
+
+func (m *AwaitStartupMiddleware) Ready() {
+	m.mu.Lock()
+	m.isReady = true
+	m.mu.Unlock()
+}
+
+func (m *AwaitStartupMiddleware) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.mu.RLock()
+		ready := m.isReady
+		m.mu.RUnlock()
+		if !ready {
+			logger.Info("apid temporarily unavailable during startup")
+			if m.RetryAfterSeconds > 0 {
+				w.Header().Set("Retry-After", fmt.Sprint(m.RetryAfterSeconds))
+			}
+			text := http.StatusText(http.StatusServiceUnavailable)
+			if m.ResponseText != "" {
+				text = m.ResponseText
+			}
+			http.Error(w, text, http.StatusServiceUnavailable)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/apid/routers/ready.go
+++ b/backend/apid/routers/ready.go
@@ -1,0 +1,20 @@
+package routers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type ReadyRouter struct{}
+
+func (r *ReadyRouter) Mount(parent *mux.Router) {
+	parent.HandleFunc("/ready", r.ready).Methods(http.MethodGet)
+}
+
+func (r *ReadyRouter) ready(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ready")
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -603,6 +603,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		ListenAddress:       config.APIListenAddress,
 		RequestLimit:        config.APIRequestLimit,
 		WriteTimeout:        config.APIWriteTimeout,
+		ServeWaitTime:       config.APIServeWaitTime,
 		URL:                 config.APIURL,
 		Bus:                 bus,
 		Store:               b.Store,

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -50,6 +50,7 @@ const (
 	flagAPIRequestLimit       = "api-request-limit"
 	flagAPIURL                = "api-url"
 	flagAPIWriteTimeout       = "api-write-timeout"
+	flagAPIServeWaitTime      = "api-serve-wait-time"
 	flagAssetsRateLimit       = "assets-rate-limit"
 	flagAssetsBurstLimit      = "assets-burst-limit"
 	flagDashboardHost         = "dashboard-host"
@@ -227,6 +228,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				APIRequestLimit:       viper.GetInt64(flagAPIRequestLimit),
 				APIURL:                viper.GetString(flagAPIURL),
 				APIWriteTimeout:       viper.GetDuration(flagAPIWriteTimeout),
+				APIServeWaitTime:      viper.GetDuration(flagAPIServeWaitTime),
 				AssetsRateLimit:       rate.Limit(viper.GetFloat64(flagAssetsRateLimit)),
 				AssetsBurstLimit:      viper.GetInt(flagAssetsBurstLimit),
 				DashboardHost:         viper.GetString(flagDashboardHost),
@@ -528,6 +530,7 @@ func flagSet(server bool) *pflag.FlagSet {
 		flagSet.Int64(flagAPIRequestLimit, viper.GetInt64(flagAPIRequestLimit), "maximum API request body size, in bytes")
 		flagSet.String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")
 		flagSet.Duration(flagAPIWriteTimeout, viper.GetDuration(flagAPIWriteTimeout), "maximum duration before timing out writes of responses")
+		flagSet.Duration(flagAPIServeWaitTime, viper.GetDuration(flagAPIServeWaitTime), "wait time before serving API requests on startup")
 		flagSet.Float64(flagAssetsRateLimit, viper.GetFloat64(flagAssetsRateLimit), "maximum number of assets fetched per second")
 		flagSet.Int(flagAssetsBurstLimit, viper.GetInt(flagAssetsBurstLimit), "asset fetch burst limit")
 		flagSet.String(flagDashboardHost, viper.GetString(flagDashboardHost), "dashboard listener host")

--- a/backend/config.go
+++ b/backend/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	APIRequestLimit  int64
 	APIURL           string
 	APIWriteTimeout  time.Duration
+	APIServeWaitTime time.Duration
 
 	// AssetsRateLimit is the maximum number of assets per second that will be fetched.
 	AssetsRateLimit rate.Limit


### PR DESCRIPTION
https://github.com/sensu/sensu-go/issues/4826
https://github.com/sensu/sensu-go/issues/4827

## What is this change?

* Adds a `--api-serve-wait-time` flag to the backend to delay serving apid traffic.
* Adds a `/ready` API endpoint.

## Why is this change necessary?

Sensu-go backends can be delicate during initial startup in high traffic environments. This allows users to configure a delay after startup before apid will serve API traffic.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Big time.

This introduces a new readiness API endpoint and a new backend configuration option. @hillaryfraley 

## How did you verify this change?

Manual

## Is this change a patch?

Not unless it needs to be.
