### PR TITLE
remove redundant OPC CheckIn

### DIFF
--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -602,35 +602,6 @@ func (k *Keepalived) handleUpdate(e *corev2.Event) error {
 	}
 	entity := e.Entity
 
-	warning := int(e.Check.Timeout)
-	critical := int(e.Check.Ttl)
-	interval := int(e.Check.Interval)
-	ttl := time.Duration(warning) * time.Second
-
-	ctx := corev2.SetContextFromResource(context.Background(), entity)
-	agentMeta := agentMetadata{
-		Warning:  warning,
-		Critical: critical,
-		Interval: interval,
-	}
-	metadata, _ := json.Marshal(agentMeta)
-	state := store.OperatorState{
-		Namespace: e.Entity.Namespace,
-		Name:      e.Entity.Name,
-		Type:      store.AgentOperator,
-		Controller: &store.OperatorKey{
-			Name: k.backendName,
-			Type: store.BackendOperator,
-		},
-		CheckInTimeout: ttl,
-		Present:        true,
-		Metadata:       (*json.RawMessage)(&metadata),
-	}
-	if err := k.operatorConcierge.CheckIn(ctx, state); err != nil {
-		// Warning: do not wrap this error
-		return err
-	}
-
 	entity.LastSeen = e.Timestamp
 	_, entityState := corev3.V2EntityToV3(entity)
 


### PR DESCRIPTION
Not totally sure what was going on here. It appears that there is a redundant CheckIn operation in handleUpdate. Stats from the performance testing cluster's postgres instance show that it is spending more time executing this statement than any others at baseline (many agents connected, but not processing significant event load.) This should cut that baseline in half 😄, although I suspect it will still be at or near the top.

First CheckIn immediately preceding calling handleUpdate: https://github.com/sensu/sensu-go/blob/main/backend/keepalived/keepalived.go#L283-L317