### PR TITLE
Bump graphql-go to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c
-	github.com/graphql-go/graphql v0.8.0
+	github.com/graphql-go/graphql v0.8.1
 	github.com/hashicorp/go-version v1.2.0
 	github.com/influxdata/line-protocol v0.0.0-20210311194329-9aa0e372d097
 	github.com/jackc/pgx/v5 v5.1.1

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sensu/sensu-go
 
 go 1.18
 
-replace github.com/graphql-go/graphql => github.com/jamesdphillips/graphql-go v0.8.2
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14
 	github.com/atlassian/gostatsd v0.0.0-20180514010436-af796620006e

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c h1:94S+uoVVMpQAEOrqGjCDyUdML4dJDkh6aC4MYmXECg4=
 github.com/graph-gophers/dataloader v0.0.0-20180104184831-78139374585c/go.mod h1:jk4jk0c5ZISbKaMe8WsVopGB5/15GvGHMdMdPtwlRp4=
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -228,8 +230,6 @@ github.com/jackc/pgx/v5 v5.1.1 h1:pZD79K1SYv8wc2HmCQA6VdmRQi7/OtCfv9bM3WAXUYA=
 github.com/jackc/pgx/v5 v5.1.1/go.mod h1:Ptn7zmohNsWEsdxRawMzk3gaKma2obW+NWTnKa0S4nk=
 github.com/jackc/puddle/v2 v2.1.2 h1:0f7vaaXINONKTsxYDn4otOAiJanX/BMeAtY//BXqzlg=
 github.com/jackc/puddle/v2 v2.1.2/go.mod h1:2lpufsF5mRHO6SuZkm0fNYxM6SWHfvyFj62KwNzgels=
-github.com/jamesdphillips/graphql-go v0.8.2 h1:9hjfohl7Ump5jTEI5O46uy+Lw1y+oZg1KAVCXjZ17ss=
-github.com/jamesdphillips/graphql-go v0.8.2/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/jbenet/go-reuseport v0.0.0-20180416043609-15a1cd37f050 h1:bfBi3IYMggKaHTwDr42m05AYbG/OQpo21oCQWuNelCg=
 github.com/jbenet/go-reuseport v0.0.0-20180416043609-15a1cd37f050/go.mod h1:hry/Nwg2mFor95Ql+X52uC4zdrZsdH8a0noOj8BLt9g=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -116,8 +116,9 @@ func (service *Service) RegisterUnion(t UnionDesc, impl UnionTypeResolver) {
 	cfg := t.Config()
 	registrar := func(m graphql.TypeMap) graphql.Type {
 		cfg = t.Config()
-		newTypes := make([]*graphql.Object, len(cfg.Types))
-		for i, t := range cfg.Types {
+		cfgTypes := cfg.Types.([]*graphql.Object)
+		newTypes := make([]*graphql.Object, len(cfgTypes))
+		for i, t := range cfgTypes {
 			objType := m[t.PrivateName].(*graphql.Object)
 			newTypes[i] = objType
 		}


### PR DESCRIPTION
Brings over the change in #4995 to the `main` branch.