### PR TITLE
List-like store methods include all namespaces when unspecified

### DIFF
--- a/backend/store/postgres/config_schema.go
+++ b/backend/store/postgres/config_schema.go
@@ -61,15 +61,19 @@ const GetConfigQuery = `SELECT id, labels, annotations, resource, created_at, up
 	WHERE api_version=$1 AND api_type=$2 AND namespace=$3 AND name=$4 AND NOT isfinite(deleted_at);`
 
 const CountConfigQueryTmpl = `
+	{{if not .Namespaced}} WITH ignored as (SELECT $3::text) {{end}}
     SELECT count(*)
     FROM configuration
-	WHERE api_version=$1 AND api_type=$2 AND namespace=$3 AND NOT isfinite(deleted_at)
+	WHERE api_version=$1 AND api_type=$2 AND NOT isfinite(deleted_at)
+        {{if .Namespaced}} AND namespace=$3 {{end}}
         {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}};`
 
 const ListConfigQueryTmpl = `
+	{{if not .Namespaced}} WITH ignored as (SELECT $3::text) {{end}}
     SELECT id, labels, annotations, resource, created_at, updated_at
     FROM configuration
-	WHERE api_version=$1 AND api_type=$2 AND namespace=$3 AND NOT isfinite(deleted_at)
+	WHERE api_version=$1 AND api_type=$2 AND NOT isfinite(deleted_at)
+        {{if .Namespaced}} AND namespace=$3 {{end}}
         {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}}
     ORDER BY namespace, name ASC
     {{if (gt .Limit 0)}} LIMIT {{.Limit}} {{end}} OFFSET {{ .Offset }};`

--- a/backend/store/postgres/config_store_test.go
+++ b/backend/store/postgres/config_store_test.go
@@ -219,6 +219,13 @@ func TestConfigStore_List(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
+		for i := 0; i < 10; i++ {
+			toCreate.Metadata.Name = entityName
+			toCreate.Metadata.Namespace = fmt.Sprintf("ns%d", i)
+			err := createIfNotExists(ctx, s, toCreate)
+			assert.NoError(t, err)
+		}
+
 		entities, err = listEntities(ctx, s, defaultNamespace, &store.SelectionPredicate{})
 		assert.NoError(t, err)
 		assert.Equal(t, 100, len(entities))
@@ -226,6 +233,10 @@ func TestConfigStore_List(t *testing.T) {
 		entities, err = listEntities(ctx, s, defaultNamespace, &store.SelectionPredicate{Limit: 20})
 		assert.NoError(t, err)
 		assert.Equal(t, 20, len(entities))
+
+		entities, err = listEntities(ctx, s, "", &store.SelectionPredicate{})
+		assert.NoError(t, err)
+		assert.Equal(t, 110, len(entities))
 	})
 }
 
@@ -384,9 +395,20 @@ func TestConfigStore_Count(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
+		for i := 0; i < 10; i++ {
+			toCreate.Metadata.Name = entityName
+			toCreate.Metadata.Namespace = fmt.Sprintf("ns%d", i)
+			err := createIfNotExists(ctx, s, toCreate)
+			assert.NoError(t, err)
+		}
+
 		ct, err := countEntities(ctx, s, defaultNamespace)
 		assert.NoError(t, err)
 		assert.Equal(t, 100, ct)
+
+		ct, err = countEntities(ctx, s, "")
+		assert.NoError(t, err)
+		assert.Equal(t, 110, ct)
 	})
 }
 

--- a/backend/store/postgres/entity_state_store_test.go
+++ b/backend/store/postgres/entity_state_store_test.go
@@ -1188,6 +1188,41 @@ func TestEntityStateStore_List(t *testing.T) {
 				return states
 			}(),
 		},
+		{
+			name: "succeeds when namespace is unspecified",
+			args: args{
+				ctx:       context.Background(),
+				namespace: "",
+			},
+			beforeHook: func(t *testing.T, ns storev2.NamespaceStore, ec storev2.EntityConfigStore, s storev2.EntityStateStore) {
+				createNamespace(t, ns, "ns0")
+				createNamespace(t, ns, "ns1")
+				createNamespace(t, ns, "ns2")
+				for i := 0; i < 9; i++ {
+					entityName := fmt.Sprintf("foo-%d", i)
+					createEntityConfig(t, ec, fmt.Sprintf("ns%d", i%3), entityName)
+					createEntityState(t, s, fmt.Sprintf("ns%d", i%3), entityName)
+				}
+			},
+			want: func() []*corev3.EntityState {
+				states := []*corev3.EntityState{
+					corev3.FixtureEntityState("foo-0"),
+					corev3.FixtureEntityState("foo-3"),
+					corev3.FixtureEntityState("foo-6"),
+					corev3.FixtureEntityState("foo-1"),
+					corev3.FixtureEntityState("foo-4"),
+					corev3.FixtureEntityState("foo-7"),
+					corev3.FixtureEntityState("foo-2"),
+					corev3.FixtureEntityState("foo-5"),
+					corev3.FixtureEntityState("foo-8"),
+				}
+				for i, state := range states {
+					state.GetMetadata().Namespace = fmt.Sprintf("ns%d", i/3)
+					state.System.Processes = nil
+				}
+				return states
+			}(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1270,6 +1305,23 @@ func TestEntityStateStore_Count(t *testing.T) {
 				}
 			},
 			want: 10,
+		},
+		{
+			name: "succeeds when namespace is unspecified",
+			args: args{
+				ctx: context.Background(),
+			},
+			beforeHook: func(t *testing.T, ns storev2.NamespaceStore, ec storev2.EntityConfigStore, s storev2.EntityStateStore) {
+				createNamespace(t, ns, "ns0")
+				createNamespace(t, ns, "ns1")
+				createNamespace(t, ns, "ns2")
+				for i := 0; i < 9; i++ {
+					entityName := fmt.Sprintf("foo-%d", i)
+					createEntityConfig(t, ec, fmt.Sprintf("ns%d", i%3), entityName)
+					createEntityState(t, s, fmt.Sprintf("ns%d", i%3), entityName)
+				}
+			},
+			want: 9,
 		},
 	}
 	for _, tt := range tests {

--- a/backend/store/postgres/entity_states_schema.go
+++ b/backend/store/postgres/entity_states_schema.go
@@ -554,7 +554,7 @@ WITH namespace AS (
 		array_agg(entities_networks.addresses) AS addresses
 	FROM entities_networks
 	LEFT OUTER JOIN entity_states ON entity_states.id = entities_networks.entity_id
-	WHERE entity_states.namespace_id = (SELECT id FROM namespace)
+	JOIN namespace ON entity_states.namespace_id = namespace.id
 	GROUP BY entity_states.id
 ), system AS (
 	SELECT
@@ -573,7 +573,7 @@ WITH namespace AS (
 		entities_systems.float_type,
 		entities_systems.sensu_agent_version
 	FROM entities_systems LEFT OUTER JOIN entity_states ON entity_states.id = entities_systems.entity_id
-	WHERE entity_states.namespace_id = (SELECT id FROM namespace)
+	JOIN namespace ON entity_states.namespace_id = namespace.id
 )
 SELECT 
 	namespace.name,
@@ -635,7 +635,7 @@ WITH namespace AS (
 		entities_systems.float_type,
 		entities_systems.sensu_agent_version
 	FROM entities_systems LEFT OUTER JOIN entity_states ON entity_states.id = entities_systems.entity_id
-	WHERE entity_states.namespace_id = (SELECT id FROM namespace)
+	JOIN namespace ON entity_states.namespace_id = namespace.id
 )
 SELECT
 	COUNT(*)
@@ -658,7 +658,7 @@ WITH namespace AS (
 		array_agg(entities_networks.addresses) AS addresses
 	FROM entities_networks
 	LEFT OUTER JOIN entity_states ON entity_states.id = entities_networks.entity_id
-	WHERE entity_states.namespace_id = (SELECT id FROM namespace)
+	JOIN namespace ON entity_states.namespace_id = namespace.id
 	GROUP BY entity_states.id
 ), system AS (
 	SELECT
@@ -677,7 +677,7 @@ WITH namespace AS (
 		entities_systems.float_type,
 		entities_systems.sensu_agent_version
 	FROM entities_systems LEFT OUTER JOIN entity_states ON entity_states.id = entities_systems.entity_id
-	WHERE entity_states.namespace_id = (SELECT id FROM namespace)
+	JOIN namespace ON entity_states.namespace_id = namespace.id
 )
 SELECT
 	namespace.name,

--- a/backend/store/postgres/silences_store.go
+++ b/backend/store/postgres/silences_store.go
@@ -39,10 +39,9 @@ SELECT
 	silences.begin,
 	silences.expire_at
 FROM
-	silences, namespaces
-WHERE
-	silences.namespace = namespaces.id
-	AND namespaces.name = $1;
+	silences
+	JOIN namespaces ON silences.namespace = namespaces.id
+	WHERE namespaces.name = $1 OR $1 = '';
 `
 
 type scanFunc func(...interface{}) error

--- a/backend/store/postgres/store.go
+++ b/backend/store/postgres/store.go
@@ -118,6 +118,7 @@ type configRecord struct {
 type listTemplateValues struct {
 	Limit       int64
 	Offset      int64
+	Namespaced  bool
 	SelectorSQL string
 }
 
@@ -297,6 +298,7 @@ func (s *ConfigStore) List(ctx context.Context, request storev2.ResourceRequest,
 		Limit:       predicate.Limit,
 		Offset:      predicate.Offset,
 		SelectorSQL: strings.TrimSpace(selectorSQL),
+		Namespaced:  request.Namespace != "",
 	}
 	if err := tmpl.Execute(&queryBuilder, templValues); err != nil {
 		return nil, err
@@ -412,6 +414,7 @@ func (s *ConfigStore) Count(ctx context.Context, request storev2.ResourceRequest
 	var queryBuilder strings.Builder
 	templValues := listTemplateValues{
 		SelectorSQL: strings.TrimSpace(selectorSQL),
+		Namespaced:  request.Namespace != "",
 	}
 	if err := tmpl.Execute(&queryBuilder, templValues); err != nil {
 		return 0, err


### PR DESCRIPTION
Add test cases for unspecified namespace for all List or Count methods. Fix config store, entity state and silences store behavior when namespace is unspecified.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>
