### PR TITLE
Enable ad hoc checks

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -288,7 +288,7 @@ func Initialize(ctx context.Context, pgdb postgres.DBI, config *Config) (*Backen
 
 	pgOPC := postgres.NewOPC(pgdb)
 
-	go CheckInLoop(ctx, pgOPC)
+	go CheckInLoop(ctx, b.Cfg.Name, pgOPC)
 
 	// Initialize eventd
 	event, err := eventd.New(
@@ -315,7 +315,7 @@ func Initialize(ctx context.Context, pgdb postgres.DBI, config *Config) (*Backen
 
 	// Initialize work queue
 	pgQueue := postgres.NewQueue(pgdb)
-	workQueue := queue.NewClusteredQueue(pgQueue, pgOPC)
+	workQueue := queue.NewClusteredQueue(pgQueue, b.Cfg.Name, pgOPC)
 
 	// Initialize schedulerd
 	scheduler, err := schedulerd.New(

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -69,6 +69,7 @@ const (
 	flagLogLevel              = "log-level"
 	flagLabels                = "labels"
 	flagAnnotations           = "annotations"
+	flagName                  = "name"
 
 	// Postgres store
 	flagPGDSN = "pg-dsn"
@@ -171,6 +172,7 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				DashboardWriteTimeout: viper.GetDuration(flagDashboardWriteTimeout),
 				DeregistrationHandler: viper.GetString(flagDeregistrationHandler),
 				CacheDir:              viper.GetString(flagCacheDir),
+				Name:                  viper.GetString(flagName),
 
 				Labels:                         viper.GetStringMapString(flagLabels),
 				Annotations:                    viper.GetStringMapString(flagAnnotations),
@@ -343,6 +345,14 @@ func handleConfig(cmd *cobra.Command, arguments []string, server bool) error {
 		viper.SetDefault(flagEventLogBufferSize, 100000)
 		viper.SetDefault(flagEventLogFile, "")
 		viper.SetDefault(flagEventLogParallelEncoders, false)
+
+		backendName, err := os.Hostname()
+		if err != nil {
+			// According to `man gethostname`, this should never happen, unless
+			// there is a bug in Go's use of gethostname
+			panic(err)
+		}
+		viper.SetDefault(flagName, backendName)
 	}
 
 	// Merge in flag set so that it appears in command usage
@@ -394,6 +404,7 @@ func flagSet(server bool) *pflag.FlagSet {
 
 	if server {
 		// Main Flags
+		flagSet.String(flagName, viper.GetString(flagName), "backend name")
 		flagSet.String(flagAgentHost, viper.GetString(flagAgentHost), "agent listener host")
 		flagSet.Int(flagAgentPort, viper.GetInt(flagAgentPort), "agent listener port")
 		flagSet.String(flagAPIListenAddress, viper.GetString(flagAPIListenAddress), "address to listen on for api traffic")

--- a/backend/config.go
+++ b/backend/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	// Backend Configuration
 	StateDir string
 	CacheDir string
+	Name     string
 
 	// Agentd Configuration
 	AgentHost         string

--- a/backend/opc.go
+++ b/backend/opc.go
@@ -2,19 +2,12 @@ package backend
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/sensu/sensu-go/backend/store"
 )
 
-func CheckInLoop(ctx context.Context, opc store.OperatorConcierge) {
-	backendName, err := os.Hostname()
-	if err != nil {
-		// According to `man gethostname`, this should never happen, unless
-		// there is a bug in Go's use of gethostname
-		panic(err)
-	}
+func CheckInLoop(ctx context.Context, backendName string, opc store.OperatorConcierge) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	state := store.OperatorState{

--- a/backend/queue/queue.go
+++ b/backend/queue/queue.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -55,27 +56,28 @@ type Reservation interface {
 // Given a queueName, ClusteredQueue Enqueues to queueName/{{backendID}} for
 // each backend, and Reserves only from queueName/{{this backendID}}
 type ClusteredQueue struct {
-	// Client underlying queue implementation
-	Client Client
-	// GetBackendID gets the current backend process's id.
-	// TODO(ck): just hostname per backend/opc.go?
-	GetBackendID func() string
-	// GetAllBackendIDs returns the set of currently present backends.
-	// TODO(ck): Find source for this. The OPC table makes sense as a source of
-	// truth for this, but we need more flexible query mechanism.
-	GetAllBackendIDs func(context.Context) ([]string, error)
+	// client underlying queue implementation
+	client     Client
+	opcQueryer store.OperatorQueryer
+}
+
+func NewClusteredQueue(client Client, opc store.OperatorQueryer) *ClusteredQueue {
+	return &ClusteredQueue{
+		client:     client,
+		opcQueryer: opc,
+	}
 }
 
 // Enqueue Item to "{{item.Queue}}/{{backend id}}" for each backend id
 func (q *ClusteredQueue) Enqueue(ctx context.Context, item Item) error {
-	backendIDs, err := q.GetAllBackendIDs(ctx)
+	backendIDs, err := q.getAllBackendIDs(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting backend IDs: %w", err)
 	}
 	baseQueue := item.Queue
 	for _, id := range backendIDs {
 		item.Queue = path.Join(baseQueue, id)
-		if err := q.Client.Enqueue(ctx, item); err != nil {
+		if err := q.client.Enqueue(ctx, item); err != nil {
 			return fmt.Errorf("error enqueuing item to queue %s: %w", item.Queue, err)
 		}
 	}
@@ -84,5 +86,26 @@ func (q *ClusteredQueue) Enqueue(ctx context.Context, item Item) error {
 
 // Reserve Item from "{{queue}}/{{backend id}}"
 func (q *ClusteredQueue) Reserve(ctx context.Context, queue string) (Reservation, error) {
-	return q.Client.Reserve(ctx, path.Join(queue, q.GetBackendID()))
+	return q.client.Reserve(ctx, path.Join(queue, q.getBackendID()))
+}
+
+func (q *ClusteredQueue) getBackendID() string {
+	hostname, _ := os.Hostname()
+	return hostname
+}
+
+func (q *ClusteredQueue) getAllBackendIDs(ctx context.Context) ([]string, error) {
+	operators, err := q.opcQueryer.ListOperators(ctx, store.OperatorKey{
+		Type: store.BackendOperator,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(operators))
+	for _, op := range operators {
+		if op.Present {
+			ids = append(ids, op.Name)
+		}
+	}
+	return ids, nil
 }

--- a/backend/schedulerd/adhoc_scheduler.go
+++ b/backend/schedulerd/adhoc_scheduler.go
@@ -1,0 +1,85 @@
+package schedulerd
+
+import (
+	"context"
+	"encoding/json"
+
+	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/backend/queue"
+	"github.com/sirupsen/logrus"
+)
+
+func NewAdhocScheduler(ctx context.Context, queue queue.Client, executor *CheckExecutor) *AdhocScheduler {
+	ctx, cancel := context.WithCancel(ctx)
+	executor.force = true
+	return &AdhocScheduler{
+		queue:    queue,
+		executor: executor,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+type AdhocScheduler struct {
+	queue    queue.Client
+	executor *CheckExecutor
+	ctx      context.Context
+	cancel   context.CancelFunc
+}
+
+func (a *AdhocScheduler) Start() {
+	go a.schedule()
+}
+
+func (a *AdhocScheduler) schedule() {
+	ctx := a.ctx
+	defer a.cancel()
+	for {
+		res, err := a.queue.Reserve(ctx, adhocQueueName)
+		if err != nil {
+			if err == ctx.Err() {
+				return
+			}
+			logger.WithError(err).Error("unexpected error reserving adhoc check")
+			continue
+		}
+		item := res.Item()
+		var check corev2.CheckConfig
+		if err := json.Unmarshal(item.Value, &check); err != nil {
+			logger.WithError(err).WithField("value", string(item.Value)).Error("error unmarshaling adhoc check")
+			if ackErr := res.Ack(ctx); ackErr != nil {
+				logger.WithError(ackErr).
+					WithField("item_id", item.ID).
+					Error("error acknowleding invalid adhoc check. potential poison record")
+			}
+			continue
+		}
+		logFields := logrus.Fields{
+			"queue_item_id":   item.ID,
+			"check_namespace": check.Namespace,
+			"check_name":      check.Name,
+		}
+		logger.WithFields(logFields).Debug("attempting to schedule ad hoc check")
+
+		if err := a.executor.processCheck(ctx, &check); err != nil {
+			logger.WithError(err).WithFields(logFields).Error("error processing adhoc check request")
+			if nackErr := res.Nack(ctx); nackErr != nil {
+				logger.WithError(nackErr).
+					WithFields(logFields).
+					Error("error returning unprocessed adhoc check to queue")
+			}
+			continue
+		}
+
+		if err := res.Ack(ctx); err != nil {
+			logger.WithError(err).
+				WithFields(logFields).
+				Error("error acknowledging processed adhoc check. potential double delivery")
+		}
+		logger.WithFields(logFields).Debug("sucesfully scheduled ad hoc check")
+	}
+}
+
+func (a *AdhocScheduler) Stop() {
+	a.cancel()
+}

--- a/backend/schedulerd/check_scheduler_test.go
+++ b/backend/schedulerd/check_scheduler_test.go
@@ -87,7 +87,7 @@ func newIntervalScheduler(ctx context.Context, t *testing.T, executor string) *T
 	if err != nil {
 		t.Fatal(err)
 	}
-	exec := NewCheckExecutor(scheduler.msgBus, "default", s, cache, pm)
+	exec := NewCheckExecutor(scheduler.msgBus, s, cache, pm)
 	scheduler.scheduler = NewIntervalScheduler(ctx, scheduler.check, exec)
 	scheduler.exec = exec
 
@@ -131,12 +131,12 @@ func newCronScheduler(ctx context.Context, t *testing.T, executor string) *TestC
 	if err != nil {
 		t.Fatal(err)
 	}
-	exec := NewCheckExecutor(scheduler.msgBus, "default", s, cache, pm)
+	exec := NewCheckExecutor(scheduler.msgBus, s, cache, pm)
 	scheduler.scheduler = NewCronScheduler(ctx, scheduler.check, exec)
 
 	assert.NoError(scheduler.msgBus.Start())
 
-	scheduler.exec = NewCheckExecutor(scheduler.msgBus, "default", s, cache, pm)
+	scheduler.exec = NewCheckExecutor(scheduler.msgBus, s, cache, pm)
 
 	return scheduler
 }

--- a/backend/schedulerd/executor.go
+++ b/backend/schedulerd/executor.go
@@ -21,14 +21,14 @@ import (
 type CheckExecutor struct {
 	bus                    messaging.MessageBus
 	store                  storev2.Interface
-	namespace              string
 	entityCache            EntityCache
 	secretsProviderManager *secrets.ProviderManager
+	force                  bool
 }
 
 // NewCheckExecutor creates a new check executor
-func NewCheckExecutor(bus messaging.MessageBus, namespace string, store storev2.Interface, cache EntityCache, secretsProviderManager *secrets.ProviderManager) *CheckExecutor {
-	return &CheckExecutor{bus: bus, namespace: namespace, store: store, entityCache: cache, secretsProviderManager: secretsProviderManager}
+func NewCheckExecutor(bus messaging.MessageBus, store storev2.Interface, cache EntityCache, secretsProviderManager *secrets.ProviderManager) *CheckExecutor {
+	return &CheckExecutor{bus: bus, store: store, entityCache: cache, secretsProviderManager: secretsProviderManager}
 }
 
 // ProcessCheck processes a check by publishing its proxy requests (if any)
@@ -47,7 +47,7 @@ func (c *CheckExecutor) publishProxyCheckRequests(entities []*corev3.EntityConfi
 
 func (c *CheckExecutor) execute(check *corev2.CheckConfig) error {
 	// Ensure the check is configured to publish check requests
-	if !check.Publish {
+	if !c.force && !check.Publish {
 		return nil
 	}
 

--- a/backend/schedulerd/schedulerd.go
+++ b/backend/schedulerd/schedulerd.go
@@ -10,11 +10,14 @@ import (
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/queue"
 	"github.com/sensu/sensu-go/backend/ringv2"
 	"github.com/sensu/sensu-go/backend/secrets"
 	cachev2 "github.com/sensu/sensu-go/backend/store/cache/v2"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
+
+const adhocQueueName = "adhocRequest"
 
 var (
 	intervalCounter = prometheus.NewGaugeVec(
@@ -65,9 +68,11 @@ type Schedulerd struct {
 	ringPool               *ringv2.RingPool
 	entityCache            EntityCache
 	secretsProviderManager *secrets.ProviderManager
+	queue                  queue.Client
 
-	checks     namespacedChecks
-	schedulers map[string]Scheduler
+	checks         namespacedChecks
+	schedulers     map[string]Scheduler
+	adhocScheduler *AdhocScheduler
 }
 
 // Config configures Schedulerd.
@@ -77,6 +82,7 @@ type Config struct {
 	Bus                    messaging.MessageBus
 	SecretsProviderManager *secrets.ProviderManager
 	RefreshInterval        time.Duration
+	Queue                  queue.Client
 }
 
 // New creates a new Schedulerd.
@@ -88,6 +94,7 @@ func New(ctx context.Context, c Config) (*Schedulerd, error) {
 		errChan:                make(chan error, 1),
 		ringPool:               c.RingPool,
 		secretsProviderManager: c.SecretsProviderManager,
+		queue:                  c.Queue,
 
 		checks:     make(namespacedChecks),
 		schedulers: make(map[string]Scheduler),
@@ -117,6 +124,8 @@ func (s *Schedulerd) Start() error {
 
 // start initializes schedulerd and begins polling for scheduling state changes
 func (s *Schedulerd) start() error {
+	s.adhocScheduler = NewAdhocScheduler(s.ctx, s.queue, s.makeExecutor())
+	s.adhocScheduler.Start()
 	if err := s.refresh(); err != nil {
 		return err
 	}
@@ -133,6 +142,7 @@ func (s *Schedulerd) start() error {
 			}
 		}
 	}()
+
 	return nil
 }
 
@@ -175,16 +185,16 @@ func (s *Schedulerd) refresh() error {
 
 		switch GetSchedulerType(check) {
 		case IntervalType:
-			scheduler = NewIntervalScheduler(s.ctx, check, s.makeExecutor(check.Namespace))
+			scheduler = NewIntervalScheduler(s.ctx, check, s.makeExecutor())
 		case CronType:
-			scheduler = NewCronScheduler(s.ctx, check, s.makeExecutor(check.Namespace))
+			scheduler = NewCronScheduler(s.ctx, check, s.makeExecutor())
 		case RoundRobinIntervalType:
-			scheduler = NewRoundRobinIntervalScheduler(s.ctx, check, s.makeExecutor(check.Namespace), s.ringPool, s.entityCache)
+			scheduler = NewRoundRobinIntervalScheduler(s.ctx, check, s.makeExecutor(), s.ringPool, s.entityCache)
 		case RoundRobinCronType:
-			scheduler = NewRoundRobinCronScheduler(s.ctx, check, s.makeExecutor(check.Namespace), s.ringPool, s.entityCache)
+			scheduler = NewRoundRobinCronScheduler(s.ctx, check, s.makeExecutor(), s.ringPool, s.entityCache)
 		default:
 			logger.Error("bad scheduler type, falling back to interval scheduler")
-			scheduler = NewIntervalScheduler(s.ctx, check, s.makeExecutor(check.Namespace))
+			scheduler = NewIntervalScheduler(s.ctx, check, s.makeExecutor())
 		}
 
 		// Start scheduling check
@@ -221,14 +231,15 @@ func (s *Schedulerd) refresh() error {
 
 }
 
-func (s *Schedulerd) makeExecutor(namespace string) *CheckExecutor {
-	return NewCheckExecutor(s.bus, namespace, s.store, s.entityCache, s.secretsProviderManager)
+func (s *Schedulerd) makeExecutor() *CheckExecutor {
+	return NewCheckExecutor(s.bus, s.store, s.entityCache, s.secretsProviderManager)
 }
 
 // Stop the scheduler daemon.
 func (s *Schedulerd) Stop() error {
 	s.cancel()
 	close(s.errChan)
+	s.adhocScheduler.Stop()
 	return nil
 }
 

--- a/backend/schedulerd/schedulerd_test.go
+++ b/backend/schedulerd/schedulerd_test.go
@@ -2,14 +2,18 @@ package schedulerd
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/messaging"
+	"github.com/sensu/sensu-go/backend/queue"
 	"github.com/sensu/sensu-go/backend/secrets"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/testing/mockqueue"
 	"github.com/sensu/sensu-go/testing/mockstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -25,12 +29,119 @@ func TestSchedulerd(t *testing.T) {
 
 	// start schedulerd
 	// observe bus messages
+	stor := stubStoreForCheck(intervalCheck)
+
+	never := make(chan time.Time)
+	mockQ := &mockqueue.MockQueue{}
+	mockQ.On("Reserve", mock.Anything, adhocQueueName).WaitUntil(never)
+	// subscribe to the wizard bus for check's sub
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
+	require.NoError(t, err)
+	require.NoError(t, bus.Start())
+
+	discoC := make(chan interface{}, 10)
+	discoS := testSubscriber{
+		ch: discoC,
+	}
+	discoSub, err := bus.Subscribe(messaging.SubscriptionTopic("default", "disco"), "testing", discoS)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, discoSub.Cancel())
+	}()
+
+	sched, err := New(context.Background(), Config{
+		Store:                  stor,
+		Bus:                    bus,
+		SecretsProviderManager: secrets.NewProviderManager(&mockEventReceiver{}),
+		Queue:                  mockQ,
+	})
+	require.NoError(t, err)
+	require.NoError(t, sched.Start())
+	mockTime.Start()
+	defer mockTime.Stop()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		raw := <-discoC
+		checkRequest, ok := raw.(*corev2.CheckRequest)
+		assert.True(t, ok, "expected CheckRequest")
+		assert.Equal(t, intervalCheck, checkRequest.Config)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestSchedulerdAdhoc(t *testing.T) {
+	// store stub with diabled check
+	disabledCheck := corev2.FixtureCheckConfig("adhoc")
+	disabledCheck.Labels = map[string]string{"label-1": "1"}
+	disabledCheck.Annotations = map[string]string{"annotation-1": "1"}
+	disabledCheck.Subscriptions = append(disabledCheck.Subscriptions, "disco")
+	disabledCheck.Interval = 1
+	disabledCheck.Publish = false
+
+	disabledCheckB, _ := json.Marshal(disabledCheck)
+
+	stor := stubStoreForCheck(disabledCheck)
+
+	// start schedulerd
+	// observe bus messages
+	testPublish := make(chan time.Time)
+	mockQRes := &mockqueue.MockReservation{}
+	mockQRes.On("Item").Return(queue.Item{ID: "aaa", Queue: adhocQueueName, Value: disabledCheckB})
+	mockQRes.On("Ack", mock.Anything).Return(nil)
+	mockQ := &mockqueue.MockQueue{}
+	mockQ.On("Reserve", mock.Anything, adhocQueueName).
+		WaitUntil(testPublish).
+		Return(mockQRes, nil)
+	// subscribe to the wizard bus for check's sub
+	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
+	require.NoError(t, err)
+	require.NoError(t, bus.Start())
+
+	discoC := make(chan interface{}, 10)
+	discoS := testSubscriber{
+		ch: discoC,
+	}
+	discoSub, err := bus.Subscribe(messaging.SubscriptionTopic("default", "disco"), "testing", discoS)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, discoSub.Cancel())
+	}()
+
+	sched, err := New(context.Background(), Config{
+		Store:                  stor,
+		Bus:                    bus,
+		SecretsProviderManager: secrets.NewProviderManager(&mockEventReceiver{}),
+		Queue:                  mockQ,
+	})
+	require.NoError(t, err)
+	require.NoError(t, sched.Start())
+	mockTime.Start()
+	defer mockTime.Stop()
+
+	testPublish <- time.Now()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		raw := <-discoC
+		checkRequest, ok := raw.(*corev2.CheckRequest)
+		assert.True(t, ok, "expected CheckRequest")
+		assert.Equal(t, disabledCheck, checkRequest.Config)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func stubStoreForCheck(check *corev2.CheckConfig) storev2.Interface {
 	stor := &mockstore.V2MockStore{}
 	cs := &mockstore.ConfigStore{}
 	cs.On(
 		"List", mock.Anything, mock.MatchedBy(func(req storev2.ResourceRequest) bool { return req.Type == "CheckConfig" }), mock.Anything,
 	).Return(
-		mockstore.WrapList[*corev2.CheckConfig]([]*corev2.CheckConfig{intervalCheck}),
+		mockstore.WrapList[*corev2.CheckConfig]([]*corev2.CheckConfig{check}),
 		nil,
 	)
 	cs.On(
@@ -54,39 +165,5 @@ func TestSchedulerd(t *testing.T) {
 	)
 	stor.On("GetConfigStore").Return(cs)
 	stor.On("GetEntityConfigStore").Return(es)
-	// subscribe to the wizard bus for check's sub
-	bus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
-	require.NoError(t, err)
-	require.NoError(t, bus.Start())
-
-	discoC := make(chan interface{}, 10)
-	discoS := testSubscriber{
-		ch: discoC,
-	}
-	discoSub, err := bus.Subscribe(messaging.SubscriptionTopic("default", "disco"), "testing", discoS)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, discoSub.Cancel())
-	}()
-
-	sched, err := New(context.Background(), Config{
-		Store:                  stor,
-		Bus:                    bus,
-		SecretsProviderManager: secrets.NewProviderManager(&mockEventReceiver{}),
-	})
-	require.NoError(t, err)
-	require.NoError(t, sched.Start())
-	mockTime.Start()
-	defer mockTime.Stop()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		raw := <-discoC
-		checkRequest, ok := raw.(*corev2.CheckRequest)
-		assert.True(t, ok, "expected CheckRequest")
-		assert.Equal(t, intervalCheck, checkRequest.Config)
-		wg.Done()
-	}()
-	wg.Wait()
+	return stor
 }

--- a/backend/store/opc.go
+++ b/backend/store/opc.go
@@ -147,6 +147,7 @@ type OperatorMonitor interface {
 // OperatorQueryer lets users query for operators.
 type OperatorQueryer interface {
 	QueryOperator(context.Context, OperatorKey) (OperatorState, error)
+	ListOperators(context.Context, OperatorKey) ([]OperatorState, error)
 }
 
 // OperatorConcierge is responsible for checking operators in and out.

--- a/backend/store/postgres/opc_schema.go
+++ b/backend/store/postgres/opc_schema.go
@@ -22,7 +22,7 @@ const getOperatorID = `
 -- $3 operator name (string)
 WITH ns AS (
 	(SELECT id AS id
-	FROM namespaces 
+	FROM namespaces
 	WHERE namespaces.name = $1)
 	UNION (SELECT NULL AS id)
 	ORDER BY id NULLS LAST
@@ -52,7 +52,7 @@ const opcCheckInInsert = `
 -- $9 controller_name (string)
 WITH ns AS (
 	(SELECT id AS id
-	FROM namespaces 
+	FROM namespaces
 	WHERE namespaces.name = $1)
 	UNION (SELECT null AS id)
 	ORDER BY id NULLS LAST
@@ -151,7 +151,7 @@ WHERE id = $1
 const opcCheckOut = `
 WITH ns AS (
 	(SELECT id AS id
-	FROM namespaces 
+	FROM namespaces
 	WHERE namespaces.name = $1)
 	UNION (SELECT null AS id)
 	ORDER BY id NULLS LAST
@@ -283,6 +283,27 @@ FROM opc LEFT OUTER JOIN namespaces ON opc.namespace = namespaces.id
 WHERE ($1 = '' OR namespaces.name = $1)
   AND opc.operator_type = $2
   AND opc.operator_name = $3
+;
+`
+
+const opcListOperators = `
+-- opcGetOperator gets an operator by namespace, type and name.
+--
+-- $1: namespace (text)
+-- $2: operator type (int)
+-- $3: operator name (text)
+SELECT COALESCE(namespaces.name, '')
+     , opc.operator_type
+     , opc.operator_name
+	 , present
+	 , to_timestamp(opc.last_update::double precision / 1000000)
+	 , opc.timeout_micro * 1000 -- nanoseconds for Go time.Duration
+	 , opc.metadata
+	 , opc.controller
+FROM opc LEFT OUTER JOIN namespaces ON opc.namespace = namespaces.id
+WHERE ($1 = '' OR namespaces.name = $1)
+  AND ($2 = 0 OR opc.operator_type = $2)
+  AND ($3 = '' OR opc.operator_name = $3)
 ;
 `
 

--- a/backend/store/postgres/opc_schema_test.go
+++ b/backend/store/postgres/opc_schema_test.go
@@ -25,6 +25,7 @@ func TestOPCQuerySyntax(t *testing.T) {
 			opcUpdateNotifications,
 			opcReassignAbsentControllers,
 			opcGetOperator,
+			opcListOperators,
 			opcGetOperatorByID,
 		}
 		for i := range queries {

--- a/testing/mockqueue/queue.go
+++ b/testing/mockqueue/queue.go
@@ -23,3 +23,19 @@ func (m *MockQueue) Reserve(ctx context.Context, name string) (queue.Reservation
 	args := m.Called(ctx, name)
 	return args.Get(0).(queue.Reservation), args.Error(1)
 }
+
+type MockReservation struct {
+	mock.Mock
+}
+
+func (m *MockReservation) Item() queue.Item {
+	return m.Called().Get(0).(queue.Item)
+}
+
+func (m *MockReservation) Ack(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+func (m *MockReservation) Nack(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}

--- a/testing/mockstore/opc.go
+++ b/testing/mockstore/opc.go
@@ -16,6 +16,11 @@ func (o *OPC) QueryOperator(ctx context.Context, key store.OperatorKey) (store.O
 	return args.Get(0).(store.OperatorState), args.Error(1)
 }
 
+func (o *OPC) ListOperators(ctx context.Context, key store.OperatorKey) ([]store.OperatorState, error) {
+	args := o.Called(ctx, key)
+	return args.Get(0).([]store.OperatorState), args.Error(1)
+}
+
 func (o *OPC) MonitorOperators(ctx context.Context, req store.MonitorOperatorsRequest) <-chan []store.OperatorState {
 	args := o.Called(ctx, req)
 	return args.Get(0).(<-chan []store.OperatorState)


### PR DESCRIPTION
Reimplements ad hoc check scheduling.

Adds a ListOperators function to the OperatorQueryer Interface.
Adds a new backend configuration flag `--name` to allow us to override the hostname as a backend identifier.
Completes the queue.ClusteredQueue using the ListOperators interface.
Adds ad hoc scheduling back to schedulerd.