### PR TITLE
Fix multi-expression "Deny" filters

### DIFF
--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -28,6 +28,10 @@ migrated from Etcd.
 - GlobalResource interface in core/v3 allows core/v3 resources to
 be marked as global resources.
 
+### Fixed
+- Fixed an issue where multi-expression exclusive "Deny" filters were not
+  evaluated as described in the documentation.
+
 ### Changed
 - Changed parameters for `sensuctl cluster-role create` to be plural
 - Deregistration events are now silenced if a silenced entry exists matching the


### PR DESCRIPTION
## What is this change?

This makes it so multi-expression "Deny" filters are correctly evaluated: their
expressions are OR'd together to decide whether to filter or not.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/2351

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

We were not 100% sure if this was a regression or not. It turned out to be
(introduced in 6.5).

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation change is required: this changes makes the behavior line up
with the documentation.

## How did you verify this change?

- Relevant unit tests
- Manual testing as described in https://github.com/sensu/sensu-enterprise-go/issues/2351

## Is this change a patch?

Yes, it needs to also be backported to `develop/6`