### PR TITLE
Add Count Methods to Stores

### DIFF
--- a/backend/store/postgres/config_schema.go
+++ b/backend/store/postgres/config_schema.go
@@ -51,6 +51,12 @@ const ExistsConfigQuery = `SELECT count(*) AS total FROM configuration
 const GetConfigQuery = `SELECT id, labels, annotations, resource, created_at, updated_at FROM configuration
 	WHERE api_version=$1 AND api_type=$2 AND namespace=$3 AND name=$4 AND NOT isfinite(deleted_at);`
 
+const CountConfigQueryTmpl = `
+    SELECT count(*)
+    FROM configuration
+	WHERE api_version=$1 AND api_type=$2 AND namespace=$3 AND NOT isfinite(deleted_at)
+        {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}};`
+
 const ListConfigQueryTmpl = `
     SELECT id, labels, annotations, resource, created_at, updated_at
     FROM configuration

--- a/backend/store/postgres/entity_config_store.go
+++ b/backend/store/postgres/entity_config_store.go
@@ -287,6 +287,28 @@ func (s *EntityConfigStore) List(ctx context.Context, namespace string, pred *st
 	return configs, nil
 }
 
+// Count returns the count of EntityConfigs found matching the namespace
+// and entity class provided.
+func (s *EntityConfigStore) Count(ctx context.Context, namespace, entityClass string) (int, error) {
+	var sqlNamespace sql.NullString
+	if namespace != "" {
+		sqlNamespace.String = namespace
+		sqlNamespace.Valid = true
+	}
+	var sqlEntityClass sql.NullString
+	if entityClass != "" {
+		sqlEntityClass.String = entityClass
+		sqlEntityClass.Valid = true
+	}
+
+	row := s.db.QueryRow(ctx, countEntityConfigQuery, sqlNamespace, sqlEntityClass)
+	var ct int
+	if err := row.Scan(&ct); err != nil {
+		return 0, err
+	}
+	return ct, nil
+}
+
 func (s *EntityConfigStore) Patch(ctx context.Context, namespace, name string, patcher patch.Patcher, conditions *store.ETagCondition) (fErr error) {
 	if namespace == "" {
 		return &store.ErrNotValid{Err: errors.New("must specify namespace")}

--- a/backend/store/postgres/entity_configs_schema.go
+++ b/backend/store/postgres/entity_configs_schema.go
@@ -332,6 +332,20 @@ LIMIT $2
 OFFSET $3
 `
 
+const countEntityConfigQuery = `
+-- This query counts entity configs from a given namespace and entity class.
+--
+SELECT
+	COUNT(*)
+FROM entity_configs
+LEFT OUTER JOIN namespaces ON entity_configs.namespace_id = namespaces.id
+WHERE
+	(namespaces.name = $1 OR $1 IS NULL) AND
+	(entity_configs.entity_class = $2 OR $2 IS NULL) AND
+	namespaces.deleted_at IS NULL AND
+	entity_configs.deleted_at IS NULL;
+`
+
 const existsEntityConfigQuery = `
 -- This query discovers if an entity config exists, without retrieving it.
 --

--- a/backend/store/postgres/entity_state_store.go
+++ b/backend/store/postgres/entity_state_store.go
@@ -285,6 +285,24 @@ func (s *EntityStateStore) List(ctx context.Context, namespace string, pred *sto
 	return states, nil
 }
 
+// Count returns the count of EntityStates in the namespace.
+func (s *EntityStateStore) Count(ctx context.Context, namespace string) (int, error) {
+	query := countEntityStateQuery
+
+	var sqlNamespace sql.NullString
+	if namespace != "" {
+		sqlNamespace.String = namespace
+		sqlNamespace.Valid = true
+	}
+
+	row := s.db.QueryRow(ctx, query, sqlNamespace)
+	var ct int
+	if err := row.Scan(&ct); err != nil {
+		return 0, err
+	}
+	return ct, nil
+}
+
 func (s *EntityStateStore) Patch(ctx context.Context, namespace, name string, patcher patch.Patcher, conditions *store.ETagCondition) (fErr error) {
 	if namespace == "" {
 		return &store.ErrNotValid{Err: errors.New("must specify namespace")}

--- a/backend/store/postgres/namespace_store.go
+++ b/backend/store/postgres/namespace_store.go
@@ -273,6 +273,14 @@ func (s *NamespaceStore) List(ctx context.Context, pred *store.SelectionPredicat
 	return namespaces, nil
 }
 
+func (s *NamespaceStore) Count(ctx context.Context) (int, error) {
+	row := s.db.QueryRow(ctx, countNamespaceQuery)
+
+	var ct int
+	err := row.Scan(&ct)
+	return ct, err
+}
+
 func (s *NamespaceStore) Patch(ctx context.Context, name string, patcher patch.Patcher, conditions *store.ETagCondition) (fErr error) {
 	if name == "" {
 		return &store.ErrNotValid{Err: errors.New("must specify name")}

--- a/backend/store/postgres/namespaces_schema.go
+++ b/backend/store/postgres/namespaces_schema.go
@@ -146,6 +146,15 @@ SELECT NOT EXISTS (
 );
 `
 
+const countNamespaceQuery = `
+-- This query lists all namespaces.
+--
+SELECT
+	count(*)
+FROM namespaces
+WHERE deleted_at IS NULL;
+`
+
 const listNamespaceQuery = `
 -- This query lists all namespaces.
 --

--- a/backend/store/v2/etcdstore/entity_config_store.go
+++ b/backend/store/v2/etcdstore/entity_config_store.go
@@ -110,6 +110,9 @@ func (s *EntityConfigStore) List(ctx context.Context, namespace string, pred *st
 	}
 	return configs, nil
 }
+func (s *EntityConfigStore) Count(ctx context.Context, namespace, eClass string) (int, error) {
+	return 0, nil
+}
 
 func (s *EntityConfigStore) Patch(ctx context.Context, namespace, name string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	// Fetch the current entity config & wrap it

--- a/backend/store/v2/etcdstore/entity_state_store.go
+++ b/backend/store/v2/etcdstore/entity_state_store.go
@@ -113,6 +113,10 @@ func (s *EntityStateStore) List(ctx context.Context, namespace string, pred *sto
 	return states, nil
 }
 
+func (s *EntityStateStore) Count(ctx context.Context, namespace string) (int, error) {
+	return 0, nil
+}
+
 func (s *EntityStateStore) Patch(ctx context.Context, namespace, name string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	// Fetch the current entity state & wrap it
 	state, err := s.Get(ctx, namespace, name)

--- a/backend/store/v2/etcdstore/namespace_store.go
+++ b/backend/store/v2/etcdstore/namespace_store.go
@@ -117,6 +117,10 @@ func (s *NamespaceStore) List(ctx context.Context, pred *store.SelectionPredicat
 	return namespaces, nil
 }
 
+func (s *NamespaceStore) Count(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
 func (s *NamespaceStore) Patch(ctx context.Context, name string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	// Fetch the current namespace & wrap it
 	namespace, err := s.Get(ctx, name)

--- a/backend/store/v2/etcdstore/store.go
+++ b/backend/store/v2/etcdstore/store.go
@@ -3,6 +3,7 @@ package etcdstore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -389,6 +390,10 @@ func (s *Store) List(ctx context.Context, req storev2.ResourceRequest, pred *sto
 		pred.Continue = ""
 	}
 	return result, nil
+}
+
+func (s *Store) Count(ctx context.Context, req storev2.ResourceRequest) (int, error) {
+	return -1, errors.New("not implemented")
 }
 
 func (s *Store) Exists(ctx context.Context, req storev2.ResourceRequest) (bool, error) {

--- a/backend/store/v2/generic_test.go
+++ b/backend/store/v2/generic_test.go
@@ -46,6 +46,10 @@ func (m *mockEntityConfigStore) List(ctx context.Context, namespace string, pred
 	args := m.Called(ctx, namespace, pred)
 	return args.Get(0).([]*corev3.EntityConfig), args.Error(1)
 }
+func (m *mockEntityConfigStore) Count(ctx context.Context, namespace string, entityClass string) (int, error) {
+	args := m.Called(ctx, namespace, entityClass)
+	return args.Get(0).(int), args.Error(1)
+}
 func (m *mockEntityConfigStore) Exists(ctx context.Context, namespace string, name string) (bool, error) {
 	args := m.Called(ctx, namespace, name)
 	return args.Get(0).(bool), args.Error(1)
@@ -88,6 +92,10 @@ func (m *mockEntityStateStore) List(ctx context.Context, namespace string, pred 
 	return args.Get(0).([]*corev3.EntityState), args.Error(1)
 }
 
+func (m *mockEntityStateStore) Count(ctx context.Context, namespace string) (int, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(int), args.Error(1)
+}
 func (m *mockEntityStateStore) Exists(ctx context.Context, namespace string, name string) (bool, error) {
 	args := m.Called(ctx, namespace, name)
 	return args.Get(0).(bool), args.Error(1)
@@ -129,6 +137,11 @@ func (m *mockNamespaceStore) Delete(ctx context.Context, namespace string) error
 func (m *mockNamespaceStore) List(ctx context.Context, pred *store.SelectionPredicate) ([]*corev3.Namespace, error) {
 	args := m.Called(ctx, pred)
 	return args.Get(0).([]*corev3.Namespace), args.Error(1)
+}
+
+func (m *mockNamespaceStore) Count(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int), args.Error(1)
 }
 
 func (m *mockNamespaceStore) Exists(ctx context.Context, namespace string) (bool, error) {

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -60,6 +60,10 @@ type Interface interface {
 	// selection predicate.
 	List(context.Context, ResourceRequest, *store.SelectionPredicate) (WrapList, error)
 
+	// Count returns a count of all resources matching the set of constraints
+	// specified by the resource request.
+	Count(context.Context, ResourceRequest) (int, error)
+
 	// Exists returns true if the resource indicated by the request exists
 	Exists(context.Context, ResourceRequest) (bool, error)
 
@@ -97,6 +101,9 @@ type NamespaceStore interface {
 	// List lists all corev3.Namespace resources.
 	List(context.Context, *store.SelectionPredicate) ([]*corev3.Namespace, error)
 
+	// Count returns a count of all namespaces
+	Count(context.Context) (int, error)
+
 	// Exists returns true if the corev3.Namespace with the provided name exists.
 	Exists(context.Context, string) (bool, error)
 
@@ -131,6 +138,10 @@ type EntityConfigStore interface {
 	// List lists all corev3.EntityConfig resources.
 	List(context.Context, string, *store.SelectionPredicate) ([]*corev3.EntityConfig, error)
 
+	// Count returns a count of entites by namespace
+	// and optionally by entity class
+	Count(ctx context.Context, namespace, entityClass string) (int, error)
+
 	// Exists returns true if the corev3.EntityConfig exists for the provided
 	// namespace and name.
 	Exists(context.Context, string, string) (bool, error)
@@ -162,6 +173,9 @@ type EntityStateStore interface {
 
 	// List lists all corev3.EntityState resources.
 	List(context.Context, string, *store.SelectionPredicate) ([]*corev3.EntityState, error)
+
+	// Count returns a count of entity states by namespace
+	Count(context.Context, string) (int, error)
 
 	// Exists returns true if the corev3.EntityState exists for the provided
 	// namespace and name.

--- a/backend/store/v2/proxy.go
+++ b/backend/store/v2/proxy.go
@@ -67,6 +67,12 @@ func (p *Proxy) List(ctx context.Context, req ResourceRequest, pred *store.Selec
 	return p.impl.List(ctx, req, pred)
 }
 
+func (p *Proxy) Count(ctx context.Context, req ResourceRequest) (int, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.impl.Count(ctx, req)
+}
+
 // Exists returns true if the resource indicated by the request exists
 func (p *Proxy) Exists(ctx context.Context, req ResourceRequest) (bool, error) {
 	p.mu.RLock()

--- a/backend/store/v2/storetest/entity_config_store.go
+++ b/backend/store/v2/storetest/entity_config_store.go
@@ -52,6 +52,11 @@ func (s *EntityConfigStore) List(ctx context.Context, namespace string, pred *st
 	return args.Get(0).([]*corev3.EntityConfig), args.Error(1)
 }
 
+func (s *EntityConfigStore) Count(ctx context.Context, namespace string, entityClass string) (int, error) {
+	args := s.Called(ctx, namespace, entityClass)
+	return args.Get(0).(int), args.Error(1)
+}
+
 func (s *EntityConfigStore) Patch(ctx context.Context, namespace, entity string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	args := s.Called(ctx, namespace, entity, patcher, conditions)
 	return args.Error(0)

--- a/backend/store/v2/storetest/entity_state_store.go
+++ b/backend/store/v2/storetest/entity_state_store.go
@@ -52,6 +52,11 @@ func (s *EntityStateStore) List(ctx context.Context, namespace string, pred *sto
 	return args.Get(0).([]*corev3.EntityState), args.Error(1)
 }
 
+func (s *EntityStateStore) Count(ctx context.Context, namespace string) (int, error) {
+	args := s.Called(ctx, namespace)
+	return args.Get(0).(int), args.Error(1)
+}
+
 func (s *EntityStateStore) Patch(ctx context.Context, namespace, entity string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	args := s.Called(ctx, namespace, entity, patcher, conditions)
 	return args.Error(0)

--- a/backend/store/v2/storetest/mock.go
+++ b/backend/store/v2/storetest/mock.go
@@ -50,6 +50,11 @@ func (s *Store) List(ctx context.Context, req storev2.ResourceRequest, pred *sto
 	return args.Get(0).(storev2.WrapList), args.Error(1)
 }
 
+func (s *Store) Count(ctx context.Context, req storev2.ResourceRequest) (int, error) {
+	args := s.Called(ctx, req)
+	return args.Get(0).(int), args.Error(1)
+}
+
 func (s *Store) Exists(ctx context.Context, req storev2.ResourceRequest) (bool, error) {
 	args := s.Called(ctx, req)
 	return args.Get(0).(bool), args.Error(1)

--- a/backend/store/v2/storetest/namespace_store.go
+++ b/backend/store/v2/storetest/namespace_store.go
@@ -52,6 +52,10 @@ func (s *NamespaceStore) List(ctx context.Context, pred *store.SelectionPredicat
 	return args.Get(0).([]*corev3.Namespace), args.Error(1)
 }
 
+func (s *NamespaceStore) Count(ctx context.Context) (int, error) {
+	args := s.Called(ctx)
+	return args.Get(0).(int), args.Error(1)
+}
 func (s *NamespaceStore) Patch(ctx context.Context, namespace string, patcher patch.Patcher, conditions *store.ETagCondition) error {
 	args := s.Called(ctx, namespace, patcher, conditions)
 	return args.Error(0)

--- a/testing/mockstore/v2.go
+++ b/testing/mockstore/v2.go
@@ -43,6 +43,11 @@ func (v *V2MockStore) List(ctx context.Context, req storev2.ResourceRequest, pre
 	return list, args.Error(1)
 }
 
+func (v *V2MockStore) Count(ctx context.Context, req storev2.ResourceRequest) (int, error) {
+	args := v.Called(ctx, req)
+	return args.Get(0).(int), args.Error(1)
+}
+
 func (v *V2MockStore) Exists(ctx context.Context, req storev2.ResourceRequest) (bool, error) {
 	args := v.Called(ctx, req)
 	return args.Get(0).(bool), args.Error(1)


### PR DESCRIPTION
Closes https://github.com/sensu/sensu-go/issues/4899

## What is this change?

Adds Count Methods to Stores, largely mimicking their existing List behavior.


## Differences from issue spec.

* Dropped the SelectionPredicate argument for Count, as ordering and pagination are not very useful in the context of generating a count.
* EntityConfigStore's Count method includes filtering for both namespace AND entity class.
