### PR TITLE
JWT Authentication Rework

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -12,6 +12,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
 - Added silences sorting by expiration to GraphQL service
 - Added log-millisecond-timestamps backend configuration flag
+- Added a session store, used to detect and prevent refresh token reuse
+
+### Changed
+- Users are now automatically logged out after a period of inactivity (12h)
+
 ## [6.9.2] - 2023-03-08
 
 ### Added

--- a/backend/apid/routers/authentication.go
+++ b/backend/apid/routers/authentication.go
@@ -47,7 +47,7 @@ func (a *AuthenticationRouter) login(w http.ResponseWriter, r *http.Request) {
 	// issuer URL
 	ctx := context.WithValue(r.Context(), jwt.IssuerURLKey, issuerURL(r))
 
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := api.NewAuthenticationClient(a.authenticator, a.store)
 	tokens, err := client.CreateAccessToken(ctx, username, password)
 	if err != nil {
 		if err == corev2.ErrUnauthorized {
@@ -76,7 +76,7 @@ func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := api.NewAuthenticationClient(a.authenticator, a.store)
 	err := client.TestCreds(r.Context(), username, password)
 	if err == nil {
 		return
@@ -90,7 +90,7 @@ func (a *AuthenticationRouter) test(w http.ResponseWriter, r *http.Request) {
 
 // logout handles the logout flow
 func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := api.NewAuthenticationClient(a.authenticator, a.store)
 	if err := client.Logout(r.Context()); err == nil {
 		return
 	}
@@ -100,7 +100,7 @@ func (a *AuthenticationRouter) logout(w http.ResponseWriter, r *http.Request) {
 
 // token handles logic for issuing new access tokens
 func (a *AuthenticationRouter) token(w http.ResponseWriter, r *http.Request) {
-	client := api.NewAuthenticationClient(a.authenticator)
+	client := api.NewAuthenticationClient(a.authenticator, a.store)
 
 	// Determine the URL that serves this request so it can be later used as the
 	// issuer URL

--- a/backend/apid/routers/authentication_test.go
+++ b/backend/apid/routers/authentication_test.go
@@ -52,6 +52,9 @@ func TestLoginSuccessful(t *testing.T) {
 	store.
 		On("AuthenticateUser", mock.Anything, "foo", "P@ssw0rd!").
 		Return(user, nil)
+	store.
+		On("UpdateSession", mock.Anything, "foo", mock.Anything, mock.Anything).
+		Return(nil)
 
 	req, _ := http.NewRequest(http.MethodGet, "/auth", nil)
 	req.SetBasicAuth("foo", "P@ssw0rd!")

--- a/backend/authentication/authenticator.go
+++ b/backend/authentication/authenticator.go
@@ -25,7 +25,7 @@ func (a *Authenticator) Authenticate(ctx context.Context, username, password str
 	// TODO(palourde): The Go runtime randomizes map iteration order so the
 	// providers resolution order might vary on each authentication, and
 	// consequently provoke weird behavior if the same username/password
-	// combinaison exists in multiple providers.
+	// combination exists in multiple providers.
 	for _, provider := range a.providers {
 		claims, err := provider.Authenticate(ctx, username, password)
 		if err != nil || claims == nil {

--- a/backend/authentication/jwt/jwt.go
+++ b/backend/authentication/jwt/jwt.go
@@ -198,6 +198,17 @@ func InitSecret(store store.Store) error {
 	return nil
 }
 
+// InitSession initializes a new session for the given username, returning a
+// unique identifier for the new session.
+func InitSession(username string) (string, error) {
+	sessionID, err := GenJTI()
+	if err != nil {
+		return "", err
+	}
+
+	return sessionID, nil
+}
+
 // parseToken takes a signed token and parse it to verify its integrity
 func parseToken(tokenString string) (*jwt.Token, error) {
 	t, err := jwt.ParseWithClaims(tokenString, &types.Claims{}, func(token *jwt.Token) (interface{}, error) {

--- a/backend/authentication/jwt/jwt_test.go
+++ b/backend/authentication/jwt/jwt_test.go
@@ -121,7 +121,7 @@ func TestValidateTokenError(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The token should expire after the expiration time
-	testTime.Set(time.Now().Add(defaultExpiration + time.Hour))
+	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Hour))
 	_, err = ValidateToken(tokenString)
 	assert.Error(t, err)
 }
@@ -134,7 +134,7 @@ func TestValidateExpiredToken(t *testing.T) {
 	_, tokenString, _ := AccessToken(claims)
 
 	// Wait for the token to expire
-	testTime.Set(time.Now().Add(defaultExpiration + time.Second))
+	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Second))
 	_, err := ValidateExpiredToken(tokenString)
 	assert.NoError(t, err, "An expired token should not be considered as invalid")
 }
@@ -158,7 +158,7 @@ func TestValidateExpiredTokenInvalid(t *testing.T) {
 	_, tokenString, _ := AccessToken(claims)
 
 	// The token will expire
-	testTime.Set(time.Now().Add(defaultExpiration + time.Second))
+	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Second))
 
 	// Modify the secret so it's no longer valid
 	secret = []byte("qux")

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -1,0 +1,50 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sensu/sensu-go/backend/store"
+	"go.etcd.io/etcd/client/v3"
+)
+
+func userSessionPath(username, sessionID string) string {
+	return fmt.Sprintf("%s/user_sessions/%s/%s", EtcdRoot, username, sessionID)
+}
+
+// GetSession retrieves the session state uniquely identified by the given
+// username and session ID.
+func (s *Store) GetSession(ctx context.Context, username, sessionID string) (string, error) {
+	sessionPath := userSessionPath(username, sessionID)
+
+	resp, err := s.client.Get(ctx, sessionPath, clientv3.WithLimit(1))
+	if err != nil {
+		return "", err
+	}
+
+	if len(resp.Kvs) == 0 {
+		return "", &store.ErrNotFound{Key: sessionPath}
+	}
+
+	return string(resp.Kvs[0].Value), nil
+}
+
+// UpdateSession applies the supplied state to the session uniquely identified
+// by the given username and session ID.
+func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
+	if _, err := s.client.Put(ctx, userSessionPath(username, sessionID), state); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteSession deletes the session uniquely identified by the given username
+// and session ID.
+func (s *Store) DeleteSession(ctx context.Context, username, sessionID string) error {
+	if _, err := s.client.Delete(ctx, userSessionPath(username, sessionID)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/store/etcd/session_test.go
+++ b/backend/store/etcd/session_test.go
@@ -1,0 +1,41 @@
+//go:build integration && !race
+// +build integration,!race
+
+package etcd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sensu/sensu-go/backend/store"
+)
+
+func TestSessionStore(t *testing.T) {
+	testWithEtcd(t, func(s store.Store) {
+		ctx := context.Background()
+		username := "user1"
+		sessionID := "abcdefghijklmnopqrstuvwxyz"
+		state := "some stored state"
+
+		// Create some new session state
+		err := s.UpdateSession(ctx, username, sessionID, state)
+		assert.NoError(t, err)
+
+		// Retrieve session
+		retrievedState, err := s.GetSession(ctx, username, sessionID)
+		assert.NoError(t, err)
+		assert.Equal(t, retrievedState, state)
+
+		// Delete session
+		err = s.DeleteSession(ctx, username, sessionID)
+		assert.NoError(t, err)
+
+		// Retrieve non existent session
+		unknownUser := "unknown_user"
+		unknownSessionID := "unknown_session_id"
+		_, err = s.GetSession(ctx, unknownUser, unknownSessionID)
+		assert.Error(t, err)
+	})
+}

--- a/backend/store/proxy.go
+++ b/backend/store/proxy.go
@@ -463,6 +463,24 @@ func (s *StoreProxy) UpdateRole(ctx context.Context, role *types.Role) error {
 	return s.do().UpdateRole(ctx, role)
 }
 
+// GetSession retrieves the session state uniquely identified by the given
+// username and session ID.
+func (s *StoreProxy) GetSession(ctx context.Context, username, sessionID string) (string, error) {
+	return s.do().GetSession(ctx, username, sessionID)
+}
+
+// UpdateSession applies the supplied state to the session uniquely identified
+// by the given username and session ID.
+func (s *StoreProxy) UpdateSession(ctx context.Context, username, sessionID, state string) error {
+	return s.do().UpdateSession(ctx, username, sessionID, state)
+}
+
+// DeleteSession deletes the session uniquely identified by the give username
+// and session ID.
+func (s *StoreProxy) DeleteSession(ctx context.Context, username, sessionID string) error {
+	return s.do().DeleteSession(ctx, username, sessionID)
+}
+
 // DeleteSilencedEntryByName deletes an entry using the given id.
 func (s *StoreProxy) DeleteSilencedEntryByName(ctx context.Context, id ...string) error {
 	return s.do().DeleteSilencedEntryByName(ctx, id...)

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -214,6 +214,9 @@ type Store interface {
 	// RoleBindingStore provides an interface for managing role bindings
 	RoleBindingStore
 
+	// SessionStore provides an interface for managing user sessions
+	SessionStore
+
 	// SilencedStore provides an interface for managing silenced entries,
 	// consisting of entities, subscriptions and/or checks
 	SilencedStore
@@ -261,6 +264,21 @@ type AuthenticationStore interface {
 
 	// UpdateJWTSecret updates the JWT secret with the given secret.
 	UpdateJWTSecret(secret []byte) error
+}
+
+// SessionStore provides methods for managing user sessions
+type SessionStore interface {
+	// GetSession retrieves the session state uniquely identified by the given
+	// username and session ID.
+	GetSession(ctx context.Context, username, sessionID string) (string, error)
+
+	// UpdateSession applies the supplied state to the session uniquely
+	// identified by the given username and session ID.
+	UpdateSession(ctx context.Context, username, sessionID string, state string) error
+
+	// DeleteSession deletes the session uniquely identified by the given
+	// username and session ID.
+	DeleteSession(ctx context.Context, username, sessionID string) error
 }
 
 // CheckConfigStore provides methods for managing checks configuration

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
 	github.com/go-test/deep v1.0.8
 	github.com/kr/pty v1.1.8 // indirect
-	github.com/sensu/core/v2 v2.17.0
+	github.com/sensu/core/v2 v2.19.0
 	github.com/sensu/core/v3 v3.8.1
 	github.com/sensu/sensu-api-tools v0.0.0-20221025205055-db03ae2f8099
 	github.com/sensu/sensu-go/types v0.12.0-alpha6

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,9 @@ github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmR
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sensu/core/v2 v2.16.0-alpha1/go.mod h1:vFoPc++U8m30t0fXKNGqOqHLOFr7VuqFc+Hkz+eTdmU=
 github.com/sensu/core/v2 v2.16.0-alpha6/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
-github.com/sensu/core/v2 v2.17.0 h1:f8apafxkAqvnFTOMnlTFdFbDrmuW9/MC5lgvgC8UmWs=
 github.com/sensu/core/v2 v2.17.0/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
+github.com/sensu/core/v2 v2.19.0 h1:EoCOYr1sNFUXNTrN5WcYcsc77N+Jbhliz8XnAXiSi7o=
+github.com/sensu/core/v2 v2.19.0/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
 github.com/sensu/core/v3 v3.8.0-alpha6/go.mod h1:HUrsxGfeUSvd+iU5ROGgfBchv3eYjhS3Apz6XzNB8Gg=
 github.com/sensu/core/v3 v3.8.1 h1:RhSlvUUOmIR2SF3AqtjVvowSLgRVAaAKAh1SOQRDx5E=
 github.com/sensu/core/v3 v3.8.1/go.mod h1:pxfUL8YOhebsaE2SUBov/gsUUqIzkeLM61yFpTeavhs=

--- a/testing/mockstore/session.go
+++ b/testing/mockstore/session.go
@@ -1,0 +1,18 @@
+package mockstore
+
+import "context"
+
+func (s *MockStore) GetSession(ctx context.Context, username, sessionID string) (string, error) {
+	args := s.Called(ctx, username, sessionID)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (s *MockStore) UpdateSession(ctx context.Context, username, sessionID, state string) error {
+	args := s.Called(ctx, username, sessionID, state)
+	return args.Error(0)
+}
+
+func (s *MockStore) DeleteSession(ctx context.Context, username, sessionID string) error {
+	args := s.Called(ctx, username, sessionID)
+	return args.Error(0)
+}


### PR DESCRIPTION
## What is this change?

- Add refresh token rotation, to reduce the impact of stolen refresh tokens
- Add a session store, used to detect and prevent refresh token reuse
- Use a new `SessionID` custom claim in the JWTs
- The session store allows for server side "refresh JWT invalidation"

## Why is this change necessary?

Fix and mitigate https://github.com/sensu/sensu-enterprise-go/issues/2605

## Does your change need a Changelog entry?

Added.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation needed.

## How did you verify this change?

- Unit and integration tests
- Manual testing

## Is this change a patch?

No.
