### PR TITLE
Silences expiration sort

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
+- Added silences sorting by expiration to GraphQL service
 
 ## [6.9.1] - 2022-12-01
 

--- a/backend/apid/graphql/namespace.go
+++ b/backend/apid/graphql/namespace.go
@@ -227,6 +227,10 @@ func (r *namespaceImpl) Silences(p schema.NamespaceSilencesFieldResolverParams) 
 		sort.Sort(sort.Reverse(corev2.SortSilencedByBegin(filteredResults)))
 	case schema.SilencesListOrders.BEGIN:
 		sort.Sort(corev2.SortSilencedByBegin(filteredResults))
+	case schema.SilencesListOrders.EXPIRE_AT_DESC:
+		sort.Sort(sort.Reverse(corev2.SortSilencedByExpireAt(filteredResults)))
+	case schema.SilencesListOrders.EXPIRE_AT:
+		sort.Sort(corev2.SortSilencedByExpireAt(filteredResults))
 	case schema.SilencesListOrders.ID_DESC:
 		sort.Sort(sort.Reverse(corev2.SortSilencedByName(filteredResults)))
 	case schema.SilencesListOrders.ID:

--- a/backend/apid/graphql/schema/silenced.gql.go
+++ b/backend/apid/graphql/schema/silenced.gql.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 )
 
+//
 // SilencedFieldResolvers represents a collection of methods whose products represent the
 // response values of the 'Silenced' type.
 type SilencedFieldResolvers interface {
@@ -536,6 +537,7 @@ func _InterfaceTypeSilenceableConfigFn() graphql1.InterfaceConfig {
 // describe Silenceable's configuration; kept private to avoid unintentional tampering of configuration at runtime.
 var _InterfaceTypeSilenceableDesc = graphql.InterfaceDesc{Config: _InterfaceTypeSilenceableConfigFn}
 
+//
 // SilencedConnectionFieldResolvers represents a collection of methods whose products represent the
 // response values of the 'SilencedConnection' type.
 type SilencedConnectionFieldResolvers interface {
@@ -635,10 +637,12 @@ type SilencesListOrder string
 
 // SilencesListOrders holds enum values
 var SilencesListOrders = _EnumTypeSilencesListOrderValues{
-	BEGIN:      "BEGIN",
-	BEGIN_DESC: "BEGIN_DESC",
-	ID:         "ID",
-	ID_DESC:    "ID_DESC",
+	BEGIN:          "BEGIN",
+	BEGIN_DESC:     "BEGIN_DESC",
+	EXPIRE_AT:      "EXPIRE_AT",
+	EXPIRE_AT_DESC: "EXPIRE_AT_DESC",
+	ID:             "ID",
+	ID_DESC:        "ID_DESC",
 }
 
 // SilencesListOrderType Describes ways in which a list of silences can be ordered.
@@ -662,6 +666,16 @@ func _EnumTypeSilencesListOrderConfigFn() graphql1.EnumConfig {
 				DeprecationReason: "",
 				Description:       "self descriptive",
 				Value:             "BEGIN_DESC",
+			},
+			"EXPIRE_AT": &graphql1.EnumValueConfig{
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Value:             "EXPIRE_AT",
+			},
+			"EXPIRE_AT_DESC": &graphql1.EnumValueConfig{
+				DeprecationReason: "",
+				Description:       "self descriptive",
+				Value:             "EXPIRE_AT_DESC",
 			},
 			"ID": &graphql1.EnumValueConfig{
 				DeprecationReason: "",
@@ -689,4 +703,8 @@ type _EnumTypeSilencesListOrderValues struct {
 	BEGIN SilencesListOrder
 	// BEGIN_DESC - self descriptive
 	BEGIN_DESC SilencesListOrder
+	// EXPIRE_AT - self descriptive
+	EXPIRE_AT SilencesListOrder
+	// EXPIRE_AT_DESC - self descriptive
+	EXPIRE_AT_DESC SilencesListOrder
 }

--- a/backend/apid/graphql/schema/silenced.graphql
+++ b/backend/apid/graphql/schema/silenced.graphql
@@ -69,4 +69,6 @@ enum SilencesListOrder {
   ID_DESC
   BEGIN
   BEGIN_DESC
+  EXPIRE_AT
+  EXPIRE_AT_DESC
 }

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/go-test/deep v1.0.8
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/kr/pty v1.1.8 // indirect
-	github.com/sensu/core/v2 v2.16.0-alpha6
+	github.com/sensu/core/v2 v2.16.1
 	github.com/sensu/core/v3 v3.8.0-alpha6
 	github.com/sensu/sensu-api-tools v0.0.0-20221025205055-db03ae2f8099
 	github.com/sensu/sensu-go/types v0.12.0-alpha6

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sensu/core/v2 v2.16.0-alpha1/go.mod h1:vFoPc++U8m30t0fXKNGqOqHLOFr7VuqFc+Hkz+eTdmU=
 github.com/sensu/core/v2 v2.16.0-alpha6 h1:6WTEevm2tQEgCx50IL4aXomAXQip7s6kX4xR3uNVYlI=
 github.com/sensu/core/v2 v2.16.0-alpha6/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
+github.com/sensu/core/v2 v2.16.1 h1:lYicLM1PXq5Zwj5h7akXMFXvWcja12qMLzKsJr3qM4Q=
+github.com/sensu/core/v2 v2.16.1/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
 github.com/sensu/core/v3 v3.8.0-alpha6 h1:ywO14aIHippeIAe2HBHrPhSdyBMs1pQtjvkYaHmEwGw=
 github.com/sensu/core/v3 v3.8.0-alpha6/go.mod h1:HUrsxGfeUSvd+iU5ROGgfBchv3eYjhS3Apz6XzNB8Gg=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=


### PR DESCRIPTION
Signed-off-by: Gustav Danielsson <gdanielsson@sumologic.com>

## What is this change?

Wires up `SortSilencedByExpireAt` from sensu/core/v2 to provide silences sorting by expiration ascending and descending.

## Why is this change necessary?

Related to https://github.com/sensu/sensu-go/issues/4159

## Does your change need a Changelog entry?

Updated
