### PR TITLE
Improvement threshold annotations format (for 6.x)

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added silences sorting by expiration to GraphQL service
 - Added log-millisecond-timestamps backend configuration flag
 - Added a session store, used to detect and prevent refresh token reuse
+- Added threshold annotation even when OK status
 
 ### Changed
 - Log handler error at error level instead of info level

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 - Log handler error at error level instead of info level
 - Users are now automatically logged out after a period of inactivity (12h)
+- Changed the format of threshold annotations
 
 ## [6.9.2] - 2023-03-08
 

--- a/agent/check_handler.go
+++ b/agent/check_handler.go
@@ -25,10 +25,6 @@ const (
 	allowListOnDenyStatus        = "allow_list_on_deny_status"
 	allowListOnDenyOutput        = "check command denied by the agent allow list"
 	undocumentedTestCheckCommand = "!sensu_test_check!"
-
-	measureMin        = "min"
-	measureMax        = "max"
-	measureNullStatus = "null-status"
 )
 
 var (
@@ -418,13 +414,15 @@ func evaluateOutputMetricThresholds(event *corev2.Event) uint32 {
 	points := event.Metrics.Points
 	thresholds := event.Check.OutputMetricThresholds
 
-	var status uint32 = 0
+	var overallStatus uint32 = 0
 	annotationValue := ""
 	for _, thresholdRule := range thresholds {
 		ruleMatched := false
 		for _, metricPoint := range points {
 			if thresholdRule.MatchesMetricPoint(metricPoint) {
 				ruleMatched = true
+				var status uint32 = 0
+				isExceeded := false
 				for _, rule := range thresholdRule.Thresholds {
 					if rule.Min != "" {
 						min, err := strconv.ParseFloat(rule.Min, 64)
@@ -432,15 +430,17 @@ func evaluateOutputMetricThresholds(event *corev2.Event) uint32 {
 							continue
 						}
 						if metricPoint.Value < min {
-							addThresholdAnnotation(event, thresholdRule, measureMin, rule.Status, metricPoint.Value, rule.Min, true)
+							isExceeded = true
 							if status < rule.Status {
 								status = rule.Status
-								annotationValue = getAnnotationValue(thresholdRule, measureMin, metricPoint.Value, rule.Min, true)
+							}
+							if overallStatus < rule.Status {
+								overallStatus = rule.Status
+								annotationValue = getAnnotationValue(thresholdRule, metricPoint.Value, isExceeded)
 							}
 							continue
 						} else {
-							addThresholdAnnotation(event, thresholdRule, measureMin, 0, metricPoint.Value, rule.Min, false)
-							annotationValue = getAnnotationValue(thresholdRule, measureMin, metricPoint.Value, rule.Min, false)
+							annotationValue = getAnnotationValue(thresholdRule, metricPoint.Value, isExceeded)
 						}
 					}
 					if rule.Max != "" {
@@ -449,24 +449,27 @@ func evaluateOutputMetricThresholds(event *corev2.Event) uint32 {
 							continue
 						}
 						if metricPoint.Value > max {
-							addThresholdAnnotation(event, thresholdRule, measureMax, rule.Status, metricPoint.Value, rule.Max, true)
+							isExceeded = true
 							if status < rule.Status {
 								status = rule.Status
-								annotationValue = getAnnotationValue(thresholdRule, measureMax, metricPoint.Value, rule.Max, true)
+							}
+							if overallStatus < rule.Status {
+								overallStatus = rule.Status
+								annotationValue = getAnnotationValue(thresholdRule, metricPoint.Value, isExceeded)
 							}
 						} else {
-							addThresholdAnnotation(event, thresholdRule, measureMax, 0, metricPoint.Value, rule.Max, false)
-							annotationValue = getAnnotationValue(thresholdRule, measureMax, metricPoint.Value, rule.Max, false)
+							annotationValue = getAnnotationValue(thresholdRule, metricPoint.Value, isExceeded)
 						}
 					}
 				}
+				addThresholdAnnotation(event, thresholdRule, status, metricPoint.Value, isExceeded)
 			}
 		}
 		if !ruleMatched {
 			if thresholdRule.NullStatus > 0 {
 				addNullStatusThresholdAnnotation(event, thresholdRule, thresholdRule.NullStatus)
-				if status < thresholdRule.NullStatus {
-					status = thresholdRule.NullStatus
+				if overallStatus < thresholdRule.NullStatus {
+					overallStatus = thresholdRule.NullStatus
 					annotationValue = getNullStatusAnnotationValue(thresholdRule)
 				}
 			}
@@ -474,21 +477,21 @@ func evaluateOutputMetricThresholds(event *corev2.Event) uint32 {
 	}
 
 	if annotationValue != "" {
-		event.AddAnnotation("sensu.io/notifications/"+corev2.CheckStatusToCaption(status), annotationValue)
+		event.AddAnnotation("sensu.io/notifications/"+corev2.CheckStatusToCaption(overallStatus), annotationValue)
 	}
 
-	return status
+	return overallStatus
 }
 
-func addThresholdAnnotation(event *corev2.Event, metricThreshold *corev2.MetricThreshold, measure string, status uint32, value float64, threshold string, isExceeded bool) {
-	event.AddAnnotation(getAnnotationKey(metricThreshold, measure, status), getAnnotationValue(metricThreshold, measure, value, threshold, isExceeded))
+func addThresholdAnnotation(event *corev2.Event, metricThreshold *corev2.MetricThreshold, status uint32, value float64, isExceeded bool) {
+	event.AddAnnotation(getAnnotationKey(metricThreshold, status), getAnnotationValue(metricThreshold, value, isExceeded))
 }
 
 func addNullStatusThresholdAnnotation(event *corev2.Event, metricThreshold *corev2.MetricThreshold, status uint32) {
-	event.AddAnnotation(getAnnotationKey(metricThreshold, measureNullStatus, status), getNullStatusAnnotationValue(metricThreshold))
+	event.AddAnnotation(getAnnotationKey(metricThreshold, status), getNullStatusAnnotationValue(metricThreshold))
 }
 
-func getAnnotationKey(metricThreshold *corev2.MetricThreshold, measure string, status uint32) string {
+func getAnnotationKey(metricThreshold *corev2.MetricThreshold, status uint32) string {
 	var key strings.Builder
 
 	key.WriteString("sensu.io/output_metric_thresholds/")
@@ -498,14 +501,12 @@ func getAnnotationKey(metricThreshold *corev2.MetricThreshold, measure string, s
 		key.WriteString(tag.Value)
 	}
 	key.WriteString("/")
-	key.WriteString(measure)
-	key.WriteString("/")
 	key.WriteString(corev2.CheckStatusToCaption(status))
 
 	return key.String()
 }
 
-func getAnnotationValue(metricThreshold *corev2.MetricThreshold, measure string, value float64, threshold string, isExceeded bool) string {
+func getAnnotationValue(metricThreshold *corev2.MetricThreshold, value float64, isExceeded bool) string {
 	var val strings.Builder
 	var tagsKeyVal strings.Builder
 
@@ -526,16 +527,33 @@ func getAnnotationValue(metricThreshold *corev2.MetricThreshold, measure string,
 		val.WriteString(")")
 	}
 	if isExceeded {
-		val.WriteString(" exceeded the configured threshold (")
+		val.WriteString(" exceeded the configured threshold")
 	} else {
-		val.WriteString(" is within the configured threshold (")
+		val.WriteString(" is within the configured threshold")
 	}
-	val.WriteString(measure)
-	val.WriteString(": ")
-	val.WriteString(threshold)
-	val.WriteString(", actual: ")
+
+	for _, t := range metricThreshold.Thresholds {
+		hasMin := len(t.Min) > 0
+		hasMax := len(t.Max) > 0
+		val.WriteString("; expected ")
+		if hasMin {
+			val.WriteString("min: ")
+			val.WriteString(t.Min)
+		}
+		if hasMin && hasMax {
+			val.WriteString(" - ")
+		}
+		if hasMax {
+			val.WriteString("max: ")
+			val.WriteString(t.Max)
+		}
+		val.WriteString(" (status: ")
+		val.WriteString(corev2.CheckStatusToCaption(t.Status))
+		val.WriteString(")")
+	}
+
+	val.WriteString("; actual: ")
 	val.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
-	val.WriteString(").")
 
 	return val.String()
 }

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -661,13 +661,11 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 	statusWarningAnnotation := "sensu.io/notifications/warning"
 	statusUnknownAnnotation := "sensu.io/notifications/unknown"
 	statusCriticalAnnotation := "sensu.io/notifications/critical"
-	diskOKMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/ok"
-	diskOKMaxAnnotation := "sensu.io/output_metric_thresholds/disk_rate/max/ok"
-	diskCriticalMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/critical"
-	diskCriticalMaxAnnotation := "sensu.io/output_metric_thresholds/disk_rate/max/critical"
-	diskWarningMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/warning"
-	netUnknownMaxAnnotation := "sensu.io/output_metric_thresholds/network_rate/max/unknown"
-	notDiskWarningNullAnnotation := "sensu.io/output_metric_thresholds/not_a_disk_rate/null-status/warning"
+	diskOKAnnotation := "sensu.io/output_metric_thresholds/disk_rate/ok"
+	diskCriticalAnnotation := "sensu.io/output_metric_thresholds/disk_rate/critical"
+	diskWarningAnnotation := "sensu.io/output_metric_thresholds/disk_rate/warning"
+	netUnknownAnnotation := "sensu.io/output_metric_thresholds/network_rate/unknown"
+	notDiskWarningNullAnnotation := "sensu.io/output_metric_thresholds/not_a_disk_rate/warning"
 
 	testCases := []struct {
 		name                string
@@ -683,42 +681,42 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "200000.0", Status: 2}}}},
 			expectedStatus:      2,
-			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalMinAnnotation},
+			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalAnnotation},
 		}, {
 			name:                "maximum rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Max: "50000.0", Status: 2}}}},
 			expectedStatus:      2,
-			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalMaxAnnotation},
+			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalAnnotation},
 		}, {
 			name:                "no min rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "50000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{statusOKAnnotation, diskOKMinAnnotation},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKAnnotation},
 		}, {
 			name:                "no max rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Max: "200000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{statusOKAnnotation, diskOKMaxAnnotation},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKAnnotation},
 		}, {
 			name:                "min and max rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "200000.0", Status: 1}, {Max: "75000.0", Status: 2}}}},
 			expectedStatus:      2,
-			expectedAnnotations: []string{statusCriticalAnnotation, diskWarningMinAnnotation, diskCriticalMaxAnnotation},
+			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalAnnotation},
 		}, {
 			name:                "only one rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "200000.0", Status: 1}, {Max: "200000.0", Status: 2}}}},
 			expectedStatus:      1,
-			expectedAnnotations: []string{statusWarningAnnotation, diskWarningMinAnnotation, diskOKMaxAnnotation},
+			expectedAnnotations: []string{statusWarningAnnotation, diskWarningAnnotation},
 		}, {
 			name:                "no filter match - null status",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
@@ -732,14 +730,14 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			metrics:             []*corev2.MetricPoint{metric1, metric2},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", NullStatus: 1, Thresholds: []*corev2.MetricThresholdRule{{Max: "200000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{statusOKAnnotation, diskOKMaxAnnotation},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKAnnotation},
 		}, {
 			name:                "multi metric and filter and rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1, metric2},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", NullStatus: 1, Thresholds: []*corev2.MetricThresholdRule{{Max: "50000.0", Status: 2}}}},
 			expectedStatus:      2,
-			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalMaxAnnotation},
+			expectedAnnotations: []string{statusCriticalAnnotation, diskCriticalAnnotation},
 		}, {
 			name:    "multi metric and multi rule match",
 			event:   &corev2.Event{Check: &corev2.Check{Status: 0}},
@@ -747,7 +745,7 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			thresholds: []*corev2.MetricThreshold{{Name: "disk_rate", NullStatus: 1, Thresholds: []*corev2.MetricThresholdRule{{Max: "50000.0", Status: 2}}},
 				{Name: "network_rate", Thresholds: []*corev2.MetricThresholdRule{{Max: "40000", Status: 3}}}},
 			expectedStatus:      3,
-			expectedAnnotations: []string{statusUnknownAnnotation, diskCriticalMaxAnnotation, netUnknownMaxAnnotation},
+			expectedAnnotations: []string{statusUnknownAnnotation, diskCriticalAnnotation, netUnknownAnnotation},
 		},
 	}
 

--- a/agent/check_handler_internal_test.go
+++ b/agent/check_handler_internal_test.go
@@ -657,9 +657,12 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 	metric1 := &corev2.MetricPoint{Name: "disk_rate", Value: 99999.0, Timestamp: now, Tags: nil}
 	metric2 := &corev2.MetricPoint{Name: "network_rate", Value: 100001.0, Timestamp: now, Tags: []*corev2.MetricTag{{Name: "device", Value: "eth0"}}}
 
+	statusOKAnnotation := "sensu.io/notifications/ok"
 	statusWarningAnnotation := "sensu.io/notifications/warning"
 	statusUnknownAnnotation := "sensu.io/notifications/unknown"
 	statusCriticalAnnotation := "sensu.io/notifications/critical"
+	diskOKMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/ok"
+	diskOKMaxAnnotation := "sensu.io/output_metric_thresholds/disk_rate/max/ok"
 	diskCriticalMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/critical"
 	diskCriticalMaxAnnotation := "sensu.io/output_metric_thresholds/disk_rate/max/critical"
 	diskWarningMinAnnotation := "sensu.io/output_metric_thresholds/disk_rate/min/warning"
@@ -694,14 +697,14 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "50000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKMinAnnotation},
 		}, {
 			name:                "no max rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Max: "200000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKMaxAnnotation},
 		}, {
 			name:                "min and max rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
@@ -715,7 +718,7 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			metrics:             []*corev2.MetricPoint{metric1},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", Thresholds: []*corev2.MetricThresholdRule{{Min: "200000.0", Status: 1}, {Max: "200000.0", Status: 2}}}},
 			expectedStatus:      1,
-			expectedAnnotations: []string{statusWarningAnnotation, diskWarningMinAnnotation},
+			expectedAnnotations: []string{statusWarningAnnotation, diskWarningMinAnnotation, diskOKMaxAnnotation},
 		}, {
 			name:                "no filter match - null status",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},
@@ -729,7 +732,7 @@ func TestEvaluateOutputMetricThresholds(t *testing.T) {
 			metrics:             []*corev2.MetricPoint{metric1, metric2},
 			thresholds:          []*corev2.MetricThreshold{{Name: "disk_rate", NullStatus: 1, Thresholds: []*corev2.MetricThresholdRule{{Max: "200000.0", Status: 2}}}},
 			expectedStatus:      0,
-			expectedAnnotations: []string{},
+			expectedAnnotations: []string{statusOKAnnotation, diskOKMaxAnnotation},
 		}, {
 			name:                "multi metric and filter and rule match",
 			event:               &corev2.Event{Check: &corev2.Check{Status: 0}},


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

This PR adds annotations to the event even if the threshold check is normal.
In addition, the format is changed so that the min-max range can be output in a single annotation.

See #4987

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

Adding the threshold annotation when normal will allow to ensure that the thresholds are normal when notifying some communication platform of the Event.
This change also makes it easier to ensure that the threshold checks are working correctly.

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

Yes, required as **Added** and **Changed**.

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

This PR is for Sensu Go 6.x (develop/6 branch).

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

This section [Add event annotations based on metric threshold evaluation](https://docs.sensu.io/sensu-go/6.9/observability-pipeline/observe-schedule/metrics/#add-event-annotations-based-on-metric-threshold-evaluation) may need to be rewritten.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

Setup a test environment using `output_metric_thresholds` and verified that the annotations have been added.

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->

No.