### PR TITLE
Use native Semgrep in CI

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -23,4 +23,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: SemgrepSensu
         run: semgrep ci
-        env: SEMGREP_APP_TOKEN
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,20 +4,23 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     name: Check
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Semgrep
-        id: semgrep
-        uses: returntocorp/semgrep-action@v1
-        with:
-          config: p/semgrep-go-correctness
+        run: semgrep ci -c p/semgrep-go-correctness
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
   semgrep-sensu: # looks for .semgrep.yml due to missing config section
     runs-on: ubuntu-latest
     name: Check
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: SemgrepSensu
-        id: semgrep-sensu
-        uses: returntocorp/semgrep-action@v1
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semgrep ci
+        env: SEMGREP_APP_TOKEN

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,7 +3,6 @@ on: [pull_request]
 jobs:
   semgrep:
     runs-on: ubuntu-latest
-    name: Check
     container:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
@@ -11,17 +10,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Semgrep
         run: semgrep ci -c p/semgrep-go-correctness
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-  semgrep-sensu: # looks for .semgrep.yml due to missing config section
+  semgrep-sensu:
     runs-on: ubuntu-latest
-    name: Check
     container:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
       - name: SemgrepSensu
-        run: semgrep ci
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        run: semgrep ci -c .semgrep.yml


### PR DESCRIPTION
The GitHub Action that we were using for Semgrep was deprecated and has now been removed. Use native Semgrep instead.