### PR TITLE
Add support for etag and preconditions to store

### DIFF
--- a/backend/store/postgres/migrations.go
+++ b/backend/store/postgres/migrations.go
@@ -161,6 +161,21 @@ var Migrations = []migration.Migrator{
 		_, err := tx.Exec(context.Background(), addConfigurationFields)
 		return err
 	},
+	// Migration 26
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), "CREATE EXTENSION pgcrypto;")
+		return err
+	},
+	// Migration 27
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), "ALTER TABLE configuration ADD COLUMN etag bytea;")
+		return err
+	},
+	// Migration 28
+	func(tx migration.LimitedTx) error {
+		_, err := tx.Exec(context.Background(), "UPDATE configuration SET etag = digest(resource::text, 'sha1')")
+		return err
+	},
 }
 
 type eventRecord struct {

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	SensuCreatedAtKey	= "sensu.io/created_at"
-	SensuUpdatedAtKey	= "sensu.io/updated_at"
-	SensuDeletedAtKey	= "sensu.io/deleted_at"
+	SensuCreatedAtKey = "sensu.io/created_at"
+	SensuUpdatedAtKey = "sensu.io/updated_at"
+	SensuDeletedAtKey = "sensu.io/deleted_at"
+	SensuETagKey      = "sensu.io/etag"
 )
 
 // ErrAlreadyExists is returned when an object already exists
@@ -26,8 +27,8 @@ func (e *ErrAlreadyExists) Error() string {
 
 // ErrDecode is returned when an object could not be decoded
 type ErrDecode struct {
-	Key	string
-	Err	error
+	Key string
+	Err error
 }
 
 func (e *ErrDecode) Error() string {
@@ -36,8 +37,8 @@ func (e *ErrDecode) Error() string {
 
 // ErrEncode is returned when an object could not be decoded
 type ErrEncode struct {
-	Key	string
-	Err	error
+	Key string
+	Err error
 }
 
 func (e *ErrEncode) Error() string {
@@ -111,48 +112,48 @@ type SelectionPredicate struct {
 	// Continue provides the key from which the selection should start. If
 	// returned empty from the store, it indicates that there's no additional
 	// resources available
-	Continue	string
+	Continue string
 	// Limit indicates the number of resources to retrieve
-	Limit	int64
+	Limit int64
 	// Offset into the collection
-	Offset	int64
+	Offset int64
 	// Subcollection represents a sub-collection of the primary collection
-	Subcollection	string
+	Subcollection string
 	// Ordering indicates the property to sort on, if supported by the store
-	Ordering	string
+	Ordering string
 	// Descending indicates the sort direction is in descending order.
-	Descending	bool
+	Descending bool
 	// UpdatedSince selects only items that have been updated since this timestamp
-	UpdatedSince	string
+	UpdatedSince string
 	// IncludeDeletes selects items that were previously soft-deleted
-	IncludeDeletes	bool
+	IncludeDeletes bool
 }
 
 // A WatchEventCheckConfig contains the modified store object and the action
 // that occurred during the modification.
 type WatchEventCheckConfig struct {
-	CheckConfig	*corev2.CheckConfig
-	Action		WatchActionType
+	CheckConfig *corev2.CheckConfig
+	Action      WatchActionType
 }
 
 // A WatchEventHookConfig contains the modified asset object and the action that
 // occurred during the modification.
 type WatchEventHookConfig struct {
-	HookConfig	*corev2.HookConfig
-	Action		WatchActionType
+	HookConfig *corev2.HookConfig
+	Action     WatchActionType
 }
 
 // WatchEventTessenConfig is a notification that the tessen config store has
 // been updated.
 type WatchEventTessenConfig struct {
-	TessenConfig	*corev2.TessenConfig
-	Action		WatchActionType
+	TessenConfig *corev2.TessenConfig
+	Action       WatchActionType
 }
 
 // WatchEventResource is a store event about a specific resource
 type WatchEventResource struct {
-	Resource	corev2.Resource
-	Action		WatchActionType
+	Resource corev2.Resource
+	Action   WatchActionType
 }
 
 // WatchEventResourceV3 is a notification that a corev3.Resource has been
@@ -160,10 +161,10 @@ type WatchEventResource struct {
 type WatchEventResourceV3 struct {
 	// Resource is the resource associated with the event. It is nil when Action
 	// is WatchError or WatchUnknown.
-	Resource	corev3.Resource
+	Resource corev3.Resource
 
 	// Action is the type of action that affected the resource.
-	Action	WatchActionType
+	Action WatchActionType
 }
 
 // Store is used to abstract the durable storage used by the Sensu backend

--- a/backend/store/v2/context_test.go
+++ b/backend/store/v2/context_test.go
@@ -46,12 +46,12 @@ func TestContext(t *testing.T) {
 			Read:   TxInfoFromContext,
 		},
 		contextTest[IfMatch]{
-			Value:  IfMatch{"hello", "world"},
+			Value:  IfMatch{ETag("hello"), ETag("world")},
 			Create: ContextWithIfMatch,
 			Read:   IfMatchFromContext,
 		},
 		contextTest[IfNoneMatch]{
-			Value:  IfNoneMatch{"hello", "world"},
+			Value:  IfNoneMatch{ETag("hello"), ETag("world")},
 			Create: ContextWithIfNoneMatch,
 			Read:   IfNoneMatchFromContext,
 		},

--- a/backend/store/v2/interface.go
+++ b/backend/store/v2/interface.go
@@ -1,7 +1,9 @@
 package v2
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 
 	corev2 "github.com/sensu/core/v2"
@@ -39,7 +41,23 @@ type WrapList interface {
 }
 
 // ETag represents a unique hash of the resource.
-type ETag string
+type ETag []byte
+
+// String returns the base64-encoded form of the ETag.
+func (e ETag) String() string {
+	return base64.RawStdEncoding.EncodeToString(e)
+}
+
+// DecodeETag attempts to parse an encoded ETag. It returns an error if the
+// input is not base64-encoded.
+func DecodeETag(data string) (ETag, error) {
+	b, err := base64.RawStdEncoding.DecodeString(data)
+	return ETag(b), err
+}
+
+func (e ETag) Equals(other ETag) bool {
+	return bytes.Equal(e, other)
+}
 
 // EntityConfigStoreGetter gets you an EntityConfigStore.
 type EntityConfigStoreGetter interface {

--- a/backend/store/v2/wrap/wrapper.go
+++ b/backend/store/v2/wrap/wrapper.go
@@ -13,9 +13,9 @@ import (
 	"github.com/golang/snappy"
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
+	"github.com/sensu/core/v3/types"
 	apitools "github.com/sensu/sensu-api-tools"
 	"github.com/sensu/sensu-go/backend/store"
-	"github.com/sensu/core/v3/types"
 )
 
 // Encoding is the serialization encoding of the wrapped value.
@@ -86,6 +86,9 @@ type Wrapper struct {
 	// DeletedAt is the time the resource was deleted. If it is the zero value,
 	// then the resource was not deleted.
 	DeletedAt time.Time
+
+	// ETag is a hex-encoded ETag.
+	ETag string
 }
 
 func (m *Wrapper) GetTypeMeta() *corev2.TypeMeta {
@@ -315,6 +318,7 @@ func (w *Wrapper) Unwrap() (corev3.Resource, error) {
 	meta.Labels[store.SensuCreatedAtKey] = string(createdAt)
 	updatedAt, _ := w.UpdatedAt.MarshalText()
 	meta.Labels[store.SensuUpdatedAtKey] = string(updatedAt)
+	meta.Annotations[store.SensuETagKey] = w.ETag
 
 	if !w.DeletedAt.IsZero() {
 		deletedAt, _ := w.DeletedAt.MarshalText()

--- a/backend/store/v2/wrap/wrapper_test.go
+++ b/backend/store/v2/wrap/wrapper_test.go
@@ -88,6 +88,7 @@ func TestWrapResourceSimple(t *testing.T) {
 	delete(meta.Labels, store.SensuCreatedAtKey)
 	delete(meta.Labels, store.SensuUpdatedAtKey)
 	delete(meta.Labels, store.SensuDeletedAtKey)
+	delete(meta.Annotations, store.SensuETagKey)
 	if got, want := unwrapped.GetMetadata(), resource.GetMetadata(); !proto.Equal(got, want) {
 		t.Errorf("bad resource: got %#v, want %#v", got, want)
 	}
@@ -175,6 +176,7 @@ func TestWrapResourceOptions(t *testing.T) {
 			delete(meta.Labels, store.SensuCreatedAtKey)
 			delete(meta.Labels, store.SensuUpdatedAtKey)
 			delete(meta.Labels, store.SensuDeletedAtKey)
+			delete(meta.Annotations, store.SensuETagKey)
 			if got, want := resource.GetMetadata(), test.Resource.GetMetadata(); !proto.Equal(got, want) {
 				t.Errorf("bad resource: got %v, want %v", got, want)
 			}


### PR DESCRIPTION
## What is this change?

This commit adds support for store preconditions and etags. Store users can request IfMatch and IfNoneMatch by way of context value. Resources returned by the store now encode a base64-encoded ETag in their annotations.

It's also possible to detect the side effects a given store method had, by providing a TxInfo object to the method, also via context value. The store will write into TxInfo whether the object has been created, updated, or deleted.