### PR TITLE
GraphQL authenticated query depth limit

### DIFF
--- a/graphql/service.go
+++ b/graphql/service.go
@@ -193,19 +193,11 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 		return &graphql.Result{Errors: gqlerrors.FormatErrors(err)}
 	}
 
-	// run validators for unauthorized requests
-	if !p.IsAuthed {
-		rules := UnauthedValidators()
-		validationResult := graphql.ValidateDocument(&schema, AST, rules)
-		if !validationResult.IsValid {
-			return &graphql.Result{Errors: validationResult.Errors}
-		}
-	}
-
 	// validate document
 	if !p.SkipValidation {
 		validationFinishFn := MiddlewareHandleValidationDidStart(service, &params)
-		validationResult := graphql.ValidateDocument(&schema, AST, nil)
+		rules := Validators()
+		validationResult := graphql.ValidateDocument(&schema, AST, rules)
 		validationFinishFn(validationResult.Errors)
 		if !validationResult.IsValid {
 			return &graphql.Result{Errors: validationResult.Errors}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -193,11 +193,17 @@ func (service *Service) Do(ctx context.Context, p QueryParams) *Result {
 		return &graphql.Result{Errors: gqlerrors.FormatErrors(err)}
 	}
 
-	// validate document
+	// run mandatory (un-skippable) validators
+	rules := MandatoryValidators()
+	validationResult := graphql.ValidateDocument(&schema, AST, rules)
+	if !validationResult.IsValid {
+		return &graphql.Result{Errors: validationResult.Errors}
+	}
+
+	// run built-in validators e.g. schema type validation
 	if !p.SkipValidation {
 		validationFinishFn := MiddlewareHandleValidationDidStart(service, &params)
-		rules := Validators()
-		validationResult := graphql.ValidateDocument(&schema, AST, rules)
+		validationResult := graphql.ValidateDocument(&schema, AST, nil)
 		validationFinishFn(validationResult.Errors)
 		if !validationResult.IsValid {
 			return &graphql.Result{Errors: validationResult.Errors}

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxQueryDepthLimit = 10
+	MaxQueryDepthLimit = 15
 )
 
 type maxDepthRule struct {
@@ -18,9 +18,8 @@ type maxDepthRule struct {
 	depthLimit int
 }
 
-func Validators() []graphql.ValidationRuleFn {
-	customRules := []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryDepthLimit)}
-	return append(graphql.SpecifiedRules, customRules...)
+func MandatoryValidators() []graphql.ValidationRuleFn {
+	return []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryDepthLimit)}
 }
 
 func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {

--- a/graphql/validators.go
+++ b/graphql/validators.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxQueryNodeDepth = 5
+	MaxQueryDepthLimit = 10
 )
 
 type maxDepthRule struct {
@@ -18,10 +18,9 @@ type maxDepthRule struct {
 	depthLimit int
 }
 
-// These GraphQL validators will be run on unauthed requests
-func UnauthedValidators() []graphql.ValidationRuleFn {
-	rules := []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryNodeDepth)}
-	return rules
+func Validators() []graphql.ValidationRuleFn {
+	customRules := []graphql.ValidationRuleFn{MaxDepthRule(MaxQueryDepthLimit)}
+	return append(graphql.SpecifiedRules, customRules...)
 }
 
 func MaxDepthRule(depthLimit int) graphql.ValidationRuleFn {


### PR DESCRIPTION
## What is this change?

Changes GraphQL service to run query depth limit validation on all requests (previously running just for un-authenticated requests). Ups the depth limit as our Web UI requires deeper queries. The default limit is about double what the Web UI needs – one could conceive of queries in GraphIQL that exceed this limit. 

Also introduces notion of mandatory GraphQL validation that can't be skipped with a parameter. The depth limit validation doesn't conflict with the reason for allowing validation to be skipped outlined here https://github.com/sensu/sensu-go/pull/3379 

In the future, we could group built-in GraphQL validators into skippable and not https://pkg.go.dev/github.com/graphql-go/graphql#SpecifiedRules. However, changes to federation in future Sensu versions could make this unnecessary as skipping validation won't be necessary 

## Why is this change necessary?

Security team request to extend this validation to authenticated requests