### PR TITLE
Replace golang.org/x/net/context usage with stdlib

### DIFF
--- a/backend/apid/actions/health.go
+++ b/backend/apid/actions/health.go
@@ -1,8 +1,9 @@
 package actions
 
 import (
+	"context"
+
 	corev2 "github.com/sensu/core/v2"
-	"golang.org/x/net/context"
 )
 
 // HealthController exposes actions which a viewer can perform

--- a/backend/apid/actions/tessen.go
+++ b/backend/apid/actions/tessen.go
@@ -1,11 +1,12 @@
 package actions
 
 import (
+	"context"
+
 	corev2 "github.com/sensu/core/v2"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
-	"golang.org/x/net/context"
 )
 
 // TessenController exposes actions which a viewer can perform

--- a/backend/apid/actions/version.go
+++ b/backend/apid/actions/version.go
@@ -1,10 +1,11 @@
 package actions
 
 import (
+	"context"
+
 	corev2 "github.com/sensu/core/v2"
 	apitools "github.com/sensu/sensu-api-tools"
 	"github.com/sensu/sensu-go/version"
-	"golang.org/x/net/context"
 )
 
 // VersionController exposes actions which a viewer can perform

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	go.uber.org/atomic v1.10.0
 	golang.org/x/crypto v0.3.0
 	golang.org/x/mod v0.7.0
-	golang.org/x/net v0.3.0
 	golang.org/x/sys v0.3.0
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.4.0
@@ -124,6 +123,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/net v0.3.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect


### PR DESCRIPTION
A low priority depen**d**abot ale**r**t https://github.com/sensu/sensu-go/security/dependabot/18 f**o**r the golang.org/x/net module has been **p**ublished. Rather than bumping to a patched version, we have the opportunity to drop the (direct) dependency on the module.

It **st**ill ends up being **a**n indirec**t** dependency, due to an older go**s**tatsd depen**d**ency.