### PR TITLE
Generic Store Watch

### DIFF
--- a/backend/poll/polling.go
+++ b/backend/poll/polling.go
@@ -133,9 +133,12 @@ func merge(rows []Row, cache map[string]Row) []Row {
 			results = append(results, row)
 			continue
 		}
+		isDeleted := row.DeletedAt != nil
+		wasDeleted := prev.DeletedAt != nil
 		if row.UpdatedAt != prev.UpdatedAt ||
 			row.CreatedAt != prev.CreatedAt ||
-			row.DeletedAt != prev.DeletedAt {
+			isDeleted != wasDeleted ||
+			(isDeleted && wasDeleted && !row.DeletedAt.Equal(*prev.DeletedAt)) {
 			results = append(results, row)
 			continue
 		}

--- a/backend/store/postgres/store.go
+++ b/backend/store/postgres/store.go
@@ -543,7 +543,7 @@ func (e *configurationPoller) Since(ctx context.Context, updatedSince time.Time)
 		if err := rows.Err(); err != nil {
 			return nil, &store.ErrInternal{Message: err.Error()}
 		}
-		id := fmt.Sprintf("%s/%s", record.namespace, record.name)
+		id := fmt.Sprint(record.id)
 		pollResult := poll.Row{
 			Id: id,
 			Resource: &wrap.Wrapper{

--- a/backend/store/v2/generic.go
+++ b/backend/store/v2/generic.go
@@ -46,7 +46,10 @@ func prepare(resource corev3.Resource) (ResourceRequest, Wrapper, error) {
 	return req, wrapper, err
 }
 
-var errNoSpecialization = errors.New("no specialization available")
+var (
+	errNoSpecialization   = errors.New("no specialization available")
+	errUnsupportedForType = errors.New("method not supported for type")
+)
 
 func (g Generic[R, T]) trySpecializeCreateOrUpdate(ctx context.Context, resource R) error {
 	switch value := any(resource).(type) {
@@ -450,17 +453,41 @@ func getGenericTypeMeta[R Resource[T], T any]() corev2.TypeMeta {
 	return tm
 }
 
-func (g Generic[R, T]) CanWatch() bool {
+func (g Generic[R, T]) trySpecializeWatch(ctx context.Context, id ID) (<-chan []WatchEvent, error) {
 	switch any(new(T)).(type) {
+	case *corev3.EntityConfig:
+		watch := g.Interface.GetEntityConfigStore().Watch(ctx, id.Name, id.Namespace)
+		return watch, nil
 	case *corev3.EntityState,
 		*corev3.Namespace,
 		*corev2.Entity,
 		*corev2.Event,
 		*corev2.Silenced:
-		return false
-	default:
-		return true
+		return nil, fmt.Errorf("%w: %T", errUnsupportedForType, new(T))
 	}
+	return nil, errNoSpecialization
+
+}
+
+func (g Generic[R, T]) Watch(ctx context.Context, id ID) <-chan []GenericEvent[R] {
+	watch, err := g.trySpecializeWatch(ctx, id)
+	if err != nil {
+		if err != errNoSpecialization {
+			errEvent := make(chan []GenericEvent[R], 1)
+			errEvent <- []GenericEvent[R]{{Err: err}}
+			close(errEvent)
+			return errEvent
+		}
+	} else {
+		return wrapWatch[R](ctx, watch)
+	}
+
+	var r R
+	tm := getGenericTypeMeta[R]()
+	req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
+	watch = g.Interface.GetConfigStore().Watch(ctx, req)
+	return wrapWatch[R](ctx, watch)
+
 }
 
 type GenericEvent[R any] struct {
@@ -471,57 +498,44 @@ type GenericEvent[R any] struct {
 	Err           error
 }
 
-func (g Generic[R, T]) Watch(ctx context.Context, id ID) <-chan []GenericEvent[R] {
-	if !g.CanWatch() {
-		panic(fmt.Sprintf("Watch not supported for %T", g))
-	}
-
-	switch any(new(T)).(type) {
-	case *corev3.EntityConfig:
-		return nil
-	default:
-		var r R
-		tm := getGenericTypeMeta[R]()
-		req := NewResourceRequest(tm, id.Namespace, id.Name, r.StoreName())
-		watch := g.Interface.GetConfigStore().Watch(ctx, req)
-		out := make(chan []GenericEvent[R], cap(watch))
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
+func wrapWatch[R Resource[T], T any](ctx context.Context, in <-chan []WatchEvent) <-chan []GenericEvent[R] {
+	out := make(chan []GenericEvent[R], cap(in))
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e, ok := <-in:
+				if !ok {
+					close(out)
 					return
-				case e, ok := <-watch:
-					if !ok {
-						close(out)
-						return
-					}
-					events := make([]GenericEvent[R], len(e))
-					for i, event := range e {
-						key := corev2.ObjectMeta{
-							Name:      event.Key.Name,
-							Namespace: event.Key.Namespace,
-						}
-						var resource, prev T
-						if event.Value != nil {
-							event.Value.UnwrapInto(&resource)
-						}
-						if event.PreviousValue != nil {
-							event.PreviousValue.UnwrapInto(&prev)
-						}
-
-						events[i] = GenericEvent[R]{
-							Type:          event.Type,
-							Key:           key,
-							Value:         &resource,
-							PreviousValue: &prev,
-							Err:           event.Err,
-						}
-					}
-					out <- events
 				}
-			}
-		}()
-		return out
-	}
+				events := make([]GenericEvent[R], len(e))
+				for i, event := range e {
+					key := corev2.ObjectMeta{
+						Name:      event.Key.Name,
+						Namespace: event.Key.Namespace,
+					}
+					var resource, prev T
+					if event.Value != nil {
+						event.Value.UnwrapInto(&resource)
+					}
+					if event.PreviousValue != nil {
+						event.PreviousValue.UnwrapInto(&prev)
+					}
 
+					events[i] = GenericEvent[R]{
+						Type:          event.Type,
+						Key:           key,
+						Value:         &resource,
+						PreviousValue: &prev,
+						Err:           event.Err,
+					}
+				}
+				out <- events
+			}
+		}
+	}()
+
+	return out
 }


### PR DESCRIPTION
## What is this change?

Adds a Watch function to the generic store. Also fixes some watch poller bugs.

This turned out to be necessary for resource replicators in the enterprise product.