### PR TITLE
Support specialized stores in the generic store

### DIFF
--- a/backend/store/postgres/config_store.go
+++ b/backend/store/postgres/config_store.go
@@ -58,6 +58,18 @@ func NewConfigStore(db *pgxpool.Pool) *ConfigStore {
 	}
 }
 
+func (c *ConfigStore) GetEntityConfigStore() storev2.EntityConfigStore {
+	return NewEntityConfigStore(c.db)
+}
+
+func (c *ConfigStore) GetEntityStateStore() storev2.EntityStateStore {
+	return NewEntityStateStore(c.db)
+}
+
+func (c *ConfigStore) GetNamespaceStore() storev2.NamespaceStore {
+	return NewNamespaceStore(c.db)
+}
+
 func (s *ConfigStore) Initialize(ctx context.Context, fn storev2.InitializeFunc) error {
 	return nil
 }

--- a/backend/store/v2/generic.go
+++ b/backend/store/v2/generic.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"reflect"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
@@ -21,6 +22,10 @@ type Resource[T any] interface {
 // a type safe set of methods for dealing with resource CRUD operations.
 // It allows users to avoid dealing with the Wrapper abstraction, and handles
 // list allocations optimally.
+//
+// If Interface can be type asserted to be one of a EntityConfigStoreGetter,
+// EntityStateStoreGetter, or NamespaceStoreGetter, then operations on those
+// types will be dispatched to the store that the getter returns.
 type Generic[R Resource[T], T any] struct {
 	Interface Interface
 }
@@ -40,7 +45,40 @@ func prepare(resource corev3.Resource) (ResourceRequest, Wrapper, error) {
 	return req, wrapper, err
 }
 
+var errNoSpecialization = errors.New("no specialization available")
+
+func (g Generic[R, T]) trySpecializeCreateOrUpdate(ctx context.Context, resource R) error {
+	switch value := any(resource).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().CreateOrUpdate(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().CreateOrUpdate(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().CreateOrUpdate(ctx, value)
+		}
+		return errNoSpecialization
+	default:
+		return errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) CreateOrUpdate(ctx context.Context, resource R) error {
+	// try specialized path first
+	if err := g.trySpecializeCreateOrUpdate(ctx, resource); err != nil {
+		if err != errNoSpecialization {
+			return err
+		}
+	} else {
+		return nil
+	}
+	// fall back to common path
 	req, wrapper, err := prepare(resource)
 	if err != nil {
 		return err
@@ -48,7 +86,38 @@ func (g Generic[R, T]) CreateOrUpdate(ctx context.Context, resource R) error {
 	return g.Interface.CreateOrUpdate(ctx, req, wrapper)
 }
 
+func (g Generic[R, T]) trySpecializeUpdateIfExists(ctx context.Context, resource R) error {
+	switch value := any(resource).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().UpdateIfExists(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().UpdateIfExists(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().UpdateIfExists(ctx, value)
+		}
+		return errNoSpecialization
+	default:
+		return errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) UpdateIfExists(ctx context.Context, resource R) error {
+	// try specialized path first
+	if err := g.trySpecializeUpdateIfExists(ctx, resource); err != nil {
+		if err != errNoSpecialization {
+			return err
+		}
+	} else {
+		return nil
+	}
+	// fall back to common path
 	req, wrapper, err := prepare(resource)
 	if err != nil {
 		return err
@@ -56,7 +125,38 @@ func (g Generic[R, T]) UpdateIfExists(ctx context.Context, resource R) error {
 	return g.Interface.UpdateIfExists(ctx, req, wrapper)
 }
 
+func (g Generic[R, T]) trySpecializeCreateIfNotExists(ctx context.Context, resource R) error {
+	switch value := any(resource).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().CreateIfNotExists(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().CreateIfNotExists(ctx, value)
+		}
+		return errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().CreateIfNotExists(ctx, value)
+		}
+		return errNoSpecialization
+	default:
+		return errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) CreateIfNotExists(ctx context.Context, resource R) error {
+	// try specialized path first
+	if err := g.trySpecializeCreateIfNotExists(ctx, resource); err != nil {
+		if err != errNoSpecialization {
+			return err
+		}
+	} else {
+		return nil
+	}
+	// common path
 	req, wrapper, err := prepare(resource)
 	if err != nil {
 		return err
@@ -64,7 +164,40 @@ func (g Generic[R, T]) CreateIfNotExists(ctx context.Context, resource R) error 
 	return g.Interface.CreateIfNotExists(ctx, req, wrapper)
 }
 
+func (g Generic[R, T]) trySpecializeGet(ctx context.Context, id ID) (R, error) {
+	switch any(new(T)).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			val, err := getter.GetEntityConfigStore().Get(ctx, id.Namespace, id.Name)
+			return any(val).(R), err
+		}
+		return *new(R), errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			val, err := getter.GetEntityStateStore().Get(ctx, id.Namespace, id.Name)
+			return any(val).(R), err
+		}
+		return *new(R), errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			val, err := getter.GetNamespaceStore().Get(ctx, id.Name)
+			return any(val).(R), err
+		}
+		return *new(R), errNoSpecialization
+	default:
+		return *new(R), errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) Get(ctx context.Context, id ID) (R, error) {
+	// try specialized path first
+	if val, err := g.trySpecializeGet(ctx, id); err != nil {
+		if err != errNoSpecialization {
+			return val, err
+		}
+	} else {
+		return val, nil
+	}
 	result := makeResource[R, T]()
 	tm := getGenericTypeMeta[R, T]()
 	var r R
@@ -79,7 +212,38 @@ func (g Generic[R, T]) Get(ctx context.Context, id ID) (R, error) {
 	return result, nil
 }
 
+func (g Generic[R, T]) trySpecializeDelete(ctx context.Context, id ID) error {
+	switch any(new(T)).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().Delete(ctx, id.Namespace, id.Name)
+		}
+		return errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().Delete(ctx, id.Namespace, id.Name)
+		}
+		return errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().Delete(ctx, id.Name)
+		}
+		return errNoSpecialization
+	default:
+		return errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) Delete(ctx context.Context, id ID) error {
+	// try specialized path first
+	if err := g.trySpecializeDelete(ctx, id); err != nil {
+		if err != errNoSpecialization {
+			return err
+		}
+	} else {
+		return nil
+	}
+	// common path
 	var r R
 	tm := getGenericTypeMeta[R, T]()
 	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
@@ -88,7 +252,61 @@ func (g Generic[R, T]) Delete(ctx context.Context, id ID) error {
 	return g.Interface.Delete(ctx, req)
 }
 
+func (g Generic[R, T]) trySpecializeList(ctx context.Context, id ID, pred *store.SelectionPredicate) ([]T, error) {
+	switch any(*new(R)).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			values, err := getter.GetEntityConfigStore().List(ctx, id.Namespace, pred)
+			if err != nil {
+				return nil, err
+			}
+			result := make([]T, len(values))
+			for i := range values {
+				result[i] = any(*values[i]).(T)
+			}
+			return result, nil
+		}
+		return nil, errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			values, err := getter.GetEntityStateStore().List(ctx, id.Namespace, pred)
+			if err != nil {
+				return nil, err
+			}
+			result := make([]T, len(values))
+			for i := range values {
+				result[i] = any(*values[i]).(T)
+			}
+			return result, nil
+		}
+		return nil, errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			values, err := getter.GetNamespaceStore().List(ctx, pred)
+			if err != nil {
+				return nil, err
+			}
+			result := make([]T, len(values))
+			for i := range values {
+				result[i] = any(*values[i]).(T)
+			}
+			return result, nil
+		}
+		return nil, errNoSpecialization
+	default:
+		return nil, errNoSpecialization
+	}
+
+}
+
 func (g Generic[R, T]) List(ctx context.Context, id ID, pred *store.SelectionPredicate) ([]T, error) {
+	if lst, err := g.trySpecializeList(ctx, id, pred); err != nil {
+		if err != errNoSpecialization {
+			return nil, err
+		}
+	} else {
+		return lst, nil
+	}
 	var r R
 	tm := getGenericTypeMeta[R, T]()
 	req := NewResourceRequest(tm, id.Namespace, "", r.StoreName())
@@ -104,14 +322,75 @@ func (g Generic[R, T]) List(ctx context.Context, id ID, pred *store.SelectionPre
 	return result, nil
 }
 
+func (g Generic[R, T]) trySpecializeExists(ctx context.Context, id ID) (bool, error) {
+	switch any(new(T)).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().Exists(ctx, id.Namespace, id.Name)
+		}
+		return false, errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().Exists(ctx, id.Namespace, id.Name)
+		}
+		return false, errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().Exists(ctx, id.Name)
+		}
+		return false, errNoSpecialization
+	default:
+		return false, errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) Exists(ctx context.Context, id ID) (bool, error) {
+	if ok, err := g.trySpecializeExists(ctx, id); err != nil {
+		if err != errNoSpecialization {
+			return false, err
+		}
+	} else {
+		return ok, nil
+	}
 	tm := getGenericTypeMeta[R, T]()
 	var r R
 	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
 	return g.Interface.Exists(ctx, req)
 }
 
+func (g Generic[R, T]) trySpecializePatch(ctx context.Context, resource R, patcher patch.Patcher, etag *store.ETagCondition) error {
+	meta := resource.GetMetadata()
+	namespace := meta.Namespace
+	name := meta.Name
+	switch any(new(T)).(type) {
+	case *corev3.EntityConfig:
+		if getter, ok := g.Interface.(EntityConfigStoreGetter); ok {
+			return getter.GetEntityConfigStore().Patch(ctx, namespace, name, patcher, etag)
+		}
+		return errNoSpecialization
+	case *corev3.EntityState:
+		if getter, ok := g.Interface.(EntityStateStoreGetter); ok {
+			return getter.GetEntityStateStore().Patch(ctx, namespace, name, patcher, etag)
+		}
+		return errNoSpecialization
+	case *corev3.Namespace:
+		if getter, ok := g.Interface.(NamespaceStoreGetter); ok {
+			return getter.GetNamespaceStore().Patch(ctx, name, patcher, etag)
+		}
+		return errNoSpecialization
+	default:
+		return errNoSpecialization
+	}
+}
+
 func (g Generic[R, T]) Patch(ctx context.Context, resource R, patcher patch.Patcher, etag *store.ETagCondition) error {
+	if err := g.trySpecializePatch(ctx, resource, patcher, etag); err != nil {
+		if err != errNoSpecialization {
+			return err
+		}
+	} else {
+		return nil
+	}
 	req, wrapper, err := prepare(resource)
 	if err != nil {
 		return err

--- a/backend/store/v2/generic_test.go
+++ b/backend/store/v2/generic_test.go
@@ -5,11 +5,145 @@ import (
 	"testing"
 
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	corev3 "github.com/sensu/sensu-go/api/core/v3"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/backend/store/patch"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sensu/sensu-go/backend/store/v2/wrap"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/mock"
 )
+
+type extendedMockStoreV2 struct {
+	mockstore.V2MockStore
+}
+
+func (e *extendedMockStoreV2) GetEntityConfigStore() storev2.EntityConfigStore {
+	return e.Called().Get(0).(storev2.EntityConfigStore)
+}
+
+type mockEntityConfigStore struct {
+	mock.Mock
+}
+
+func (m *mockEntityConfigStore) CreateOrUpdate(ctx context.Context, entity *corev3.EntityConfig) error {
+	return m.Called(ctx, entity).Error(0)
+}
+func (m *mockEntityConfigStore) UpdateIfExists(ctx context.Context, entity *corev3.EntityConfig) error {
+	return m.Called(ctx, entity).Error(0)
+}
+func (m *mockEntityConfigStore) CreateIfNotExists(ctx context.Context, entity *corev3.EntityConfig) error {
+	return m.Called(ctx, entity).Error(0)
+}
+func (m *mockEntityConfigStore) Get(ctx context.Context, namespace string, name string) (*corev3.EntityConfig, error) {
+	args := m.Called(ctx, namespace, name)
+	return args.Get(0).(*corev3.EntityConfig), args.Error(1)
+}
+func (m *mockEntityConfigStore) Delete(ctx context.Context, namespace string, name string) error {
+	return m.Called(ctx, namespace, name).Error(0)
+}
+func (m *mockEntityConfigStore) List(ctx context.Context, namespace string, pred *store.SelectionPredicate) ([]*corev3.EntityConfig, error) {
+	args := m.Called(ctx, namespace, pred)
+	return args.Get(0).([]*corev3.EntityConfig), args.Error(1)
+}
+func (m *mockEntityConfigStore) Exists(ctx context.Context, namespace string, name string) (bool, error) {
+	args := m.Called(ctx, namespace, name)
+	return args.Get(0).(bool), args.Error(1)
+}
+func (m *mockEntityConfigStore) Patch(ctx context.Context, namespace string, name string, patcher patch.Patcher, cond *store.ETagCondition) error {
+	return m.Called(ctx, namespace, name, patcher, cond).Error(0)
+}
+
+func (e *extendedMockStoreV2) GetEntityStateStore() storev2.EntityStateStore {
+	return e.Called().Get(0).(storev2.EntityStateStore)
+}
+
+type mockEntityStateStore struct {
+	mock.Mock
+}
+
+func (m *mockEntityStateStore) CreateOrUpdate(ctx context.Context, entity *corev3.EntityState) error {
+	return m.Called(ctx, entity).Error(0)
+}
+
+func (m *mockEntityStateStore) UpdateIfExists(ctx context.Context, entity *corev3.EntityState) error {
+	return m.Called(ctx, entity).Error(0)
+}
+
+func (m *mockEntityStateStore) CreateIfNotExists(ctx context.Context, entity *corev3.EntityState) error {
+	return m.Called(ctx, entity).Error(0)
+}
+
+func (m *mockEntityStateStore) Get(ctx context.Context, namespace string, name string) (*corev3.EntityState, error) {
+	args := m.Called(ctx, namespace, name)
+	return args.Get(0).(*corev3.EntityState), args.Error(1)
+}
+
+func (m *mockEntityStateStore) Delete(ctx context.Context, namespace string, name string) error {
+	return m.Called(ctx, namespace, name).Error(0)
+}
+
+func (m *mockEntityStateStore) List(ctx context.Context, namespace string, pred *store.SelectionPredicate) ([]*corev3.EntityState, error) {
+	args := m.Called(ctx, namespace, pred)
+	return args.Get(0).([]*corev3.EntityState), args.Error(1)
+}
+
+func (m *mockEntityStateStore) Exists(ctx context.Context, namespace string, name string) (bool, error) {
+	args := m.Called(ctx, namespace, name)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *mockEntityStateStore) Patch(ctx context.Context, namespace string, name string, patcher patch.Patcher, cond *store.ETagCondition) error {
+	return m.Called(ctx, namespace, name, patcher, cond).Error(0)
+}
+
+func (e *extendedMockStoreV2) GetNamespaceStore() storev2.NamespaceStore {
+	return e.Called().Get(0).(storev2.NamespaceStore)
+}
+
+type mockNamespaceStore struct {
+	mock.Mock
+}
+
+func (m *mockNamespaceStore) CreateOrUpdate(ctx context.Context, namespace *corev3.Namespace) error {
+	return m.Called(ctx, namespace).Error(0)
+}
+
+func (m *mockNamespaceStore) UpdateIfExists(ctx context.Context, namespace *corev3.Namespace) error {
+	return m.Called(ctx, namespace).Error(0)
+}
+
+func (m *mockNamespaceStore) CreateIfNotExists(ctx context.Context, namespace *corev3.Namespace) error {
+	return m.Called(ctx, namespace).Error(0)
+}
+
+func (m *mockNamespaceStore) Get(ctx context.Context, namespace string) (*corev3.Namespace, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(*corev3.Namespace), args.Error(1)
+}
+
+func (m *mockNamespaceStore) Delete(ctx context.Context, namespace string) error {
+	return m.Called(ctx, namespace).Error(0)
+}
+
+func (m *mockNamespaceStore) List(ctx context.Context, pred *store.SelectionPredicate) ([]*corev3.Namespace, error) {
+	args := m.Called(ctx, pred)
+	return args.Get(0).([]*corev3.Namespace), args.Error(1)
+}
+
+func (m *mockNamespaceStore) Exists(ctx context.Context, namespace string) (bool, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *mockNamespaceStore) IsEmpty(ctx context.Context, namespace string) (bool, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *mockNamespaceStore) Patch(ctx context.Context, namespace string, patcher patch.Patcher, cond *store.ETagCondition) error {
+	return m.Called(ctx, namespace, patcher, cond).Error(0)
+}
 
 func TestGenericStoreCreateOrUpdate(t *testing.T) {
 	sv2 := new(mockstore.V2MockStore)
@@ -26,6 +160,42 @@ func TestGenericStoreCreateOrUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 	sv2.AssertCalled(t, "CreateOrUpdate", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStoreCreateOrUpdateEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if err := store.CreateOrUpdate(context.Background(), corev3.FixtureEntityConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "CreateOrUpdate", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreCreateOrUpdateEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if err := store.CreateOrUpdate(context.Background(), corev3.FixtureEntityState("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "CreateOrUpdate", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreCreateOrUpdateNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if err := store.CreateOrUpdate(context.Background(), corev3.FixtureNamespace("foo")); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "CreateOrUpdate", mock.Anything, mock.Anything)
 }
 
 func TestGenericStoreUpdateIfExists(t *testing.T) {
@@ -45,6 +215,42 @@ func TestGenericStoreUpdateIfExists(t *testing.T) {
 	sv2.AssertCalled(t, "UpdateIfExists", mock.Anything, req, mock.Anything)
 }
 
+func TestGenericStoreUpdateIfExistsEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("UpdateIfExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if err := store.UpdateIfExists(context.Background(), corev3.FixtureEntityConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "UpdateIfExists", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreUpdateIfExistsEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("UpdateIfExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if err := store.UpdateIfExists(context.Background(), corev3.FixtureEntityState("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "UpdateIfExists", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreUpdateIfExistsNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("UpdateIfExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if err := store.UpdateIfExists(context.Background(), corev3.FixtureNamespace("foo")); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "UpdateIfExists", mock.Anything, mock.Anything)
+}
+
 func TestGenericStoreCreateIfNotExists(t *testing.T) {
 	sv2 := new(mockstore.V2MockStore)
 	req := storev2.ResourceRequest{
@@ -60,6 +266,42 @@ func TestGenericStoreCreateIfNotExists(t *testing.T) {
 		t.Fatal(err)
 	}
 	sv2.AssertCalled(t, "CreateIfNotExists", mock.Anything, req, mock.Anything)
+}
+
+func TestGenericStoreCreateIfNotExistsEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if err := store.CreateIfNotExists(context.Background(), corev3.FixtureEntityConfig("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "CreateIfNotExists", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreCreateIfNotExistsEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if err := store.CreateIfNotExists(context.Background(), corev3.FixtureEntityState("foo")); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "CreateIfNotExists", mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreCreateIfNotExistsNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("CreateIfNotExists", mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if err := store.CreateIfNotExists(context.Background(), corev3.FixtureNamespace("foo")); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "CreateIfNotExists", mock.Anything, mock.Anything)
 }
 
 func TestGenericStoreGet(t *testing.T) {
@@ -86,6 +328,42 @@ func TestGenericStoreGet(t *testing.T) {
 	sv2.AssertCalled(t, "Get", mock.Anything, req)
 }
 
+func TestGenericStoreGetEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(corev3.FixtureEntityConfig("foo"), nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if _, err := store.Get(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreGetEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(corev3.FixtureEntityState("foo"), nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if _, err := store.Get(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreGetNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("Get", mock.Anything, mock.Anything).Return(corev3.FixtureNamespace("foo"), nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if _, err := store.Get(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "Get", mock.Anything, mock.Anything)
+}
+
 func TestGenericStoreDelete(t *testing.T) {
 	sv2 := new(mockstore.V2MockStore)
 	req := storev2.ResourceRequest{
@@ -101,6 +379,42 @@ func TestGenericStoreDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	sv2.AssertCalled(t, "Delete", mock.Anything, req)
+}
+
+func TestGenericStoreDeleteEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if err := store.Delete(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreDeleteEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if err := store.Delete(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreDeleteNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if err := store.Delete(context.Background(), storev2.ID{}); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "Delete", mock.Anything, mock.Anything)
 }
 
 func TestGenericStoreList(t *testing.T) {
@@ -129,6 +443,42 @@ func TestGenericStoreList(t *testing.T) {
 	sv2.AssertCalled(t, "List", mock.Anything, req, mock.Anything)
 }
 
+func TestGenericStoreListEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("List", mock.Anything, mock.Anything, mock.Anything).Return([]*corev3.EntityConfig{}, nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if _, err := store.List(context.Background(), storev2.ID{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "List", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreListEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("List", mock.Anything, mock.Anything, mock.Anything).Return([]*corev3.EntityState{}, nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if _, err := store.List(context.Background(), storev2.ID{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "List", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStoreListNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("List", mock.Anything, mock.Anything).Return([]*corev3.Namespace{}, nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if _, err := store.List(context.Background(), storev2.ID{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "List", mock.Anything, mock.Anything)
+}
+
 func TestGenericStorePatch(t *testing.T) {
 	sv2 := new(mockstore.V2MockStore)
 	sv2.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -137,4 +487,40 @@ func TestGenericStorePatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	sv2.AssertCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStorePatchEntityConfig(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entConfigStore := new(mockEntityConfigStore)
+	entConfigStore.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityConfigStore").Return(entConfigStore)
+	store := storev2.NewGenericStore[*corev3.EntityConfig](sv2)
+	if err := store.Patch(context.Background(), corev3.FixtureEntityConfig("foo"), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	entConfigStore.AssertCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStorePatchEntityState(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	entStateStore := new(mockEntityStateStore)
+	entStateStore.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetEntityStateStore").Return(entStateStore)
+	store := storev2.NewGenericStore[*corev3.EntityState](sv2)
+	if err := store.Patch(context.Background(), corev3.FixtureEntityState("foo"), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	entStateStore.AssertCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestGenericStorePatchNamespace(t *testing.T) {
+	sv2 := new(extendedMockStoreV2)
+	nsStore := new(mockNamespaceStore)
+	nsStore.On("Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	sv2.On("GetNamespaceStore").Return(nsStore)
+	store := storev2.NewGenericStore[*corev3.Namespace](sv2)
+	if err := store.Patch(context.Background(), corev3.FixtureNamespace("foo"), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	nsStore.AssertCalled(t, "Patch", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -22,6 +22,21 @@ type WrapList interface {
 	Len() int
 }
 
+// EntityConfigStoreGetter gets you an EntityConfigStore.
+type EntityConfigStoreGetter interface {
+	GetEntityConfigStore() EntityConfigStore
+}
+
+// EntityStateStoreGetter gets you an EntityStateStore.
+type EntityStateStoreGetter interface {
+	GetEntityStateStore() EntityStateStore
+}
+
+// NamespaceStoreGetter gets you a NamespaceStore.
+type NamespaceStoreGetter interface {
+	GetNamespaceStore() NamespaceStore
+}
+
 // Interface specifies the interface of a v2 store.
 type Interface interface {
 	// CreateOrUpdate creates or updates the wrapped resource.


### PR DESCRIPTION
By supplying special methods that are checked at runtime, the generic store can make use of specialized store implementations for certain types.