### PR TITLE
Remove Go installation cache, cache Go installer instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,16 @@ jobs:
       name: windows/default
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - go-installer-<< pipeline.parameters.go_version >>
       - run:
           name: Download & Install Go
           command: .\ci\install-go.ps1 << pipeline.parameters.go_version >>
+      - save_cache:
+          key: go-installer-<< pipeline.parameters.go_version >>
+          paths:
+            - C:\go-installers
       - run: go version
       - run: go env
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,24 +53,17 @@ jobs:
       name: windows/default
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - go-cache
       - run:
           name: Download & Install Go
           command: .\ci\install-go.ps1 << pipeline.parameters.go_version >>
-      - save_cache:
-          key: go-cache
-          paths:
-            - C:\Program Files\Go
       - run: go version
       - run: go env
       - restore_cache:
           keys:
-            - go-mod-and-build-cache
+            - go-mod-and-build-cache-<< pipeline.parameters.go_version >>
       - run: go mod download
       - save_cache:
-          key: go-mod-and-build-cache
+          key: go-mod-and-build-cache-<< pipeline.parameters.go_version >>
           paths:
             - C:\Users\circleci\go
             - C:\Users\circleci\AppData\Local\go-build

--- a/ci/install-go.ps1
+++ b/ci/install-go.ps1
@@ -42,16 +42,15 @@ If (Test-CommandExists "go") {
     Write-Output "go not found"
 }
 
-Write-Output "Installing Go $version"
-
-$uri="https://storage.googleapis.com/golang/go$version.windows-amd64.msi"
-
-Write-Output "Downloading $uri"
-
 New-Item -ItemType Directory -Force -Path C:\go-installers
 
-Invoke-WebRequest -Uri $uri -OutFile "C:\go-installers\go$version.msi"
+$installerPath="C:\go-installers\go$version.msi"
+
+If (-Not (Test-Path -Path $installerPath -PathType Leaf)) {
+    $uri="https://storage.googleapis.com/golang/go$version.windows-amd64.msi"
+    Write-Output "Downloading $uri"
+    Invoke-WebRequest -Uri $uri -OutFile $installerPath
+}
 
 Write-Output "Installing go$version.msi"
-
-msiexec /i C:\go-installers\go$version.msi /q
+msiexec /i $installerPath /q

--- a/ci/install-go.ps1
+++ b/ci/install-go.ps1
@@ -48,8 +48,10 @@ $uri="https://storage.googleapis.com/golang/go$version.windows-amd64.msi"
 
 Write-Output "Downloading $uri"
 
-Invoke-WebRequest -Uri $uri -OutFile "C:\go.msi"
+New-Item -ItemType Directory -Force -Path C:\go-installers
 
-Write-Output "Installing go.msi"
+Invoke-WebRequest -Uri $uri -OutFile "C:\go-installers\go$version.msi"
 
-msiexec /i C:\go.msi /q
+Write-Output "Installing go$version.msi"
+
+msiexec /i C:\go-installers\go$version.msi /q


### PR DESCRIPTION
CI tests on Windows are broken due to restoring Go from cache overtop of the built-in Go installation. To quickly remediate this I've removed the caching of Go installations and added caching of the Go installer. Caching the Go installer vs no cache improves build times by approximately 4 minutes.