### PR TITLE
Don't use os.Hostname in daemons

### DIFF
--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -174,6 +174,7 @@ type Eventd struct {
 	operatorConcierge   store.OperatorConcierge
 	operatorMonitor     store.OperatorMonitor
 	operatorQueryer     store.OperatorQueryer
+	backendName         string
 }
 
 // Option is a functional option.
@@ -193,6 +194,7 @@ type Config struct {
 	OperatorConcierge   store.OperatorConcierge
 	OperatorMonitor     store.OperatorMonitor
 	OperatorQueryer     store.OperatorQueryer
+	BackendName         string
 }
 
 // New creates a new Eventd.
@@ -228,6 +230,7 @@ func New(ctx context.Context, c Config, opts ...Option) (*Eventd, error) {
 		Logger:              NoopLogger{},
 		operatorConcierge:   c.OperatorConcierge,
 		operatorMonitor:     c.OperatorMonitor,
+		backendName:         c.BackendName,
 	}
 
 	e.ctx, e.cancel = context.WithCancel(ctx)

--- a/backend/eventd/opc.go
+++ b/backend/eventd/opc.go
@@ -2,27 +2,16 @@ package eventd
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/sensu/sensu-go/backend/store"
 )
 
-var hostname string
-
-func init() {
-	var err error
-	hostname, err = os.Hostname()
-	if err != nil {
-		panic(err)
-	}
-}
-
 func (e *Eventd) monitorCheckTTLs(ctx context.Context) {
 	req := store.MonitorOperatorsRequest{
 		Type:           store.CheckOperator,
 		ControllerType: store.BackendOperator,
-		ControllerName: hostname,
+		ControllerName: e.backendName,
 		Micromanage:    true,
 		Every:          time.Second,
 		ErrorHandler: func(err error) {


### PR DESCRIPTION
Fix a bug where os.Hostname was used as the backend name in keepalived and eventd. This breaks keepalives and check TTLs when a backend name is configured in the backend config file. The backend name is now correctly passed through to these daemons.