### PR TITLE
Fix consistency errors when deleting entities

### DIFF
--- a/backend/store/postgres/entity_configs_schema.go
+++ b/backend/store/postgres/entity_configs_schema.go
@@ -293,9 +293,8 @@ SELECT
 FROM entity_configs
 LEFT OUTER JOIN namespaces ON entity_configs.namespace_id = namespaces.id
 WHERE
-	namespaces.name = $1 OR $1 IS NULL AND
-	namespaces.deleted_at IS NULL AND
-	entity_configs.deleted_at IS NULL
+	entity_configs.deleted_at IS NULL AND
+	(namespaces.name = $1 OR $1 IS NULL)
 ORDER BY ( namespaces.name, entity_configs.name ) ASC
 LIMIT $2
 OFFSET $3
@@ -325,8 +324,8 @@ SELECT
 FROM entity_configs
 LEFT OUTER JOIN namespaces ON namespaces.id = entity_configs.namespace_id
 WHERE
-	namespaces.name = $1 OR $1 IS NULL AND
-	entity_configs.deleted_at IS NULL
+	entity_configs.deleted_at IS NULL AND
+	(namespaces.name = $1 OR $1 IS NULL)
 ORDER BY ( namespaces.name, entity_configs.name ) DESC
 LIMIT $2
 OFFSET $3

--- a/backend/store/postgres/entity_store.go
+++ b/backend/store/postgres/entity_store.go
@@ -55,7 +55,22 @@ func (s *EntityStore) DeleteEntity(ctx context.Context, entity *corev2.Entity) e
 
 	namespace := entity.GetNamespace()
 	name := entity.GetName()
+	return s.deleteEntity(ctx, name, namespace)
+}
 
+// DeleteEntityByName deletes an entity using the given name and the
+// namespace stored in ctx.
+func (s *EntityStore) DeleteEntityByName(ctx context.Context, name string) error {
+	if name == "" {
+		return &store.ErrNotValid{Err: errors.New("must specify name")}
+	}
+
+	return s.deleteEntity(ctx, name, corev2.ContextNamespace(ctx))
+}
+
+// DeleteEntityByName deletes an entity using the given name and the
+// namespace stored in ctx.
+func (s *EntityStore) deleteEntity(ctx context.Context, name, namespace string) error {
 	entityConfigStore, entityStateStore, cleanup, err := prepareEntityStores(ctx, s.db)
 	if err != nil {
 		return err
@@ -80,19 +95,6 @@ func (s *EntityStore) DeleteEntity(ctx context.Context, entity *corev2.Entity) e
 	}
 
 	return nil
-}
-
-// DeleteEntityByName deletes an entity using the given name and the
-// namespace stored in ctx.
-func (s *EntityStore) DeleteEntityByName(ctx context.Context, name string) error {
-	if name == "" {
-		return &store.ErrNotValid{Err: errors.New("must specify name")}
-	}
-
-	meta := corev2.NewObjectMeta(name, corev2.ContextNamespace(ctx))
-	entity := corev2.NewEntity(meta)
-
-	return s.DeleteEntity(ctx, entity)
 }
 
 type uniqueResource struct {


### PR DESCRIPTION
* Fixes the EntityStore's DeleteEntityByName method, previously untested
    and broken.
* Fixes the EntityConfigStore's GetEntities method which had been
    returning soft deleted entities.