### PR TITLE
Add log-millisecond-timestamps backend configuration flag

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
 - Added silences sorting by expiration to GraphQL service
+- Added log-precision-time backend configuration flag
 
 ## [6.9.1] - 2022-12-01
 

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -11,7 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
 - Added silences sorting by expiration to GraphQL service
-- Added log-precision-time backend configuration flag
+- Added log-millisecond-timestamps backend configuration flag
 
 ## [6.9.1] - 2022-12-01
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -224,6 +224,9 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 		// Set etcd client log level
 		logConfig := logutil.DefaultZapLoggerConfig
 		logConfig.Level.SetLevel(etcd.LogLevelToZap(config.EtcdClientLogLevel))
+		if config.EtcdLogPrecisionTime {
+			logConfig.EncoderConfig.EncodeTime = etcd.PrecisionTimeEncoder
+		}
 		clientv3Config.LogConfig = &logConfig
 
 		// Don't start up an embedded etcd, return a client that connects to an
@@ -252,6 +255,7 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 	cfg.DiscoverySrv = config.EtcdDiscoverySrv
 	cfg.Name = config.EtcdName
 	cfg.LogLevel = config.EtcdLogLevel
+	cfg.LogPrecisionTime = config.EtcdLogPrecisionTime
 	cfg.ClientLogLevel = config.EtcdClientLogLevel
 
 	// Heartbeat interval

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -17,6 +17,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
@@ -224,8 +225,8 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 		// Set etcd client log level
 		logConfig := logutil.DefaultZapLoggerConfig
 		logConfig.Level.SetLevel(etcd.LogLevelToZap(config.EtcdClientLogLevel))
-		if config.EtcdLogPrecisionTime {
-			logConfig.EncoderConfig.EncodeTime = etcd.PrecisionTimeEncoder
+		if config.EtcdLogTimestampLayout != "" {
+			logConfig.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(config.EtcdLogTimestampLayout)
 		}
 		clientv3Config.LogConfig = &logConfig
 
@@ -255,7 +256,7 @@ func newClient(ctx context.Context, config *Config, backend *Backend) (*clientv3
 	cfg.DiscoverySrv = config.EtcdDiscoverySrv
 	cfg.Name = config.EtcdName
 	cfg.LogLevel = config.EtcdLogLevel
-	cfg.LogPrecisionTime = config.EtcdLogPrecisionTime
+	cfg.LogTimestampLayout = config.EtcdLogTimestampLayout
 	cfg.ClientLogLevel = config.EtcdClientLogLevel
 
 	// Heartbeat interval

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -68,7 +68,7 @@ const (
 	flagInsecureSkipTLSVerify = "insecure-skip-tls-verify"
 	flagDebug                 = "debug"
 	flagLogLevel              = "log-level"
-	flagLogPrecisionTime      = "log-precision-time"
+	flagLogMillisecondTime    = "log-millisecond-timestamps"
 	flagLabels                = "labels"
 	flagAnnotations           = "annotations"
 
@@ -142,7 +142,7 @@ const (
 	// URLs to advertise to the rest of the cluster
 	defaultEtcdAdvertiseClientURL = "http://localhost:2379"
 
-	timestampFormatPrecision = "2006-01-02T15:04:05.999Z07:00"
+	timestampFormatMillisecond = "2006-01-02T15:04:05.999Z07:00"
 
 	// Start command usage template
 	startUsageTemplate = `Usage:{{if .Runnable}}
@@ -214,12 +214,12 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 			}
 			logrus.SetLevel(level)
 
-			if precisionTime := viper.GetBool(flagLogPrecisionTime); precisionTime {
+			if millisecondTime := viper.GetBool(flagLogMillisecondTime); millisecondTime {
 				formatter := logrus.StandardLogger().Formatter
 				var copy logrus.JSONFormatter
 				if orig, ok := formatter.(*logrus.JSONFormatter); ok {
 					copy = *orig
-					copy.TimestampFormat = timestampFormatPrecision
+					copy.TimestampFormat = timestampFormatMillisecond
 					logrus.SetFormatter(&copy)
 				}
 			}
@@ -272,7 +272,6 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				EtcdHeartbeatInterval:          viper.GetUint(flagEtcdHeartbeatInterval),
 				EtcdElectionTimeout:            viper.GetUint(flagEtcdElectionTimeout),
 				EtcdLogLevel:                   viper.GetString(flagEtcdLogLevel),
-				EtcdLogPrecisionTime:           viper.GetBool(flagLogPrecisionTime),
 				EtcdClientLogLevel:             viper.GetString(flagEtcdClientLogLevel),
 				EtcdClientUsername:             viper.GetString(envEtcdClientUsername),
 				EtcdClientPassword:             viper.GetString(envEtcdClientPassword),
@@ -348,6 +347,10 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 				default:
 					cfg.EtcdLogLevel = level.String()
 				}
+			}
+
+			if viper.GetBool(flagLogMillisecondTime) {
+				cfg.EtcdLogTimestampLayout = timestampFormatMillisecond
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -564,7 +567,7 @@ func flagSet(server bool) *pflag.FlagSet {
 		flagSet.Bool(flagInsecureSkipTLSVerify, viper.GetBool(flagInsecureSkipTLSVerify), "skip TLS verification (not recommended!)")
 		flagSet.Bool(flagDebug, false, "enable debugging and profiling features")
 		flagSet.String(flagLogLevel, viper.GetString(flagLogLevel), "logging level [panic, fatal, error, warn, info, debug, trace]")
-		flagSet.Bool(flagLogPrecisionTime, false, "use precision timestamps in logging output")
+		flagSet.Bool(flagLogMillisecondTime, false, "use millisecond precision timestamps in logging output")
 		flagSet.Int(backend.FlagEventdWorkers, viper.GetInt(backend.FlagEventdWorkers), "number of workers spawned for processing incoming events")
 		flagSet.Int(backend.FlagEventdBufferSize, viper.GetInt(backend.FlagEventdBufferSize), "number of incoming events that can be buffered")
 		flagSet.Int(backend.FlagKeepalivedWorkers, viper.GetInt(backend.FlagKeepalivedWorkers), "number of workers spawned for processing incoming keepalives")

--- a/backend/config.go
+++ b/backend/config.go
@@ -114,9 +114,10 @@ type Config struct {
 
 	TLS *corev2.TLSOptions
 
-	LogLevel           string
-	EtcdLogLevel       string
-	EtcdClientLogLevel string
+	LogLevel             string
+	EtcdLogPrecisionTime bool
+	EtcdLogLevel         string
+	EtcdClientLogLevel   string
 
 	// Etcd unsafe configuration
 	EtcdUnsafeNoFsync bool

--- a/backend/config.go
+++ b/backend/config.go
@@ -114,10 +114,10 @@ type Config struct {
 
 	TLS *corev2.TLSOptions
 
-	LogLevel             string
-	EtcdLogPrecisionTime bool
-	EtcdLogLevel         string
-	EtcdClientLogLevel   string
+	LogLevel               string
+	EtcdLogTimestampLayout string
+	EtcdLogLevel           string
+	EtcdClientLogLevel     string
 
 	// Etcd unsafe configuration
 	EtcdUnsafeNoFsync bool

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -102,9 +102,9 @@ type Config struct {
 	MaxRequestBytes   uint
 	QuotaBackendBytes int64
 
-	LogLevel         string
-	ClientLogLevel   string
-	LogPrecisionTime bool
+	LogLevel           string
+	ClientLogLevel     string
+	LogTimestampLayout string
 
 	UnsafeNoFsync bool
 }
@@ -277,8 +277,9 @@ func NewEtcd(config *Config) (*Etcd, error) {
 		logutil.DefaultZapLoggerConfig.Level.SetLevel(LogLevelToZap(config.LogLevel))
 	}
 
-	if config.LogPrecisionTime {
-		logutil.DefaultZapLoggerConfig.EncoderConfig.EncodeTime = PrecisionTimeEncoder
+	if config.LogTimestampLayout != "" {
+		encoder := zapcore.TimeEncoderOfLayout(config.LogTimestampLayout)
+		logutil.DefaultZapLoggerConfig.EncoderConfig.EncodeTime = encoder
 	}
 
 	// Unsafe options.

--- a/backend/etcd/etcd.go
+++ b/backend/etcd/etcd.go
@@ -102,8 +102,9 @@ type Config struct {
 	MaxRequestBytes   uint
 	QuotaBackendBytes int64
 
-	LogLevel       string
-	ClientLogLevel string
+	LogLevel         string
+	ClientLogLevel   string
+	LogPrecisionTime bool
 
 	UnsafeNoFsync bool
 }
@@ -274,6 +275,10 @@ func NewEtcd(config *Config) (*Etcd, error) {
 	if config.LogLevel != "" {
 		cfg.LogLevel = config.LogLevel
 		logutil.DefaultZapLoggerConfig.Level.SetLevel(LogLevelToZap(config.LogLevel))
+	}
+
+	if config.LogPrecisionTime {
+		logutil.DefaultZapLoggerConfig.EncoderConfig.EncodeTime = PrecisionTimeEncoder
 	}
 
 	// Unsafe options.

--- a/backend/etcd/zap_time.go
+++ b/backend/etcd/zap_time.go
@@ -1,0 +1,9 @@
+package etcd
+
+import zapcore "go.uber.org/zap/zapcore"
+
+const precisionTimeLayout = "2006-01-02T15:04:05.999Z07:00"
+
+// PrecisionTimeEncoder serializes a time.Time to an RFC3339-formatted string
+// with millisecond precision.
+var PrecisionTimeEncoder = zapcore.TimeEncoderOfLayout(precisionTimeLayout)

--- a/backend/etcd/zap_time.go
+++ b/backend/etcd/zap_time.go
@@ -1,9 +1,0 @@
-package etcd
-
-import zapcore "go.uber.org/zap/zapcore"
-
-const precisionTimeLayout = "2006-01-02T15:04:05.999Z07:00"
-
-// PrecisionTimeEncoder serializes a time.Time to an RFC3339-formatted string
-// with millisecond precision.
-var PrecisionTimeEncoder = zapcore.TimeEncoderOfLayout(precisionTimeLayout)


### PR DESCRIPTION
The log-millisecond-timestamps configuration allows users to configure a sensu backend to use RFC3339 formatted timestamp strings with millisecond precision in its backend logs.

## What is this change?

Closes https://github.com/sensu/sensu-enterprise-go/issues/2518

## Why is this change necessary?


## Does your change need a Changelog entry?

Y

## Do you need clarification on anything?

N

## Were there any complications while making this change?

N

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes! New configuration flag.

## How did you verify this change?

`./sensu-backend start -c <base config path> --log-millisecond-timestamps --log-level debug |& jq .time`

## Is this change a patch?

N