### PR TITLE
GraphQL service max query depth

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
 - Added silences sorting by expiration to GraphQL service
+- Added GraphQL validator for query node depth
 
 ## [6.9.1] - 2022-12-01
 

--- a/backend/apid/routers/graphql.go
+++ b/backend/apid/routers/graphql.go
@@ -83,6 +83,7 @@ func (r *GraphQLRouter) query(req *http.Request) (interface{}, error) {
 			Query:          query,
 			Variables:      queryVars,
 			SkipValidation: skipValidate,
+			IsAuthed:       claims != nil,
 		})
 		results = append(results, map[string]interface{}{
 			"data":   result.Data,

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -193,8 +193,9 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 		return &graphql.Result{Errors: gqlerrors.FormatErrors(err)}
 	}
 
+	// run validators for unauthorized requests
 	if !p.IsAuthed {
-		rules := []graphql.ValidationRuleFn{ProvideMaxDepthRule}
+		rules := ProvideUnauthedValidators(UnauthedValidatorOpts{DepthLimit: 5})
 		validationResult := graphql.ValidateDocument(&schema, AST, rules)
 		if !validationResult.IsValid {
 			return &graphql.Result{Errors: validationResult.Errors}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -195,7 +195,7 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 
 	// run validators for unauthorized requests
 	if !p.IsAuthed {
-		rules := ProvideUnauthedValidators(UnauthedValidatorOpts{DepthLimit: 5})
+		rules := UnauthedValidators()
 		validationResult := graphql.ValidateDocument(&schema, AST, rules)
 		if !validationResult.IsValid {
 			return &graphql.Result{Errors: validationResult.Errors}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -158,6 +158,7 @@ func (service *Service) Middleware() []Middleware {
 
 // QueryParams describe parameters of a GraphQL query.
 type QueryParams struct {
+	IsAuthed       bool
 	OperationName  string
 	Query          string
 	RootObject     map[string]interface{}
@@ -190,6 +191,14 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 	parseFinishFn(err)
 	if err != nil {
 		return &graphql.Result{Errors: gqlerrors.FormatErrors(err)}
+	}
+
+	if !p.IsAuthed {
+		rules := []graphql.ValidationRuleFn{ProvideMaxDepthRule}
+		validationResult := graphql.ValidateDocument(&schema, AST, rules)
+		if !validationResult.IsValid {
+			return &graphql.Result{Errors: validationResult.Errors}
+		}
 	}
 
 	// validate document

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -8,6 +8,10 @@ import (
 	"github.com/graphql-go/graphql/language/visitor"
 )
 
+const (
+	MaxQueryNodeDepth = 8
+)
+
 func reportError(context *graphql.ValidationContext, message string, nodes []ast.Node) (string, interface{}) {
 	context.ReportError(gqlerrors.NewError(message, nodes, "", nil, []int{}, nil))
 	return visitor.ActionNoChange, nil
@@ -78,7 +82,7 @@ func ProvideMaxDepthRule(ctx *graphql.ValidationContext) *graphql.ValidationRule
 				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
 					node := p.Node.(ast.Node)
 					if node != nil {
-						validateMaxDepth(ctx, node, 0, 8)
+						validateMaxDepth(ctx, node, 0, MaxQueryNodeDepth)
 					}
 					return visitor.ActionNoChange, nil
 				},

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -14,6 +14,7 @@ const (
 
 type maxDepthRule struct {
 	context    *graphql.ValidationContext
+	depth      int
 	depthLimit int
 }
 
@@ -22,10 +23,15 @@ func UnauthedValidators() []graphql.ValidationRuleFn {
 	return rules
 }
 
-func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
+func newMaxDepthRule(depthLimit int) *maxDepthRule {
 	rule := &maxDepthRule{
 		depthLimit: depthLimit,
 	}
+	return rule
+}
+
+func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
+	rule := newMaxDepthRule(depthLimit)
 	return rule.maxDepthRuleWithContext
 }
 
@@ -44,7 +50,8 @@ func (rule *maxDepthRule) maxDepthVisitorOptions() *visitor.VisitorOptions {
 				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
 					node := p.Node.(ast.Node)
 					if node != nil {
-						validateMaxDepth(rule.context, node, 1, rule.depthLimit, nil)
+						maxDepth := validateMaxDepth(rule.context, node, 1, rule.depthLimit, nil)
+						rule.depth = maxDepth
 					}
 					return visitor.ActionNoChange, nil
 				},

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -12,13 +12,55 @@ const (
 	MaxQueryNodeDepth = 5
 )
 
-func reportError(context *graphql.ValidationContext, message string, nodes []ast.Node) (string, interface{}) {
-	context.ReportError(gqlerrors.NewError(message, nodes, "", nil, []int{}, nil))
-	return visitor.ActionNoChange, nil
+type maxDepthRule struct {
+	context    *graphql.ValidationContext
+	depthLimit int
+}
+
+func UnauthedValidators() []graphql.ValidationRuleFn {
+	rules := []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryNodeDepth)}
+	return rules
+}
+
+func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
+	rule := &maxDepthRule{
+		depthLimit: depthLimit,
+	}
+	return rule.maxDepthRuleWithContext
+}
+
+func (r *maxDepthRule) maxDepthRuleWithContext(context *graphql.ValidationContext) *graphql.ValidationRuleInstance {
+	rule := &maxDepthRule{
+		context:    context,
+		depthLimit: r.depthLimit,
+	}
+	return &graphql.ValidationRuleInstance{VisitorOpts: rule.maxDepthVisitorOptions()}
+}
+
+func (rule *maxDepthRule) maxDepthVisitorOptions() *visitor.VisitorOptions {
+	return &visitor.VisitorOptions{
+		KindFuncMap: map[string]visitor.NamedVisitFuncs{
+			kinds.OperationDefinition: {
+				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+					node := p.Node.(ast.Node)
+					if node != nil {
+						validateMaxDepth(rule.context, node, 1, rule.depthLimit, nil)
+					}
+					return visitor.ActionNoChange, nil
+				},
+			},
+		},
+	}
 }
 
 // validate max depth of a GraphQL query with a depthLimit
-func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, currentDepth int, depthLimit int) int {
+func validateMaxDepth(
+	context *graphql.ValidationContext,
+	node ast.Node,
+	currentDepth int,
+	depthLimit int,
+	visited map[*ast.FragmentDefinition]bool,
+) int {
 	// end recursion early if error reported
 	if errors := context.Errors(); len(errors) > 0 {
 		return -1
@@ -27,6 +69,11 @@ func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, current
 	if currentDepth > depthLimit {
 		reportError(context, "Max depth exceeded", []ast.Node{node})
 		return -1
+	}
+
+	// keep map of visited fragment spreads to prevent infinite loop
+	if visited == nil {
+		visited = map[*ast.FragmentDefinition]bool{}
 	}
 
 	var selectionSet *ast.SelectionSet
@@ -38,21 +85,23 @@ func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, current
 			selections := selectionSet.Selections
 			maxDepth := currentDepth
 			for _, selection := range selections {
-				nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth+1, depthLimit)
+				nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth+1, depthLimit, visited)
 				if nextDepth > maxDepth {
 					maxDepth = nextDepth
 				}
 			}
 			return maxDepth
 		}
-		return 0
+		return currentDepth
 	case kinds.FragmentSpread:
 		fragName := node.(*ast.FragmentSpread).Name.Value
-		spreadFragment := context.Fragment(fragName)
-		if spreadFragment != nil {
-			return validateMaxDepth(context, spreadFragment, currentDepth, depthLimit)
+		fragment := context.Fragment(fragName)
+		if fragment == nil || visited[fragment] {
+			return currentDepth
 		}
-		return 0
+		visited[fragment] = true
+		// fragment spreads don't increase the depth
+		return validateMaxDepth(context, fragment, currentDepth, depthLimit, visited)
 	case kinds.InlineFragment:
 		selectionSet = node.(*ast.InlineFragment).GetSelectionSet()
 	case kinds.FragmentDefinition:
@@ -65,61 +114,17 @@ func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, current
 		selections := selectionSet.Selections
 		maxDepth := currentDepth
 		for _, selection := range selections {
-			nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth, depthLimit)
+			// inline fragments, fragment definitions and operation definitions don't increase the depth
+			nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth, depthLimit, visited)
 			if nextDepth > maxDepth {
 				maxDepth = nextDepth
 			}
 		}
 		return maxDepth
 	}
-	return 0
+	return currentDepth
 }
 
-func (rule *maxDepthRule) maxDepthVisitorOptions() *visitor.VisitorOptions {
-	return &visitor.VisitorOptions{
-		KindFuncMap: map[string]visitor.NamedVisitFuncs{
-			kinds.OperationDefinition: {
-				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
-					node := p.Node.(ast.Node)
-					if node != nil {
-						validateMaxDepth(rule.context, node, 0, rule.depthLimit)
-					}
-					return visitor.ActionNoChange, nil
-				},
-			},
-		},
-	}
-}
-
-type maxDepthRule struct {
-	context    *graphql.ValidationContext
-	depthLimit int
-}
-
-func newMaxDepthRule(context *graphql.ValidationContext, depthLimit int) *maxDepthRule {
-	return &maxDepthRule{
-		context:    context,
-		depthLimit: depthLimit,
-	}
-}
-
-func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
-	rule := &maxDepthRule{
-		depthLimit: depthLimit,
-	}
-	return rule.validateRule
-}
-
-func (r *maxDepthRule) validateRule(context *graphql.ValidationContext) *graphql.ValidationRuleInstance {
-	rule := newMaxDepthRule(context, r.depthLimit)
-	return &graphql.ValidationRuleInstance{VisitorOpts: rule.maxDepthVisitorOptions()}
-}
-
-type UnauthedValidatorOpts struct {
-	DepthLimit int
-}
-
-func ProvideUnauthedValidators(opts UnauthedValidatorOpts) []graphql.ValidationRuleFn {
-	rules := []graphql.ValidationRuleFn{MaxDepthRule(opts.DepthLimit)}
-	return rules
+func reportError(context *graphql.ValidationContext, message string, nodes []ast.Node) {
+	context.ReportError(gqlerrors.NewError(message, nodes, "", nil, []int{}, nil))
 }

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -18,21 +18,23 @@ type maxDepthRule struct {
 	depthLimit int
 }
 
+// These GraphQL validators will be run on unauthed requests
 func UnauthedValidators() []graphql.ValidationRuleFn {
 	rules := []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryNodeDepth)}
 	return rules
 }
 
+func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
+	rule := newMaxDepthRule(depthLimit)
+	return rule.maxDepthRuleWithContext
+}
+
+// provide MaxDepthRule with depth limit
 func newMaxDepthRule(depthLimit int) *maxDepthRule {
 	rule := &maxDepthRule{
 		depthLimit: depthLimit,
 	}
 	return rule
-}
-
-func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {
-	rule := newMaxDepthRule(depthLimit)
-	return rule.maxDepthRuleWithContext
 }
 
 func (r *maxDepthRule) maxDepthRuleWithContext(context *graphql.ValidationContext) *graphql.ValidationRuleInstance {

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -1,0 +1,92 @@
+package graphql
+
+import (
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/graphql-go/graphql/language/visitor"
+)
+
+func reportError(context *graphql.ValidationContext, message string, nodes []ast.Node) (string, interface{}) {
+	context.ReportError(gqlerrors.NewError(message, nodes, "", nil, []int{}, nil))
+	return visitor.ActionNoChange, nil
+}
+
+func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, currentDepth int, depthLimit int) int {
+	// end recursion early if error reported
+	if errors := context.Errors(); len(errors) > 0 {
+		return -1
+	}
+
+	if currentDepth > depthLimit {
+		reportError(context, "Max depth exceeded", []ast.Node{node})
+		return -1
+	}
+
+	var selectionSet *ast.SelectionSet
+
+	switch node.GetKind() {
+	case kinds.Field:
+		selectionSet = node.(*ast.Field).GetSelectionSet()
+		if selectionSet != nil {
+			selections := selectionSet.Selections
+			maxDepth := currentDepth
+			for _, selection := range selections {
+				nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth+1, depthLimit)
+				if nextDepth > maxDepth {
+					maxDepth = nextDepth
+				}
+			}
+			return maxDepth
+		}
+		return 0
+	case kinds.FragmentSpread:
+		fragName := node.(*ast.FragmentSpread).Name.Value
+		spreadFragment := context.Fragment(fragName)
+		if spreadFragment != nil {
+			return validateMaxDepth(context, spreadFragment, currentDepth, depthLimit)
+		}
+		return 0
+	case kinds.InlineFragment:
+		selectionSet = node.(*ast.InlineFragment).GetSelectionSet()
+	case kinds.FragmentDefinition:
+		selectionSet = node.(*ast.FragmentDefinition).GetSelectionSet()
+	case kinds.OperationDefinition:
+		selectionSet = node.(*ast.OperationDefinition).GetSelectionSet()
+	}
+
+	if selectionSet != nil {
+		selections := selectionSet.Selections
+		maxDepth := currentDepth
+		for _, selection := range selections {
+			nextDepth := validateMaxDepth(context, selection.(ast.Node), currentDepth, depthLimit)
+			if nextDepth > maxDepth {
+				maxDepth = nextDepth
+			}
+		}
+		return maxDepth
+	}
+	return 0
+}
+
+func ProvideMaxDepthRule(ctx *graphql.ValidationContext) *graphql.ValidationRuleInstance {
+
+	visitorOpts := &visitor.VisitorOptions{
+		KindFuncMap: map[string]visitor.NamedVisitFuncs{
+			kinds.OperationDefinition: {
+				Kind: func(p visitor.VisitFuncParams) (string, interface{}) {
+					node := p.Node.(ast.Node)
+					if node != nil {
+						validateMaxDepth(ctx, node, 0, 8)
+					}
+					return visitor.ActionNoChange, nil
+				},
+			},
+		},
+	}
+
+	return &graphql.ValidationRuleInstance{
+		VisitorOpts: visitorOpts,
+	}
+}

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxQueryNodeDepth = 8
+	MaxQueryNodeDepth = 5
 )
 
 func reportError(context *graphql.ValidationContext, message string, nodes []ast.Node) (string, interface{}) {
@@ -17,6 +17,7 @@ func reportError(context *graphql.ValidationContext, message string, nodes []ast
 	return visitor.ActionNoChange, nil
 }
 
+// validate max depth of a GraphQL query with a depthLimit
 func validateMaxDepth(context *graphql.ValidationContext, node ast.Node, currentDepth int, depthLimit int) int {
 	// end recursion early if error reported
 	if errors := context.Errors(); len(errors) > 0 {

--- a/graphql/validators_test.go
+++ b/graphql/validators_test.go
@@ -3,31 +3,125 @@ package graphql
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/visitor"
 )
 
-// use graphql-go testutil to confirm validator provided correctly
-func TestMaxDepthRule(t *testing.T) {
-	testutil.ExpectPassesRule(t, MaxDepthRule(5), `
-	query MyQuery {
-		forwardTo(cluster: "~") {
-			forwardTo(cluster: "~") {
-				health {
-					postgresql {
-						healthy
-					}
-				}
-			}
-		}
-	}`)
+var (
+	schema   *graphql.Schema
+	typeInfo *graphql.TypeInfo
+)
 
-	testutil.ExpectFailsRule(t, MaxDepthRule(1), `
-		query MyQuery {   # depth 0
-			health {        # depth 1
-				healthy				# depth 2 <-- exceeds max depth of 1
-			}
-		}`,
-		// `healthy` node which breaks rule is on line 4, column 5 of the query document
-		[]gqlerrors.FormattedError{testutil.RuleError("Max depth exceeded", 4, 5)})
+// init stubbed GraphQL schema
+func init() {
+	// NOTE: the max-depth validator doesn't care about a valid schema, only depth of nodes in the graph
+	queryType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"foobar": &graphql.Field{
+				Type: graphql.String,
+			},
+		},
+	})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{Query: queryType})
+	if err != nil {
+		panic(err)
+	}
+	typeInfo = graphql.NewTypeInfo(&graphql.TypeInfoConfig{Schema: &schema})
+}
+
+// helper to parse a graphql query document
+func parseQuery(t *testing.T, q string) *ast.Document {
+	t.Helper()
+	astDoc, err := parser.Parse(parser.ParseParams{Source: q})
+	if err != nil {
+		t.Fatalf("parse failed: %s", err)
+	}
+	return astDoc
+}
+
+// helper to assert query depth matches expected
+func testDepth(t *testing.T, query string, depthLimit int, expectedDepth int) *maxDepthRule {
+	t.Helper()
+	astDoc := parseQuery(t, query)
+	context := graphql.NewValidationContext(schema, astDoc, typeInfo)
+	rule := newMaxDepthRule(depthLimit)
+	rule.context = context
+	visitor.Visit(astDoc, rule.maxDepthVisitorOptions(), nil)
+	if rule.depth != expectedDepth {
+		t.Fatalf("wrong depth expected: want=%d got=%d", expectedDepth, rule.depth)
+	}
+	return rule
+}
+
+// helper to assert errors set when depth limit reached
+func testMaxDepthError(t *testing.T, query string, depthLimit int) *maxDepthRule {
+	t.Helper()
+	astDoc := parseQuery(t, query)
+	context := graphql.NewValidationContext(schema, astDoc, typeInfo)
+	rule := newMaxDepthRule(depthLimit)
+	rule.context = context
+	visitor.Visit(astDoc, rule.maxDepthVisitorOptions(), nil)
+	if len(context.Errors()) == 0 {
+		t.Fatalf("expected errors but none returned")
+	}
+	return rule
+}
+
+func TestMaxDepth(t *testing.T) {
+	testDepth(t, `query MyQuery {   # depth 0
+		postgres {                    # depth 1
+			healthy				              # depth 2
+		}
+	}`, 5, 2)
+}
+
+func TestMaxDepthFragment(t *testing.T) {
+	testDepth(t, `
+	query MyQuery {   # depth 0
+		pet {           # depth 1
+			breed				  # depth 2
+			...dog 				# depth 2
+		}
+	}
+	fragment dog on Pet {
+		name           # depth 2
+		owner {
+			name         # depth 3
+		}
+	}`, 5, 3)
+}
+
+// test don't break on cyclical fragment spread
+func TestMaxDepthFragmentCycle(t *testing.T) {
+	testDepth(t, `
+		fragment X on Query { ...Y }
+		fragment Y on Query { ...X }
+		query {
+			...X
+		}
+	`, 5, 1)
+}
+
+func TestMaxDepthInlineFragment(t *testing.T) {
+	testDepth(t, `
+	query MyQuery {     # depth 0
+		pet {             # depth 1
+			breed				    # depth 2
+			... on Pet {    # depth 2
+				name          # depth 2
+			} 
+		}
+	}`, 5, 2)
+}
+
+func TestMaxDepthFail(t *testing.T) {
+	testMaxDepthError(t, `query MyQuery {    # depth 0
+		postgres {                             # depth 1
+			healthy				                       # depth 2 <-- max depth reached here
+		}
+	}`, 1)
 }

--- a/graphql/validators_test.go
+++ b/graphql/validators_test.go
@@ -73,102 +73,102 @@ func testMaxDepthError(t *testing.T, query string, depthLimit int) *maxDepthRule
 
 func TestMaxDepth(t *testing.T) {
 	testDepth(t, `
-	query MyQuery {   # depth 0
-		postgres {      # depth 1
-			healthy				# depth 2
-		}
-	}`, 5, 2)
+  query MyQuery {   # depth 0
+    postgres {      # depth 1
+      healthy       # depth 2
+    }
+  }`, 5, 2)
 }
 
 func TestMaxDepthFragment(t *testing.T) {
 	testDepth(t, `
-	query MyQuery {   # depth 0
-		pet {           # depth 1
-			breed				  # depth 2
-			...dog 				# depth 2
-		}
-	}
-	fragment dog on Pet {
-		name           # depth 2
-		owner {
-			name         # depth 3
-		}
-	}`, 5, 3)
+  query MyQuery {   # depth 0
+    pet {           # depth 1
+      breed         # depth 2
+      ...dog        # depth 2
+    }
+  }
+  fragment dog on Pet {
+    name           # depth 2
+    owner {
+      name         # depth 3
+    }
+  }`, 5, 3)
 }
 
 // test don't break on cyclical fragment spread
 func TestMaxDepthFragmentCycle(t *testing.T) {
 	testDepth(t, `
-		fragment X on Query { ...Y }
-		fragment Y on Query { ...X }
-		query {
-			...X
-		}
-	`, 5, 1)
+    fragment X on Query { ...Y }
+    fragment Y on Query { ...X }
+    query {
+      ...X
+    }
+  `, 5, 1)
 }
 
 func TestMaxDepthInlineFragment(t *testing.T) {
 	testDepth(t, `
-	query MyQuery {     # depth 0
-		pet {             # depth 1
-			breed				    # depth 2
-			... on Pet {    # depth 2
-				name          # depth 2
-			} 
-		}
-	}`, 5, 2)
+  query MyQuery {     # depth 0
+    pet {             # depth 1
+      breed           # depth 2
+      ... on Pet {    # depth 2
+        name          # depth 2
+      } 
+    }
+  }`, 5, 2)
 }
 
 func TestMaxDepthInlineFragmentNested(t *testing.T) {
 	testDepth(t, `
-	query MyQuery {     # depth 0
-		pet {             # depth 1
-			breed				    # depth 2
-			children {      # depth 2
-				... on Pet {  # depth 3
-					name        # depth 3
-				} 
-			}
-		}
-	}`, 5, 3)
+  query MyQuery {     # depth 0
+    pet {             # depth 1
+      breed           # depth 2
+      children {      # depth 2
+        ... on Pet {  # depth 3
+          name        # depth 3
+        } 
+      }
+    }
+  }`, 5, 3)
 }
 
 func TestMaxDepthFail(t *testing.T) {
 	testMaxDepthError(t, `query MyQuery {    # depth 0
-		postgres {                             # depth 1
-			healthy				                       # depth 2 <-- max depth reached here
-		}
-	}`, 1)
+    postgres {                             # depth 1
+      healthy                              # depth 2 <-- max depth reached here
+    }
+  }`, 1)
 }
 
 func TestMaxDepthFailWithFragment(t *testing.T) {
 	testMaxDepthError(t, `
-	query MyQuery {   # depth 0
-		pet {           # depth 1
-			breed				  # depth 2
-			children {
-				...dog 			# depth 3
-			}
-		}
-	}
-	fragment dog on Pet {
-		name           # depth 3
-		owner {
-			name         # depth 4 <-- max depth reached here
-		}
-	}`, 3)
+  query MyQuery {   # depth 0
+    pet {           # depth 1
+      breed         # depth 2
+      children {
+        ...dog      # depth 3
+      }
+    }
+  }
+  fragment dog on Pet {
+    name           # depth 3
+    owner {
+      name         # depth 4 <-- max depth reached here
+    }
+  }`, 3)
 }
 
 func TestMaxDepthFailWithNestedInlineFragment(t *testing.T) {
 	testMaxDepthError(t, `
-	query MyQuery {     # depth 0
-		pet {             # depth 1
-			breed				    # depth 2
-			children {      # depth 2
-				... on Pet {  # depth 3
-					name        # depth 3
-				} 
-			}
-		}
-	}`, 2)
+  query MyQuery {     # depth 0
+    pet {             # depth 1
+      breed           # depth 2
+      children {      # depth 2
+        ... on Pet {  # depth 3
+          name        # depth 3
+        } 
+      }
+    }
+  }`, 2)
 }

--- a/graphql/validators_test.go
+++ b/graphql/validators_test.go
@@ -12,13 +12,9 @@ func TestValidateMaxDepth(t *testing.T) {
 	query MyQuery {
 		forwardTo(cluster: "~") {
 			forwardTo(cluster: "~") {
-				forwardTo(cluster: "~") {
-					forwardTo(cluster: "~") {
-						health {
-							postgresql {
-								healthy
-							}
-						}
+				health {
+					postgresql {
+						healthy
 					}
 				}
 			}
@@ -28,8 +24,8 @@ func TestValidateMaxDepth(t *testing.T) {
 	// NOTE: the graphql-go testutil requires a line and column in the query document
 	// 	of the error node. The query is formatted this way to easily find the `healthy`
 	// 	node which breaks the max depth rule
-	testutil.ExpectFailsRule(t, ProvideMaxDepthRule, `query MyQuery{forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {health {postgresql {
-healthy # <-- max depth exceeded here at line 2, column 1 of the query document
-}}}}}}}}}}`,
+	testutil.ExpectFailsRule(t, ProvideMaxDepthRule, `query MyQuery {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {health {postgresql {
+healthy # <-- this node is at depth six, breaking the max depth of 5 rule
+		}}}}}}}`,
 		[]gqlerrors.FormattedError{testutil.RuleError("Max depth exceeded", 2, 1)})
 }

--- a/graphql/validators_test.go
+++ b/graphql/validators_test.go
@@ -1,0 +1,35 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/graphql-go/graphql/testutil"
+)
+
+func TestValidateMaxDepth(t *testing.T) {
+	testutil.ExpectPassesRule(t, ProvideMaxDepthRule, `
+	query MyQuery {
+		forwardTo(cluster: "~") {
+			forwardTo(cluster: "~") {
+				forwardTo(cluster: "~") {
+					forwardTo(cluster: "~") {
+						health {
+							postgresql {
+								healthy
+							}
+						}
+					}
+				}
+			}
+		}
+	}`)
+
+	// NOTE: the graphql-go testutil requires a line and column in the query document
+	// 	of the error node. The query is formatted this way to easily find the `healthy`
+	// 	node which breaks the max depth rule
+	testutil.ExpectFailsRule(t, ProvideMaxDepthRule, `query MyQuery{forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {forwardTo(cluster: "~") {health {postgresql {
+healthy # <-- max depth exceeded here at line 2, column 1 of the query document
+}}}}}}}}}}`,
+		[]gqlerrors.FormattedError{testutil.RuleError("Max depth exceeded", 2, 1)})
+}


### PR DESCRIPTION
## What is this change?

This adds a GraphQL validator to limit max query depth. The validator is run on queries from un-authed requests

Logic heavily inspired by:
- https://github.com/cungminh2710/graphql-depth-limiter (JS library for `graphql-js`, which is the basis for our `graphql-go`)
- https://github.com/graph-gophers/graphql-go/blob/master/internal/validation/validation.go (another GraphQL library in Go that has a max-depth validation built-in)


## Why is this change necessary?

Relates to https://github.com/sensu/sensu-enterprise-go/issues/1952

## Does your change need a Changelog entry?

Updated


## How did you verify this change?

Manually testing with a Web-UI and running queries with curl. Also added a couple unit test cases.
