### PR TITLE
Add support escape special characters in InfluxDB Line (for 6.x)

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Added silences sorting by expiration to GraphQL service
 - Added log-millisecond-timestamps backend configuration flag
 - Added a session store, used to detect and prevent refresh token reuse
+- Added support escape special characters in InfluxDB Line
 
 ### Changed
 - Log handler error at error level instead of info level

--- a/agent/transformers/influx_db.go
+++ b/agent/transformers/influx_db.go
@@ -57,28 +57,28 @@ OUTER:
 		fields["line"] = l
 		l++
 		i := Influx{}
-		args := strings.Split(line, " ")
+		args := splitWithoutEscaped(line, " ")
 		if len(args) != 3 && len(args) != 2 {
 			logger.WithFields(fields).WithError(ErrMetricExtraction).Error("influxdb line format requires 2 arguments with a 3rd (optional) timestamp")
 			continue
 		}
 
-		measurementTag := strings.Split(args[0], ",")
-		i.Measurement = measurementTag[0]
+		measurementTag := splitWithoutEscaped(args[0], ",")
+		i.Measurement = unescape(measurementTag[0])
 		tagList := []*types.MetricTag{}
 		if len(measurementTag) == 1 {
 			i.TagSet = tagList
 		} else {
 			for i, tagSet := range measurementTag {
 				if i != 0 {
-					ts := strings.Split(tagSet, "=")
+					ts := splitWithoutEscaped(tagSet, "=")
 					if len(ts) != 2 {
 						logger.WithFields(fields).WithError(ErrMetricExtraction).Error("metric tag set is invalid, must contain a key=value pair")
 						continue OUTER
 					}
 					tag := &types.MetricTag{
-						Name:  ts[0],
-						Value: ts[1],
+						Name:  unescape(ts[0]),
+						Value: unescape(ts[1]),
 					}
 					tagList = append(tagList, tag)
 				}
@@ -90,10 +90,10 @@ OUTER:
 			i.TagSet = append(i.TagSet, event.Check.OutputMetricTags...)
 		}
 
-		fieldSets := strings.Split(args[1], ",")
+		fieldSets := splitWithoutEscaped(args[1], ",")
 		fieldList := []*Field{}
 		for _, fieldSet := range fieldSets {
-			fs := strings.Split(fieldSet, "=")
+			fs := splitWithoutEscaped(fieldSet, "=")
 			if len(fs) != 2 {
 				logger.WithFields(fields).WithError(ErrMetricExtraction).Error("metric field set is invalid, must contain a key=value pair")
 				continue OUTER
@@ -104,7 +104,7 @@ OUTER:
 				continue OUTER
 			}
 			field := &Field{
-				Key:   fs[0],
+				Key:   unescape(fs[0]),
 				Value: f,
 			}
 			fieldList = append(fieldList, field)
@@ -132,4 +132,20 @@ OUTER:
 	}
 
 	return influxList
+}
+
+func splitWithoutEscaped(s, sep string) []string {
+	s = strings.ReplaceAll(s, `\` + sep, "\x00")
+	segments := strings.Split(s, sep)
+	for i := range segments {
+		segments[i] = strings.ReplaceAll(segments[i], "\x00", sep)
+	}
+	return segments
+}
+
+func unescape(s string) string {
+	s = strings.ReplaceAll(s, `\\`, "\x00")
+	s = strings.ReplaceAll(s, `\`, "")
+	s = strings.ReplaceAll(s, "\x00", `\`)
+	return s
 }

--- a/agent/transformers/influx_db_test.go
+++ b/agent/transformers/influx_db_test.go
@@ -130,6 +130,46 @@ func TestParseInflux(t *testing.T) {
 			},
 		},
 		{
+			metric: "wea\\ ther,locat\\,ion=us-mid\\=west,sea\"son=sum\\\\mer te\\ mp\\,er\\=at\"ure=82,h\\ um\\,id\\=it\"y=30 1465839830100400200\nw\\ e\\,a\\=t\"her te\\ mp\\,er\\=at\"ure=82 1465839830100400200\n",
+			expectedFormat: InfluxList{
+				{
+					Measurement: "wea ther",
+					TagSet: []*types.MetricTag{
+						{
+							Name:  "locat,ion",
+							Value: "us-mid=west",
+						},
+						{
+							Name:  `sea"son`,
+							Value: `sum\mer`,
+						},
+					},
+					FieldSet: []*Field{
+						{
+							Key:   `te mp,er=at"ure`,
+							Value: 82,
+						},
+						{
+							Key:   `h um,id=it"y`,
+							Value: 30,
+						},
+					},
+					Timestamp: 1465839830,
+				},
+				{
+					Measurement: `w e,a=t"her`,
+					TagSet:      []*types.MetricTag{},
+					FieldSet: []*Field{
+						{
+							Key:   `te mp,er=at"ure`,
+							Value: 82,
+						},
+					},
+					Timestamp: 1465839830,
+				},
+			},
+		},
+		{
 			metric:           "weather temperature=82",
 			timeInconclusive: true,
 		},


### PR DESCRIPTION
## What is this change?

<!-- A brief one-sentence-ish description of the change. -->

#5030 Implementation.

## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

Here is also #5030 as shown.

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

Yes. Added.
This is an extension of the existing InfluxDB Line format, so it is marked as Added instead of Changed.

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->

## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

No. I do not think there is any need for this.

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

Tested with Mimir 2.9.0 and InfluxDB 2.7.1.
Both confirm that the metrics are stored correctly.

<details>
<summary>spoilers</summary>

- CheckConfig

```yaml
---
type: CheckConfig
api_version: core/v2
metadata:
  name: output_metrics_as_influxdb_line
spec:
  command: |
    cat << 'EOS'
    test_metrics1,test_tag1=foo,test_tag2=bar value=1
    test_metrics2,test_tag1=ho\ ge,test_tag2=hu\,ga,test_tag3=hi\=ge,test_tag4=ha"ge value=1
    EOS
  output_metric_format: influxdb_line
  output_metric_handlers:
  - mimir
  - influxdb
  subscriptions:
  - test
  interval: 15
  publish: true
```

- Handlers

```yaml
---
type: Handler
api_version: core/v2
metadata:
  name: influxdb
spec:
  command: 'sensu-influxdb-handler -a http://i:8086 -b default -c -o test -t hogehogeunko'
  type: pipe
  runtime_assets:
  - sensu-influxdb-handler

---
type: Asset
api_version: core/v2
metadata:
  name: sensu-influxdb-handler
  labels: 
  annotations:
    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-influxdb-handler
    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-influxdb-handler
    io.sensu.bonsai.tier: Supported
    io.sensu.bonsai.version: 4.0.0
    io.sensu.bonsai.namespace: sensu
    io.sensu.bonsai.name: sensu-influxdb-handler
    io.sensu.bonsai.tags: ''
spec:
  builds:
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_linux_amd64.tar.gz
    sha512: 86fa6645b7a103cda393fb1611c29a2f6cbf4283d800ded8c3a3bbcdc6279d2d2e235331a092f580bd18a2b1b7a3f095612d80bb265b3e70ddb75236ae6aae60
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'amd64'
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_linux_386.tar.gz
    sha512: 9e0386f053478e36307665ccda72091c56a53bd69397d71a5200e3003f1e33f7cb6cd2ce210cfdc1af598322de279ef5513ca2f17bbca23bf4bbdd88a06ad279
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == '386'
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_linux_arm64.tar.gz
    sha512: adf3c9e4f0d2840b11736fae446b22534a54818081361ab94d0e073cdcfcc74ea78e7c9d951f7976eae64e8a4954b65d312a7b6a7e0db16328b9aeedd3c6f546
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'arm64'
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_linux_armv7.tar.gz
    sha512: 19a9ccbbf05e80298aa35b657426e91781034f3eba3fc877c9f19622b2592aeedba363c9fb3c76bc4410e4122a04c43c781d42304a9009fcb125538438260393
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'armv7'
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_darwin_amd64.tar.gz
    sha512: a1b3d0a8ec1ce2b82413f5799fd782e0a53155de58312559a22b7901b2ecfa403deea30f023cf3c5755bb3410456b94aa004136b1247f6aa08738b4fbe98f1bc
    filters:
    - entity.system.os == 'darwin'
    - entity.system.arch == 'amd64'
  - url: https://assets.bonsai.sensu.io/4ef9132e9c75e90db0625f81f54e16b258065bed/sensu-influxdb-handler_4.0.0_windows_amd64.tar.gz
    sha512: 92e77345bd5daa8d92b2acce8f2e7cdc7db2e6223f26c904e00507b17dd50e386602156dff02d93c5342da653b3c343cffbca8f08680c73d055f05d3bad3e919
    filters:
    - entity.system.os == 'windows'
    - entity.system.arch == 'amd64'

---
type: Handler
api_version: core/v2
metadata:
  name: mimir
spec:
  command: 'sensu-prometheus-remote-write-handler -e http://m:8080/api/v1/push -H "X-Scope-OrgID: test"'
  type: pipe
  runtime_assets:
  - sensu-prometheus-remote-write-handler

---
type: Asset
api_version: core/v2
metadata:
  name: sensu-prometheus-remote-write-handler
  labels: 
  annotations:
    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/jadiunr/sensu-prometheus-remote-write-handler
    io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/jadiunr/sensu-prometheus-remote-write-handler
    io.sensu.bonsai.tier: Community
    io.sensu.bonsai.version: 0.1.0
    io.sensu.bonsai.namespace: jadiunr
    io.sensu.bonsai.name: sensu-prometheus-remote-write-handler
    io.sensu.bonsai.tags: ''
spec:
  builds:
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_linux_amd64.tar.gz
    sha512: a79aeb5a4e5817bf6360f6b2429dcb4321ff1b3728a429afb515e80fef59a1e86c7be26cf604044a7d7b5cd1e664a23623e46fa938099be0549ad26ee2e7e907
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'amd64'
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_linux_arm64.tar.gz
    sha512: 41f041a8df6565d07b0fe07222fd97fa21d4718b0e13f55a1ae4dfa96b5fec7715b45711c67bdedf0be9313ba44bbacb05e1a585e3473c6c5aab190e2de59de9
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'arm64'
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_linux_armv7.tar.gz
    sha512: 3ce5c37b9e57e8c82d279fccb94f269677df4b784d0ec0a522c812c584aee530d0a3bf223a046fc7afa0d31e9167c084b0b591d69d74c5d44665447685e0be87
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'arm'
    - entity.system.arm_version == 7
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_linux_armv6.tar.gz
    sha512: a956938e7e8c512c9ce9b05f0375f175593834138cf18f9586699bca21ffa5ec4652c5aa2280d51b999241f3b55d335dd0d9d53be7e8bde464a1d324050bc8f4
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == 'arm'
    - entity.system.arm_version == 6
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_linux_386.tar.gz
    sha512: 4566ec88aff0af47dd44467b893ed6649927d18bb0624a371d07a1f9ac3a070c80dd9d9fa03cf22b10f205937ff7f70028a18d7d835757055501015a979e4cfe
    filters:
    - entity.system.os == 'linux'
    - entity.system.arch == '386'
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_darwin_amd64.tar.gz
    sha512: 06ae5e5c24efae30a527f0bafc242d6183718da6a21afa9391bfd142e87a047be1ad009b48e0f606101fdd9322406eb63574af147f653524578c088291905e51
    filters:
    - entity.system.os == 'darwin'
    - entity.system.arch == 'amd64'
  - url: https://assets.bonsai.sensu.io/3800f9a28de1fcbfd0cd5f101f19c4bd333f4cfb/sensu-prometheus-remote-write-handler_0.1.0_windows_amd64.tar.gz
    sha512: 42617eaa5b482d1cb8a05d2e2aa6bc5f08d21f07b013a8515790d0f54bd9d4e0459a2788a4df5b3390a25bc21d192cb26685f9c9a49c7b676a380f5f84ef8c92
    filters:
    - entity.system.os == 'windows'
    - entity.system.arch == 'amd64'
```

</details>

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->

No.