### PR TITLE
Add store based synchronization.

### DIFF
--- a/backend/store/postgres/sync.go
+++ b/backend/store/postgres/sync.go
@@ -1,0 +1,113 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+// SynchronizedExecutor functions as a postgresql advisory lock based mutex.
+type SynchronizedExecutor struct {
+	DB DBI
+
+	CheckinInterval time.Duration
+}
+
+// Execute blocks until the Mutex can be locked, executes the handler function,
+// then unlocks the Mutex. Implemented with postgresql advisory locks.
+func (se *SynchronizedExecutor) Execute(ctx context.Context, mux store.Mutex, handler store.MutexHandler) error {
+	var next time.Time
+	for {
+		now := time.Now()
+		if next.After(now) {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(next.Sub(now)):
+			}
+		}
+		tx, err := se.tryLock(ctx, mux)
+		if err != nil {
+			logger.WithError(err).Errorf("error trying to lock mutex: %d", mux)
+			continue
+		}
+		if tx != nil {
+			defer func() {
+				if err := tx.Rollback(ctx); err != nil {
+					if !errors.Is(err, pgx.ErrTxClosed) {
+						logger.WithError(err).
+							Errorf("unexpected error rolling back transaction holding mutex lock. %d", mux)
+					}
+				}
+			}()
+			return se.handle(ctx, tx, mux, handler)
+		}
+		next = time.Now().Add(se.CheckinInterval)
+	}
+}
+
+func (se *SynchronizedExecutor) handle(ctx context.Context, conn DBI, mux store.Mutex, handler store.MutexHandler) error {
+	handleCtx, cancel := context.WithCancel(ctx)
+
+	var checkinErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := se.checkin(handleCtx, conn, mux); err != nil {
+			checkinErr = err
+		}
+		cancel()
+	}()
+
+	err := handler(handleCtx)
+	cancel()
+	wg.Wait()
+	if err == nil {
+		err = checkinErr
+	}
+	return err
+}
+
+func (se *SynchronizedExecutor) tryLock(ctx context.Context, mux store.Mutex) (pgx.Tx, error) {
+	tx, err := se.DB.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	locked, err := lockMux(ctx, tx, mux)
+	if !locked || err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, err
+	}
+
+	return tx, err
+}
+
+// checkin periodically (re)locks the advisory lock in order to ensure that the
+// txn is not booted for being idle. Postgres guarantees that lock requests for
+// a lock already held by that transaction will always succeed.
+func (se *SynchronizedExecutor) checkin(ctx context.Context, conn DBI, mux store.Mutex) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(se.CheckinInterval):
+		}
+
+		if _, err := lockMux(ctx, conn, mux); err != nil {
+			logger.WithError(err).Error("error renewing lock")
+			return err
+		}
+	}
+}
+
+func lockMux(ctx context.Context, db DBI, mux store.Mutex) (bool, error) {
+	row := db.QueryRow(ctx, "SELECT pg_try_advisory_xact_lock($1) as locked;", mux)
+	var locked bool
+	err := row.Scan(&locked)
+	return locked, err
+}

--- a/backend/store/postgres/sync.go
+++ b/backend/store/postgres/sync.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/sensu/sensu-go/backend/store"
+	"github.com/sensu/sensu-go/util/retry"
 )
 
 // SynchronizedExecutor functions as a postgresql advisory lock based mutex.
@@ -20,34 +21,30 @@ type SynchronizedExecutor struct {
 // Execute blocks until the Mutex can be locked, executes the handler function,
 // then unlocks the Mutex. Implemented with postgresql advisory locks.
 func (se *SynchronizedExecutor) Execute(ctx context.Context, mux store.Mutex, handler store.MutexHandler) error {
-	var next time.Time
-	for {
-		now := time.Now()
-		if next.After(now) {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(next.Sub(now)):
-			}
-		}
+	backoff := retry.ExponentialBackoff{
+		Ctx:                  ctx,
+		InitialDelayInterval: se.CheckinInterval / 4,
+		MaxDelayInterval:     se.CheckinInterval,
+	}
+	return backoff.Retry(func(_ int) (bool, error) {
 		tx, err := se.tryLock(ctx, mux)
 		if err != nil {
 			logger.WithError(err).Errorf("error trying to lock mutex: %d", mux)
-			continue
+			return false, nil
 		}
-		if tx != nil {
-			defer func() {
-				if err := tx.Rollback(ctx); err != nil {
-					if !errors.Is(err, pgx.ErrTxClosed) {
-						logger.WithError(err).
-							Errorf("unexpected error rolling back transaction holding mutex lock. %d", mux)
-					}
+		if tx == nil {
+			return false, nil
+		}
+		defer func() {
+			if err := tx.Commit(ctx); err != nil {
+				if !errors.Is(err, pgx.ErrTxClosed) {
+					logger.WithError(err).
+						Errorf("unexpected error committing transaction holding mutex lock. %d", mux)
 				}
-			}()
-			return se.handle(ctx, tx, mux, handler)
-		}
-		next = time.Now().Add(se.CheckinInterval)
-	}
+			}
+		}()
+		return true, se.handle(ctx, tx, mux, handler)
+	})
 }
 
 func (se *SynchronizedExecutor) handle(ctx context.Context, conn DBI, mux store.Mutex, handler store.MutexHandler) error {
@@ -77,7 +74,7 @@ func (se *SynchronizedExecutor) tryLock(ctx context.Context, mux store.Mutex) (p
 	}
 	locked, err := lockMux(ctx, tx, mux)
 	if !locked || err != nil {
-		_ = tx.Rollback(ctx)
+		_ = tx.Commit(ctx)
 		return nil, err
 	}
 

--- a/backend/store/postgres/sync_test.go
+++ b/backend/store/postgres/sync_test.go
@@ -1,0 +1,109 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sensu/sensu-go/backend/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSynchronizedExecutor(t *testing.T) {
+	withPostgres(t, func(ctx context.Context, db *pgxpool.Pool, dsn string) {
+		executor := &SynchronizedExecutor{
+			DB:              db,
+			CheckinInterval: time.Millisecond * 20,
+		}
+
+		err := executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error { return errors.New("error A") })
+		assert.EqualError(t, err, "error A")
+		err = executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error { return errors.New("error B") })
+		assert.EqualError(t, err, "error B")
+
+		// test concurrent executions of different mutexes
+		step := make(chan struct{}, 1)
+		go executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error {
+			<-step
+			return nil
+		})
+
+		done := make(chan struct{})
+		go executor.Execute(ctx, store.Mutex(222), func(ctx context.Context) error {
+			close(done)
+			return nil
+		})
+
+		select {
+		case <-done:
+			// OK
+		case <-time.After(time.Millisecond * 100):
+			t.Error("expected concurrent executions of different mutexes")
+		}
+
+		// test concurrent executions of the same mutex
+		done = make(chan struct{})
+		go executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error {
+			close(done)
+			return nil
+		})
+
+		select {
+		case <-done:
+			t.Error("expected concurrent execution of busy mutex to block")
+		case <-time.After(time.Millisecond * 100):
+			// OK
+		}
+
+		// unblock first execution
+		step <- struct{}{}
+		select {
+		case <-done:
+			// OK
+		case <-time.After(time.Millisecond * 100):
+			t.Error("expected the second handler to take over after the first completed")
+		}
+
+		isLocked := make(chan struct{})
+		// test many queued executions
+		// heuristic to ensure many executors do not exhaust the connection pool
+		go executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error {
+			close(isLocked)
+			<-step
+			return nil
+		})
+		<-isLocked
+
+		results := make(chan error, 1)
+		for i := 0; i < 256; i++ {
+			go func() {
+				results <- executor.Execute(ctx, store.Mutex(333), func(ctx context.Context) error { return nil })
+			}()
+		}
+
+		select {
+		case <-results:
+			t.Error("expected handlers to await lock")
+		case <-time.After(time.Millisecond * 100):
+		}
+		step <- struct{}{}
+
+		// see that mutex begins to be claimed by other executors.
+		// only 10 because 256*CheckInInterval is a long time.
+		done = make(chan struct{})
+		go func() {
+			for i := 0; i < 10; i++ {
+				<-results
+			}
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Millisecond * 200):
+			t.Error("expected other handlers to begin running")
+		}
+	})
+}

--- a/backend/store/sync.go
+++ b/backend/store/sync.go
@@ -13,7 +13,7 @@ type Mutex int64
 const (
 	// BitmaskMutexOSS bitmask for sensu-go mutexes.
 	BitmaskMutexOSS Mutex = 0
-	// BitmaskMutexOSS bitmask for mutexes in the enterprise build.
+	// BitmaskMutexEE bitmask for mutexes in the enterprise build.
 	BitmaskMutexEE Mutex = 0xee << 32
 )
 

--- a/backend/store/sync.go
+++ b/backend/store/sync.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"context"
+)
+
+// Mutex is a static identifier for a particular mutex.
+//
+// In lieu of a central repository of mutex identities, use the four most
+// significant bytes as a codebase identifier.
+type Mutex int64
+
+const (
+	// BitmaskMutexOSS bitmask for sensu-go mutexes.
+	BitmaskMutexOSS Mutex = 0
+	// BitmaskMutexOSS bitmask for mutexes in the enterprise build.
+	BitmaskMutexEE Mutex = 0xee << 32
+)
+
+// Mutexes
+const (
+	// mutex for tessend telemetry
+	MutexTelemetry Mutex = iota ^ BitmaskMutexOSS
+)
+
+// MutexHandler should listen for context cancellation. If a mutex is lost,
+// a SynchronizedExecutor will signal the handler to wrap up this way.
+type MutexHandler func(context.Context) error
+
+type SynchronizedExecutor interface {
+	// Execute MutexHandler once the mutex can be acquired.
+	Execute(context.Context, Mutex, MutexHandler) error
+}


### PR DESCRIPTION
Adds a store-based Mutex and synchronized executor.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>

### Background Info on Advisory Locks

https://www.postgresql.org/docs/15/explicit-locking.html#ADVISORY-LOCKS