### PR TITLE
Include Backend Name with Agent WS Connection

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -11,6 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fixed an issue where multi-expression exclusive "Deny" filters were not
   evaluated as described in the documentation.
 
+### Added
+- Agent websocket connection logging includes backend entity name.
+
 ## [6.8.0] - 2022-08-24
 
 ### Changed

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -777,8 +777,13 @@ func (a *Agent) connectWithBackoff(ctx context.Context) (transport.Transport, er
 			logger.WithError(err).Error("reconnection attempt failed")
 			return false, nil
 		}
+		backendID := respHeader.Get("Backend-ID")
 
-		logger.Info("successfully connected")
+		fields := logrus.Fields{
+			"backend-id":  backendID,
+			"backend-url": backendURL,
+		}
+		logger.WithFields(fields).Info("successfully connected")
 
 		conn = c
 

--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -104,6 +104,7 @@ type Agentd struct {
 	healthRouter        *routers.HealthRouter
 	serveWaitTime       time.Duration
 	ready               func()
+	backendEntity       *corev2.Entity
 }
 
 // Config configures an Agentd.
@@ -119,6 +120,7 @@ type Config struct {
 	Client              *clientv3.Client
 	EtcdClientTLSConfig *tls.Config
 	Watcher             <-chan store.WatchEventEntityConfig
+	BackendEntity       *corev2.Entity
 }
 
 // Option is a functional option.
@@ -146,6 +148,7 @@ func New(c Config, opts ...Option) (*Agentd, error) {
 		client:              c.Client,
 		etcdClientTLSConfig: c.EtcdClientTLSConfig,
 		serveWaitTime:       c.ServeWaitTime,
+		backendEntity:       c.BackendEntity,
 	}
 
 	// prepare server TLS config
@@ -350,6 +353,7 @@ func (a *Agentd) webSocketHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	responseHeader := make(http.Header)
+	responseHeader.Add("Backend-ID", a.backendEntity.Name)
 	responseHeader.Add("Accept", agent.ProtobufSerializationHeader)
 	lager.WithField("header", fmt.Sprintf("Accept: %s", agent.ProtobufSerializationHeader)).Debug("setting header")
 	responseHeader.Add("Accept", agent.JSONSerializationHeader)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -655,6 +655,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 		Client:              b.Client,
 		Watcher:             entityConfigWatcher,
 		EtcdClientTLSConfig: b.EtcdClientTLSConfig,
+		BackendEntity:       backendEntity,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", agent.Name(), err)


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-enterprise-go/issues/2270

## What is this change?

Adds a backend-id header to the agent ws upgrade response and log it on the agent side.

## Why is this change necessary?

It can be difficult to debug issues that appear to only affect specific backends. Logging more backend connection info on the agent side may assist users in identifying problem backends.

## Does your change need a Changelog entry?

Y
## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?


## Is this change a patch?

N