### PR TITLE
Make keepalive monitor less CPU intensive

### DIFF
--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -157,7 +157,7 @@ func (k *Keepalived) monitorOperators(ctx context.Context) {
 		Type:           store.AgentOperator,
 		ControllerType: store.BackendOperator,
 		ControllerName: k.backendName,
-		Every:          time.Second,
+		Every:          10 * time.Second,
 		ErrorHandler: func(err error) {
 			logger.WithError(err).Error("error monitoring agent keepalives")
 		},

--- a/backend/store/postgres/migrations.go
+++ b/backend/store/postgres/migrations.go
@@ -138,6 +138,15 @@ var migrations = []migration.Migrator{
 		_, err := tx.Exec(context.Background(), recreateEventsTable)
 		return err
 	},
+	// Migration 23
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), "CREATE INDEX ON opc ( controller )")
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(context.Background(), "CREATE INDEX ON opc ( controller_type )")
+		return err
+	},
 }
 
 type eventRecord struct {


### PR DESCRIPTION
This change adds indices to the opc table and also relaxes the keepalive monitoring loop so that it is only every 10 seconds.