### PR TITLE
Add context helpers for TxInfo and ETag directives

### DIFF
--- a/backend/store/v2/context.go
+++ b/backend/store/v2/context.go
@@ -1,0 +1,75 @@
+package v2
+
+import "context"
+
+// contextKeyTxInfo is the context key that identifies a TxInfo.
+type contextKeyTxInfo struct{}
+
+// TxInfo is a record of store actions that were performed as a result of a
+// ResourceRequest.
+type TxInfo struct {
+	// Records will contain an entry for each store record that was affected
+	// by the resource request.
+	Records []TxRecordInfo
+}
+
+// TxRecordInfo is a record of a store write.
+type TxRecordInfo struct {
+	Created  bool
+	Updated  bool
+	Deleted  bool
+	ETag     ETag
+	PrevETag ETag
+}
+
+// ContextWithTxInfo returns a new context that contains the supplied TxInfo.
+// Implementations that read *TxInfo from a context bearing it should write
+// transaction stats into it that reflect the effects of the transaction.
+func ContextWithTxInfo(ctx context.Context, tx *TxInfo) context.Context {
+	return context.WithValue(ctx, contextKeyTxInfo{}, tx)
+}
+
+// TxInfoFromContext returns the *TxInfo from the context, or nil if it is missing.
+func TxInfoFromContext(ctx context.Context) *TxInfo {
+	val := ctx.Value(contextKeyTxInfo{})
+	if val == nil {
+		return nil
+	}
+	return val.(*TxInfo)
+}
+
+// IfMatch is a list of Etags
+type IfMatch []ETag
+type contextKeyIfMatch struct{}
+
+// ContextWithIfMatch returns a new context that contains the supplied IfMatch.
+func ContextWithIfMatch(ctx context.Context, list IfMatch) context.Context {
+	return context.WithValue(ctx, contextKeyIfMatch{}, list)
+}
+
+// IfMatch returns the IfMatch from the context, or nil if it is missing.
+func IfMatchFromContext(ctx context.Context) IfMatch {
+	val := ctx.Value(contextKeyIfMatch{})
+	if val == nil {
+		return nil
+	}
+	return val.(IfMatch)
+}
+
+// IfNoneMatch is a list of ETags.
+type IfNoneMatch []ETag
+type contextKeyIfNoneMatch struct{}
+
+// ContextWithIfNoneMatch returns a new context that contains the supplied IfNoneMatch.
+func ContextWithIfNoneMatch(ctx context.Context, list IfNoneMatch) context.Context {
+	return context.WithValue(ctx, contextKeyIfNoneMatch{}, list)
+}
+
+// IfMatch returns the IfNoneMatch from the context, or nil if it is missing.
+func IfNoneMatchFromContext(ctx context.Context) IfNoneMatch {
+	val := ctx.Value(contextKeyIfNoneMatch{})
+	if val == nil {
+		return nil
+	}
+	return val.(IfNoneMatch)
+}

--- a/backend/store/v2/context_test.go
+++ b/backend/store/v2/context_test.go
@@ -1,0 +1,62 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type contextTest[T any] struct {
+	Value  T
+	Create func(ctx context.Context, val T) context.Context
+	Read   func(ctx context.Context) T
+}
+
+func (c contextTest[T]) Test(t *testing.T) {
+	name := fmt.Sprintf("%T", c.Value)
+	t.Run(name+"_success", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = c.Create(ctx, c.Value)
+		if got, want := c.Read(ctx), c.Value; !cmp.Equal(got, want) {
+			t.Errorf("bad %T: got %v, want %v", got, got, want)
+		}
+	})
+	t.Run(name+"_missing", func(t *testing.T) {
+		value := c.Read(context.Background())
+		if !reflect.ValueOf(value).IsZero() {
+			t.Errorf("missing value is not zero value for %T: %v", value, value)
+		}
+	})
+}
+
+type tester interface {
+	Test(*testing.T)
+}
+
+func TestContext(t *testing.T) {
+	tests := []tester{
+		contextTest[*TxInfo]{
+			Value: &TxInfo{
+				Records: []TxRecordInfo{{}},
+			},
+			Create: ContextWithTxInfo,
+			Read:   TxInfoFromContext,
+		},
+		contextTest[IfMatch]{
+			Value:  IfMatch{"hello", "world"},
+			Create: ContextWithIfMatch,
+			Read:   IfMatchFromContext,
+		},
+		contextTest[IfNoneMatch]{
+			Value:  IfNoneMatch{"hello", "world"},
+			Create: ContextWithIfNoneMatch,
+			Read:   IfNoneMatchFromContext,
+		},
+	}
+	for _, test := range tests {
+		test.Test(t)
+	}
+}

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
@@ -20,6 +21,10 @@ type Interface interface {
 	SilencesStoreGetter
 }
 
+// ErrPreconditionFailed is returned when a store method evaluates an If-Match
+// or If-None-Match and finds that it is false.
+var ErrPreconditionFailed = errors.New("precondition failed")
+
 // Wrapper is an abstraction of a store wrapper.
 type Wrapper interface {
 	Unwrap() (corev3.Resource, error)
@@ -32,6 +37,9 @@ type WrapList interface {
 	UnwrapInto(interface{}) error
 	Len() int
 }
+
+// ETag represents a unique hash of the resource.
+type ETag string
 
 // EntityConfigStoreGetter gets you an EntityConfigStore.
 type EntityConfigStoreGetter interface {


### PR DESCRIPTION
## What is this change?

This commit adds some utility functions for putting ETag directives into store requests, and also a way for stores to write back transaction metadata with TxInfo.

## Why is this change necessary?

These functions are going to be used by the postgres store, as well as apid, to provide end-to-end support for the HTTP ETag, If-Match, and If-None-Match headers.