### PR TITLE
Remove CI constraint forbiding go.mod replace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ workflows:
       - test-module:
           name: types
           path: types
-      - assert-no-replace
   build:
     jobs:
       # darwin/amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,22 +22,6 @@ go_test_env: &sensu_go_test_env
       GOPROXY: 'https://proxy.golang.org'
 
 jobs:
-  assert-no-replace:
-    <<: *sensu_go_build_env
-    <<: *sensu_go_test_env
-    steps:
-      - checkout
-      - run:
-          name: Check For Replace Directives
-          command: |
-            replaces=$(grep -R --include="go.mod" "^replace " || :)
-            if [ -n "$replaces" ]
-            then
-              echo "replace directives not allowed"
-              echo "$replaces"
-              exit 1
-            fi
-
   test:
     <<: *sensu_go_build_env
     <<: *sensu_go_test_env


### PR DESCRIPTION
Replace directives can be useful when we need to fork
our own version of a dependency but do not wish to edit
all import paths.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>