### PR TITLE
Upgrade to Go 1.21.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 parameters:
   go_version:
     type: string
-    default: "1.17.12"
+    default: "1.21.3"
 
 sensu_go_build_env: &sensu_go_build_env
   docker:

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Upgraded CI Go version to 1.21.3
+
+
 ## [6.10.0] - 2023-05-23
 
 ### Added

--- a/backend/authorization/rbac/rbac_test.go
+++ b/backend/authorization/rbac/rbac_test.go
@@ -27,9 +27,9 @@ func TestAuthorize(t *testing.T) {
 			name:  "no bindings",
 			attrs: &authorization.Attributes{Namespace: "acme"},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilRoleBindings, nil)
 			},
 			want: false,
@@ -37,7 +37,7 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "ClusterRoleBindings store err",
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, errors.New("error"))
 			},
 			wantErr: true,
@@ -51,13 +51,13 @@ func TestAuthorize(t *testing.T) {
 				},
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.ClusterRoleBinding{{
 						Subjects: []corev2.Subject{
 							{Type: corev2.UserType, Name: "bar"},
 						},
 					}}, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilRoleBindings, nil)
 			},
 			want: false,
@@ -70,7 +70,7 @@ func TestAuthorize(t *testing.T) {
 				},
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.ClusterRoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
@@ -96,7 +96,7 @@ func TestAuthorize(t *testing.T) {
 				},
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.ClusterRoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
@@ -121,9 +121,9 @@ func TestAuthorize(t *testing.T) {
 			name:  "RoleBindings store err",
 			attrs: &authorization.Attributes{Namespace: "acme"},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilRoleBindings, errors.New("error"))
 			},
 			wantErr: true,
@@ -137,9 +137,9 @@ func TestAuthorize(t *testing.T) {
 				},
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.RoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
@@ -164,9 +164,9 @@ func TestAuthorize(t *testing.T) {
 				},
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.RoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
@@ -193,10 +193,10 @@ func TestAuthorize(t *testing.T) {
 				ResourceName: "check-cpu",
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.RoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
@@ -227,10 +227,10 @@ func TestAuthorize(t *testing.T) {
 				Resource: "users",
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.RoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "ClusterRole",
@@ -262,10 +262,10 @@ func TestAuthorize(t *testing.T) {
 				ResourceName: "check-cpu",
 			},
 			storeFunc: func(s *mockstore.MockStore) {
-				s.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return(nilClusterRoleBindings, nil)
 
-				s.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+				s.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 					Return([]*corev2.RoleBinding{{
 						RoleRef: corev2.RoleRef{
 							Type: "Role",
@@ -442,7 +442,7 @@ func TestVisitRulesFor(t *testing.T) {
 	a := &Authorizer{
 		Store: stor,
 	}
-	stor.On("ListClusterRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+	stor.On("ListClusterRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 		Return([]*corev2.ClusterRoleBinding{{
 			RoleRef: corev2.RoleRef{
 				Type: "ClusterRole",
@@ -453,7 +453,7 @@ func TestVisitRulesFor(t *testing.T) {
 			},
 		}}, nil)
 
-	stor.On("ListRoleBindings", mock.AnythingOfType("*context.emptyCtx"), &store.SelectionPredicate{}).
+	stor.On("ListRoleBindings", mock.Anything, &store.SelectionPredicate{}).
 		Return([]*corev2.RoleBinding{{
 			RoleRef: corev2.RoleRef{
 				Type: "Role",


### PR DESCRIPTION
## What is this change?

Upgrades Go to 1.21.3.

## Why is this change necessary?

We're far behind on keeping up to date with the latest Go versions.

## Does your change need a Changelog entry?

Yes.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Yes, we had to merge #5033 to fix an issue with the types module.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No new documentation is required.

## How did you verify this change?

Unit tests.

## Is this change a patch?

No.
