### PR TITLE
Make check TTL work again

### DIFF
--- a/backend/agentd/agentd.go
+++ b/backend/agentd/agentd.go
@@ -253,19 +253,8 @@ func (a *Agentd) runWatcher() {
 }
 
 func (a *Agentd) handleEvent(event storev2.WatchEvent) error {
-	changeEvent := entityChange{
-		Type: event.Type,
-	}
-
-	var err error
-
-	changeEvent.EntityConfig, err = storev2.ReadEventValue[*corev3.EntityConfig](event)
-	if err != nil {
-		return err
-	}
-
 	topic := messaging.EntityConfigTopic(event.Key.Namespace, event.Key.Name)
-	if err := a.bus.Publish(topic, &changeEvent); err != nil {
+	if err := a.bus.Publish(topic, event); err != nil {
 		logger.WithField("topic", topic).WithError(err).
 			Error("unable to publish an entity config update to the bus")
 		return err
@@ -525,9 +514,4 @@ func (a *Agentd) EntityLimiterMiddleware(next http.Handler) http.Handler {
 
 type Authenticator interface {
 	Authenticate(ctx context.Context, username, password string) (*corev2.Claims, error)
-}
-
-type entityChange struct {
-	Type         storev2.WatchActionType
-	EntityConfig *corev3.EntityConfig
 }

--- a/backend/eventd/opc.go
+++ b/backend/eventd/opc.go
@@ -1,0 +1,45 @@
+package eventd
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+var hostname string
+
+func init() {
+	var err error
+	hostname, err = os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (e *Eventd) monitorCheckTTLs(ctx context.Context) {
+	req := store.MonitorOperatorsRequest{
+		Type:           store.CheckOperator,
+		ControllerType: store.BackendOperator,
+		ControllerName: hostname,
+		Micromanage:    true,
+		Every:          time.Second,
+		ErrorHandler: func(err error) {
+			logger.WithError(err).Error("error monitoring check TTLs")
+		},
+	}
+	stateCh := e.operatorMonitor.MonitorOperators(ctx, req)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case states := <-stateCh:
+			for _, state := range states {
+				if err := e.handleCheckTTLNotification(ctx, state); err != nil {
+					logger.WithError(err).Error("error handling check TTL failure")
+				}
+			}
+		}
+	}
+}

--- a/backend/store/opc.go
+++ b/backend/store/opc.go
@@ -85,6 +85,15 @@ type OperatorState struct {
 	Metadata *json.RawMessage
 }
 
+// Key gets the OperatorKey information from the OperatorState.
+func (o OperatorState) Key() OperatorKey {
+	return OperatorKey{
+		Namespace: o.Namespace,
+		Name:      o.Name,
+		Type:      o.Type,
+	}
+}
+
 // MonitorOperatorsRequest is a request to watch a specific operator space
 // for updates, whether those updates are generated as repeated absence alerts
 // or check ins. The OPC will send all error encountered for each poll to the
@@ -119,6 +128,13 @@ type MonitorOperatorsRequest struct {
 	// ErrorHandler is a function tha handles any errors generated in the
 	// monitoring process.
 	ErrorHandler func(error)
+
+	// If Micromanage is set, then the monitoring request applies to all of the
+	// grandchildren controllees instead of the controllees of the operator.
+	// That is, the set of monitored operators will be equal to the union of
+	// all of the sets of the controlled operators that are controlled by the
+	// specified operator.
+	Micromanage bool
 }
 
 // OperatorMonitor monitors operators for updates or missed check-ins.

--- a/backend/store/v2/watcher.go
+++ b/backend/store/v2/watcher.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -31,7 +29,6 @@ func ReadEventValue[R Resource[T], T any](w WatchEvent) (R, error) {
 		return nil, nil
 	}
 	val := new(T)
-	fmt.Println("val", val)
 	if err := w.Value.UnwrapInto(val); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit makes check TTL work with the new OPC system. Each check that specifies the TTL field will have an entry stored in the OPC table for each agent entity that executes the check.

A new OPC monitoring option has been added to the
MonitorOperatorsRequest struct, which allows selecting all of the grandchildren of the requested controller operator instead of the children.