### PR TITLE
Adds agent-serve-wait-time backend configuration

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -19,6 +19,10 @@ be marked as global resources.
 for a period of time after startup.
 - Added `/ready` endpoint to the sensu-go API. Returns 200 when the API is ready
 to serve traffic.
+- Added `--agent-serve-wait-time` backend flag to delay accepting agent
+connections for a period of time after startup.
+- Added `/ready` endpoint to the agent listener. Returns 200 when the listener
+is ready to accept agent connections.
 
 ### Fixed
 - Fixed a bug where sensu-backend could crash if the BackendIDGetter

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -181,6 +181,10 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 	route.HandleFunc("/", a.webSocketHandler)
 	route.Use(awaitStart.Then, agentLimit, authenticate, authorize)
 
+	readySubRouter := router.NewRoute().Subrouter()
+	new(routers.ReadyRouter).Mount(readySubRouter)
+	readySubRouter.Use(awaitStart.Then)
+
 	a.httpServer = &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.Host, a.Port),
 		Handler:      router,

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -22,6 +22,10 @@ var AgentLimiterMiddleware mux.MiddlewareFunc
 // headers if the entity limit has been reached.
 var EntityLimiterMiddleware mux.MiddlewareFunc
 
+// EntityLimiterMiddleware represents the middleware used to mark the service
+// as temporarily unavailable until startup has completed.
+var AwaitStartupMiddleware mux.MiddlewareFunc
+
 // authenticate is the abstraction layer required to be able to change at
 // runtime the actual function assigned to AuthenticationMiddleware above
 func authenticate(next http.Handler) http.Handler {
@@ -32,6 +36,12 @@ func authenticate(next http.Handler) http.Handler {
 // runtime the actual function assigned to AuthenticationMiddleware above
 func authorize(next http.Handler) http.Handler {
 	return AuthorizationMiddleware(next)
+}
+
+// awaitStartup is the abstraction layer required to be able to change at
+// runtime the actual function assigned to AwaitStartupMiddleware above
+func awaitStartup(next http.Handler) http.Handler {
+	return AwaitStartupMiddleware(next)
 }
 
 // agentLimit is the abstraction layer required to be able to change at

--- a/backend/agentd/middlewares.go
+++ b/backend/agentd/middlewares.go
@@ -22,10 +22,6 @@ var AgentLimiterMiddleware mux.MiddlewareFunc
 // headers if the entity limit has been reached.
 var EntityLimiterMiddleware mux.MiddlewareFunc
 
-// EntityLimiterMiddleware represents the middleware used to mark the service
-// as temporarily unavailable until startup has completed.
-var AwaitStartupMiddleware mux.MiddlewareFunc
-
 // authenticate is the abstraction layer required to be able to change at
 // runtime the actual function assigned to AuthenticationMiddleware above
 func authenticate(next http.Handler) http.Handler {
@@ -36,12 +32,6 @@ func authenticate(next http.Handler) http.Handler {
 // runtime the actual function assigned to AuthenticationMiddleware above
 func authorize(next http.Handler) http.Handler {
 	return AuthorizationMiddleware(next)
-}
-
-// awaitStartup is the abstraction layer required to be able to change at
-// runtime the actual function assigned to AwaitStartupMiddleware above
-func awaitStartup(next http.Handler) http.Handler {
-	return AwaitStartupMiddleware(next)
 }
 
 // agentLimit is the abstraction layer required to be able to change at

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -648,6 +648,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		TLS:                 config.AgentTLSOptions,
 		RingPool:            b.RingPool,
 		WriteTimeout:        config.AgentWriteTimeout,
+		ServeWaitTime:       config.AgentServeWaitTime,
 		Client:              b.Client,
 		Watcher:             entityConfigWatcher,
 		EtcdClientTLSConfig: b.EtcdClientTLSConfig,

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -46,6 +46,7 @@ const (
 	flagConfigFile            = "config-file"
 	flagAgentHost             = "agent-host"
 	flagAgentPort             = "agent-port"
+	flagAgentServeWaitTime    = "agent-serve-wait-time"
 	flagAPIListenAddress      = "api-listen-address"
 	flagAPIRequestLimit       = "api-request-limit"
 	flagAPIURL                = "api-url"
@@ -224,6 +225,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				AgentHost:             viper.GetString(flagAgentHost),
 				AgentPort:             viper.GetInt(flagAgentPort),
 				AgentWriteTimeout:     viper.GetInt(backend.FlagAgentWriteTimeout),
+				AgentServeWaitTime:    viper.GetDuration(flagAgentServeWaitTime),
 				APIListenAddress:      viper.GetString(flagAPIListenAddress),
 				APIRequestLimit:       viper.GetInt64(flagAPIRequestLimit),
 				APIURL:                viper.GetString(flagAPIURL),
@@ -526,6 +528,7 @@ func flagSet(server bool) *pflag.FlagSet {
 		// Main Flags
 		flagSet.String(flagAgentHost, viper.GetString(flagAgentHost), "agent listener host")
 		flagSet.Int(flagAgentPort, viper.GetInt(flagAgentPort), "agent listener port")
+		flagSet.Duration(flagAgentServeWaitTime, viper.GetDuration(flagAgentServeWaitTime), "wait time before accepting agent connections on startup")
 		flagSet.String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")
 		flagSet.Int64(flagAPIRequestLimit, viper.GetInt64(flagAPIRequestLimit), "maximum API request body size, in bytes")
 		flagSet.String(flagAPIURL, viper.GetString(flagAPIURL), "url of the api to connect to")

--- a/backend/config.go
+++ b/backend/config.go
@@ -51,10 +51,11 @@ type Config struct {
 	CacheDir string
 
 	// Agentd Configuration
-	AgentHost         string
-	AgentPort         int
-	AgentTLSOptions   *corev2.TLSOptions
-	AgentWriteTimeout int
+	AgentHost          string
+	AgentPort          int
+	AgentTLSOptions    *corev2.TLSOptions
+	AgentWriteTimeout  int
+	AgentServeWaitTime time.Duration
 
 	// Apid Configuration
 	APIListenAddress string


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/4825

https://github.com/sensu/sensu-go/issues/4827

## What is this change?

* Adds a `--agent-serve-wait-time` flag to the backend to delay serving agent traffic.
* Adds a `/ready` API endpoint to agent listener

## Why is this change necessary?

Sensu-go backends can be delicate during initial startup in high traffic environments. This allows users to configure a delay after startup before agentd will accept agent traffic.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Big time.

This introduces a new readiness API endpoint and a new backend configuration option. @hillaryfraley 

## How did you verify this change?

Manual

## Is this change a patch?

Not unless it needs to be.
