### PR TITLE
Add a Postgres-backed Queue implementation

### DIFF
--- a/backend/apid/actions/checks_test.go
+++ b/backend/apid/actions/checks_test.go
@@ -18,7 +18,7 @@ func TestNewCheckController(t *testing.T) {
 	assert := assert.New(t)
 
 	store := &mockstore.V2MockStore{}
-	actions := NewCheckController(store, queue.NewMemoryGetter())
+	actions := NewCheckController(store, queue.NewMemoryClient())
 
 	assert.NotNil(actions)
 	assert.Equal(store, actions.store)
@@ -61,9 +61,7 @@ func TestCheckAdhoc(t *testing.T) {
 		cs := new(mockstore.ConfigStore)
 		store.On("GetConfigStore").Return(cs)
 		queue := &mockqueue.MockQueue{}
-		getter := &mockqueue.Getter{}
-		getter.On("GetQueue", mock.Anything).Return(queue)
-		actions := NewCheckController(store, getter)
+		actions := NewCheckController(store, queue)
 
 		t.Run(tc.name, func(t *testing.T) {
 			assert := assert.New(t)

--- a/backend/apid/routers/checks.go
+++ b/backend/apid/routers/checks.go
@@ -13,8 +13,8 @@ import (
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/queue"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	"github.com/sensu/sensu-go/types"
 )
 
 // checkController represents the controller needs of the ChecksRouter.
@@ -31,9 +31,9 @@ type ChecksRouter struct {
 }
 
 // NewChecksRouter instantiates new router for controlling check resources
-func NewChecksRouter(store storev2.Interface, getter types.QueueGetter) *ChecksRouter {
+func NewChecksRouter(store storev2.Interface, queue queue.Client) *ChecksRouter {
 	return &ChecksRouter{
-		controller: actions.NewCheckController(store, getter),
+		controller: actions.NewCheckController(store, queue),
 		store:      store,
 	}
 }

--- a/backend/apid/routers/checks_test.go
+++ b/backend/apid/routers/checks_test.go
@@ -48,9 +48,7 @@ func TestHttpApiChecksAdhocRequest(t *testing.T) {
 	checkConfig := corev2.FixtureCheckConfig("check1")
 	cs.On("Get", mock.Anything, mock.Anything).Return(mockstore.Wrapper[*corev2.CheckConfig]{Value: checkConfig}, nil)
 	queue.On("Enqueue", mock.Anything, mock.Anything).Return(nil)
-	getter := &mockqueue.Getter{}
-	getter.On("GetQueue", mock.Anything).Return(queue)
-	checkController := actions.NewCheckController(store, getter)
+	checkController := actions.NewCheckController(store, queue)
 	c := &ChecksRouter{controller: checkController}
 	payload, _ := json.Marshal(adhocRequest)
 

--- a/backend/queue/memory_test.go
+++ b/backend/queue/memory_test.go
@@ -1,0 +1,17 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sensu/sensu-go/backend/queue"
+	"github.com/sensu/sensu-go/backend/queue/testspec"
+)
+
+func TestMemoryClient(t *testing.T) {
+	q := queue.NewMemoryClient()
+
+	ctx := context.Background()
+
+	testspec.RunClientTestSuite(t, ctx, q)
+}

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -2,7 +2,8 @@ package queue
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"path"
 	"time"
 
 	"github.com/sensu/sensu-go/backend/store"
@@ -20,34 +21,68 @@ var (
 	backendIDKeyPrefix = store.NewKeyBuilder("backends").Build()
 )
 
-type BackendIDGetter interface {
-	GetBackendID() int64
+// Client interface to queue backend
+type Client interface {
+	// Enqueue Item
+	Enqueue(context.Context, Item) error
+	// Reserve an Item from the queue
+	// Blocks until an item can be reserved or the context expires
+	Reserve(ctx context.Context, queue string) (Reservation, error)
 }
 
-// Item is a Queue item.
+// Item is a Queue Item.
 type Item struct {
-	key   string
-	value string
+	// ID of queue item. Ignored on Enqueue
+	ID string
+	// Queue name
+	Queue string
+	// Value of queue item
+	Value []byte
 }
 
-// Key returns the key of the Item.
-func (i *Item) Key() string {
-	return i.key
+// Reservation for a Queue Item.
+// Must be either Ack'd or Nack'd.
+type Reservation interface {
+	Item() Item
+	// Ack the Item was handeled and can be deleted.
+	Ack(context.Context) error
+	// Nack the Item could not be handled. Return to the queue.
+	Nack(context.Context) error
 }
 
-// Value returns the value of the Item.
-func (i *Item) Value() string {
-	return i.value
+// ClusteredQueue is a Client wrapper meant to function as a simple pub/sub
+// across all active sensu backends in a cluster.
+// Given a queueName, ClusteredQueue Enqueues to queueName/{{backendID}} for
+// each backend, and Reserves only from queueName/{{this backendID}}
+type ClusteredQueue struct {
+	// Client underlying queue implementation
+	Client Client
+	// GetBackendID gets the current backend process's id.
+	// TODO(ck): just hostname per backend/opc.go?
+	GetBackendID func() string
+	// GetAllBackendIDs returns the set of currently present backends.
+	// TODO(ck): Find source for this. The OPC table makes sense as a source of
+	// truth for this, but we need more flexible query mechanism.
+	GetAllBackendIDs func(context.Context) ([]string, error)
 }
 
-// Ack acknowledges the Item has been received and processed, and deletes it
-// from the in flight lane.
-func (i *Item) Ack(ctx context.Context) error {
-	return errors.New("not implemented")
+// Enqueue Item to "{{item.Queue}}/{{backend id}}" for each backend id
+func (q *ClusteredQueue) Enqueue(ctx context.Context, item Item) error {
+	backendIDs, err := q.GetAllBackendIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting backend IDs: %w", err)
+	}
+	baseQueue := item.Queue
+	for _, id := range backendIDs {
+		item.Queue = path.Join(baseQueue, id)
+		if err := q.Client.Enqueue(ctx, item); err != nil {
+			return fmt.Errorf("error enqueuing item to queue %s: %w", item.Queue, err)
+		}
+	}
+	return nil
 }
 
-// Nack returns the Item to the work queue and deletes it from the in-flight
-// lane.
-func (i *Item) Nack(ctx context.Context) error {
-	return errors.New("not implemented")
+// Reserve Item from "{{queue}}/{{backend id}}"
+func (q *ClusteredQueue) Reserve(ctx context.Context, queue string) (Reservation, error) {
+	return q.Client.Reserve(ctx, path.Join(queue, q.GetBackendID()))
 }

--- a/backend/queue/testspec/client.go
+++ b/backend/queue/testspec/client.go
@@ -1,0 +1,176 @@
+package testspec
+
+import (
+	"context"
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sensu/sensu-go/backend/queue"
+)
+
+func RunClientTestSuite(t *testing.T, ctx context.Context, clientUnderTest queue.Client) {
+	t.Run("integration test suite", func(t *testing.T) {
+		runIntegrationSuite(t, ctx, clientUnderTest)
+	})
+	t.Run("queue isolation", func(t *testing.T) {
+		runQueueIsolationSuite(t, ctx, clientUnderTest)
+	})
+	t.Run("reservation timeout", func(t *testing.T) {
+		runReservationTimeout(t, ctx, clientUnderTest)
+	})
+}
+
+// runIntegrationSuite attempts to simulate heavy utilization of a queue.
+// It feeds the queue with a set of items, starts workers that either Ack
+// or Nack their reservation after a some random interval, and validates that
+// all published items were recieved exactly once.
+func runIntegrationSuite(t *testing.T, ctx context.Context, clientUnderTest queue.Client) {
+	var toEnqueue []queue.Item
+	for i := uint8(0); i < 100; i++ {
+		item := queue.Item{
+			Queue: "test-queue",
+			Value: []byte{i},
+		}
+		toEnqueue = append(toEnqueue, item)
+	}
+
+	enqueueFn := func(q queue.Client, items []queue.Item) {
+		for _, item := range items {
+			q.Enqueue(ctx, item)
+			jitter := time.Duration(20 * rand.Float64())
+			time.Sleep(time.Millisecond * jitter)
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	actualResults := make([]queue.Item, 100)
+
+	nackerFn := func(q queue.Client) {
+		defer wg.Done()
+		// Do not poll indefinately
+		rCtx, cancel := context.WithTimeout(ctx, time.Millisecond*50)
+		defer cancel()
+
+		res, err := q.Reserve(rCtx, "test-queue")
+		if err != nil {
+			if err == rCtx.Err() {
+				return
+			}
+			t.Errorf("unexpected reservation error: %v", err)
+		}
+		jitter := time.Duration(20 * rand.Float64())
+		time.Sleep(time.Millisecond * jitter)
+
+		// return item to queue
+		res.Nack(ctx)
+
+	}
+	workerFn := func(q queue.Client, n int) {
+		defer wg.Done()
+		res, err := q.Reserve(ctx, "test-queue")
+		if err != nil {
+			t.Errorf("unexpected reservation error: %v", err)
+		}
+		jitter := time.Duration(20 * rand.Float64())
+		time.Sleep(time.Millisecond * jitter)
+
+		actualResults[n] = res.Item()
+		if err := res.Ack(ctx); err != nil {
+			t.Errorf("unexpected ack error: %v", err)
+		}
+	}
+
+	go enqueueFn(clientUnderTest, toEnqueue)
+	wg.Add(20)
+	// Reserve but then Nack 20 items
+	for i := 0; i < 20; i++ {
+		go nackerFn(clientUnderTest)
+	}
+	wg.Add(100)
+	// Reserve and Ack 100, recording the restults
+	for i := 0; i < 100; i++ {
+		go workerFn(clientUnderTest, i)
+	}
+
+	wg.Wait()
+
+	// NOT a FIFO, order delivery not guaranteed
+	sort.Slice(actualResults, func(i, j int) bool {
+		return actualResults[i].Value[0] < actualResults[j].Value[0]
+	})
+
+	for idx, result := range actualResults {
+		got := result.Value[0]
+		want := uint8(idx)
+		if got != want {
+			t.Errorf("unexpected result order. wanted: %d got: %d - id: %s", want, got, result.ID)
+		}
+	}
+}
+
+// runQueueIsolationSuite publishes to multiple queues and ensures delivery
+// happens on the appropriate queue.
+func runQueueIsolationSuite(t *testing.T, ctx context.Context, clientUnderTest queue.Client) {
+
+	err := clientUnderTest.Enqueue(ctx, queue.Item{
+		Queue: "queue-1",
+		Value: []byte("hello world")},
+	)
+	if err != nil {
+		t.Errorf("unexpected enqueue error: %v", err)
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		clientUnderTest.Reserve(ctx, "queue-2")
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Millisecond * 100):
+		// okay
+	case <-done:
+		t.Error("unexpected reservation on queue-2")
+	}
+	resQueue1, _ := clientUnderTest.Reserve(ctx, "queue-1")
+	resQueue1.Ack(ctx)
+
+	clientUnderTest.Enqueue(ctx, queue.Item{
+		Queue: "queue-2",
+		Value: []byte("hello world")},
+	)
+
+	select {
+	case <-time.After(time.Second):
+		t.Error("expected reservation on queue-2")
+	case <-done:
+		// okay
+	}
+
+}
+
+// runReservationTimeout checks that a blocked Reserve call times out when the
+// context expires.
+func runReservationTimeout(t *testing.T, ctx context.Context, clientUnderTest queue.Client) {
+	tCtx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
+	defer cancel()
+
+	reserveErr := make(chan error)
+	go func() {
+		_, err := clientUnderTest.Reserve(tCtx, "empty-queue")
+		reserveErr <- err
+		close(reserveErr)
+	}()
+	select {
+	case <-time.After(time.Millisecond * 500):
+		t.Errorf("expected queue Reservaiton to time out")
+	case err := <-reserveErr:
+		if got, want := err, tCtx.Err(); got != want {
+			t.Errorf("unexpected error reserving queue item: got %v, want %v", got, want)
+		}
+	}
+}

--- a/backend/store/postgres/migrations.go
+++ b/backend/store/postgres/migrations.go
@@ -128,6 +128,11 @@ var migrations = []migration.Migrator{
 		_, err := tx.Exec(context.Background(), ConfigurationDDL)
 		return err
 	},
+	// Migration 21
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), queueSchema)
+		return err
+	},
 }
 
 type eventRecord struct {

--- a/backend/store/postgres/queue.go
+++ b/backend/store/postgres/queue.go
@@ -1,0 +1,92 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sensu/sensu-go/backend/queue"
+)
+
+type Queue struct {
+	db           DBI
+	pollDuration time.Duration
+}
+
+func NewQueue(db DBI) *Queue {
+	return &Queue{
+		db:           db,
+		pollDuration: time.Second * 5,
+	}
+}
+
+// Enqueue a queue item
+func (q *Queue) Enqueue(ctx context.Context, item queue.Item) error {
+	_, err := q.db.Exec(ctx, queueEnqueue, item.Queue, item.Value)
+	return err
+}
+
+// Reserve reserves a queue item.
+// When the queue is empty Reserve will block and poll for new items until either
+// an item is found, or the context is cancelled.
+//
+// When Reserve returns a Reservation, the caller MUST Ack or Nack that Reservation.
+// Otherwise a transaction + connection could be leaked depending on the session
+// settings (i.e. idle_in_transaction_session_timeout.)
+func (q *Queue) Reserve(ctx context.Context, queueName string) (queue.Reservation, error) {
+	first := true
+	for {
+		if !first {
+			select {
+			case <-time.After(q.pollDuration):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		first = false
+
+		tx, err := q.db.Begin(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var item queue.Item
+
+		row := tx.QueryRow(ctx, queueReserveItem, queueName)
+		if err := row.Scan(&item.ID, &item.Queue, &item.Value); err != nil {
+			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+				return nil, fmt.Errorf("unexpected rollback error: %w", rollbackErr)
+			}
+			if err == pgx.ErrNoRows {
+				continue
+			}
+			return nil, fmt.Errorf("error reserving queue item: %w", err)
+		}
+		return &queueReservation{
+			tx:   tx,
+			item: item,
+		}, nil
+
+	}
+}
+
+type queueReservation struct {
+	tx   pgx.Tx
+	item queue.Item
+}
+
+func (l *queueReservation) Item() queue.Item {
+	return l.item
+}
+
+func (l *queueReservation) Ack(ctx context.Context) error {
+	if _, err := l.tx.Exec(ctx, queueDeleteItem, l.item.ID); err != nil {
+		defer func() { _ = l.Nack(ctx) }()
+		return err
+	}
+	return l.tx.Commit(ctx)
+}
+
+func (l *queueReservation) Nack(ctx context.Context) error {
+	return l.tx.Rollback(ctx)
+}

--- a/backend/store/postgres/queue_schema.go
+++ b/backend/store/postgres/queue_schema.go
@@ -1,0 +1,26 @@
+package postgres
+
+const queueSchema = `
+CREATE TABLE IF NOT EXISTS queue_items (
+	id			bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+	queue		text NOT NULL,
+	updated_at	timestamptz NOT NULL DEFAULT NOW(),
+	value		bytea NOT NULL
+);
+`
+
+const queueEnqueue = `
+INSERT INTO queue_items  (queue, value)
+	VALUES ($1, $2);
+`
+
+const queueReserveItem = `
+SELECT
+	id, queue, value
+ FROM queue_items
+WHERE queue = $1
+ORDER BY updated_at LIMIT 1
+FOR UPDATE SKIP LOCKED;
+`
+
+const queueDeleteItem = `DELETE FROM queue_items WHERE id = $1;`

--- a/backend/store/postgres/queue_test.go
+++ b/backend/store/postgres/queue_test.go
@@ -1,0 +1,21 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sensu/sensu-go/backend/queue/testspec"
+)
+
+func TestQueueSpec(t *testing.T) {
+	withPostgres(t, func(ctx context.Context, db *pgxpool.Pool, dsn string) {
+		q := &Queue{
+			db:           db,
+			pollDuration: time.Millisecond * 50,
+		}
+
+		testspec.RunClientTestSuite(t, ctx, q)
+	})
+}

--- a/testing/mockqueue/queue.go
+++ b/testing/mockqueue/queue.go
@@ -3,7 +3,7 @@ package mockqueue
 import (
 	"context"
 
-	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-go/backend/queue"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -13,28 +13,13 @@ type MockQueue struct {
 }
 
 // Enqueue ...
-func (m *MockQueue) Enqueue(ctx context.Context, value string) error {
+func (m *MockQueue) Enqueue(ctx context.Context, value queue.Item) error {
 	args := m.Called(ctx, value)
 	return args.Error(0)
 }
 
-// Dequeue ...
-func (m *MockQueue) Dequeue(ctx context.Context) (types.QueueItem, error) {
-	args := m.Called(ctx)
-	return args.Get(0).(types.QueueItem), args.Error(1)
-}
-
-// Getter ...
-type Getter struct {
-	mock.Mock
-}
-
-// GetQueue ...
-func (g *Getter) GetQueue(path ...string) types.Queue {
-	ifaceArgs := make([]interface{}, len(path))
-	for i := range path {
-		ifaceArgs[i] = path[i]
-	}
-	args := g.Called(ifaceArgs...)
-	return args.Get(0).(types.Queue)
+// Reserve ...
+func (m *MockQueue) Reserve(ctx context.Context, name string) (queue.Reservation, error) {
+	args := m.Called(ctx, name)
+	return args.Get(0).(queue.Reservation), args.Error(1)
 }


### PR DESCRIPTION
Replaces the types.Queue interface in the backend/queue package with minor cosmetic changes. Adds a queue implementation based on row-level locks on a new postgres table, queue_items. Needed to re-enable ad hoc scheduling.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>