### PR TITLE
Strip network agent entity state

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unrealased]
+
+### Added
+- Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
+
 ## [6.9.1] - 2022-12-01
 
 ### Changed

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -1,11 +1,12 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unrealased]
+## [Unreleased]
 
 ### Added
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -253,15 +253,9 @@ func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
 	var info corev2.System
 	var err error
 
-	info, err = system.Info()
+	info, err = system.Info(!a.config.StripNetworks)
 	if err != nil {
 		return err
-	}
-	if !a.config.StripNetworks {
-		network, err := system.NetworkInfo()
-		if err == nil {
-			info.Network = network
-		}
 	}
 
 	if a.config.DetectCloudProvider {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -257,6 +257,12 @@ func (a *Agent) RefreshSystemInfo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if !a.config.StripNetworks {
+		network, err := system.NetworkInfo()
+		if err == nil {
+			info.Network = network
+		}
+	}
 
 	if a.config.DetectCloudProvider {
 		info.CloudProvider = system.GetCloudProvider(ctx)

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -83,6 +83,7 @@ const (
 	flagRetryMax                  = "retry-max"
 	flagRetryMultiplier           = "retry-multiplier"
 	flagMaxSessionLength          = "max-session-length"
+	flagStripNetworks             = "strip-networks"
 
 	// TLS flags
 	flagTrustedCAFile         = "trusted-ca-file"
@@ -148,6 +149,7 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.RetryMax = viper.GetDuration(flagRetryMax)
 	cfg.RetryMultiplier = viper.GetFloat64(flagRetryMultiplier)
 	cfg.MaxSessionLength = viper.GetDuration(flagMaxSessionLength)
+	cfg.StripNetworks = viper.GetBool(flagStripNetworks)
 
 	// Set the labels & annotations using values defined configuration files
 	// and/or environment variables for now
@@ -331,6 +333,7 @@ func handleConfig(cmd *cobra.Command, arguments []string) error {
 	viper.SetDefault(flagRetryMax, 120*time.Second)
 	viper.SetDefault(flagRetryMultiplier, 2.0)
 	viper.SetDefault(flagMaxSessionLength, 0*time.Second)
+	viper.SetDefault(flagStripNetworks, false)
 
 	// Merge in flag set so that it appears in command usage
 	flags := flagSet()
@@ -456,6 +459,7 @@ func flagSet() *pflag.FlagSet {
 	flagSet.Duration(flagRetryMax, viper.GetDuration(flagRetryMax), "maximum amount of time to wait before retrying an agent connection to the backend")
 	flagSet.Float64(flagRetryMultiplier, viper.GetFloat64(flagRetryMultiplier), "value multiplied with the current retry delay to produce a longer retry delay (bounded by --retry-max)")
 	flagSet.Duration(flagMaxSessionLength, viper.GetDuration(flagMaxSessionLength), "maximum amount of time after which the agent will reconnect to one of the configured backends (no maximum by default)")
+	flagSet.Bool(flagStripNetworks, viper.GetBool(flagStripNetworks), "do not include Network info in agent entity state")
 
 	flagSet.SetOutput(ioutil.Discard)
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -223,6 +223,10 @@ type Config struct {
 	// MaxSessionLength is the maximum duration after which the agent will
 	// reconnect to one of the backends.
 	MaxSessionLength time.Duration
+
+	// StripNetworks is a boolean to specify if we need to strip network
+	// information from the agent entity state
+	StripNetworks bool
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -967,7 +967,7 @@ func getDefaultBackendID() string {
 
 // getSystemInfo returns the system info of the backend
 func getSystemInfo() corev2.System {
-	info, err := system.Info()
+	info, err := system.Info(true)
 	if err != nil {
 		logger.WithError(err).Error("error getting system info")
 	}

--- a/backend/resource/backend.go
+++ b/backend/resource/backend.go
@@ -110,7 +110,7 @@ func (br *BackendResource) GenerateBackendEvent(component string, status uint32,
 }
 
 func getEntity() (*corev2.Entity, error) {
-	systemInfo, err := system.Info()
+	systemInfo, err := system.Info(true)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmdmanager/manager.go
+++ b/cli/cmdmanager/manager.go
@@ -79,7 +79,7 @@ func (p *CommandPlugin) SetObjectMeta(meta corev2.ObjectMeta) {
 
 func getEntity() (*corev2.Entity, error) {
 	// create an entity for using with command asset filtering
-	systemInfo, err := system.Info()
+	systemInfo, err := system.Info(true)
 	if err != nil {
 		return nil, err
 	}

--- a/system/system.go
+++ b/system/system.go
@@ -53,11 +53,6 @@ func Info() (types.System, error) {
 		system.Hostname = defaultHostname
 	}
 
-	network, err := NetworkInfo()
-	if err == nil {
-		system.Network = network
-	}
-
 	vmSystem, vmRole, err := host.Virtualization()
 	if err == nil {
 		system.VMSystem = vmSystem

--- a/system/system.go
+++ b/system/system.go
@@ -32,7 +32,7 @@ type azureMetadata struct {
 
 // Info describes the local system, hostname, OS, platform, platform
 // family, platform version, and network interfaces.
-func Info() (types.System, error) {
+func Info(includeNetworks bool) (types.System, error) {
 	info, err := host.Info()
 	if err != nil {
 		return types.System{}, err
@@ -51,6 +51,12 @@ func Info() (types.System, error) {
 
 	if system.Hostname == "" {
 		system.Hostname = defaultHostname
+	}
+	if includeNetworks {
+		network, err := NetworkInfo()
+		if err == nil {
+			system.Network = network
+		}
 	}
 
 	vmSystem, vmRole, err := host.Virtualization()

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestInfo(t *testing.T) {
-	info, err := Info()
+	// Test first with network information included
+	info, err := Info(true)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, info.Arch)
 	assert.NotEmpty(t, info.Hostname)
@@ -19,7 +20,24 @@ func TestInfo(t *testing.T) {
 		assert.NotEmpty(t, info.PlatformFamily)
 	}
 	assert.NotEmpty(t, info.PlatformVersion)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, info.Network.Interfaces)
+	nInterface := info.Network.Interfaces[0]
+	assert.NotEmpty(t, nInterface.Name)
 
+	// Then we have to test if with network data stripped
+	infoWithoutNet, err := Info(false)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, infoWithoutNet.Arch)
+	assert.NotEmpty(t, infoWithoutNet.Hostname)
+	assert.NotEmpty(t, infoWithoutNet.OS)
+	assert.NotEmpty(t, infoWithoutNet.Platform)
+	if info.Platform == "linux" {
+		assert.NotEmpty(t, infoWithoutNet.PlatformFamily)
+	}
+	assert.NotEmpty(t, infoWithoutNet.PlatformVersion)
+	assert.NoError(t, err)
+	assert.Empty(t, infoWithoutNet.Network.Interfaces)
 }
 
 func TestNetworkInfo(t *testing.T) {

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -19,9 +19,14 @@ func TestInfo(t *testing.T) {
 		assert.NotEmpty(t, info.PlatformFamily)
 	}
 	assert.NotEmpty(t, info.PlatformVersion)
-	assert.NotEmpty(t, info.Network.Interfaces)
-	nInterface := info.Network.Interfaces[0]
+
+}
+
+func TestNetworkInfo(t *testing.T) {
+	network, err := NetworkInfo()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, network.Interfaces)
+	nInterface := network.Interfaces[0]
 	assert.NotEmpty(t, nInterface.Name)
-	//assert.NotEmpty(t, nInterface.MAC) // can be empty
-	assert.NotEmpty(t, nInterface.Addresses)
+	// assert.NotEmpty(t, nInterface.MAC) // can be empty
 }


### PR DESCRIPTION
## What is this change?

Disable sending network information from sensu-agent to sensu-backend when a flag is passed to the agent


## Why is this change necessary?

Solving #4787

## Does your change need a Changelog entry?

Yes


## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

No


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

No, I think it was easy to implement.
By default it will still add the information, the only behaviour change will be when the flag will be set. 

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->
Documentation has been updated and [a pull request](https://github.com/sensu/sensu-docs/pull/4162) was created

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->
I run the automated test.
In addition to this I build the sensu-agent binary for x86-64 linux & arm7 linux. I tested them against and up to date sensu-go-backend (6.9.1).
I performed 3 different tests (between each tests agents were removed from the backend):

- Start the agent without the flag to observe that network information were still retrieved (and visible in the sensu-go webui)
- Start the agent with the flag on the command line to observe that network information were removed from the webUI
- Start the agent with the environment variable  to observe that network information were removed from the webUI

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->

I think it can considered to be a patch since its small. If not I will change the target branch. let me know.