### PR TITLE
Agent ingests graphite plaintext metric tags

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Include support for handling metric tags in the graphite plaintext
+  protocol. Agents now respect the new graphite tag specification.
+
 ## [6.8.2] - 2022-10-06
 
 ### Changed

--- a/agent/transformers/graphite_test.go
+++ b/agent/transformers/graphite_test.go
@@ -75,6 +75,20 @@ func TestParseGraphite(t *testing.T) {
 			metric:         "metric.value 1 noon",
 			expectedFormat: GraphiteList(nil),
 		},
+		{
+			metric: "os.disk.used_bytes;GH=#4677;type=issue 2048 123456789",
+			expectedFormat: GraphiteList{
+				{
+					Path:      "os.disk.used_bytes",
+					Value:     2048,
+					Timestamp: 123456789,
+					Tags: []*types.MetricTag{
+						{Name: "GH", Value: "#4677"},
+						{Name: "type", Value: "issue"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Graphite has support for storing data in tags to identify series of metrics. This change introduces support for this feature in the graphite text protocol. Presently the agent ingests
`my.series;tag1=value1 1 999999999` as a metric point with name "my.series;tag1=value1". Per the graphite spec this will now be ingested as a metric point with name "my.series" and a tag for ("tag1": "value1")

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>


Closes https://github.com/sensu/sensu-go/issues/4677
