### PR TITLE
Remove debugging panic

### DIFF
--- a/backend/store/postgres/event_store.go
+++ b/backend/store/postgres/event_store.go
@@ -392,7 +392,6 @@ func (e *EventStore) UpdateEvent(ctx context.Context, event *corev2.Event) (uEve
 			// the namespace doesn't exist
 			return nil, nil, &store.ErrNamespaceMissing{Namespace: event.Entity.Namespace}
 		}
-		panic(err)
 		return nil, nil, &store.ErrInternal{Message: err.Error()}
 	}
 


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
