### PR TITLE
Agent logs dup check name

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+- Agent logs now include check name when a check request is not executed.
+
 ## [6.8.1] - 2022-09-13
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-go/api/core/v2 v2.14.0
-	github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68
+	github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf
 	github.com/sensu/sensu-go/types v0.10.0
 	github.com/shirou/gopsutil/v3 v3.21.12
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -397,10 +397,8 @@ github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU
 github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/api/core/v3 v3.6.2 h1:NEkHcPxkaYwPlH4gG6kgvdvYLlwBBaswMHscA7X3V+4=
 github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912171820-366b64ed1a62 h1:PeP63bXXwwB586EjCb73jg0oqzE3Tg3aOH38g9qG58k=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912171820-366b64ed1a62/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68 h1:t5AsMszceHgj4yGHflRi705L3mZbb15yi5pRJfiWmy8=
-github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220912182551-a5a7db519e68/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf h1:K1VrKHGwQ4UpOQmy2J6IFyv0u17OKTwWrfAGILClpbw=
+github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
 github.com/sensu/sensu-go/types v0.10.0 h1:sm+dLuqEEECVxjW5EfXkU5weGPwrg/Jymbm28HdQpl8=
 github.com/sensu/sensu-go/types v0.10.0/go.mod h1:vFZJ9TYBAjSPYtYt+82PpS9P6m73Vzr4O23lmJonzrA=
 github.com/shirou/gopsutil/v3 v3.21.12 h1:VoGxEW2hpmz0Vt3wUvHIl9fquzYLNpVpgNNB7pGJimA=

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,6 @@ github.com/sensu/lasr v1.2.1/go.mod h1:VIMtIK67Bcef6dTfctRCBg8EY9M9TtCY9NEFT6Zw5
 github.com/sensu/sensu-go/api/core/v2 v2.14.0 h1:z4JVqy7z6iFgMDUH0uc1Ns0bqLFKTpc5bi4Iw7qweks=
 github.com/sensu/sensu-go/api/core/v2 v2.14.0/go.mod h1:XCgUjY78ApTahizBz/pkc5KU17L/E5BexeZHkGDdTls=
 github.com/sensu/sensu-go/api/core/v3 v3.6.1/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
-github.com/sensu/sensu-go/api/core/v3 v3.6.2 h1:NEkHcPxkaYwPlH4gG6kgvdvYLlwBBaswMHscA7X3V+4=
-github.com/sensu/sensu-go/api/core/v3 v3.6.2/go.mod h1:aqNOkJxkrwRq+rPW47XtVWeb5Rk1K5adlCZGBW9nsvM=
 github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf h1:K1VrKHGwQ4UpOQmy2J6IFyv0u17OKTwWrfAGILClpbw=
 github.com/sensu/sensu-go/api/core/v3 v3.6.3-0.20220913191107-10ae2ae7d8cf/go.mod h1:n2dhnBTovMrzmE1P0D7gvEbUG7TPH6hdtr7qvoPf/sY=
 github.com/sensu/sensu-go/types v0.10.0 h1:sm+dLuqEEECVxjW5EfXkU5weGPwrg/Jymbm28HdQpl8=


### PR DESCRIPTION
## What is this change?

Closes https://github.com/sensu/sensu-enterprise-go/issues/2453

Updates agent log messages to include check name for errors preventing a check from being executed (duplicate and old requests, in progress check executions)


## Why is this change necessary?

A followup to https://github.com/sensu/sensu-go/pull/4773

When multiple subscriptions configured on a check target an entity it can result in many duplicate check execution requests that can be difficult to find. Including check name should help operators identify misconfigured checks.

## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

Manual

```
{"check":"check-1","component":"agent","error":"check request has already been received - agent and check may have multiple matching subscriptions","level":"warning","msg":"error handling message","time":"2022-09-26T17:04:13-07:00"}
```
## Is this change a patch?

Y