### PR TITLE
Do not implement core/v3 wrapper behaviour for LicenseFile

### DIFF
--- a/types/wrapper.go
+++ b/types/wrapper.go
@@ -207,7 +207,8 @@ V3RESOURCE:
 	w.ObjectMeta = *innerMeta
 
 	// Set the inner ObjectMeta
-	if r, ok := resource.(corev3Resource); ok {
+	license := w.Type == "LicenseFile"
+	if r, ok := resource.(corev3Resource); ok && !license {
 		if innerMeta.Labels == nil {
 			innerMeta.Labels = make(map[string]string)
 		}


### PR DESCRIPTION
We need LicenseFile to render in a very particular way, and if labels and annotations are set non-nil, rendering round tripping will break existing licenses.