### PR TITLE
Temporarily Fix the api/core/v3 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.14.0
-	github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68
+	github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf
 	github.com/sensu/sensu-go/types v0.10.0
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -397,10 +397,8 @@ github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU
 github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/api/core/v3 v3.6.2 h1:NEkHcPxkaYwPlH4gG6kgvdvYLlwBBaswMHscA7X3V+4=
 github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912171820-366b64ed1a62 h1:PeP63bXXwwB586EjCb73jg0oqzE3Tg3aOH38g9qG58k=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912171820-366b64ed1a62/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68 h1:t5AsMszceHgj4yGHflRi705L3mZbb15yi5pRJfiWmy8=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf h1:K1VrKHGwQ4UpOQmy2J6IFyv0u17OKTwWrfAGILClpbw=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
 github.com/sensu/sensu-go/types v0.10.0 h1:sm+dLuqEEECVxjW5EfXkU5weGPwrg/Jymbm28HdQpl8=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/shirou/gopsutil/v3 v3.21.12 h1:VoGxEW2hpmz0Vt3wUvHIl9fquzYLNpVpgNNB7pGJimA=


### PR DESCRIPTION
## What is this change?

We've landed ourselves in a state. develop/6 currently does not build since the api/core/v3 dependency is pointing at a squashed commit.

This updates the dep to a commit that is not likely to ever be squished (the current develop/6 HEAD), but I believe we should follow up with merging the core/v3 changes into main and publishing a new v3.x tag for it to point at before a release.
