### PR TITLE
rewrite TestEntityConfigPoller test

### DIFF
--- a/backend/store/postgres/entity_config_store_test.go
+++ b/backend/store/postgres/entity_config_store_test.go
@@ -466,9 +466,7 @@ func TestEntityConfigStore_Get(t *testing.T) {
 				}
 
 				if got != nil {
-					// delete some of the metadata keys we can't easily predict for comparison
-					delete(got.Metadata.Labels, store.SensuUpdatedAtKey)
-					delete(got.Metadata.Labels, store.SensuCreatedAtKey)
+					purgeIndeterminateStoreLabels(got)
 				}
 
 				if !reflect.DeepEqual(got, tt.want) {
@@ -665,9 +663,7 @@ func TestEntityConfigStore_GetMultiple(t *testing.T) {
 				}
 
 				for _, g := range got {
-					// delete some of the metadata keys we can't easily predict for comparison
-					delete(g.Metadata.Labels, store.SensuUpdatedAtKey)
-					delete(g.Metadata.Labels, store.SensuCreatedAtKey)
+					purgeIndeterminateStoreLabels(g)
 				}
 				if diff := deep.Equal(got, tt.want); diff != nil {
 					t.Errorf("EntityConfigStore.GetMultiple() got differs from want: %v", diff)
@@ -1031,9 +1027,7 @@ func TestEntityConfigStore_List(t *testing.T) {
 					return
 				}
 				for _, g := range got {
-					// delete some of the metadata keys we can't easily predict for comparison
-					delete(g.Metadata.Labels, store.SensuUpdatedAtKey)
-					delete(g.Metadata.Labels, store.SensuCreatedAtKey)
+					purgeIndeterminateStoreLabels(g)
 				}
 				if diff := deep.Equal(got, tt.want); len(diff) > 0 {
 					t.Errorf("EntityConfigStore.List() got differs from want: %v", diff)

--- a/backend/store/postgres/test_helpers.go
+++ b/backend/store/postgres/test_helpers.go
@@ -258,3 +258,13 @@ func deleteEntityState(tb testing.TB, s storev2.EntityStateStore, namespace, nam
 		tb.Error(err)
 	}
 }
+
+// purgeIndeterminateStoreLabels clears out labels set on resources by the
+// store implementation that are indeterminate. ex: created_at
+func purgeIndeterminateStoreLabels(r corev3.Resource) {
+	meta := r.GetMetadata()
+	delete(meta.Labels, store.SensuCreatedAtKey)
+	delete(meta.Labels, store.SensuDeletedAtKey)
+	delete(meta.Labels, store.SensuUpdatedAtKey)
+	r.SetMetadata(meta)
+}


### PR DESCRIPTION
The entity config poller test isn't working well in CI, and I suspect the reason is resource constraints that do not play well with the time sensitive nature of the test as written (ex: [this ](https://github.com/sensu/sensu-go/blob/3cd917904ddd81d639f4dd66821b34ecb3e8c21f/backend/store/postgres/poller_test.go#L107-L108) delay is meant to give the poller time to catch up and deliver any events after the final change occurs, but picking a duration for that delay becomes a difficult balancing act). This should cover most of the code paths as before while being much less sensitive to goroutine scheduling and postgres responsiveness.