### PR TITLE
Log handler error at error level instead of info level

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Adding a flag at agent level to avoid collecting system.networks property in the agent entity state
 - Added silences sorting by expiration to GraphQL service
 - Added log-millisecond-timestamps backend configuration flag
+
+### Changed
+- Log handler error at error level instead of info level
+
 ## [6.9.2] - 2023-03-08
 
 ### Added

--- a/backend/pipeline/handler/legacy.go
+++ b/backend/pipeline/handler/legacy.go
@@ -84,7 +84,11 @@ func (l *LegacyAdapter) Handle(ctx context.Context, ref *corev2.ResourceReferenc
 		}
 		fields["status"] = result.Status
 		fields["output"] = result.Output
-		logger.WithFields(fields).Info("event pipe handler executed")
+		if result.Status == 0 {
+			logger.WithFields(fields).Info("event pipe handler executed")
+		} else {
+			logger.WithFields(fields).Error("event pipe handler returned non ok status code")
+		}
 	case "tcp", "udp":
 		err := l.socketHandler(ctx, handler, event, mutatedData)
 		if err != nil {


### PR DESCRIPTION
## What is this change?

When a handler returns an error (i.e. a non-zero return value) log the error at the error level instead of info.

## Why is this change necessary?

Helps customers troubleshoot handler errors since they typically use the error log level by default. It prevents them from having to change the log level and restart the backend.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

There was no error returned in case of handler so I left the behavior as is.

## Were there any complications while making this change?



## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual testing.

## Is this change a patch?

No.