### PR TITLE
Reorder proxy entity state and config creation

### DIFF
--- a/backend/eventd/entity.go
+++ b/backend/eventd/entity.go
@@ -84,16 +84,6 @@ func createProxyEntity(event *corev2.Event, s storev2.Interface) (fErr error) {
 				config, state = corev3.V2EntityToV3(event.Entity)
 			}
 
-			state.Metadata.CreatedBy = event.CreatedBy
-
-			// Store the new entity's state. We use CreateOrUpdate()
-			// because we want to overwrite any existing EntityState that could
-			// have been left behind due to a failed operation or failure to
-			// clean up old state.
-			if err := esstore.CreateOrUpdate(context.Background(), state); err != nil {
-				return err
-			}
-
 			config.EntityClass = corev2.EntityProxyClass
 			config.Subscriptions = append(config.Subscriptions, corev2.GetEntitySubscription(entityName))
 
@@ -101,6 +91,16 @@ func createProxyEntity(event *corev2.Event, s storev2.Interface) (fErr error) {
 			// CreateIfNotExists() to assert that this EntityConfig is indeed
 			// brand new.
 			if err := ecstore.CreateIfNotExists(context.Background(), config); err != nil {
+				return err
+			}
+
+			state.Metadata.CreatedBy = event.CreatedBy
+
+			// Store the new entity's state. We use CreateOrUpdate()
+			// because we want to overwrite any existing EntityState that could
+			// have been left behind due to a failed operation or failure to
+			// clean up old state.
+			if err := esstore.CreateOrUpdate(context.Background(), state); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
Eventd creates proxy entities when they are contained in an event but do not already exist. Avoid a SQL NOT NULL constraint by creating the entity config before entity state.


Found in staging from this log line
```
{
  "check_name": "proxy-check",
  "check_namespace": "default",
  "component": "eventd",
  "entity_name": "staging-agent-0-managed-entity",
  "entity_namespace": "default",
  "error": "internal error: ERROR: null value in column \"entity_config_id\" violates not-null constraint (SQLSTATE 23502)",
  "event_id": "2cc79025-b6ed-403b-ae4a-b8e858300ce8",
  "level": "error",
  "msg": "error handling event from event channel",
  "time": "2023-04-24T22:51:54Z"
}
```