### PR TITLE
Allow Graphql Middleware Init funcs to add to Context

### DIFF
--- a/graphql/service.go
+++ b/graphql/service.go
@@ -207,7 +207,7 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 		Schema:  schema,
 		AST:     AST,
 		Args:    p.Variables,
-		Context: ctx,
+		Context: params.Context,
 	})
 }
 


### PR DESCRIPTION
## What is this change?

We've got a graphql middlewares framework, but the Init functions currently do not have any side effects on the context used to service operations, despite their interface suggesting that it should:
> 	// Init is called at the beginning of an execution. Helpful for initializing
	// anything used during the execution of the query.
	Init(context.Context, *graphql.Params) context.Context

This changes that behavior.

Related to https://github.com/sensu/sensu-enterprise-go/issues/2558

## Why is this change necessary?

Per a recently uncovered UI bug, it is helpful to scope some context variables to graphql operation (instead of http request scoped.) This will allow us to register graphql middlewares that enrich the context used throughout the request.

## Does your change need a Changelog entry?

N

## Do you need clarification on anything?

N

## Were there any complications while making this change?

This was the complication.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

N/A

## How did you verify this change?

TBD/Manual

## Is this change a patch?

Y
