### PR TITLE
Update logging for unrunable pipelines

### DIFF
--- a/backend/pipeline/adapter.go
+++ b/backend/pipeline/adapter.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
@@ -14,9 +15,28 @@ type Adapter interface {
 	Run(context.Context, *corev2.ResourceReference, interface{}) error
 }
 
+// ErrMisconfiguredPipeline interface implemented by errors that indicate
+// a misconfigured pipeline that cannot be executed.
+type ErrMisconfiguredPipeline interface {
+	MisconfiguredPipeline()
+}
+
 // ErrNoWorkflows is returned when a pipeline has no workflows
 type ErrNoWorkflows struct{}
 
 func (e *ErrNoWorkflows) Error() string {
 	return "pipeline has no workflows"
 }
+
+func (e *ErrNoWorkflows) MisconfiguredPipeline() {}
+
+// ErrNoLegacyHandlers is returned when no legacy handlers exist
+type errNoLegacyHandlers struct {
+	Msg string
+}
+
+func (e *errNoLegacyHandlers) Error() string {
+	return fmt.Sprintf("legacy pipeline found no existing handlers: %s", e.Msg)
+}
+
+func (e *errNoLegacyHandlers) MisconfiguredPipeline() {}

--- a/backend/pipeline/adapterv1.go
+++ b/backend/pipeline/adapterv1.go
@@ -285,6 +285,12 @@ func (a *AdapterV1) generateLegacyPipeline(ctx context.Context, event *corev2.Ev
 		return nil, err
 	}
 
+	if len(handlers) < 1 {
+		return nil, &errNoLegacyHandlers{
+			Msg: fmt.Sprintf("none of %s exist", legacyHandlerNames),
+		}
+	}
+
 	pipeline := &corev2.Pipeline{
 		ObjectMeta: corev2.ObjectMeta{
 			Name:      LegacyPipelineName,


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-enterprise-go/issues/2323

## What is this change?

Makes logging adjustments for situations where an event processing pipeline can't be ran due to its configuration.

**Fixes misleading log messages**
Before either of these two situations resulted in a log line like this `pipeline has no workflows, skipping execution of pipeline`:
* (The obvious) An event references a pipeline for which no workflows are configured
* (The misleading) An event has handlers specified, but none of the handlers exist.

Now the log message is specific to the later situation: `legacy pipeline found no existing handlers: none of [handlerDNE] exist, skipping execution of pipeline`.

**Adjusts log levels**

Previously this log was emitted at a Warning level. I felt it was better at Info as there isn't necessarily anything wrong. Definitely debatable, though, as issues like these are difficult for users to debug.

Previously this log was omitted when the check name is "keepalive", as many clusters are likely to generate a lot of these due to the default keepalive handler we add on keepalive events. I thought including these at Info might be problematic, but especially with the addition of keepalive pipelines this can be tricky to troubleshoot, so I've included them at the Debug level.

## Does your change need a Changelog entry?

I don't really think so.

## Do you need clarification on anything?

N


## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?
Manual

## Is this change a patch?
N