### PR TITLE
Pass predicate through UserController to store

### DIFF
--- a/backend/apid/actions/users.go
+++ b/backend/apid/actions/users.go
@@ -28,7 +28,7 @@ func NewUserController(store storev2.Interface) UserController {
 func (a UserController) List(ctx context.Context, pred *store.SelectionPredicate) ([]corev3.Resource, error) {
 	// Fetch from store
 	ustore := storev2.Of[*corev2.User](a.store)
-	users, err := ustore.List(ctx, storev2.ID{Namespace: corev2.ContextNamespace(ctx)}, nil)
+	users, err := ustore.List(ctx, storev2.ID{Namespace: corev2.ContextNamespace(ctx)}, pred)
 	if err != nil {
 		switch err := err.(type) {
 		case *store.ErrNotFound:

--- a/backend/apid/actions/users_test.go
+++ b/backend/apid/actions/users_test.go
@@ -29,37 +29,37 @@ func TestUserList(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		records		[]*corev2.User
-		storeErr	error
-		expectedLen	int
-		expectedErr	error
+		name        string
+		ctx         context.Context
+		records     []*corev2.User
+		storeErr    error
+		expectedLen int
+		expectedErr error
 	}{
 		{
-			name:		"No Users",
-			ctx:		ctxWithAuthorizedViewer,
-			storeErr:	nil,
-			expectedLen:	0,
-			expectedErr:	nil,
+			name:        "No Users",
+			ctx:         ctxWithAuthorizedViewer,
+			storeErr:    nil,
+			expectedLen: 0,
+			expectedErr: nil,
 		},
 		{
-			name:	"With Users",
-			ctx:	ctxWithAuthorizedViewer,
+			name: "With Users",
+			ctx:  ctxWithAuthorizedViewer,
 			records: []*corev2.User{
 				corev2.FixtureUser("user1"),
 				corev2.FixtureUser("user2"),
 			},
-			expectedLen:	2,
-			storeErr:	nil,
-			expectedErr:	nil,
+			expectedLen: 2,
+			storeErr:    nil,
+			expectedErr: nil,
 		},
 		{
-			name:		"store Failure",
-			ctx:		ctxWithAuthorizedViewer,
-			expectedLen:	0,
-			storeErr:	errors.New(""),
-			expectedErr:	NewError(InternalErr, errors.New("")),
+			name:        "store Failure",
+			ctx:         ctxWithAuthorizedViewer,
+			expectedLen: 0,
+			storeErr:    errors.New(""),
+			expectedErr: NewError(InternalErr, errors.New("")),
 		},
 	}
 
@@ -73,10 +73,11 @@ func TestUserList(t *testing.T) {
 			assert := assert.New(t)
 
 			// Mock store methods
-			s.On("List", mock.Anything, mock.Anything, mock.Anything).Return(mockstore.WrapList[*corev2.User](tc.records), tc.storeErr)
+			pred := new(store.SelectionPredicate)
+			s.On("List", mock.Anything, mock.Anything, pred).Return(mockstore.WrapList[*corev2.User](tc.records), tc.storeErr)
 
 			// Exec Query
-			results, err := actions.List(tc.ctx, new(store.SelectionPredicate))
+			results, err := actions.List(tc.ctx, pred)
 
 			// Assert
 			assert.EqualValues(tc.expectedErr, err)
@@ -91,44 +92,44 @@ func TestUserGet(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		argument	string
-		storedRecord	*corev2.User
-		storeErr	error
-		expected	bool
-		expectedErrCode	ErrCode
+		name            string
+		ctx             context.Context
+		argument        string
+		storedRecord    *corev2.User
+		storeErr        error
+		expected        bool
+		expectedErrCode ErrCode
 	}{
 		{
-			name:			"No name given",
-			ctx:			ctxWithAuthorizedViewer,
-			argument:		"",
-			expected:		false,
-			expectedErrCode:	NotFound,
-			storeErr:		&store.ErrNotFound{},
+			name:            "No name given",
+			ctx:             ctxWithAuthorizedViewer,
+			argument:        "",
+			expected:        false,
+			expectedErrCode: NotFound,
+			storeErr:        &store.ErrNotFound{},
 		},
 		{
-			name:		"Found",
-			ctx:		ctxWithAuthorizedViewer,
-			storedRecord:	corev2.FixtureUser("user1"),
-			argument:	"user1",
-			expected:	true,
+			name:         "Found",
+			ctx:          ctxWithAuthorizedViewer,
+			storedRecord: corev2.FixtureUser("user1"),
+			argument:     "user1",
+			expected:     true,
 		},
 		{
-			name:			"store Err",
-			ctx:			ctxWithAuthorizedViewer,
-			argument:		"user1",
-			storeErr:		errors.New("test"),
-			expected:		false,
-			expectedErrCode:	InternalErr,
+			name:            "store Err",
+			ctx:             ctxWithAuthorizedViewer,
+			argument:        "user1",
+			storeErr:        errors.New("test"),
+			expected:        false,
+			expectedErrCode: InternalErr,
 		},
 		{
-			name:			"Not Found",
-			ctx:			ctxWithAuthorizedViewer,
-			argument:		"user1",
-			expected:		false,
-			expectedErrCode:	NotFound,
-			storeErr:		&store.ErrNotFound{},
+			name:            "Not Found",
+			ctx:             ctxWithAuthorizedViewer,
+			argument:        "user1",
+			expected:        false,
+			expectedErrCode: NotFound,
+			storeErr:        &store.ErrNotFound{},
 		},
 	}
 
@@ -173,41 +174,41 @@ func TestUserCreateOrReplace(t *testing.T) {
 	badUser.Username = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		argument	*corev2.User
-		fetchResult	*corev2.User
-		fetchErr	error
-		createErr	error
-		expectedErr	bool
-		expectedErrCode	ErrCode
+		name            string
+		ctx             context.Context
+		argument        *corev2.User
+		fetchResult     *corev2.User
+		fetchErr        error
+		createErr       error
+		expectedErr     bool
+		expectedErrCode ErrCode
 	}{
 		{
-			name:		"Created",
-			ctx:		defaultCtx,
-			argument:	corev2.FixtureUser("user1"),
-			expectedErr:	false,
+			name:        "Created",
+			ctx:         defaultCtx,
+			argument:    corev2.FixtureUser("user1"),
+			expectedErr: false,
 		},
 		{
-			name:		"Already Exists",
-			ctx:		defaultCtx,
-			argument:	corev2.FixtureUser("user1"),
-			fetchResult:	corev2.FixtureUser("user1"),
+			name:        "Already Exists",
+			ctx:         defaultCtx,
+			argument:    corev2.FixtureUser("user1"),
+			fetchResult: corev2.FixtureUser("user1"),
 		},
 		{
-			name:			"store Err on Create",
-			ctx:			defaultCtx,
-			argument:		corev2.FixtureUser("user1"),
-			createErr:		errors.New("dunno"),
-			expectedErr:		true,
-			expectedErrCode:	InternalErr,
+			name:            "store Err on Create",
+			ctx:             defaultCtx,
+			argument:        corev2.FixtureUser("user1"),
+			createErr:       errors.New("dunno"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
 		},
 		{
-			name:			"Validation Error",
-			ctx:			defaultCtx,
-			argument:		badUser,
-			expectedErr:		true,
-			expectedErrCode:	InvalidArgument,
+			name:            "Validation Error",
+			ctx:             defaultCtx,
+			argument:        badUser,
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
 		},
 	}
 
@@ -252,44 +253,44 @@ func TestUserCreate(t *testing.T) {
 	badUser.Username = "!@#!#$@#^$%&$%&$&$%&%^*%&(%@###"
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		argument	*corev2.User
-		fetchResult	*corev2.User
-		fetchErr	error
-		createErr	error
-		expectedErr	bool
-		expectedErrCode	ErrCode
+		name            string
+		ctx             context.Context
+		argument        *corev2.User
+		fetchResult     *corev2.User
+		fetchErr        error
+		createErr       error
+		expectedErr     bool
+		expectedErrCode ErrCode
 	}{
 		{
-			name:		"Created",
-			ctx:		defaultCtx,
-			argument:	corev2.FixtureUser("user1"),
-			expectedErr:	false,
+			name:        "Created",
+			ctx:         defaultCtx,
+			argument:    corev2.FixtureUser("user1"),
+			expectedErr: false,
 		},
 		{
-			name:			"Already Exists",
-			ctx:			defaultCtx,
-			argument:		corev2.FixtureUser("user1"),
-			fetchResult:		corev2.FixtureUser("user1"),
-			expectedErr:		true,
-			expectedErrCode:	AlreadyExistsErr,
-			createErr:		&store.ErrAlreadyExists{},
+			name:            "Already Exists",
+			ctx:             defaultCtx,
+			argument:        corev2.FixtureUser("user1"),
+			fetchResult:     corev2.FixtureUser("user1"),
+			expectedErr:     true,
+			expectedErrCode: AlreadyExistsErr,
+			createErr:       &store.ErrAlreadyExists{},
 		},
 		{
-			name:			"store Err on Create",
-			ctx:			defaultCtx,
-			argument:		corev2.FixtureUser("user1"),
-			createErr:		errors.New("dunno"),
-			expectedErr:		true,
-			expectedErrCode:	InternalErr,
+			name:            "store Err on Create",
+			ctx:             defaultCtx,
+			argument:        corev2.FixtureUser("user1"),
+			createErr:       errors.New("dunno"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
 		},
 		{
-			name:			"Validation Error",
-			ctx:			defaultCtx,
-			argument:		badUser,
-			expectedErr:		true,
-			expectedErrCode:	InvalidArgument,
+			name:            "Validation Error",
+			ctx:             defaultCtx,
+			argument:        badUser,
+			expectedErr:     true,
+			expectedErrCode: InvalidArgument,
 		},
 	}
 
@@ -334,39 +335,39 @@ func TestUserDisable(t *testing.T) {
 	)
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		argument	string
-		fetchResult	*corev2.User
-		fetchErr	error
-		updateErr	error
-		expectedErr	bool
-		expectedErrCode	ErrCode
+		name            string
+		ctx             context.Context
+		argument        string
+		fetchResult     *corev2.User
+		fetchErr        error
+		updateErr       error
+		expectedErr     bool
+		expectedErrCode ErrCode
 	}{
 		{
-			name:		"Disabled",
-			ctx:		defaultCtx,
-			argument:	"user1",
-			fetchResult:	corev2.FixtureUser("user1"),
-			expectedErr:	false,
+			name:        "Disabled",
+			ctx:         defaultCtx,
+			argument:    "user1",
+			fetchResult: corev2.FixtureUser("user1"),
+			expectedErr: false,
 		},
 		{
-			name:			"Does Not Exist",
-			ctx:			defaultCtx,
-			argument:		"user1",
-			fetchResult:		nil,
-			expectedErr:		true,
-			expectedErrCode:	NotFound,
-			fetchErr:		&store.ErrNotFound{},
+			name:            "Does Not Exist",
+			ctx:             defaultCtx,
+			argument:        "user1",
+			fetchResult:     nil,
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+			fetchErr:        &store.ErrNotFound{},
 		},
 		{
-			name:			"store Err on Update",
-			ctx:			defaultCtx,
-			argument:		"user1",
-			fetchResult:		corev2.FixtureUser("user1"),
-			updateErr:		errors.New("dunno"),
-			expectedErr:		true,
-			expectedErrCode:	InternalErr,
+			name:            "store Err on Update",
+			ctx:             defaultCtx,
+			argument:        "user1",
+			fetchResult:     corev2.FixtureUser("user1"),
+			updateErr:       errors.New("dunno"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
 		},
 	}
 
@@ -417,39 +418,39 @@ func TestUserEnable(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name		string
-		ctx		context.Context
-		argument	string
-		fetchResult	*corev2.User
-		fetchErr	error
-		updateErr	error
-		expectedErr	bool
-		expectedErrCode	ErrCode
+		name            string
+		ctx             context.Context
+		argument        string
+		fetchResult     *corev2.User
+		fetchErr        error
+		updateErr       error
+		expectedErr     bool
+		expectedErrCode ErrCode
 	}{
 		{
-			name:		"Enable",
-			ctx:		correctPermsCtx,
-			argument:	"user1",
-			fetchResult:	disabledUser(),
-			expectedErr:	false,
+			name:        "Enable",
+			ctx:         correctPermsCtx,
+			argument:    "user1",
+			fetchResult: disabledUser(),
+			expectedErr: false,
 		},
 		{
-			name:			"Does Not Exist",
-			ctx:			correctPermsCtx,
-			argument:		"user1",
-			fetchResult:		nil,
-			expectedErr:		true,
-			expectedErrCode:	NotFound,
-			fetchErr:		&store.ErrNotFound{},
+			name:            "Does Not Exist",
+			ctx:             correctPermsCtx,
+			argument:        "user1",
+			fetchResult:     nil,
+			expectedErr:     true,
+			expectedErrCode: NotFound,
+			fetchErr:        &store.ErrNotFound{},
 		},
 		{
-			name:			"store Err on Update",
-			ctx:			correctPermsCtx,
-			argument:		"user1",
-			fetchResult:		disabledUser(),
-			updateErr:		errors.New("dunno"),
-			expectedErr:		true,
-			expectedErrCode:	InternalErr,
+			name:            "store Err on Update",
+			ctx:             correctPermsCtx,
+			argument:        "user1",
+			fetchResult:     disabledUser(),
+			updateErr:       errors.New("dunno"),
+			expectedErr:     true,
+			expectedErrCode: InternalErr,
 		},
 	}
 


### PR DESCRIPTION
## What is this change?

Fixes bug in the UserController where it was not forwarding the SelectionPredicate to the store implementation. Broke user api pagination.