### PR TITLE
Bypass semverGreater when Go module version is (devel)

### DIFF
--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -342,6 +342,9 @@ func ResolveRaw(apiVersion string, typename string) (interface{}, error) {
 	apiGroup, reqVer := ParseAPIVersion(apiVersion)
 	foundVer, ok := availableModules[apiGroup]
 	if ok {
+		if foundVer == "(devel)" {
+			foundVer = reqVer
+		}
 		if semverGreater(reqVer, foundVer) {
 			return nil, fmt.Errorf("requested version was %s, but only %s is available", reqVer, foundVer)
 		}


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

## What is this change?

Bypasses semverGreater by setting `foundVer = reqVer` when `foundVer` equals `(devel)`.

## Why is this change necessary?

Cannot start sensu-backend when using Go workspaces.

## Does your change need a Changelog entry?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation is required.

## How did you verify this change?

Sensu backend now starts when using a Go workspace.

## Is this change a patch?

No.