### PR TITLE
Loadit backend handshake timeout

### DIFF
--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -37,6 +37,7 @@ var (
 	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number")
 	flagMaxSessionLength  = flag.Duration("max-session-length", 0*time.Second, "maximum amount of time after which the agent will reconnect to one of the configured backends (no maximum by default)")
 	flagDeregister        = flag.Bool("deregister", true, "should loadit entities automatically deregister. defaults true")
+	flagHandshakeTimeout  = flag.Int("backend-handshake-timeout", 15, "timeout for exchanging handshake with backend")
 )
 
 func main() {
@@ -95,6 +96,7 @@ func main() {
 		cfg.BackendHeartbeatTimeout = 300
 		cfg.PrometheusBinding = *flagPromBinding
 		cfg.MaxSessionLength = *flagMaxSessionLength
+		cfg.BackendHandshakeTimeout = *flagHandshakeTimeout
 
 		agent, err := agent.NewAgent(cfg)
 		if err != nil {

--- a/cmd/loadit/main.go
+++ b/cmd/loadit/main.go
@@ -37,7 +37,7 @@ var (
 	flagBaseEntityName    = flag.String("base-entity-name", "test-host", "base entity name to prepend with count number")
 	flagMaxSessionLength  = flag.Duration("max-session-length", 0*time.Second, "maximum amount of time after which the agent will reconnect to one of the configured backends (no maximum by default)")
 	flagDeregister        = flag.Bool("deregister", true, "should loadit entities automatically deregister. defaults true")
-	flagHandshakeTimeout  = flag.Int("backend-handshake-timeout", 15, "timeout for exchanging handshake with backend")
+	flagHandshakeTimeout  = flag.Int("backend-handshake-timeout", 45, "timeout for exchanging handshake with backend")
 )
 
 func main() {


### PR DESCRIPTION
Allows us to extend the default handshake timeout between agents and backends. Hopefully reduces timeouts.

Sensu 7.0 is (so far) more sensitive to mass herds of agents connecting to a backend. In addition to tuning backends to use appropriate agent connection rate limiting, extending the handshake timeout to 45s (the default suggested by our websocket library) should result in fewer client connection timeouts.