### PR TITLE
Use asset build with most specific filters

### DIFF
--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -16,6 +16,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 which now allows for the addition of labels and annotations.
 - API keys can no longer be retrieved from the database.
 - The REST APIs now use the wrapped resource format.
+- When multiple asset builds are filtered the first asset build with the highest
+number of filters is returned. Previously the first filtered asset build was
+returned regardless of filter count.
 
 ### Added
 - Added sensu-backend configuration for postgresql.

--- a/asset/filtered_manager_test.go
+++ b/asset/filtered_manager_test.go
@@ -182,3 +182,43 @@ func TestIsFiltered(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, filtered)
 }
+
+func TestEvaluateAssetBuilds(t *testing.T) {
+	_, _, filteredManager := NewTestFilteredManager()
+
+	fixtureAsset := types.FixtureAsset("test-asset")
+	fixtureAsset.Builds = []*corev2.AssetBuild{
+		{
+			URL: "asset-1",
+			Filters: []string{
+				"entity.name == 'asdf'",
+			},
+		},
+		{
+			URL: "asset-2",
+			Filters: []string{
+				"entity.name == 'test-entity'",
+			},
+		},
+		{
+			URL: "asset-3",
+			Filters: []string{
+				"entity.name == 'test-entity'",
+				"entity.namespace == 'default'",
+				"entity.system.arch == 'amd64'",
+			},
+		},
+		{
+			URL: "asset-4",
+			Filters: []string{
+				"entity.name == 'test-entity'",
+				"entity.namespace == 'default'",
+			},
+		},
+	}
+
+	actualAsset, err := filteredManager.evaluateAssetBuilds(fixtureAsset)
+	assert.NoError(t, err)
+	assert.NotNil(t, actualAsset)
+	assert.Equal(t, "asset-3", actualAsset.URL)
+}


### PR DESCRIPTION
## What is this change?

Updates `asset.FilteredManager` to evaluate all asset build filters and returns the asset build with the most specific (highest number of filters) matching the entity. This is a breaking change as it can alter which asset build is installed on existing clusters.

## Why is this change necessary?

Closes https://github.com/sensu/sensu-go/issues/3655
Closes https://github.com/sensu/sensu-go/issues/4455

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

The docs should be updated to describe this behaviour.
https://github.com/sensu/sensu-docs/issues/4185

## How did you verify this change?

I used TDD to define the behaviour before I made the change. The tests should be sufficient.

## Is this change a patch?

No.
