### PR TITLE
Fix small mistakes in function doc comments

### DIFF
--- a/backend/apid/graphql/corev3.go
+++ b/backend/apid/graphql/corev3.go
@@ -88,7 +88,7 @@ func (*corev3EntityStateExtImpl) ToJSON(p graphql.ResolveParams) (interface{}, e
 	return util_api.WrapResource(p.Source), nil
 }
 
-// State implements response to request for 'state' field.
+// Config implements response to request for 'config' field.
 func (i *corev3EntityStateExtImpl) Config(p graphql.ResolveParams) (interface{}, error) {
 	obj := p.Source.(*corev3.EntityState)
 	val := corev3.EntityConfig{}

--- a/backend/apid/graphql/globalid/components.go
+++ b/backend/apid/graphql/globalid/components.go
@@ -98,7 +98,7 @@ func (id *StandardComponents) Resource() string {
 	return id.resource
 }
 
-// Resource definition associated with this ID.
+// SetResource definition associated with this ID.
 func (id *StandardComponents) SetResource(str string) {
 	id.resource = str
 }

--- a/backend/apid/graphql/health.go
+++ b/backend/apid/graphql/health.go
@@ -76,7 +76,7 @@ func (r *etcdAlarmMemberImpl) MemberID(p graphql.ResolveParams) (string, error) 
 	return strconv.FormatUint(resp.MemberID, 10), nil
 }
 
-// MemberID implements response to request for 'memberID' field.
+// Alarm implements response to request for 'alarm' field.
 func (r *etcdAlarmMemberImpl) Alarm(p graphql.ResolveParams) (schema.EtcdAlarmType, error) {
 	resp := p.Source.(*etcdserverpb.AlarmMember)
 	return schema.EtcdAlarmType(resp.Alarm.String()), nil

--- a/backend/secrets/provider_test.go
+++ b/backend/secrets/provider_test.go
@@ -35,7 +35,7 @@ func (m *mockProvider) RBACName() string {
 	return args.Get(0).(string)
 }
 
-// StorePrefix ...
+// StoreName ...
 func (m *mockProvider) StoreName() string {
 	args := m.Called()
 	return args.Get(0).(string)

--- a/backend/store/postgres/entity_store.go
+++ b/backend/store/postgres/entity_store.go
@@ -65,8 +65,7 @@ func (s *EntityStore) DeleteEntityByName(ctx context.Context, name string) error
 	return s.deleteEntity(ctx, name, corev2.ContextNamespace(ctx))
 }
 
-// DeleteEntityByName deletes an entity using the given name and the
-// namespace stored in ctx.
+// deleteEntity deletes an entity using the given name and namespace.
 func (s *EntityStore) deleteEntity(ctx context.Context, name, namespace string) error {
 	entityConfigStore, entityStateStore, cleanup, err := prepareEntityStores(ctx, s.db)
 	if err != nil {

--- a/testing/mockpipeline/filter.go
+++ b/testing/mockpipeline/filter.go
@@ -18,7 +18,7 @@ func (m *FilterAdapter) Name() string {
 	return args.Get(0).(string)
 }
 
-// CanMutate ...
+// CanFilter ...
 func (m *FilterAdapter) CanFilter(ref *corev2.ResourceReference) bool {
 	args := m.Called(ref)
 	return args.Get(0).(bool)


### PR DESCRIPTION
This mostly fixes some places where the name of the function in the comment didn't match its definition.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!