### PR TITLE
Fix the adhoc check execute api

### DIFF
--- a/backend/apid/routers/checks_test.go
+++ b/backend/apid/routers/checks_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/core/v3/types"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/testing/mockqueue"
 	"github.com/sensu/sensu-go/testing/mockstore"
@@ -35,7 +36,6 @@ func (m *mockCheckController) QueueAdhocRequest(ctx context.Context, check strin
 }
 
 func TestHttpApiChecksAdhocRequest(t *testing.T) {
-	t.Skip("skip")
 	defaultCtx := testutil.NewContext(
 		testutil.ContextWithNamespace("default"),
 	)
@@ -50,7 +50,7 @@ func TestHttpApiChecksAdhocRequest(t *testing.T) {
 	queue.On("Enqueue", mock.Anything, mock.Anything).Return(nil)
 	checkController := actions.NewCheckController(store, queue)
 	c := &ChecksRouter{controller: checkController}
-	payload, _ := json.Marshal(adhocRequest)
+	payload, _ := json.Marshal(types.WrapResource(adhocRequest))
 
 	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(payload))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/common v0.26.0
 	github.com/robertkrimen/otto v0.0.0-20221006114523-201ab5b34f52
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/sensu/core/v2 v2.18.0
+	github.com/sensu/core/v2 v2.20.0-alpha1
 	github.com/sensu/core/v3 v3.9.0-alpha2
 	github.com/sensu/lasr v1.2.1
 	github.com/sensu/sensu-api-tools v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sensu/core/v2 v2.18.0 h1:fRxPgC5lal5kA72wTDjFONKBGAQNlILwmjCg9PK5Nj8=
-github.com/sensu/core/v2 v2.18.0/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
+github.com/sensu/core/v2 v2.20.0-alpha1 h1:0uTCjplCw4MVSVut3TqzZ5hn0HOmrMG5w24Xwurmp3U=
+github.com/sensu/core/v2 v2.20.0-alpha1/go.mod h1:2etWGsa+nx5G2Q3CKiSJY9kSg8VhCgGzgp1VyxbC6U8=
 github.com/sensu/core/v3 v3.9.0-alpha2 h1:JmrrQ6VQTaaqBA8d0cqwwTmJQ3lJMjP92tg/pArYp48=
 github.com/sensu/core/v3 v3.9.0-alpha2/go.mod h1:hFTACYGAA1q9veRekPnSMJIGZT6bXsm3n/fYTr83MoA=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=


### PR DESCRIPTION
Bump github.com/sensu/core/v2 to v2.20.0-alpha1 in order to include changes needed to register core/v2.AdhocRequest as a resource.

Closes https://github.com/sensu/sensu-go/issues/5023