### PR TITLE
Update Check Subdues to allow for overlapping intervals

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Check subdues are now evaluated on a half open interval such that there
+should be no unintended gaps between overlapping subdues.
+
 ## [6.8.0] - 2022-08-24
 
 ### Changed

--- a/api/core/v2/time_window.go
+++ b/api/core/v2/time_window.go
@@ -257,8 +257,9 @@ func (t *TimeWindowRepeated) inAbsoluteTimeRange(actualTime time.Time) bool {
 	if err != nil {
 		return false
 	}
+	endTime = endTime.Add(time.Second)
 
-	return actualTime.After(beginTime) && actualTime.Before(endTime)
+	return !actualTime.Before(beginTime) && actualTime.Before(endTime)
 }
 
 func (t *TimeWindowRepeated) inDayTimeRange(actualTime time.Time, weekday time.Weekday) bool {
@@ -284,9 +285,10 @@ func (t *TimeWindowRepeated) inDayTimeRange(actualTime time.Time, weekday time.W
 	thisWeekBegin = thisWeekBegin.AddDate(0, 0, dayOffset)
 
 	thisWeekEnd := thisWeekBegin.Add(duration)
+	thisWeekEnd = thisWeekEnd.Add(time.Second)
 	thisWeekEnd.In(beginTime.Location())
 
-	return actualTime.After(thisWeekBegin) && actualTime.Before(thisWeekEnd)
+	return !actualTime.Before(thisWeekBegin) && actualTime.Before(thisWeekEnd)
 }
 
 func (t *TimeWindowRepeated) inTimeRange(actualTime time.Time) bool {
@@ -310,8 +312,9 @@ func (t *TimeWindowRepeated) inTimeRange(actualTime time.Time) bool {
 	todayBegin := time.Date(actualTime.Year(), actualTime.Month(), actualTime.Day(), beginHour, beginMin, beginSec, 0, beginTime.Location())
 	todayEnd := todayBegin.Add(duration)
 	todayEnd = todayEnd.In(beginTime.Location())
+	todayEnd = todayEnd.Add(time.Second)
 
-	return actualTime.After(todayBegin) && actualTime.Before(todayEnd)
+	return !actualTime.Before(todayBegin) && actualTime.Before(todayEnd)
 }
 
 func (t *TimeWindowRepeated) inWeekdayTimeRange(actualTime time.Time) bool {

--- a/api/core/v2/time_window_test.go
+++ b/api/core/v2/time_window_test.go
@@ -275,12 +275,21 @@ func TestTimeWindowRepeated_InWindows(t *testing.T) {
 	assert.NotNil(t, location)
 }
 
+func parseTime(t *testing.T, s string) time.Time {
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
+}
+
 func TestTimeWindowRepeated_InDayTimeRange(t *testing.T) {
+
 	tests := []struct {
 		name           string
 		beginTime      string
 		endTime        string
-		actualTime     string
+		actualTime     time.Time
 		weekday        time.Weekday
 		expectedResult bool
 	}{
@@ -288,107 +297,121 @@ func TestTimeWindowRepeated_InDayTimeRange(t *testing.T) {
 			"simple positive",
 			"2022-03-22T09:00:00+00:00", // tuesday
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T10:00:00+00:00",
+			parseTime(t, "2022-03-22T10:00:00+00:00"),
 			time.Tuesday,
 			true,
 		}, {
 			"simple negative lower hour",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T08:00:00+00:00",
+			parseTime(t, "2022-03-22T08:00:00+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative higher hour",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T13:00:00+00:00",
+			parseTime(t, "2022-03-22T13:00:00+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative lower minutes",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T08:59:00+00:00",
+			parseTime(t, "2022-03-22T08:59:00+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative higher minutes",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T11:01:00+00:00",
+			parseTime(t, "2022-03-22T11:01:00+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative lower seconds",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T08:59:59+00:00",
+			parseTime(t, "2022-03-22T08:59:59+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative higher seconds",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T11:00:01+00:00",
+			parseTime(t, "2022-03-22T11:00:01+00:00"),
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative different day before",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-21T10:00:00+00:00", // monday
+			parseTime(t, "2022-03-21T10:00:00+00:00"), // monday
 			time.Tuesday,
 			false,
 		}, {
 			"simple negative different day after",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-23T10:00:00+00:00", // wednesday
+			parseTime(t, "2022-03-23T10:00:00+00:00"), // wednesday
 			time.Tuesday,
 			false,
 		}, {
 			"positive next week",
 			"2022-03-22T09:00:00-07:00",
 			"2022-03-22T11:00:00-07:00",
-			"2022-03-29T10:00:00-07:00", // wednesday
+			parseTime(t, "2022-03-29T10:00:00-07:00"), // wednesday
 			time.Tuesday,
 			true,
 		}, {
 			"negative next week before",
 			"2022-03-22T09:00:00-07:00",
 			"2022-03-22T11:00:00-07:00",
-			"2022-03-27T10:00:00-07:00", // wednesday
+			parseTime(t, "2022-03-27T10:00:00-07:00"), // wednesday
 			time.Tuesday,
 			false,
 		}, {
 			"negative next week after",
 			"2022-03-22T09:00:00-07:00",
 			"2022-03-22T11:00:00-07:00",
-			"2022-03-30T10:00:00-07:00", // wednesday
+			parseTime(t, "2022-03-30T10:00:00-07:00"), // wednesday
 			time.Tuesday,
 			false,
 		}, {
 			"positive next week different time offset",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-29T06:00:00-04:00", // wednesday
+			parseTime(t, "2022-03-29T06:00:00-04:00"), // wednesday
 			time.Tuesday,
 			true,
 		}, {
 			"positive multi days",
 			"2022-03-22T09:00:00+00:00",
 			"2022-03-24T11:00:00+00:00",
-			"2022-03-30T06:00:00-04:00", // wednesday
+			parseTime(t, "2022-03-30T06:00:00-04:00"), // wednesday
 			time.Tuesday,
 			true,
 		}, {
 			"negative previous week",
 			"2022-03-22T09:00:00-04:00",
 			"2022-03-22T11:00:00-04:00",
-			"2022-03-15T10:00:00-04:00", // tuesday
+			parseTime(t, "2022-03-15T10:00:00-04:00"), // tuesday
 			time.Tuesday,
 			false,
+		}, {
+			"GH-4847 lower bound day time range",
+			"2022-03-22T09:00:00+00:00",
+			"2022-03-22T11:00:00+00:00",
+			parseTime(t, "2022-03-22T09:00:00+00:00"),
+			time.Tuesday,
+			true,
+		}, {
+			"GH-4847 upper bound day time range",
+			"2022-03-22T09:00:00+00:00",
+			"2022-03-22T11:00:00+00:00",
+			parseTime(t, "2022-03-22T11:00:01+00:00").Add(-1 * time.Nanosecond),
+			time.Tuesday,
+			true,
 		},
 	}
 
@@ -399,10 +422,7 @@ func TestTimeWindowRepeated_InDayTimeRange(t *testing.T) {
 				End:   test.endTime,
 			}
 
-			actualTime, err := time.Parse(time.RFC3339, test.actualTime)
-			require.NoError(t, err)
-
-			assert.Equal(t, test.expectedResult, window.inDayTimeRange(actualTime, test.weekday))
+			assert.Equal(t, test.expectedResult, window.inDayTimeRange(test.actualTime, test.weekday))
 		})
 	}
 }
@@ -412,51 +432,63 @@ func TestTimeWindowRepeated_InTimeRange(t *testing.T) {
 		name           string
 		beginTime      string
 		endTime        string
-		actualTime     string
+		actualTime     time.Time
 		expectedResult bool
 	}{
 		{
 			"simple positive",
 			"2022-03-22T09:00:00+00:00", // tuesday
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T10:00:00+00:00",
+			parseTime(t, "2022-03-22T10:00:00+00:00"),
 			true,
 		}, {
 			"negative before valid times",
 			"2022-03-22T09:00:00-07:00", // tuesday
 			"2022-03-22T11:00:00-07:00",
-			"2022-01-12T10:00:00-07:00",
+			parseTime(t, "2022-01-12T10:00:00-07:00"),
 			false,
 		}, {
 			"simple negative before",
 			"2022-03-22T09:00:00+00:00", // tuesday
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T08:00:00+00:00",
+			parseTime(t, "2022-03-22T08:00:00+00:00"),
 			false,
 		}, {
 			"simple negative after",
 			"2022-03-22T09:00:00+00:00", // tuesday
 			"2022-03-22T11:00:00+00:00",
-			"2022-03-22T11:05:00+00:00",
+			parseTime(t, "2022-03-22T11:05:00+00:00"),
 			false,
 		}, {
 			"positive after different day",
 			"2022-03-22T09:00:00-07:00", // tuesday
 			"2022-03-22T11:00:00-07:00",
-			"2023-01-12T10:00:00-07:00",
+			parseTime(t, "2023-01-12T10:00:00-07:00"),
 			true,
 		}, {
 			"negative before different day",
 			"2022-03-22T09:00:00-07:00", // tuesday
 			"2022-03-22T11:00:00-07:00",
-			"2021-01-12T12:00:00-07:00",
+			parseTime(t, "2021-01-12T12:00:00-07:00"),
 			false,
 		}, {
 			"negative after different day",
 			"2022-03-22T09:00:00-07:00", // tuesday
 			"2022-03-22T11:00:00-07:00",
-			"2023-01-12T08:59:59-07:00",
+			parseTime(t, "2023-01-12T08:59:59-07:00"),
 			false,
+		}, {
+			"GH-4847 lower bound time range",
+			"2022-03-22T09:00:00+00:00", // tuesday
+			"2022-03-22T11:00:00+00:00",
+			parseTime(t, "2022-03-22T09:00:00+00:00"),
+			true,
+		}, {
+			"GH-4847 upper bound time range",
+			"2022-03-22T09:00:00+00:00", // tuesday
+			"2022-03-22T11:00:00+00:00",
+			parseTime(t, "2022-03-22T11:00:01+00:00").Add(-1 * time.Nanosecond),
+			true,
 		},
 	}
 
@@ -467,10 +499,7 @@ func TestTimeWindowRepeated_InTimeRange(t *testing.T) {
 				End:   test.endTime,
 			}
 
-			actualTime, err := time.ParseInLocation(time.RFC3339, test.actualTime, time.UTC)
-			require.NoError(t, err)
-
-			assert.Equal(t, test.expectedResult, window.inTimeRange(actualTime))
+			assert.Equal(t, test.expectedResult, window.inTimeRange(test.actualTime))
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Christian Kruse <ctkruse99@gmail.com>

## What is this change?

Closes https://github.com/sensu/sensu-go/issues/4847

Changes the evaluation of check subdues to be inclusive of the begin time and up to (but excluding) one second **past** the end time.

With this change subdues are a little more intuitive to use. The example straight from our docs to subdue a check all weekend currently has a second long gap (Sat night between 23:59:59 and Sun morning 00:00:00.0001.) By making the begin time inclusive and the end time + 1 second exclusive there is no longer a potential gap.
```
  - begin: "2022-04-23T00:00:00-07:00"
    end: "2022-04-23T23:59:59-07:00"
    repeat:
    - weekends
```

Alternately, users can bypass this issue today by setting the end time 2 seconds later (in this case overlapping into the next day) to avoid any potential missed subdues.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

The choice to subdue for 1 second past the end time may be a little contentious/unintuitive. We could drop this and make it a more strict [start, end) interval, and update our documentation to remove any ambiguity around subdues intervals. I think it might just get a little wordy.

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

I don't think so. I think this change brings us in line with the docs.

## How did you verify this change?

Unit tests

## Is this change a patch?

Y
