### PR TITLE
Log handler errors at error level instead of info level

### DIFF
--- a/CHANGELOG-7.md
+++ b/CHANGELOG-7.md
@@ -50,6 +50,7 @@ returned regardless of filter count.
 entity subscriptions and/or a check named `deregistration`.
 - Upgraded Go version to 1.19.5. Old Go versions are not supported.
 - The sensuctl api-key grant command now returns additional information.
+- Handler errors now logged at the error level instead of info level
 
 ### Removed
 - Removed sensu-backend upgrade command. May make an appearance again in later versions.

--- a/backend/pipeline/handler/legacy.go
+++ b/backend/pipeline/handler/legacy.go
@@ -86,7 +86,11 @@ func (l *LegacyAdapter) Handle(ctx context.Context, ref *corev2.ResourceReferenc
 		}
 		fields["status"] = result.Status
 		fields["output"] = result.Output
-		logger.WithFields(fields).Info("event pipe handler executed")
+		if result.Status == 0 {
+			logger.WithFields(fields).Info("event pipe handler executed")
+		} else {
+			logger.WithFields(fields).Error("event pipe handler returned non ok status code")
+		}
 	case "tcp", "udp":
 		err := l.socketHandler(ctx, handler, event, mutatedData)
 		if err != nil {


### PR DESCRIPTION
## What is this change?

When a handler returns an error (i.e. a non-zero return value) log the error at the error level instead of info.

## Why is this change necessary?

Helps customers troubleshoot handler errors since they typically use the error log level by default. It prevents them from having to change the log level and restart the backend.

## Does your change need a Changelog entry?

Added.

## Do you need clarification on anything?

There was no error returned in case of handler so I left the behavior as is.

PR for 7.0/main.

## Were there any complications while making this change?



## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual testing.

## Is this change a patch?

No.