### PR TITLE
Unify API Formats

### DIFF
--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - core/v2.Namespace is no longer supported. Users must use core/v3.Namespace,
 which now allows for the addition of labels and annotations.
 - API keys can no longer be retrieved from the database.
+- The REST APIs now use the wrapped resource format.
 
 ### Added
 - Added sensu-backend configuration for postgresql.

--- a/backend/apid/actions/error.go
+++ b/backend/apid/actions/error.go
@@ -52,6 +52,9 @@ const (
 	// the operation has completed successfully. For example, a successful
 	// response from a server could have been delayed long
 	DeadlineExceeded
+
+	// Gone indicates that an API that was once supported but no longer is.
+	Gone
 )
 
 // Default error messages if not message is provided.
@@ -65,6 +68,7 @@ var standardErrorMessages = map[ErrCode]string{
 	PaymentRequired:    "license required",
 	PreconditionFailed: "precondition failed",
 	DeadlineExceeded:   "deadline exceeded",
+	Gone:               "this action is no longer supported",
 }
 
 // Error describes an issue that ocurred while performing the action.

--- a/backend/apid/handlers/create_v3.go
+++ b/backend/apid/handlers/create_v3.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
@@ -16,8 +16,8 @@ import (
 // CreateV3Resource creates the resource given in the request body but only if it
 // does not already exist
 func (h Handlers[R, T]) CreateResource(r *http.Request) (corev3.Resource, error) {
-	var payload R
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	payload, err := request.Resource[R](r)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 

--- a/backend/apid/handlers/create_v3_test.go
+++ b/backend/apid/handlers/create_v3_test.go
@@ -32,7 +32,7 @@ func TestHandlers_CreateResource(t *testing.T) {
 		},
 		{
 			name: "invalid resource meta",
-			body: marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{
+			body: marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{
 				Name:      "foo",
 				Namespace: "acme",
 			}}),
@@ -41,7 +41,7 @@ func TestHandlers_CreateResource(t *testing.T) {
 		},
 		{
 			name: "store err, already exists",
-			body: marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
+			body: marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything).
 					Return(&store.ErrAlreadyExists{})
@@ -50,7 +50,7 @@ func TestHandlers_CreateResource(t *testing.T) {
 		},
 		{
 			name: "store err, not valid",
-			body: marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
+			body: marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything).
 					Return(&store.ErrNotValid{Err: errors.New("error")})
@@ -59,7 +59,7 @@ func TestHandlers_CreateResource(t *testing.T) {
 		},
 		{
 			name: "store err, default",
-			body: marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
+			body: marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything).
 					Return(&store.ErrInternal{})
@@ -68,7 +68,7 @@ func TestHandlers_CreateResource(t *testing.T) {
 		},
 		{
 			name: "successful create",
-			body: marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
+			body: marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{}}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateIfNotExists", mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -102,7 +102,7 @@ func TestV3CreatedByCreate(t *testing.T) {
 	claims, err := jwt.NewClaims(&corev2.User{Username: "admin"})
 	assert.NoError(t, err)
 	ctx := context.WithValue(context.Background(), corev2.ClaimsKey, claims)
-	body := marshal(t, fixture.V3Resource{Metadata: &corev2.ObjectMeta{}})
+	body := marshal(t, &fixture.V3Resource{Metadata: &corev2.ObjectMeta{}})
 
 	store := &mockstore.V2MockStore{}
 	cs := new(mockstore.ConfigStore)

--- a/backend/apid/handlers/handlers_test.go
+++ b/backend/apid/handlers/handlers_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	corev2 "github.com/sensu/core/v2"
+	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/testing/fixture"
+	"github.com/sensu/sensu-go/types"
 )
 
 func TestCheckMeta(t *testing.T) {
@@ -42,9 +44,9 @@ func TestCheckMeta(t *testing.T) {
 	}
 }
 
-func marshal(t *testing.T, v interface{}) []byte {
+func marshal(t *testing.T, v corev3.Resource) []byte {
 	t.Helper()
-	bytes, err := json.Marshal(v)
+	bytes, err := json.Marshal(types.WrapResource(v))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/apid/handlers/update_v3.go
+++ b/backend/apid/handlers/update_v3.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
@@ -16,11 +16,10 @@ import (
 // CreateOrUpdateResource creates or updates the resource given in the request
 // body, regardless of whether it already exists or not
 func (h Handlers[R, T]) CreateOrUpdateResource(r *http.Request) (corev3.Resource, error) {
-	var payload R
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	payload, err := request.Resource[R](r)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
-
 	meta := payload.GetMetadata()
 
 	if meta == nil {

--- a/backend/apid/handlers/update_v3_test.go
+++ b/backend/apid/handlers/update_v3_test.go
@@ -33,13 +33,13 @@ func TestHandlers_UpdateResourceV3(t *testing.T) {
 		},
 		{
 			name:    "invalid resource meta",
-			body:    marshal(t, fixture.V3Resource{Metadata: corev2.NewObjectMetaP("foo", "acme")}),
+			body:    marshal(t, &fixture.V3Resource{Metadata: corev2.NewObjectMetaP("foo", "acme")}),
 			urlVars: map[string]string{"id": "bar", "namespace": "acme"},
 			wantErr: true,
 		},
 		{
 			name: "store err, not valid",
-			body: marshal(t, fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
+			body: marshal(t, &fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
 					Return(&store.ErrNotValid{Err: errors.New("error")})
@@ -48,7 +48,7 @@ func TestHandlers_UpdateResourceV3(t *testing.T) {
 		},
 		{
 			name: "store err, default",
-			body: marshal(t, fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
+			body: marshal(t, &fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
 					Return(&store.ErrInternal{})
@@ -57,7 +57,7 @@ func TestHandlers_UpdateResourceV3(t *testing.T) {
 		},
 		{
 			name: "successful create",
-			body: marshal(t, fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
+			body: marshal(t, &fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")}),
 			storeFunc: func(s *mockstore.ConfigStore) {
 				s.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -91,7 +91,7 @@ func TestCreatedByUpdateV3(t *testing.T) {
 	claims, err := jwt.NewClaims(&corev2.User{Username: "admin"})
 	assert.NoError(t, err)
 	ctx := context.WithValue(context.Background(), corev2.ClaimsKey, claims)
-	body := marshal(t, fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")})
+	body := marshal(t, &fixture.V3Resource{Metadata: corev2.NewObjectMetaP("", "")})
 
 	store := &mockstore.V2MockStore{}
 	cs := new(mockstore.ConfigStore)

--- a/backend/apid/request/resource.go
+++ b/backend/apid/request/resource.go
@@ -1,0 +1,75 @@
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	corev3 "github.com/sensu/core/v3"
+	apitools "github.com/sensu/sensu-api-tools"
+	"github.com/sensu/sensu-go/types"
+)
+
+// Resource decodes the request body into the specified corev3.Resource type
+func Resource[R corev3.Resource](r *http.Request) (R, error) {
+	var payload R
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return payload, err
+	}
+
+	if err := validate[R](body); err != nil {
+		return payload, err
+	}
+
+	var wrapper types.Wrapper
+	if err := json.Unmarshal(body, &wrapper); err != nil {
+		return payload, err
+	}
+	if _, ok := wrapper.Value.(R); !ok {
+		return payload, fmt.Errorf("unexpected type described in the request body: expected %T, got %T", payload, wrapper.Value)
+	}
+
+	return wrapper.Value.(R), nil
+}
+
+func validate[R corev3.Resource](b []byte) error {
+	var w rawWrapper
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+
+	var missing []string
+	if w.APIVersion == "" {
+		missing = append(missing, "api_version")
+	}
+	if w.Type == "" {
+		missing = append(missing, "type")
+	}
+	if len(w.ObjectMeta) == 0 {
+		missing = append(missing, "metadata")
+	}
+	if len(w.Spec) == 0 {
+		missing = append(missing, "spec")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required resource identifying fields: %v. could be using an unsupported legacy request format", missing)
+	}
+
+	if t, err := apitools.Resolve(w.APIVersion, w.Type); err != nil {
+		return fmt.Errorf("error resolving the resource type described in the request body: %v", err)
+	} else if _, ok := t.(R); !ok {
+		var expected R
+		return fmt.Errorf("type described in the request body unexpected: expected %T, got %T", expected, t)
+	}
+	return nil
+}
+
+type rawWrapper struct {
+	APIVersion string          `json:"api_version"`
+	Type       string          `json:"type"`
+	ObjectMeta json.RawMessage `json:"metadata"`
+	Spec       json.RawMessage `json:"spec"`
+}

--- a/backend/apid/request/resource_test.go
+++ b/backend/apid/request/resource_test.go
@@ -1,0 +1,80 @@
+package request
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev2 "github.com/sensu/core/v2"
+	corev3 "github.com/sensu/core/v3"
+	"github.com/sensu/sensu-go/types"
+)
+
+func TestResource(t *testing.T) {
+	testCases := []struct {
+		Name    string
+		Request *http.Request
+
+		ExpectedResource corev3.Resource
+		CheckError       func(*testing.T, error)
+	}{
+		{
+			Name:       "empty request errors",
+			Request:    newRequest([]byte("{}")),
+			CheckError: assertError,
+		}, {
+			Name: "error for legacy request format",
+			Request: newRequest(func() []byte {
+				b, _ := json.Marshal(corev2.FixtureCheckConfig("test"))
+				return b
+			}()),
+			CheckError: func(t *testing.T, err error) {
+				assertError(t, err)
+			},
+		}, {
+			Name: "error for different resource type",
+			Request: newRequest(func() []byte {
+				b, _ := json.Marshal(types.WrapResource(corev2.FixtureHandler("test")))
+				return b
+			}()),
+			CheckError: assertError,
+		}, {
+			Name: "success",
+			Request: newRequest(func() []byte {
+				b, _ := json.Marshal(types.WrapResource(corev2.FixtureCheckConfig("test")))
+				return b
+			}()),
+			CheckError: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual, err := Resource[*corev2.CheckConfig](tc.Request)
+			tc.CheckError(t, err)
+			if tc.ExpectedResource == nil {
+				return
+			}
+			if !cmp.Equal(tc.ExpectedResource, actual) {
+				t.Error(cmp.Diff(tc.ExpectedResource, actual))
+			}
+		})
+	}
+}
+
+func newRequest(b []byte) *http.Request {
+	r, _ := http.NewRequest(http.MethodHead, "", bytes.NewBuffer(b))
+	return r
+}
+
+func assertError(t *testing.T, err error) {
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/backend/apid/routers/apikeys.go
+++ b/backend/apid/routers/apikeys.go
@@ -17,9 +17,11 @@ import (
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/authentication/bcrypt"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // APIKeysRouter handles requests for /apikeys.
@@ -51,8 +53,8 @@ func (r *APIKeysRouter) Mount(parent *mux.Router) {
 }
 
 func (r *APIKeysRouter) create(w http.ResponseWriter, req *http.Request) {
-	apikey := &corev2.APIKey{}
-	if err := UnmarshalBody(req, apikey); err != nil {
+	apikey, err := request.Resource[*corev2.APIKey](req)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -96,7 +98,7 @@ func (r *APIKeysRouter) create(w http.ResponseWriter, req *http.Request) {
 
 MARSHAL:
 
-	newBytes, err := json.Marshal(apikey)
+	newBytes, err := json.Marshal(types.WrapResource(apikey))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/backend/apid/routers/apikeys_test.go
+++ b/backend/apid/routers/apikeys_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -50,7 +51,7 @@ func TestPostAPIKey(t *testing.T) {
 
 	// Prepare the HTTP request
 	fixture := corev2.FixtureAPIKey("226f9e06-9d54-45c6-a9f6-4206bfa7ccf6", "admin")
-	payload, err := json.Marshal(fixture)
+	payload, err := json.Marshal(types.WrapResource(fixture))
 	assert.NoError(t, err)
 	client := new(http.Client)
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/apikeys", bytes.NewReader(payload))
@@ -85,7 +86,7 @@ func TestPostAPIKeyInvalidUser(t *testing.T) {
 
 	// Prepare the HTTP request
 	fixture := corev2.FixtureAPIKey("226f9e06-9d54-45c6-a9f6-4206bfa7ccf6", "admin")
-	payload, err := json.Marshal(fixture)
+	payload, err := json.Marshal(types.WrapResource(fixture))
 	assert.NoError(t, err)
 	client := new(http.Client)
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/apikeys", bytes.NewReader(payload))

--- a/backend/apid/routers/checks_test.go
+++ b/backend/apid/routers/checks_test.go
@@ -112,7 +112,7 @@ func TestChecksRouterCustomRoutes(t *testing.T) {
 			name:   "it adds a check hook to a check",
 			method: http.MethodPut,
 			path:   "/namespaces/default/checks/check1/hooks/non-zero",
-			body:   marshal(corev2.FixtureHookList("hook1")),
+			body:   marshalRaw(corev2.FixtureHookList("hook1")),
 			controllerFunc: func(c *mockCheckController) {
 				c.On("AddCheckHook", mock.Anything, "check1", mock.AnythingOfType("v2.HookList")).Return(nil)
 			},

--- a/backend/apid/routers/entities.go
+++ b/backend/apid/routers/entities.go
@@ -11,6 +11,7 @@ import (
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
@@ -77,17 +78,17 @@ func (r *EntitiesRouter) find(req *http.Request) (corev3.Resource, error) {
 }
 
 func (r *EntitiesRouter) create(req *http.Request) (corev3.Resource, error) {
-	entity := corev2.Entity{}
-	if err := UnmarshalBody(req, &entity); err != nil {
+	entity, err := request.Resource[*corev2.Entity](req)
+	if err != nil {
 		return nil, err
 	}
-	err := r.controller.Create(req.Context(), entity)
-	return &entity, err
+	err = r.controller.Create(req.Context(), *entity)
+	return entity, err
 }
 
 func (r *EntitiesRouter) createOrReplace(req *http.Request) (corev3.Resource, error) {
-	entity := corev2.Entity{}
-	if err := UnmarshalBody(req, &entity); err != nil {
+	entity, err := request.Resource[*corev2.Entity](req)
+	if err != nil {
 		return nil, err
 	}
 
@@ -95,5 +96,5 @@ func (r *EntitiesRouter) createOrReplace(req *http.Request) (corev3.Resource, er
 		return nil, actions.NewError(actions.AlreadyExistsErr, errors.New("entity is managed by its agent"))
 	}
 
-	return &entity, r.controller.CreateOrReplace(req.Context(), entity)
+	return entity, r.controller.CreateOrReplace(req.Context(), *entity)
 }

--- a/backend/apid/routers/events.go
+++ b/backend/apid/routers/events.go
@@ -11,6 +11,7 @@ import (
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
@@ -72,8 +73,8 @@ func (r *EventsRouter) delete(req *http.Request) (corev3.Resource, error) {
 }
 
 func (r *EventsRouter) create(req *http.Request) (corev3.Resource, error) {
-	event := &corev2.Event{}
-	if err := UnmarshalBody(req, event); err != nil {
+	event, err := request.Resource[*corev2.Event](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -82,13 +83,13 @@ func (r *EventsRouter) create(req *http.Request) (corev3.Resource, error) {
 		return nil, err
 	}
 
-	err := r.controller.CreateOrReplace(req.Context(), event)
+	err = r.controller.CreateOrReplace(req.Context(), event)
 	return nil, err
 }
 
 func (r *EventsRouter) createOrReplace(req *http.Request) (corev3.Resource, error) {
-	event := &corev2.Event{}
-	if err := UnmarshalBody(req, event); err != nil {
+	event, err := request.Resource[*corev2.Event](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -97,7 +98,7 @@ func (r *EventsRouter) createOrReplace(req *http.Request) (corev3.Resource, erro
 		return nil, err
 	}
 
-	err := r.controller.CreateOrReplace(req.Context(), event)
+	err = r.controller.CreateOrReplace(req.Context(), event)
 	return nil, err
 }
 

--- a/backend/apid/routers/events_test.go
+++ b/backend/apid/routers/events_test.go
@@ -122,7 +122,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 400 if the event to create is not valid",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InvalidArgument)).
@@ -134,7 +134,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while creating an event",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -146,7 +146,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 201 when an event is successfully created",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).
@@ -182,7 +182,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 400 if the event to update is not valid",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InvalidArgument)).
@@ -194,7 +194,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while updating an event",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -206,7 +206,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 201 when an event is successfully updated",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).
@@ -218,7 +218,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 201 when an event does not provide a namespace (using url namespace)",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture_wo_namespace),
+			body:   marshalWrapped(fixture_wo_namespace),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).
@@ -282,7 +282,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 400 if the event to update is invalid (post)",
 			method: http.MethodPost,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InvalidArgument)).
@@ -294,7 +294,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while updating an event (post)",
 			method: http.MethodPost,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -306,7 +306,7 @@ func TestEventsRouter(t *testing.T) {
 			name:   "it returns 201 when an event is successfully updated (post)",
 			method: http.MethodPost,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockEventController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).

--- a/backend/apid/routers/gone.go
+++ b/backend/apid/routers/gone.go
@@ -1,0 +1,15 @@
+package routers
+
+import (
+	"net/http"
+
+	"github.com/sensu/sensu-go/backend/apid/actions"
+)
+
+// HandleGone returns a http.HandlerFunc that will respond with a HTTP 410 Gone
+// status and will include the provided error message in the error body.
+func HandleGone(message string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		WriteError(w, actions.NewErrorf(actions.Gone, message))
+	}
+}

--- a/backend/apid/routers/helpers_test.go
+++ b/backend/apid/routers/helpers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 	"github.com/sensu/sensu-go/testing/mockstore"
+	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -239,7 +240,7 @@ func createResourceAlreadyExistsTestCase(resource corev3.Resource) routerTestCas
 	}
 	r.SetMetadata(&corev2.ObjectMeta{Name: "createResourceAlreadyExistsTestCase", Namespace: namespace})
 
-	body := marshal(r)
+	body := marshalWrapped(r)
 
 	return routerTestCase{
 		name:   "it returns 409 if the resource to create already exists",
@@ -266,7 +267,7 @@ func createResourceInvalidTestCase(resource corev3.Resource) routerTestCase {
 	}
 	r.SetMetadata(&corev2.ObjectMeta{Name: "createResourceInvalidTestCase", Namespace: namespace})
 
-	body := marshal(r)
+	body := marshalWrapped(r)
 
 	return routerTestCase{
 		name:   "it returns 400 if the resource to create is invalid",
@@ -293,7 +294,7 @@ func createResourceStoreErrTestCase(resource corev3.Resource) routerTestCase {
 	}
 	r.SetMetadata(&corev2.ObjectMeta{Name: "createResourceStoreErrTestCase", Namespace: namespace})
 
-	body := marshal(r)
+	body := marshalWrapped(r)
 
 	return routerTestCase{
 		name:   "it returns 500 if the store returns an error while creating",
@@ -320,7 +321,7 @@ func createResourceSuccessTestCase(resource corev3.Resource) routerTestCase {
 	}
 	r.SetMetadata(&corev2.ObjectMeta{Name: "createResourceSuccessTestCase", Namespace: namespace})
 
-	body := marshal(r)
+	body := marshalWrapped(r)
 
 	return routerTestCase{
 		name:   "it returns 201 if the resource was created",
@@ -378,7 +379,7 @@ func updateResourceInvalidTestCase(resource corev3.Resource) routerTestCase {
 		name:   "it returns 400 if the resource to update is invalid",
 		method: http.MethodPut,
 		path:   resource.URIPath(),
-		body:   marshal(resource),
+		body:   marshalWrapped(resource),
 		storeFunc: func(s *mockstore.V2MockStore) {
 			cs := s.GetConfigStore().(*mockstore.ConfigStore)
 			cs.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
@@ -395,7 +396,7 @@ func updateResourceStoreErrTestCase(resource corev3.Resource) routerTestCase {
 		name:   "it returns 500 if the store returns an error while updating",
 		method: http.MethodPut,
 		path:   resource.URIPath(),
-		body:   marshal(resource),
+		body:   marshalWrapped(resource),
 		storeFunc: func(s *mockstore.V2MockStore) {
 			cs := s.GetConfigStore().(*mockstore.ConfigStore)
 			cs.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
@@ -412,7 +413,7 @@ func updateResourceSuccessTestCase(resource corev3.Resource) routerTestCase {
 		name:   "it returns 201 if the resource was updated",
 		method: http.MethodPut,
 		path:   resource.URIPath(),
-		body:   marshal(resource),
+		body:   marshalWrapped(resource),
 		storeFunc: func(s *mockstore.V2MockStore) {
 			cs := s.GetConfigStore().(*mockstore.ConfigStore)
 			cs.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).
@@ -499,7 +500,12 @@ func deleteResourceSuccessTestCase(resource corev3.Resource) routerTestCase {
 	}
 }
 
-func marshal(v interface{}) []byte {
+func marshalWrapped(v corev3.Resource) []byte {
+	bytes, _ := json.Marshal(types.WrapResource(v))
+	return bytes
+}
+
+func marshalRaw(v any) []byte {
 	bytes, _ := json.Marshal(v)
 	return bytes
 }

--- a/backend/apid/routers/routers_test.go
+++ b/backend/apid/routers/routers_test.go
@@ -397,9 +397,6 @@ func TestUnmarshalBody(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := UnmarshalBody(tt.args.req, tt.args.record); (err != nil) != tt.wantErr {
-				t.Errorf("UnmarshalBody() error = %v, wantErr %v", err, tt.wantErr)
-			}
 		})
 	}
 }

--- a/backend/apid/routers/silenced.go
+++ b/backend/apid/routers/silenced.go
@@ -10,6 +10,7 @@ import (
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/apid/handlers"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
@@ -68,8 +69,8 @@ func (r *SilencedRouter) get(req *http.Request) (corev3.Resource, error) {
 }
 
 func (r *SilencedRouter) create(req *http.Request) (corev3.Resource, error) {
-	entry := &corev2.Silenced{}
-	if err := UnmarshalBody(req, entry); err != nil {
+	entry, err := request.Resource[*corev2.Silenced](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -77,13 +78,13 @@ func (r *SilencedRouter) create(req *http.Request) (corev3.Resource, error) {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	err := r.controller.Create(req.Context(), entry)
+	err = r.controller.Create(req.Context(), entry)
 	return nil, err
 }
 
 func (r *SilencedRouter) createOrReplace(req *http.Request) (corev3.Resource, error) {
-	entry := &corev2.Silenced{}
-	if err := UnmarshalBody(req, entry); err != nil {
+	entry, err := request.Resource[*corev2.Silenced](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -91,7 +92,7 @@ func (r *SilencedRouter) createOrReplace(req *http.Request) (corev3.Resource, er
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	err := r.controller.CreateOrReplace(req.Context(), entry)
+	err = r.controller.CreateOrReplace(req.Context(), entry)
 	return nil, err
 }
 

--- a/backend/apid/routers/silenced_test.go
+++ b/backend/apid/routers/silenced_test.go
@@ -97,7 +97,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while creating a silenced entry",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockSilencedController) {
 				c.On("Create", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -109,7 +109,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 			name:   "it returns 201 when an event is successfully created",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockSilencedController) {
 				c.On("Create", mock.Anything, mock.Anything).
 					Return(nil).
@@ -135,7 +135,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while updating a silenced entry",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockSilencedController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -147,7 +147,7 @@ func TestSilencedRouterCustomRoutes(t *testing.T) {
 			name:   "it returns 201 when a silenced entry is successfully updated",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockSilencedController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).

--- a/backend/apid/routers/tessen.go
+++ b/backend/apid/routers/tessen.go
@@ -2,11 +2,13 @@ package routers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
+	"github.com/sensu/sensu-go/backend/apid/request"
 )
 
 // TessenController represents the controller needs of the TessenRouter.
@@ -39,12 +41,12 @@ func (r *TessenRouter) Mount(parent *mux.Router) {
 }
 
 func (r *TessenRouter) createOrUpdate(req *http.Request) (corev3.Resource, error) {
-	obj := &corev2.TessenConfig{}
-	if err := UnmarshalBody(req, &obj); err != nil {
+	obj, err := request.Resource[*corev2.TessenConfig](req)
+	if err != nil {
 		return nil, err
 	}
 
-	err := r.controller.CreateOrUpdate(req.Context(), obj)
+	err = r.controller.CreateOrUpdate(req.Context(), obj)
 	return obj, err
 }
 
@@ -81,8 +83,8 @@ func (r *TessenMetricRouter) Mount(parent *mux.Router) {
 }
 
 func (r *TessenMetricRouter) publish(req *http.Request) (corev3.Resource, error) {
-	obj := []corev2.MetricPoint{}
-	if err := UnmarshalBody(req, &obj); err != nil {
+	var obj []corev2.MetricPoint
+	if err := json.NewDecoder(req.Body).Decode(&obj); err != nil {
 		return nil, err
 	}
 

--- a/backend/apid/routers/tessen_test.go
+++ b/backend/apid/routers/tessen_test.go
@@ -43,7 +43,7 @@ func TestPutTessen(t *testing.T) {
 	client := new(http.Client)
 
 	controller.On("CreateOrUpdate", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	b, _ := json.Marshal(corev2.DefaultTessenConfig())
+	b := marshalWrapped(corev2.DefaultTessenConfig())
 	body := bytes.NewReader(b)
 	endpoint := "/" + corev2.TessenResource
 	req := newRequest(t, http.MethodPut, server.URL+endpoint, body)
@@ -110,7 +110,7 @@ func TestPostTessenMetrics(t *testing.T) {
 
 	controller.On("Publish", mock.Anything, mock.Anything).Return(nil)
 	b, _ := json.Marshal([]corev2.MetricPoint{
-		corev2.MetricPoint{
+		{
 			Name:  "metric",
 			Value: 1,
 		},

--- a/backend/apid/routers/users.go
+++ b/backend/apid/routers/users.go
@@ -2,6 +2,7 @@ package routers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/backend/apid/actions"
+	"github.com/sensu/sensu-go/backend/apid/request"
 	"github.com/sensu/sensu-go/backend/store"
 	storev2 "github.com/sensu/sensu-go/backend/store/v2"
 )
@@ -79,18 +81,18 @@ func (r *UsersRouter) get(req *http.Request) (corev3.Resource, error) {
 }
 
 func (r *UsersRouter) create(req *http.Request) (corev3.Resource, error) {
-	user := &corev2.User{}
-	if err := UnmarshalBody(req, user); err != nil {
+	user, err := request.Resource[*corev2.User](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
-	err := r.controller.Create(req.Context(), user)
+	err = r.controller.Create(req.Context(), user)
 	return nil, err
 }
 
 func (r *UsersRouter) createOrReplace(req *http.Request) (corev3.Resource, error) {
-	user := &corev2.User{}
-	if err := UnmarshalBody(req, user); err != nil {
+	user, err := request.Resource[*corev2.User](req)
+	if err != nil {
 		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
@@ -104,7 +106,7 @@ func (r *UsersRouter) createOrReplace(req *http.Request) (corev3.Resource, error
 			))
 	}
 
-	err := r.controller.CreateOrReplace(req.Context(), user)
+	err = r.controller.CreateOrReplace(req.Context(), user)
 	return nil, err
 }
 
@@ -130,9 +132,9 @@ func (r *UsersRouter) reinstate(req *http.Request) (corev3.Resource, error) {
 
 // updatePassword updates a user password by requiring the current password
 func (r *UsersRouter) updatePassword(req *http.Request) (corev3.Resource, error) {
-	params := map[string]string{}
-	if err := UnmarshalBody(req, &params); err != nil {
-		return nil, err
+	params := make(map[string]string)
+	if err := json.NewDecoder(req.Body).Decode(&params); err != nil {
+		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
 	vars := mux.Vars(req)
@@ -157,9 +159,9 @@ func (r *UsersRouter) updatePassword(req *http.Request) (corev3.Resource, error)
 
 // resetPassword updates a user password without any kind of verification
 func (r *UsersRouter) resetPassword(req *http.Request) (corev3.Resource, error) {
-	params := map[string]string{}
-	if err := UnmarshalBody(req, &params); err != nil {
-		return nil, err
+	params := make(map[string]string)
+	if err := json.NewDecoder(req.Body).Decode(&params); err != nil {
+		return nil, actions.NewError(actions.InvalidArgument, err)
 	}
 
 	vars := mux.Vars(req)

--- a/backend/apid/routers/users_test.go
+++ b/backend/apid/routers/users_test.go
@@ -145,7 +145,7 @@ func TestUsersRouter(t *testing.T) {
 			name:   "it returns 400 if the user to create is not valid",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockUserController) {
 				c.On("Create", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InvalidArgument)).
@@ -157,7 +157,7 @@ func TestUsersRouter(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while creating a user",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockUserController) {
 				c.On("Create", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -169,7 +169,7 @@ func TestUsersRouter(t *testing.T) {
 			name:   "it returns 201 when a user is successfully created",
 			method: http.MethodPost,
 			path:   empty.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockUserController) {
 				c.On("Create", mock.Anything, mock.Anything).
 					Return(nil).
@@ -195,7 +195,7 @@ func TestUsersRouter(t *testing.T) {
 			name:   "it returns 500 if the store returns an error while updating a user",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockUserController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(actions.NewErrorf(actions.InternalErr)).
@@ -207,7 +207,7 @@ func TestUsersRouter(t *testing.T) {
 			name:   "it returns 201 when an event is successfully updated",
 			method: http.MethodPut,
 			path:   fixture.URIPath(),
-			body:   marshal(fixture),
+			body:   marshalWrapped(fixture),
 			controllerFunc: func(c *mockUserController) {
 				c.On("CreateOrReplace", mock.Anything, mock.Anything).
 					Return(nil).

--- a/cli/client/apikey_test.go
+++ b/cli/client/apikey_test.go
@@ -69,19 +69,27 @@ func TestListAPIKeys(t *testing.T) {
 		assert.Equal(t, r.Method, http.MethodGet)
 		assert.NotEmpty(t, r.Header["Authorization"])
 		_, _ = w.Write([]byte(`[{
-"metadata": {
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
     "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5b",
     "created_by": "admin"
   },
-  "username": "user1",
-  "created_at": 1570640363
+  "spec": {
+    "username": "user1",
+    "created_at": 1570640363
+  }
 },{
-"metadata": {
+  "type": "APIKey",
+  "api_version": "core/v2",
+  "metadata": {
     "name": "83abef1e-e7d7-4beb-91fc-79ad90084d5p",
     "created_by": "admin"
   },
-  "username": "user2",
-  "created_at": 1570640370
+  "spec": {
+    "username": "user2",
+    "created_at": 1570640370
+  }
 }]`))
 	}
 	server := httptest.NewServer(http.HandlerFunc(testHandler))

--- a/cli/client/asset.go
+++ b/cli/client/asset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // AssetsPath is the api path for assets.
@@ -24,13 +25,14 @@ func (client *RestClient) FetchAsset(name string) (*corev2.Asset, error) {
 		return &asset, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &asset)
-	return &asset, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.Asset), err
 }
 
 // CreateAsset creates an asset resource from the backend
 func (client *RestClient) CreateAsset(asset *corev2.Asset) error {
-	bytes, err := json.Marshal(asset)
+	bytes, err := json.Marshal(types.WrapResource(asset))
 	if err != nil {
 		return err
 	}
@@ -54,7 +56,7 @@ func (client *RestClient) CreateAsset(asset *corev2.Asset) error {
 
 // UpdateAsset updates an asset resource from the backend
 func (client *RestClient) UpdateAsset(asset *corev2.Asset) (err error) {
-	bytes, err := json.Marshal(asset)
+	bytes, err := json.Marshal(types.WrapResource(asset))
 	if err != nil {
 		return err
 	}

--- a/cli/client/clusterrole.go
+++ b/cli/client/clusterrole.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // ClusterRolesPath is the api path for cluster roles.
@@ -19,9 +20,9 @@ func (client *RestClient) DeleteClusterRole(name string) error {
 
 // FetchClusterRole with the given name
 func (client *RestClient) FetchClusterRole(name string) (*corev2.ClusterRole, error) {
-	clusterRole := &corev2.ClusterRole{}
-	if err := client.Get(ClusterRolesPath(name), clusterRole); err != nil {
+	var wrapper types.Wrapper
+	if err := client.Get(ClusterRolesPath(name), &wrapper); err != nil {
 		return nil, err
 	}
-	return clusterRole, nil
+	return wrapper.Value.(*corev2.ClusterRole), nil
 }

--- a/cli/client/clusterrolebinding.go
+++ b/cli/client/clusterrolebinding.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // ClusterRoleBindingsPath is the api path for cluster role bindings.
@@ -19,9 +20,9 @@ func (client *RestClient) DeleteClusterRoleBinding(name string) error {
 
 // FetchClusterRoleBinding with the given name
 func (client *RestClient) FetchClusterRoleBinding(name string) (*corev2.ClusterRoleBinding, error) {
-	clusterRoleBinding := &corev2.ClusterRoleBinding{}
-	if err := client.Get(ClusterRoleBindingsPath(name), clusterRoleBinding); err != nil {
+	var wrapper types.Wrapper
+	if err := client.Get(ClusterRoleBindingsPath(name), &wrapper); err != nil {
 		return nil, err
 	}
-	return clusterRoleBinding, nil
+	return wrapper.Value.(*corev2.ClusterRoleBinding), nil
 }

--- a/cli/client/filter.go
+++ b/cli/client/filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // FiltersPath is the api path for filters.
@@ -11,7 +12,7 @@ var FiltersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "filters")
 
 // CreateFilter creates a new filter on configured Sensu instance
 func (client *RestClient) CreateFilter(filter *corev2.EventFilter) (err error) {
-	bytes, err := json.Marshal(filter)
+	bytes, err := json.Marshal(types.WrapResource(filter))
 	if err != nil {
 		return err
 	}
@@ -36,8 +37,6 @@ func (client *RestClient) DeleteFilter(namespace, name string) error {
 
 // FetchFilter fetches a specific check
 func (client *RestClient) FetchFilter(name string) (*corev2.EventFilter, error) {
-	var filter *corev2.EventFilter
-
 	path := FiltersPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
@@ -48,13 +47,14 @@ func (client *RestClient) FetchFilter(name string) (*corev2.EventFilter, error) 
 		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &filter)
-	return filter, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.EventFilter), err
 }
 
 // UpdateFilter updates an existing filter with fields from a new one.
 func (client *RestClient) UpdateFilter(f *corev2.EventFilter) error {
-	b, err := json.Marshal(f)
+	b, err := json.Marshal(types.WrapResource(f))
 	if err != nil {
 		return err
 	}

--- a/cli/client/handler.go
+++ b/cli/client/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // HandlersPath is the api path for handlers.
@@ -11,7 +12,7 @@ var HandlersPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "handlers")
 
 // CreateHandler creates new handler on configured Sensu instance
 func (client *RestClient) CreateHandler(handler *corev2.Handler) (err error) {
-	bytes, err := json.Marshal(handler)
+	bytes, err := json.Marshal(types.WrapResource(handler))
 	if err != nil {
 		return err
 	}
@@ -36,7 +37,6 @@ func (client *RestClient) DeleteHandler(namespace, name string) (err error) {
 
 // FetchHandler fetches a specific handler
 func (client *RestClient) FetchHandler(name string) (*corev2.Handler, error) {
-	var handler *corev2.Handler
 	path := HandlersPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
@@ -47,13 +47,14 @@ func (client *RestClient) FetchHandler(name string) (*corev2.Handler, error) {
 		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &handler)
-	return handler, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.Handler), err
 }
 
 // UpdateHandler updates given handler on configured Sensu instance
 func (client *RestClient) UpdateHandler(handler *corev2.Handler) (err error) {
-	bytes, err := json.Marshal(handler)
+	bytes, err := json.Marshal(types.WrapResource(handler))
 	if err != nil {
 		return err
 	}

--- a/cli/client/hook.go
+++ b/cli/client/hook.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // HooksPath is the api path for hooks.
@@ -11,7 +12,7 @@ var HooksPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "hooks")
 
 // CreateHook creates new hook on configured Sensu instance
 func (client *RestClient) CreateHook(hook *corev2.HookConfig) (err error) {
-	bytes, err := json.Marshal(hook)
+	bytes, err := json.Marshal(types.WrapResource(hook))
 	if err != nil {
 		return err
 	}
@@ -31,7 +32,7 @@ func (client *RestClient) CreateHook(hook *corev2.HookConfig) (err error) {
 
 // UpdateHook updates given hook on configured Sensu instance
 func (client *RestClient) UpdateHook(hook *corev2.HookConfig) (err error) {
-	bytes, err := json.Marshal(hook)
+	bytes, err := json.Marshal(types.WrapResource(hook))
 	if err != nil {
 		return err
 	}
@@ -56,8 +57,6 @@ func (client *RestClient) DeleteHook(namespace, name string) error {
 
 // FetchHook fetches a specific hook
 func (client *RestClient) FetchHook(name string) (*corev2.HookConfig, error) {
-	var hook *corev2.HookConfig
-
 	path := HooksPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
@@ -68,6 +67,7 @@ func (client *RestClient) FetchHook(name string) (*corev2.HookConfig, error) {
 		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &hook)
-	return hook, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.HookConfig), err
 }

--- a/cli/client/interface.go
+++ b/cli/client/interface.go
@@ -64,7 +64,7 @@ type GenericClient interface {
 	// List retrieves all keys with the given path prefix and stores them into objs
 	List(path string, objs interface{}, options *ListOptions, header *http.Header) error
 	// Post creates the given obj at the specified path
-	Post(path string, obj interface{}) error
+	Post(path string, obj corev3.Resource) error
 	// Put creates the given obj at the specified path
 	Put(path string, obj interface{}) error
 	// PostWithResponse creates the given obj at the specified path, returning the response

--- a/cli/client/namespace.go
+++ b/cli/client/namespace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev3 "github.com/sensu/core/v3"
+	"github.com/sensu/sensu-go/types"
 )
 
 // NamespacesPath is the api path for namespaces.
@@ -11,7 +12,7 @@ var NamespacesPath = CreateBasePath("core", "v3", "namespaces")
 
 // CreateNamespace creates new namespace on configured Sensu instance
 func (client *RestClient) CreateNamespace(namespace *corev3.Namespace) error {
-	bytes, err := json.Marshal(namespace)
+	bytes, err := json.Marshal(types.WrapResource(namespace))
 	if err != nil {
 		return err
 	}
@@ -32,7 +33,7 @@ func (client *RestClient) CreateNamespace(namespace *corev3.Namespace) error {
 
 // UpdateNamespace updates given namespace on a configured Sensu instance
 func (client *RestClient) UpdateNamespace(namespace *corev3.Namespace) error {
-	bytes, err := json.Marshal(namespace)
+	bytes, err := json.Marshal(types.WrapResource(namespace))
 	if err != nil {
 		return err
 	}
@@ -57,18 +58,17 @@ func (client *RestClient) DeleteNamespace(namespace string) error {
 
 // FetchNamespace fetches an namespace by name
 func (client *RestClient) FetchNamespace(namespaceName string) (*corev3.Namespace, error) {
-	var namespace *corev3.Namespace
-
 	path := NamespacesPath(namespaceName)
 	res, err := client.R().Get(path)
 	if err != nil {
-		return namespace, err
+		return nil, err
 	}
 
 	if res.StatusCode() >= 400 {
-		return namespace, UnmarshalError(res)
+		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &namespace)
-	return namespace, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev3.Namespace), err
 }

--- a/cli/client/pipeline.go
+++ b/cli/client/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // PipelinesPath is the api path for pipelines.
@@ -11,8 +12,6 @@ var PipelinesPath = createNSBasePath(coreAPIGroup, coreAPIVersion, "pipelines")
 
 // FetchPipeline fetches a specific pipeline
 func (client *RestClient) FetchPipeline(name string) (*corev2.Pipeline, error) {
-	var pipeline *corev2.Pipeline
-
 	path := PipelinesPath(client.config.Namespace(), name)
 	res, err := client.R().Get(path)
 	if err != nil {
@@ -23,8 +22,9 @@ func (client *RestClient) FetchPipeline(name string) (*corev2.Pipeline, error) {
 		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), &pipeline)
-	return pipeline, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.Pipeline), err
 }
 
 // DeletePipeline deletes a pipeline.
@@ -34,7 +34,7 @@ func (client *RestClient) DeletePipeline(namespace, name string) error {
 
 // UpdatePipeline updates a pipeline.
 func (client *RestClient) UpdatePipeline(pipeline *corev2.Pipeline) error {
-	bytes, err := json.Marshal(pipeline)
+	bytes, err := json.Marshal(types.WrapResource(pipeline))
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (client *RestClient) UpdatePipeline(pipeline *corev2.Pipeline) error {
 
 // CreatePipeline creates a new pipeline
 func (client *RestClient) CreatePipeline(pipeline *corev2.Pipeline) (err error) {
-	bytes, err := json.Marshal(pipeline)
+	bytes, err := json.Marshal(types.WrapResource(pipeline))
 	if err != nil {
 		return err
 	}

--- a/cli/client/testing/mock_generic.go
+++ b/cli/client/testing/mock_generic.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-resty/resty/v2"
+	corev3 "github.com/sensu/core/v3"
 	"github.com/sensu/sensu-go/cli/client"
 	"github.com/sensu/sensu-go/types"
 )
@@ -27,7 +28,7 @@ func (c *MockClient) List(path string, objs interface{}, options *client.ListOpt
 }
 
 // Post ...
-func (c *MockClient) Post(path string, obj interface{}) error {
+func (c *MockClient) Post(path string, obj corev3.Resource) error {
 	args := c.Called(path, obj)
 	return args.Error(0)
 }

--- a/cli/client/user.go
+++ b/cli/client/user.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/types"
 )
 
 // UsersPath is the api path for users.
@@ -27,7 +28,7 @@ func (client *RestClient) AddGroupToUser(username, group string) error {
 // CreateUser creates new check on configured Sensu instance
 func (client *RestClient) CreateUser(user *corev2.User) error {
 	path := UsersPath("")
-	res, err := client.R().SetBody(user).Post(path)
+	res, err := client.R().SetBody(types.WrapResource(user)).Post(path)
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,6 @@ func (client *RestClient) DisableUser(username string) error {
 
 // FetchUser retrieve the given user
 func (client *RestClient) FetchUser(username string) (*corev2.User, error) {
-	user := &corev2.User{}
 	path := UsersPath(username)
 	res, err := client.R().Get(path)
 
@@ -69,8 +69,9 @@ func (client *RestClient) FetchUser(username string) (*corev2.User, error) {
 		return nil, UnmarshalError(res)
 	}
 
-	err = json.Unmarshal(res.Body(), user)
-	return user, err
+	var wrapper types.Wrapper
+	err = json.Unmarshal(res.Body(), &wrapper)
+	return wrapper.Value.(*corev2.User), err
 }
 
 // ReinstateUser reinstates a disabled user on configured Sensu instance

--- a/cli/commands/asset/add.go
+++ b/cli/commands/asset/add.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/sensu/sensu-go/bonsai"
 	"github.com/sensu/sensu-go/cli"
+	"github.com/sensu/sensu-go/cli/resource"
 	"github.com/spf13/cobra"
 
 	goversion "github.com/hashicorp/go-version"
-	"github.com/sensu/sensu-go/cli/resource"
 	"github.com/sensu/sensu-go/types/compat"
 )
 
@@ -94,6 +94,7 @@ func addCommandExecute(cli *cli.SensuCli) func(cmd *cobra.Command, args []string
 			} else {
 				meta.Name = assetPath
 			}
+			resources[i].ObjectMeta = *meta
 			compat.SetObjectMeta(resources[i].Value, meta)
 		}
 		processor := resource.NewPutter()

--- a/cli/commands/asset/list_test.go
+++ b/cli/commands/asset/list_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	corev2 "github.com/sensu/core/v2"
@@ -237,6 +238,11 @@ func TestListBuildsWithJSON(t *testing.T) {
 
 	// Make sure the asset's builds have *not* been seperated into several assets
 	output := []map[string]interface{}{}
-	_ = json.Unmarshal([]byte(out), &output)
+	dec := json.NewDecoder(strings.NewReader(out))
+	for dec.More() {
+		var r map[string]interface{}
+		dec.Decode(&r)
+		output = append(output, r)
+	}
 	assert.Len(output, 1)
 }

--- a/cli/commands/configure/configure.go
+++ b/cli/commands/configure/configure.go
@@ -179,7 +179,6 @@ func AskForDefaultFormat(c config.Config) *survey.Question {
 			Options: []string{
 				config.FormatTabular,
 				config.FormatYAML,
-				config.FormatWrappedJSON,
 				config.FormatJSON,
 			},
 			Default: format,

--- a/cli/commands/describetype/describe_type.go
+++ b/cli/commands/describetype/describe_type.go
@@ -46,7 +46,7 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 	}
 
 	format := cli.Config.Format()
-	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
+	_ = cmd.Flags().StringP("format", "", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatJSON, config.FormatYAML))
 
 	return cmd
 }
@@ -84,7 +84,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 			resources = append(resources, r)
 		}
 		switch getFormat(cli, cmd) {
-		case config.FormatJSON, config.FormatWrappedJSON:
+		case config.FormatJSON:
 			return helpers.PrintJSON(resources, cmd.OutOrStdout())
 		case config.FormatYAML:
 			return helpers.PrintYAML(resources, cmd.OutOrStdout())

--- a/cli/commands/dump/dump.go
+++ b/cli/commands/dump/dump.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"reflect"
 
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
@@ -50,10 +49,10 @@ func Command(cli *cli.SensuCli) *cobra.Command {
 
 	helpers.AddAllNamespace(cmd.Flags())
 	format := cli.Config.Format()
-	if format != config.FormatWrappedJSON && format != config.FormatYAML {
+	if format != config.FormatJSON && format != config.FormatYAML {
 		format = config.FormatYAML
 	}
-	_ = cmd.Flags().String("format", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatWrappedJSON, config.FormatYAML))
+	_ = cmd.Flags().String("format", format, fmt.Sprintf(`format of data returned ("%s"|"%s")`, config.FormatJSON, config.FormatYAML))
 	_ = cmd.Flags().StringP("file", "f", "", "file to dump resources to")
 	_ = cmd.Flags().BoolP("types", "t", false, "list supported resource types")
 	_ = cmd.Flags().MarkDeprecated("types", `please use "sensuctl describe-type all" instead`)
@@ -69,7 +68,7 @@ func printAllTypes(cli *cli.SensuCli, cmd *cobra.Command) error {
 		typeNames = append(typeNames, fmt.Sprintf("%s.%s", wrapped.APIVersion, wrapped.Type))
 	}
 	switch getFormat(cli, cmd) {
-	case config.FormatJSON, config.FormatWrappedJSON:
+	case config.FormatJSON:
 		return helpers.PrintJSON(typeNames, cmd.OutOrStdout())
 	case config.FormatYAML:
 		return helpers.PrintYAML(typeNames, cmd.OutOrStdout())
@@ -111,7 +110,7 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 		}
 		format := getFormat(cli, cmd)
 		switch format {
-		case config.FormatYAML, config.FormatWrappedJSON:
+		case config.FormatYAML, config.FormatJSON:
 		default:
 			format = config.FormatYAML
 		}
@@ -162,16 +161,11 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 				req.GetMetadata().Namespace = cli.Config.Namespace()
 			}
 
-			var val reflect.Value
-			if proxy, ok := req.(*corev3.V2ResourceProxy); ok {
-				val = reflect.New(reflect.SliceOf(reflect.TypeOf(proxy.Resource)))
-			} else {
-				val = reflect.New(reflect.SliceOf(reflect.TypeOf(req)))
-			}
+			var wrappers []types.Wrapper
 
 			err = cli.Client.List(
 				fmt.Sprintf("%s?types=%s", req.URIPath(), url.QueryEscape(types.WrapResource(req).Type)),
-				val.Interface(), &client.ListOptions{
+				&wrappers, &client.ListOptions{
 					ChunkSize: ChunkSize,
 				}, nil)
 			if err != nil {
@@ -187,21 +181,18 @@ func execute(cli *cli.SensuCli) func(*cobra.Command, []string) error {
 				return fmt.Errorf("API error: %s", err)
 			}
 
-			val = reflect.Indirect(val)
-			if val.Len() == 0 {
+			if len(wrappers) == 0 {
 				continue
 			}
 
-			resources := make([]corev3.Resource, val.Len())
+			resources := make([]corev3.Resource, len(wrappers))
 			for i := range resources {
-				resources[i] = val.Index(i).Interface().(corev3.Resource)
+				resources[i] = wrappers[i].Value.(corev3.Resource)
 			}
 
 			switch format {
 			case config.FormatJSON:
-				err = helpers.PrintJSON(resources, w)
-			case config.FormatWrappedJSON:
-				err = helpers.PrintWrappedJSONList(resources, w)
+				err = helpers.PrintResourceListJSON(resources, w)
 			case config.FormatYAML:
 				if i > 0 {
 					_, _ = fmt.Fprintln(w, "---")

--- a/cli/commands/helpers/flags.go
+++ b/cli/commands/helpers/flags.go
@@ -25,9 +25,8 @@ func AddFormatFlag(flagSet *pflag.FlagSet) {
 		"format",
 		config.DefaultFormat,
 		fmt.Sprintf(
-			`format of data returned ("%s"|"%s"|"%s"|"%s")`,
+			`format of data returned ("%s"|"%s"|"%s")`,
 			config.FormatJSON,
-			config.FormatWrappedJSON,
 			config.FormatTabular,
 			config.FormatYAML,
 		),

--- a/cli/commands/helpers/json.go
+++ b/cli/commands/helpers/json.go
@@ -31,11 +31,11 @@ func PrintJSON(r interface{}, io io.Writer) error {
 	return err
 }
 
-// PrintWrappedJSON takes a record(s) and Resource, converts the record to
+// PrintResourceJSON takes a record(s) and Resource, converts the record to
 // human-readable JSON (pretty-prints), wraps that JSON using types.Wrapper, and
 // then prints the result to the given writer. Unescapes any &, <, or >
 // characters it finds.
-func PrintWrappedJSON(r corev3.Resource, wr io.Writer) error {
+func PrintResourceJSON(r corev3.Resource, wr io.Writer) error {
 	w := types.WrapResource(r)
 
 	buf := new(bytes.Buffer)
@@ -52,13 +52,13 @@ func PrintWrappedJSON(r corev3.Resource, wr io.Writer) error {
 	return err
 }
 
-// PrintWrappedJSONList takes a resource list and an io.Writer, converts the
+// PrintResourceListJSON takes a resource list and an io.Writer, converts the
 // record to human-readable JSON (pretty-prints), wraps that JSON using
 // types.Wrapper, and then prints the result to the given writer. Unescapes
 // any &, <, or > characters it finds.
-func PrintWrappedJSONList(r []corev3.Resource, io io.Writer) error {
+func PrintResourceListJSON(r []corev3.Resource, io io.Writer) error {
 	for _, res := range r {
-		err := PrintWrappedJSON(res, io)
+		err := PrintResourceJSON(res, io)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/helpers/json_test.go
+++ b/cli/commands/helpers/json_test.go
@@ -39,11 +39,11 @@ func TestPrintWrappedJSON(t *testing.T) {
 	assert.NoError(err)
 
 	buf := new(bytes.Buffer)
-	require.NoError(t, PrintWrappedJSON(check, buf))
+	require.NoError(t, PrintResourceJSON(check, buf))
 	assert.JSONEq(string(output), buf.String())
 }
 
-func TestPrintWrappedJSONList(t *testing.T) {
+func TestPrintResourceListJSON(t *testing.T) {
 	assert := assert.New(t)
 
 	check1 := types.FixtureCheckConfig("check1")
@@ -59,7 +59,7 @@ func TestPrintWrappedJSONList(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 
-	require.NoError(t, PrintWrappedJSONList([]corev3.Resource{check1, check2}, buf))
+	require.NoError(t, PrintResourceListJSON([]corev3.Resource{check1, check2}, buf))
 	// compare each string individually
 	output3 := strings.Split(buf.String(), "}\n{")
 	assert.JSONEq(string(output1), output3[0]+"}")
@@ -79,15 +79,6 @@ func TestPrintFormatted(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 
-	require.NoError(t, PrintFormatted("", config.FormatWrappedJSON, check, buf, printToList))
-	assert.JSONEq(string(output), buf.String())
-
-	// test json format
-	output, err = json.Marshal(check)
-	assert.NoError(err)
-
-	buf = new(bytes.Buffer)
-
 	require.NoError(t, PrintFormatted("", config.FormatJSON, check, buf, printToList))
 	assert.JSONEq(string(output), buf.String())
 
@@ -104,12 +95,12 @@ func TestPrintFormatted(t *testing.T) {
 	assert.Equal("=== \n", buf.String()) // empty table
 
 	// test flag override (json format)
-	output, err = json.Marshal(check)
+	output, err = json.Marshal(types.WrapResource(check))
 	assert.NoError(err)
 
 	buf = new(bytes.Buffer)
 
-	require.NoError(t, PrintFormatted(config.FormatJSON, config.FormatWrappedJSON, check, buf, printToList))
+	require.NoError(t, PrintFormatted(config.FormatJSON, config.FormatYAML, check, buf, printToList))
 	assert.JSONEq(string(output), buf.String())
 }
 

--- a/cli/commands/helpers/print.go
+++ b/cli/commands/helpers/print.go
@@ -39,12 +39,10 @@ func Print(cmd *cobra.Command, format string, printTable printTableFunc, objects
 	}
 	switch format {
 	case config.FormatJSON:
-		return PrintJSON(v, cmd.OutOrStdout())
-	case config.FormatWrappedJSON:
 		if objects == nil {
 			return PrintJSON(v, cmd.OutOrStdout())
 		}
-		return PrintWrappedJSONList(objects, cmd.OutOrStdout())
+		return PrintResourceListJSON(objects, cmd.OutOrStdout())
 	case config.FormatYAML:
 		if objects == nil {
 			return PrintYAML(v, cmd.OutOrStdout())
@@ -65,13 +63,11 @@ func PrintFormatted(flag string, format string, v interface{}, w io.Writer, prin
 	}
 	switch format {
 	case config.FormatJSON:
-		return PrintJSON(v, w)
-	case config.FormatWrappedJSON:
 		r, ok := v.(corev3.Resource)
 		if !ok {
 			return fmt.Errorf("%t is not a Resource", v)
 		}
-		return PrintWrappedJSON(r, w)
+		return PrintResourceJSON(r, w)
 	case config.FormatYAML:
 		return PrintYAML(v, w)
 	default:
@@ -87,7 +83,7 @@ func PrintTitle(flag string, format string, title string, w io.Writer) error {
 	}
 	// checking the formats exclusively to cover invalid formats
 	// that get defaulted to tabular
-	if format != config.FormatJSON && format != config.FormatWrappedJSON && format != config.FormatYAML {
+	if format != config.FormatJSON && format != config.FormatYAML {
 		cfg := &list.Config{
 			Title: title,
 		}

--- a/cli/resource/resolve.go
+++ b/cli/resource/resolve.go
@@ -15,7 +15,7 @@ import (
 var (
 	// All is all the core resource types and associated sensuctl verbs (non-namespaced resources are intentionally ordered first).
 	All = []corev3.Resource{
-		&corev3.Namespace{},
+		&corev3.Namespace{Metadata: &corev2.ObjectMeta{}},
 		&corev2.ClusterRole{},
 		&corev2.ClusterRoleBinding{},
 		&corev2.User{},


### PR DESCRIPTION
The sensu-go APIs have been operating on raw/unwrapped json encoded
resource definitions. This is a common source of friction as most users
are primarily familiar with our wrapped resource format that sensuctl
presents to users as the interface.

This commit changes all sensu-go APIs dealing with resources to operate
on the wrapped resource format instead.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>