### PR TITLE
Migrate authentication machinery to store/v2

### DIFF
--- a/api/core/v3/internal/codegen/check_protoc/main.go
+++ b/api/core/v3/internal/codegen/check_protoc/main.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os/exec"
 	"regexp"
 )
 
-var libprotoRe = regexp.MustCompile(`^libprotoc 3.9.1\s$`)
+const protocVersion = "3.9.1"
+
+var libprotoRe = regexp.MustCompile(fmt.Sprintf(`^libprotoc %s\s$`, protocVersion))
 
 func main() {
 	out, err := exec.Command("protoc", "--version").Output()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("error: looking for protoc %s: %s", protocVersion, err)
 	}
 	if !libprotoRe.Match(out) {
 		log.Fatalf("bad protoc version: want %q, got %q", libprotoRe.String(), string(out))

--- a/api/core/v3/resource_generated.go
+++ b/api/core/v3/resource_generated.go
@@ -491,3 +491,115 @@ func (r *ResourceTemplate) GetTypeMeta() corev2.TypeMeta {
 		Type:       "ResourceTemplate",
 	}
 }
+
+// SetMetadata sets the provided metadata on the type. If the type does not
+// have any metadata, nothing will happen.
+func (s *SymmetricKey) SetMetadata(meta *corev2.ObjectMeta) {
+	// The function has to use reflection, since not all of the generated types
+	// will have metadata.
+	value := reflect.Indirect(reflect.ValueOf(s))
+	field := value.FieldByName("Metadata")
+	if !field.CanSet() {
+		return
+	}
+	field.Set(reflect.ValueOf(meta))
+}
+
+// StoreName returns the store name for SymmetricKey. It will be
+// overridden if there is a method for SymmetricKey called "storeName".
+func (s *SymmetricKey) StoreName() string {
+	var iface interface{} = s
+	if prefixer, ok := iface.(storeNamer); ok {
+		return prefixer.storeName()
+	}
+	return "symmetric_keys"
+}
+
+// RBACName returns the RBAC name for SymmetricKey. It will be overridden if
+// there is a method for SymmetricKey called "rbacName".
+func (s *SymmetricKey) RBACName() string {
+	var iface interface{} = s
+	if namer, ok := iface.(rbacNamer); ok {
+		return namer.rbacName()
+	}
+	return "symmetric_keys"
+}
+
+// URIPath returns the URI path for SymmetricKey. It will be overridden if
+// there is a method for SymmetricKey called uriPath.
+func (s *SymmetricKey) URIPath() string {
+	var iface interface{} = s
+	if pather, ok := iface.(uriPather); ok {
+		return pather.uriPath()
+	}
+	metaer, ok := iface.(getMetadataer)
+	if !ok {
+		return ""
+	}
+	meta := metaer.GetMetadata()
+	if meta == nil {
+		return uriPath("symmetric-keys", "", "")
+	}
+	return uriPath("symmetric-keys", meta.Namespace, meta.Name)
+}
+
+// Validate validates the SymmetricKey. If the SymmetricKey has metadata,
+// it will be validated via ValidateMetadata. If there is a method for
+// SymmetricKey called validate, then it will be used to cooperatively
+// validate the SymmetricKey.
+func (s *SymmetricKey) Validate() error {
+	if s == nil {
+		return errors.New("nil SymmetricKey")
+	}
+	var iface interface{} = s
+	if resource, ok := iface.(Resource); ok {
+		meta := resource.GetMetadata()
+		if err := ValidateMetadata(meta); err != nil {
+			return fmt.Errorf("invalid SymmetricKey: %s", err)
+		}
+		if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+			if err := ValidateGlobalMetadata(meta); err != nil {
+				return fmt.Errorf("invalid SymmetricKey: %s", err)
+			}
+		}
+	}
+	if validator, ok := iface.(validator); ok {
+		if err := validator.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalJSON is provided in order to ensure that metadata labels and
+// annotations are never nil.
+func (s *SymmetricKey) UnmarshalJSON(msg []byte) error {
+	type Clone SymmetricKey
+	var clone Clone
+	if err := json.Unmarshal(msg, &clone); err != nil {
+		return err
+	}
+	*s = *(*SymmetricKey)(&clone)
+	var iface interface{} = s
+	var meta *corev2.ObjectMeta
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta = metaer.GetMetadata()
+	}
+	if meta != nil {
+		if meta.Labels == nil {
+			meta.Labels = make(map[string]string)
+		}
+		if meta.Annotations == nil {
+			meta.Annotations = make(map[string]string)
+		}
+	}
+	return nil
+}
+
+// GetTypeMeta gets the type metadata for a SymmetricKey.
+func (s *SymmetricKey) GetTypeMeta() corev2.TypeMeta {
+	return corev2.TypeMeta{
+		APIVersion: "core/v3",
+		Type:       "SymmetricKey",
+	}
+}

--- a/api/core/v3/resource_generated_test.go
+++ b/api/core/v3/resource_generated_test.go
@@ -671,6 +671,171 @@ func TestResourceTemplateGetTypeMeta(t *testing.T) {
 	}
 }
 
+func TestSymmetricKeySetMetadata(t *testing.T) {
+	value := new(SymmetricKey)
+	var iface interface{} = value
+	metaer, ok := iface.(getMetadataer)
+	if !ok {
+		return
+	}
+	meta := &corev2.ObjectMeta{
+		Name:        "snoopdogg",
+		Namespace:   "lbc",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	value.SetMetadata(meta)
+	if got, want := metaer.GetMetadata(), meta; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad metadata: got %v, want %v", got, want)
+	}
+}
+
+func TestSymmetricKeyStoreName(t *testing.T) {
+	var value SymmetricKey
+	got := value.StoreName()
+	if len(got) == 0 {
+		t.Error("undefined store suffix")
+	}
+	var iface interface{} = value
+	if suffixer, ok := iface.(storeNamer); ok {
+		if got, want := value.StoreName(), suffixer.storeName(); got != want {
+			t.Errorf("bad store suffix: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestSymmetricKeyRBACName(t *testing.T) {
+	var value SymmetricKey
+	got := value.RBACName()
+	if len(got) == 0 {
+		t.Error("undefined rbac name")
+	}
+	var iface interface{} = value
+	if namer, ok := iface.(rbacNamer); ok {
+		if got, want := value.RBACName(), namer.rbacName(); got != want {
+			t.Errorf("bad rbac name: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestSymmetricKeyURIPath(t *testing.T) {
+	var value SymmetricKey
+	value.Metadata = &corev2.ObjectMeta{
+		Namespace: "default",
+		Name:      "foo",
+	}
+	got := value.URIPath()
+	if _, err := url.Parse(got); err != nil {
+		t.Error(err)
+	}
+	var iface interface{} = value
+	if pather, ok := iface.(uriPather); ok {
+		if got, want := value.URIPath(), pather.uriPath(); got != want {
+			t.Errorf("bad uri path: got %s, want %s", got, want)
+		}
+	}
+}
+
+func TestSymmetricKeyValidate(t *testing.T) {
+	var value SymmetricKey
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for nil metadata")
+	}
+	value.Metadata = &corev2.ObjectMeta{
+		Name:        "#@$@#%@#%@#%",
+		Labels:      make(map[string]string),
+		Annotations: make(map[string]string),
+	}
+	if err := value.Validate(); err == nil {
+		t.Errorf("expected non-nil error for invalid metadata name")
+	}
+	value.Metadata.Name = "foo"
+
+	var iface interface{} = &value
+
+	if gr, ok := iface.(GlobalResource); ok && gr.IsGlobalResource() {
+		value.Metadata.Namespace = "fizz"
+		if err := value.Validate(); err == nil {
+			t.Errorf("expected non-nill error for global resource with namespace set")
+		}
+		value.Metadata.Namespace = ""
+	}
+
+	if validator, ok := iface.(validator); ok {
+		if got, want := value.Validate(), validator.validate(); got.Error() != want.Error() {
+			t.Errorf("validator error: got %s, want %s", got, want)
+		}
+		return
+	}
+	if err := value.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSymmetricKeyUnmarshalJSON(t *testing.T) {
+	msg := []byte(`{"metadata": {"namespace": "default", "name": "foo"}}`)
+	var value SymmetricKey
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+	var iface interface{} = &value
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if got, want := meta.Namespace, "default"; got != want {
+			t.Errorf("bad namespace: got %s, want %s", got, want)
+		}
+		if got, want := meta.Name, "foo"; got != want {
+			t.Errorf("bad name: got %s, want %s", got, want)
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+	}
+
+	// make sure labels are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "labels": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Labels), 1; got != want {
+			t.Error("expected one label")
+		}
+	}
+
+	// make sure annotations are not accidentally zeroed out
+	msg = []byte(`{"metadata": {"namespace": "default", "name": "foo", "annotations": {"a": "b"}}}`)
+	if err := json.Unmarshal(msg, &value); err != nil {
+		t.Fatal(err)
+	}
+
+	if metaer, ok := iface.(getMetadataer); ok {
+		meta := metaer.GetMetadata()
+		if got, want := len(meta.Annotations), 1; got != want {
+			t.Error("expected one annotation")
+		}
+	}
+}
+
+func TestSymmetricKeyGetTypeMeta(t *testing.T) {
+	var value SymmetricKey
+	meta := value.GetTypeMeta()
+	if got, want := meta.APIVersion, "core/v3"; got != want {
+		t.Errorf("bad api version: got %s, want %s", got, want)
+	}
+	if got, want := meta.Type, "SymmetricKey"; got != want {
+		t.Errorf("bad type: got %s, want %s", got, want)
+	}
+}
+
 func TestResourceUniqueness(t *testing.T) {
 	types := make(map[reflect.Type]GeneratedType)
 	for _, v := range typeMap {

--- a/api/core/v3/symmetric_key.go
+++ b/api/core/v3/symmetric_key.go
@@ -1,0 +1,12 @@
+package v3
+
+import corev2 "github.com/sensu/sensu-go/api/core/v2"
+
+type SymmetricKey struct {
+	Metadata *corev2.ObjectMeta `json:"metadata"`
+	Value    []byte             `json:"value"`
+}
+
+func (s *SymmetricKey) GetMetadata() *corev2.ObjectMeta {
+	return s.Metadata
+}

--- a/api/core/v3/typemap.go
+++ b/api/core/v3/typemap.go
@@ -33,6 +33,8 @@ var typeMap = map[string]interface{}{
 	"namespace":         &Namespace{},
 	"ResourceTemplate":  &ResourceTemplate{},
 	"resource_template": &ResourceTemplate{},
+	"SymmetricKey":      &SymmetricKey{},
+	"symmetric_key":     &SymmetricKey{},
 }
 
 // rbacMap is like typemap, but its keys are RBAC names, and its values are

--- a/api/core/v3/typemap_test.go
+++ b/api/core/v3/typemap_test.go
@@ -375,6 +375,98 @@ func TestResolveV2ResourceResourceTemplate(t *testing.T) {
 	}
 }
 
+func TestResolveSymmetricKey(t *testing.T) {
+	var value interface{} = new(SymmetricKey)
+	if _, ok := value.(Resource); ok {
+		resource, err := ResolveResource("SymmetricKey")
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil metadata")
+		}
+		if meta.Annotations == nil {
+			t.Error("nil annotations")
+		}
+		return
+	}
+	_, err := ResolveResource("SymmetricKey")
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if got, want := err.Error(), `"SymmetricKey" is not a Resource`; got != want {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestResolveSymmetricKeyByRBACName(t *testing.T) {
+	value := new(SymmetricKey)
+	var iface interface{} = value
+	resource, err := ResolveResourceByRBACName(value.RBACName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveSymmetricKeyByStoreName(t *testing.T) {
+	value := new(SymmetricKey)
+	var iface interface{} = value
+	resource, err := ResolveResourceByStoreName(value.StoreName())
+	if _, ok := iface.(Resource); ok {
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta := resource.GetMetadata()
+		if meta == nil {
+			t.Fatal("nil metadata")
+		}
+		if meta.Labels == nil {
+			t.Error("nil labels")
+		}
+		if meta.Annotations == nil {
+			t.Errorf("nil annotations")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+	}
+}
+
+func TestResolveV2ResourceSymmetricKey(t *testing.T) {
+	v2Resource, err := ResolveV2Resource("SymmetricKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3Resource, err := ResolveResource("SymmetricKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := v2Resource.(*V2ResourceProxy).Resource, v3Resource; !reflect.DeepEqual(got, want) {
+		t.Fatalf("bad resource: got %v, want %v", got, want)
+	}
+}
+
 func TestResolveNotExists(t *testing.T) {
 	_, err := ResolveResource("!#$@$%@#$")
 	if err == nil {

--- a/backend/api/jwt.go
+++ b/backend/api/jwt.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/authentication/jwt"
+	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	utilbytes "github.com/sensu/sensu-go/util/bytes"
+)
+
+type JWT struct {
+	Store storev2.Interface
+}
+
+func (j JWT) GetSecret(ctx context.Context) ([]byte, error) {
+	keystore := storev2.NewGenericStore[*corev3.SymmetricKey](j.Store)
+	key, err := keystore.Get(ctx, storev2.ID{Name: jwt.Name})
+	if err != nil {
+		if _, ok := err.(*store.ErrNotFound); ok {
+			randomBytes, err := utilbytes.Random(32)
+			if err != nil {
+				return nil, fmt.Errorf("error creating jwt secret: %s", err)
+			}
+			key := &corev3.SymmetricKey{Metadata: corev2.NewObjectMetaP(jwt.Name, ""), Value: randomBytes}
+			if err := keystore.CreateIfNotExists(ctx, key); err != nil {
+				if _, ok := err.(*store.ErrAlreadyExists); ok {
+					return j.GetSecret(ctx)
+				}
+				return nil, err
+			}
+			return key.Value, nil
+		} else {
+			return nil, err
+		}
+	}
+	return key.Value, nil
+}

--- a/backend/api/jwt_test.go
+++ b/backend/api/jwt_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestJWTGetSecretNotFoundCreateIfNotExists(t *testing.T) {
+	s := new(mockstore.V2MockStore)
+	s.On("Get", mock.Anything, mock.Anything).Return(nil, &store.ErrNotFound{})
+	s.On("CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	jwtclient := JWT{Store: s}
+	value, err := jwtclient.GetSecret(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(value), 32; got != want {
+		t.Errorf("value len wrong: got %d, want %d", got, want)
+	}
+	s.AssertCalled(t, "Get", mock.Anything, mock.Anything)
+	s.AssertCalled(t, "CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -156,7 +156,7 @@ func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	)
 
 	mountRouters(subrouter,
-		routers.NewAuthenticationRouter(cfg.Authenticator),
+		routers.NewAuthenticationRouter(api.NewAuthenticationClient(cfg.Authenticator)),
 	)
 
 	return subrouter

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -8,19 +8,24 @@ import (
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 
 	"github.com/gorilla/mux"
-	"github.com/sensu/sensu-go/backend/api"
-	"github.com/sensu/sensu-go/backend/authentication"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
+type AuthenticationClient interface {
+	CreateAccessToken(ctx context.Context, username, password string) (*corev2.Tokens, error)
+	TestCreds(ctx context.Context, username, password string) error
+	Logout(context.Context) error
+	RefreshAccessToken(context.Context) (*corev2.Tokens, error)
+}
+
 // AuthenticationRouter handles authentication related requests
 type AuthenticationRouter struct {
-	authenticator *authentication.Authenticator
+	authenticator AuthenticationClient
 }
 
 // NewAuthenticationRouter instantiates new router.
-func NewAuthenticationRouter(authenticator *authentication.Authenticator) *AuthenticationRouter {
+func NewAuthenticationRouter(authenticator AuthenticationClient) *AuthenticationRouter {
 	return &AuthenticationRouter{authenticator: authenticator}
 }
 
@@ -45,7 +50,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// issuer URL
 	ctx := context.WithValue(r.Context(), jwt.IssuerURLKey, issuerURL(r))
 
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := a.authenticator
 	tokens, err := client.CreateAccessToken(ctx, username, password)
 	if err != nil {
 		if err == corev2.ErrUnauthorized {
@@ -74,7 +79,7 @@ func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := a.authenticator
 	err := client.TestCreds(r.Context(), username, password)
 	if err == nil {
 		return
@@ -88,7 +93,7 @@ func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
 
 // logout handles the logout flow
 func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := a.authenticator
 	if err := client.Logout(r.Context()); err == nil {
 		return
 	}
@@ -98,7 +103,7 @@ func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
 
 // token handles logic for issuing new access tokens
 func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := a.authenticator
 
 	// Determine the URL that serves this request so it can be later used as the
 	// issuer URL

--- a/backend/apid/routers/authentication_test.go
+++ b/backend/apid/routers/authentication_test.go
@@ -1,62 +1,79 @@
 package routers
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
-	"github.com/sensu/sensu-go/backend/authentication"
-	"github.com/sensu/sensu-go/backend/authentication/providers/basic"
-	realStore "github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
+type mockAuthenticator struct {
+	mock.Mock
+}
+
+func (m *mockAuthenticator) CreateAccessToken(ctx context.Context, username, password string) (*corev2.Tokens, error) {
+	args := m.Called(ctx, username, password)
+	return args.Get(0).(*corev2.Tokens), args.Error(1)
+}
+
+func (m *mockAuthenticator) TestCreds(ctx context.Context, username, password string) error {
+	return m.Called(ctx, username, password).Error(0)
+}
+
+func (m *mockAuthenticator) Logout(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+func (m *mockAuthenticator) RefreshAccessToken(ctx context.Context) (*corev2.Tokens, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*corev2.Tokens), args.Error(1)
+}
+
 func TestLoginNoCredentials(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
+	auth := new(mockAuthenticator)
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth", nil)
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestLoginInvalidCredentials(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
-
-	user := types.FixtureUser("foo")
-	store.
-		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
-		Return(user, fmt.Errorf("error"))
+	auth := new(mockAuthenticator)
+	auth.On("CreateAccessToken", mock.Anything, mock.Anything, mock.Anything).Return((*corev2.Tokens)(nil), corev2.ErrUnauthorized)
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth", nil)
 	req.SetBasicAuth("foo", "P@ssw0rd!")
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestLoginSuccessful(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
-
-	user := types.FixtureUser("foo")
-	store.
-		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
-		Return(user, nil)
+	auth := new(mockAuthenticator)
+	tokens := &corev2.Tokens{
+		Access:    "abcd",
+		ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		Refresh:   "abcd",
+	}
+	auth.On("CreateAccessToken", mock.Anything, "foo", "P@ssw0rd!").Return(tokens, nil)
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth", nil)
 	req.SetBasicAuth("foo", "P@ssw0rd!")
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusOK, res.Code)
 
 	// We should have the access token
@@ -71,52 +88,38 @@ func TestLoginSuccessful(t *testing.T) {
 }
 
 func TestTestNoCredentials(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
+	auth := new(mockAuthenticator)
+	auth.On("TestCreds", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("not authenticated"))
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestTestInvalidCredentials(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
-
-	user := types.FixtureUser("foo")
-	store.
-		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
-		Return(user, fmt.Errorf("error"))
+	auth := new(mockAuthenticator)
+	auth.On("TestCreds", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("not authenticated"))
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
 	req.SetBasicAuth("foo", "P@ssw0rd!")
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestTestSuccessful(t *testing.T) {
-	store := &mockstore.MockStore{}
-	a := authenticationRouter(store)
-
-	user := types.FixtureUser("foo")
-	store.
-		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
-		Return(user, nil)
+	auth := new(mockAuthenticator)
+	auth.On("TestCreds", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	router := NewAuthenticationRouter(auth)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth/test", nil)
 	req.SetBasicAuth("foo", "P@ssw0rd!")
 
-	res := processRequest(a, req)
+	res := processRequest(router, req)
 	assert.Equal(t, http.StatusOK, res.Code)
-}
-
-func authenticationRouter(store realStore.Store) *AuthenticationRouter {
-	authenticator := &authentication.Authenticator{}
-	provider := &basic.Provider{Store: store, ObjectMeta: corev2.ObjectMeta{Name: basic.Type}}
-	authenticator.AddProvider(provider)
-	return &AuthenticationRouter{authenticator: authenticator}
 }
 
 func processRequest(router Router, req *http.Request) *httptest.ResponseRecorder {

--- a/backend/authentication/jwt/jwt.go
+++ b/backend/authentication/jwt/jwt.go
@@ -25,6 +25,8 @@ const (
 	IssuerURLKey key = iota
 )
 
+const Name = "jwt"
+
 var (
 	defaultExpiration = time.Minute * 5
 	secret            []byte

--- a/backend/authentication/providers/basic/basic.go
+++ b/backend/authentication/providers/basic/basic.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
 
 // Type represents the type of the basic authentication provider
@@ -19,7 +21,7 @@ var ErrEmptyUsernamePassword = errors.New("the username and the password must no
 
 // Provider represents the basic internal authentication provider
 type Provider struct {
-	Store store.Store
+	Store storev2.Interface
 
 	// ObjectMeta contains the name, namespace, labels and annotations
 	corev2.ObjectMeta `json:"metadata"`
@@ -31,9 +33,26 @@ func (p *Provider) Authenticate(ctx context.Context, username, password string) 
 		return nil, ErrEmptyUsernamePassword
 	}
 
-	user, err := p.Store.AuthenticateUser(ctx, username, password)
+	userstore := storev2.NewGenericStore[*corev2.User](p.Store)
+
+	user, err := userstore.Get(ctx, storev2.ID{Name: username})
 	if err != nil {
 		return nil, err
+	}
+
+	if user.Disabled {
+		return nil, &store.ErrNotValid{Err: fmt.Errorf("user %s is disabled", username)}
+	}
+
+	// Check if we have an explicitly hashed password, otherwise fallback to the
+	// password field for backward compatiblility
+	passwordHash := user.PasswordHash
+	if passwordHash == "" {
+		passwordHash = user.Password
+	}
+	ok := bcrypt.CheckPassword(passwordHash, password)
+	if !ok {
+		return nil, &store.ErrNotValid{Err: fmt.Errorf("wrong password for user %s", username)}
 	}
 
 	claims, err := jwt.NewClaims(user)
@@ -49,12 +68,10 @@ func (p *Provider) Authenticate(ctx context.Context, username, password string) 
 
 // Refresh the claims of a user
 func (p *Provider) Refresh(ctx context.Context, claims *corev2.Claims) (*corev2.Claims, error) {
-	user, err := p.Store.GetUser(ctx, claims.Provider.UserID)
+	userstore := storev2.NewGenericStore[*corev2.User](p.Store)
+	user, err := userstore.Get(ctx, storev2.ID{Name: claims.Provider.UserID})
 	if err != nil {
 		return nil, err
-	}
-	if user == nil {
-		return nil, fmt.Errorf("user %q does not exist", claims.Provider.UserID)
 	}
 	if user.Disabled {
 		return nil, fmt.Errorf("user %q is disabled", claims.Provider.UserID)

--- a/backend/authentication/providers/basic/basic_test.go
+++ b/backend/authentication/providers/basic/basic_test.go
@@ -1,0 +1,205 @@
+package basic
+
+import (
+	"context"
+	"testing"
+
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
+	"github.com/sensu/sensu-go/backend/store"
+	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestProviderAuthenticate(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Store    storev2.Interface
+		Username string
+		Password string
+		Hash     string
+		Error    bool
+	}{
+		{
+			Name:     "username not supplied",
+			Username: "",
+			Password: "hello",
+			Error:    true,
+		},
+		{
+			Name:     "password not supplied",
+			Username: "Hello",
+			Password: "",
+			Error:    true,
+		},
+		{
+			Name: "user not found",
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				s.On("Get", mock.Anything, mock.Anything).Return(nil, &store.ErrNotFound{})
+				return s
+			}(),
+			Username: "eric",
+			Password: "password",
+			Error:    true,
+		},
+		{
+			Name: "user disabled",
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				user := &corev2.User{
+					Username: "eric",
+					Disabled: true,
+				}
+				s.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.User]{Value: user}, nil)
+				return s
+			}(),
+			Username: "eric",
+			Password: "password",
+			Error:    true,
+		},
+		{
+			Name: "password hash does not match",
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				pw, err := bcrypt.HashPassword("password")
+				if err != nil {
+					panic(err)
+				}
+				user := &corev2.User{
+					Username:     "eric",
+					PasswordHash: pw,
+				}
+				s.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.User]{Value: user}, nil)
+				return s
+			}(),
+			Username: "eric",
+			Password: "asldjflkdsajfl",
+			Error:    true,
+		},
+		{
+			Name: "password hash does match",
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				pw, err := bcrypt.HashPassword("password")
+				if err != nil {
+					panic(err)
+				}
+				user := &corev2.User{
+					Username:     "eric",
+					PasswordHash: pw,
+				}
+				s.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.User]{Value: user}, nil)
+				return s
+			}(),
+			Username: "eric",
+			Password: "password",
+			Error:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			provider := &Provider{
+				Store: test.Store,
+			}
+			claims, err := provider.Authenticate(context.Background(), test.Username, test.Password)
+			if err != nil {
+				if !test.Error {
+					t.Fatal(err)
+				}
+			} else {
+				if test.Error {
+					t.Fatal("want non-nil error")
+				}
+				if claims == nil {
+					t.Fatal("nil claims")
+				}
+			}
+		})
+	}
+}
+
+func TestProviderRefresh(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Claims *corev2.Claims
+		Store  storev2.Interface
+		Error  bool
+	}{
+		{
+			Name: "user not found",
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				s.On("Get", mock.Anything, mock.Anything).Return(nil, &store.ErrNotFound{})
+				return s
+			}(),
+			Claims: &corev2.Claims{
+				Provider: corev2.AuthProviderClaims{
+					UserID: "eric",
+				},
+			},
+			Error: true,
+		},
+		{
+			Name: "user disabled",
+			Claims: &corev2.Claims{
+				Provider: corev2.AuthProviderClaims{
+					UserID: "eric",
+				},
+			},
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				user := &corev2.User{
+					Username: "eric",
+					Disabled: true,
+				}
+				s.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.User]{Value: user}, nil)
+				return s
+			}(),
+			Error: true,
+		},
+		{
+			Name: "happy",
+			Claims: &corev2.Claims{
+				Provider: corev2.AuthProviderClaims{
+					UserID: "eric",
+				},
+			},
+			Store: func() storev2.Interface {
+				s := new(mockstore.V2MockStore)
+				pw, err := bcrypt.HashPassword("password")
+				if err != nil {
+					panic(err)
+				}
+				user := &corev2.User{
+					Username:     "eric",
+					PasswordHash: pw,
+				}
+				s.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.User]{Value: user}, nil)
+				return s
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			provider := &Provider{
+				Store: test.Store,
+			}
+			claims, err := provider.Refresh(context.Background(), test.Claims)
+			if err != nil {
+				if !test.Error {
+					t.Fatal(err)
+				}
+			} else {
+				if test.Error {
+					t.Fatal("want non-nil error")
+				}
+				if claims == nil {
+					t.Fatal("nil claims")
+				}
+			}
+		})
+	}
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -463,7 +463,7 @@ func Initialize(ctx context.Context, etcdConfigClient *clientv3.Client, pgConfig
 	authenticator := &authentication.Authenticator{}
 	provider := &basic.Provider{
 		ObjectMeta: corev2.ObjectMeta{Name: basic.Type},
-		Store:      b.Store,
+		Store:      b.StoreV2,
 	}
 	authenticator.AddProvider(provider)
 

--- a/backend/init.go
+++ b/backend/init.go
@@ -262,7 +262,7 @@ func InitializeStore(ctx context.Context, client *clientv3.Client, db *pgxpool.P
 	authenticator := &authentication.Authenticator{}
 	provider := &basic.Provider{
 		ObjectMeta: corev2.ObjectMeta{Name: basic.Type},
-		Store:      b.Store,
+		Store:      b.StoreV2,
 	}
 	authenticator.AddProvider(provider)
 


### PR DESCRIPTION
Removes store authentication dependencies and instead offers some new APIs built on top of store/v2.