### PR TITLE
Enhance logging for authentication providers

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,6 +7,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+
+### Added
+- The authentication module now logs successful (INFO) and unsuccessful (ERROR)
+  login attempts.
+
 ### Fixed
 - Fixed an issue where multi-expression exclusive "Deny" filters were not
   evaluated as described in the documentation.

--- a/backend/authentication/authenticator.go
+++ b/backend/authentication/authenticator.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
@@ -33,11 +35,20 @@ func (a *Authenticator) Authenticate(ctx context.Context, username, password str
 			continue
 		}
 
+		logger.WithFields(logrus.Fields{
+			"subject":         claims.Subject,
+			"groups":          claims.Groups,
+			"provider_id":     claims.Provider.ProviderID,
+			"provider_type":   claims.Provider.ProviderType,
+			"provider_userid": claims.Provider.UserID,
+		}).Info("login successful")
 		return claims, nil
 	}
 
 	// TODO(palourde): We might want to return a more meaningful and actionnable
 	// error message, but we don't want to leak sensitive information.
+
+	logger.WithField("username", username).Error("authentication failed")
 	return nil, errors.New("authentication failed")
 }
 


### PR DESCRIPTION
*This change also needs to be ported to `main`*

## What is this change?

An INFO level message is emitted upon successful login, with details about the
user and provider used. An ERROR level message is emitted upon authentication
failure, with the username that was tried.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/248

## Does your change need a Changelog entry?

Yes, added.

## Do you need clarification on anything?

No.

## How did you verify this change?

Manual testing with 2 providers and successful and unsuccessful logins.