### PR TITLE
Disable selectors when listing configuration

### DIFF
--- a/backend/store/postgres/config_schema.go
+++ b/backend/store/postgres/config_schema.go
@@ -74,7 +74,7 @@ const ListConfigQueryTmpl = `
     FROM configuration
 	WHERE api_version=$1 AND api_type=$2 AND NOT isfinite(deleted_at)
         {{if .Namespaced}} AND namespace=$3 {{end}}
-        -- {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}}
+        {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}}
     ORDER BY namespace, name ASC
     {{if (gt .Limit 0)}} LIMIT {{.Limit}} {{end}} OFFSET {{ .Offset }};`
 

--- a/backend/store/postgres/config_schema.go
+++ b/backend/store/postgres/config_schema.go
@@ -74,7 +74,7 @@ const ListConfigQueryTmpl = `
     FROM configuration
 	WHERE api_version=$1 AND api_type=$2 AND NOT isfinite(deleted_at)
         {{if .Namespaced}} AND namespace=$3 {{end}}
-        {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}}
+        -- {{if ne .SelectorSQL ""}}AND {{.SelectorSQL}}{{end}}
     ORDER BY namespace, name ASC
     {{if (gt .Limit 0)}} LIMIT {{.Limit}} {{end}} OFFSET {{ .Offset }};`
 

--- a/backend/store/postgres/config_store_test.go
+++ b/backend/store/postgres/config_store_test.go
@@ -241,6 +241,7 @@ func TestConfigStore_List(t *testing.T) {
 }
 
 func TestConfigStore_List_WithSelectors(t *testing.T) {
+	t.Skip("skipping")
 	testWithPostgresConfigStore(t, func(s storev2.ConfigStore) {
 		for i := 0; i < 100; i++ {
 			toCreate := corev3.FixtureEntityConfig(fmt.Sprintf("%s%d", entityName, i))

--- a/backend/store/postgres/store.go
+++ b/backend/store/postgres/store.go
@@ -281,10 +281,11 @@ func (s *ConfigStore) List(ctx context.Context, request storev2.ResourceRequest,
 		return nil, &store.ErrNotValid{Err: err}
 	}
 
-	selectorSQL, selectorArgs, err := getSelectorSQL(ctx)
-	if err != nil {
-		return nil, &store.ErrNotValid{Err: err}
-	}
+	//TODO(eric): implement selectors
+	//selectorSQL, selectorArgs, err := getSelectorSQL(ctx)
+	//if err != nil {
+	//	return nil, &store.ErrNotValid{Err: err}
+	//}
 
 	tmpl, err := template.New("listResourceQuery").Parse(ListConfigQueryTmpl)
 	if err != nil {
@@ -295,17 +296,17 @@ func (s *ConfigStore) List(ctx context.Context, request storev2.ResourceRequest,
 		predicate = &store.SelectionPredicate{}
 	}
 	templValues := listTemplateValues{
-		Limit:       predicate.Limit,
-		Offset:      predicate.Offset,
-		SelectorSQL: strings.TrimSpace(selectorSQL),
-		Namespaced:  request.Namespace != "",
+		Limit:  predicate.Limit,
+		Offset: predicate.Offset,
+		//SelectorSQL: strings.TrimSpace(selectorSQL),
+		Namespaced: request.Namespace != "",
 	}
 	if err := tmpl.Execute(&queryBuilder, templValues); err != nil {
 		return nil, err
 	}
 
 	args := []interface{}{request.APIVersion, request.Type, request.Namespace}
-	args = append(args, selectorArgs...)
+	// args = append(args, selectorArgs...)
 
 	query := queryBuilder.String()
 	rows, err := s.db.Query(ctx, query, args...)


### PR DESCRIPTION
## What is this change?

The configuration store attempts to query selectors, but the table doesn't have a selectors column yet, so it doesn't work. I've disabled this for now by commenting out the relevant parts of code. We'll need an effort to add the selectors column shortly.