### PR TITLE
Auto-restart agent service on Windows

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -7,17 +7,18 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-
 ### Added
 - The authentication module now logs successful (INFO) and unsuccessful (ERROR)
   login attempts.
+- Agent websocket connection logging includes backend entity name.
+
+### Changed
+- The Sensu Agent service now auto-restarts after failures on Windows.
 
 ### Fixed
 - Fixed an issue where multi-expression exclusive "Deny" filters were not
   evaluated as described in the documentation.
 
-### Added
-- Agent websocket connection logging includes backend entity name.
 ## [6.8.1] - 2022-09-13
 
 ### Changed


### PR DESCRIPTION
## What is this change?

Updates the Windows service for Sensu Agent to auto-restart every 5 seconds after a failure.


## Why is this change necessary?

Closes https://github.com/sensu/sensu-enterprise-go/issues/1575.

## Does your change need a Changelog entry?

Yes.

## Were there any complications while making this change?

I couldn't find a way of triggering a failure state in Sensu Agent to fully test this.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

We may want to describe this behaviour in the docs; what do you think @hillaryfraley?

## How did you verify this change?

I can see the failure cases set in the service after this change.

![Screen Shot 2022-10-03 at 15 51 06](https://user-images.githubusercontent.com/120659/193699815-94e303e9-749a-4489-9efe-a3ff2cd31371.png)


## Is this change a patch?

No.
