### PR TITLE
Git issue #5009 Asset cache can lead to denial of service if asset database is deleted -Fix

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -8,6 +8,14 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### 2024-02-01
+
+### Changed
+- The expandWithDuration in boltdb_manager to have a assetSHA dir cleanup.
+
+### Added
+- Added the cleanup in expander to clean the assetSHA in case of asset cache getting deleted
+
 ### Changed
 - Upgraded CI Go version to 1.21.3
 - Upgraded jwt version to 4.4.3

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -10,11 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### 2024-02-01
 
-### Changed
-- The expandWithDuration in boltdb_manager to have a assetSHA dir cleanup.
-
-### Added
-- Added the cleanup in expander to clean the assetSHA in case of asset cache getting deleted
+### Fixed
+- Assets can now be re-installed when the asset.db file has been deleted.
 
 ### Changed
 - Upgraded CI Go version to 1.21.3

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 
@@ -23,6 +24,7 @@ const (
 	// ExpandDuration is the name of the prometheus summary vec used to track
 	// average latencies of asset expansion.
 	ExpandDuration = "sensu_go_asset_expand_duration"
+	FlagCacheDir   = "cache-dir"
 )
 
 var (
@@ -240,6 +242,14 @@ func (b *boltDBAssetManager) expandWithDuration(tmpFile *os.File, asset *corev2.
 			Observe(v * float64(1000))
 	}))
 	defer timer.ObserveDuration()
+
+	assetSHA := asset.Sha512
+	CacheDir := viper.GetString(FlagCacheDir)
+	fullPath := filepath.Join(CacheDir, assetSHA)
+
+	if err := CleanUp(fullPath); err != nil { //fix for git issue 5009
+		logger.Printf("error cleaning up the SHA dir: %s", err)
+	}
 
 	assetPath = filepath.Join(b.localStorage, asset.Sha512)
 	return assetPath, b.expander.Expand(tmpFile, assetPath)

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -247,8 +247,9 @@ func (b *boltDBAssetManager) expandWithDuration(tmpFile *os.File, asset *corev2.
 	CacheDir := viper.GetString(FlagCacheDir)
 	fullPath := filepath.Join(CacheDir, assetSHA)
 
-	if err := CleanUp(fullPath); err != nil { //fix for git issue 5009
-		logger.Printf("error cleaning up the SHA dir: %s", err)
+	if err := CleanUp(fullPath); err != nil {
+		logger.WithField("assetSHA path", fullPath).WithError(err).
+			Error("error cleaning up the assetSHA")
 	}
 
 	assetPath = filepath.Join(b.localStorage, asset.Sha512)

--- a/asset/boltdb_manager.go
+++ b/asset/boltdb_manager.go
@@ -247,7 +247,7 @@ func (b *boltDBAssetManager) expandWithDuration(tmpFile *os.File, asset *corev2.
 	CacheDir := viper.GetString(FlagCacheDir)
 	fullPath := filepath.Join(CacheDir, assetSHA)
 
-	if err := CleanUp(fullPath); err != nil {
+	if err := os.RemoveAll(fullPath); err != nil {
 		logger.WithField("assetSHA path", fullPath).WithError(err).
 			Error("error cleaning up the assetSHA")
 	}

--- a/asset/boltdb_manager_test.go
+++ b/asset/boltdb_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
@@ -216,6 +217,33 @@ func TestFailedExpand(t *testing.T) {
 
 	if err == nil {
 		t.Log("expected error, got nil")
+		t.Fail()
+	}
+
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Define the SHA and file name
+	SHAName := "shaAsset.tar"
+	SHAFilePath := filepath.Join(tmpDir, SHAName)
+
+	// Create a dummy file inside the temporary directory
+	SHAFile, err := os.Create(SHAFilePath)
+	if err != nil {
+		t.Fatalf("Failed to create dummy file: %v", err)
+	}
+	SHAFile.Close()
+
+	// Call CleanUp with the SHA of the dummy file and the temporary directory
+	err = os.RemoveAll(SHAFilePath)
+	if err != nil {
+		t.Errorf("CleanUp returned an error: %v", err)
+		t.Fail()
+	}
+
+	_, err = os.Stat(SHAFilePath)
+	if !os.IsNotExist(err) {
+		t.Errorf("CleanUp did not remove the dummy file as expected")
 		t.Fail()
 	}
 }

--- a/asset/expander.go
+++ b/asset/expander.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	archiver "github.com/mholt/archiver/v3"
 
@@ -89,4 +90,15 @@ func sniffType(f io.ReadSeeker) (filetype_types.Type, error) {
 	}
 
 	return ft, nil
+}
+
+// Sudhanshu - CleanUp the SHA for the git issue 5009 fix. Making sure that in case of DOS when asset.db gets deleted it gets cleanUp so that asset can be re-downloded
+
+func CleanUp(fullPath string) error {
+	errorSHA := os.RemoveAll(fullPath)
+	if errorSHA != nil {
+		return errorSHA
+	}
+	return nil
+
 }

--- a/asset/expander.go
+++ b/asset/expander.go
@@ -3,10 +3,8 @@ package asset
 import (
 	"errors"
 	"fmt"
-	"io"
-	"os"
-
 	archiver "github.com/mholt/archiver/v3"
+	"io"
 
 	filetype "gopkg.in/h2non/filetype.v1"
 	filetype_types "gopkg.in/h2non/filetype.v1/types"
@@ -93,6 +91,6 @@ func sniffType(f io.ReadSeeker) (filetype_types.Type, error) {
 }
 
 // cleanup of the assetSHA when cache dir gets force deleted
-func CleanUp(fullPath string) error {
-	return os.RemoveAll(fullPath)
-}
+//func CleanUp(fullPath string) error {
+//	return os.RemoveAll(fullPath)
+//}

--- a/asset/expander.go
+++ b/asset/expander.go
@@ -92,8 +92,7 @@ func sniffType(f io.ReadSeeker) (filetype_types.Type, error) {
 	return ft, nil
 }
 
-// Sudhanshu - CleanUp the SHA for the git issue 5009 fix. Making sure that in case of DOS when asset.db gets deleted it gets cleanUp so that asset can be re-downloded
-
+// cleanup of the assetSHA when cache dir gets force deleted
 func CleanUp(fullPath string) error {
 	errorSHA := os.RemoveAll(fullPath)
 	if errorSHA != nil {

--- a/asset/expander.go
+++ b/asset/expander.go
@@ -94,10 +94,5 @@ func sniffType(f io.ReadSeeker) (filetype_types.Type, error) {
 
 // cleanup of the assetSHA when cache dir gets force deleted
 func CleanUp(fullPath string) error {
-	errorSHA := os.RemoveAll(fullPath)
-	if errorSHA != nil {
-		return errorSHA
-	}
-	return nil
-
+	return os.RemoveAll(fullPath)
 }

--- a/asset/expander.go
+++ b/asset/expander.go
@@ -89,8 +89,3 @@ func sniffType(f io.ReadSeeker) (filetype_types.Type, error) {
 
 	return ft, nil
 }
-
-// cleanup of the assetSHA when cache dir gets force deleted
-//func CleanUp(fullPath string) error {
-//	return os.RemoveAll(fullPath)
-//}

--- a/asset/expander_test.go
+++ b/asset/expander_test.go
@@ -115,31 +115,31 @@ func TestExpandInvalidArchive(t *testing.T) {
 }
 
 // ---Test to check CleanUp
-func TestCleanUp(t *testing.T) {
-	t.Parallel()
-
-	// Create a temporary directory for testing
-	tmpDir := t.TempDir()
-
-	// Define the SHA and file name
-	SHAName := "shaAsset.tar"
-	SHAFilePath := filepath.Join(tmpDir, SHAName)
-
-	// Create a dummy file inside the temporary directory
-	SHAFile, err := os.Create(SHAFilePath)
-	if err != nil {
-		t.Fatalf("Failed to create dummy file: %v", err)
-	}
-	SHAFile.Close()
-
-	// Call CleanUp with the SHA of the dummy file and the temporary directory
-	err = CleanUp(SHAFilePath)
-	if err != nil {
-		t.Errorf("CleanUp returned an error: %v", err)
-	}
-
-	_, err = os.Stat(SHAFilePath)
-	if !os.IsNotExist(err) {
-		t.Errorf("CleanUp did not remove the dummy file as expected")
-	}
-}
+//func TestCleanUp(t *testing.T) {
+//	t.Parallel()
+//
+//	// Create a temporary directory for testing
+//	tmpDir := t.TempDir()
+//
+//	// Define the SHA and file name
+//	SHAName := "shaAsset.tar"
+//	SHAFilePath := filepath.Join(tmpDir, SHAName)
+//
+//	// Create a dummy file inside the temporary directory
+//	SHAFile, err := os.Create(SHAFilePath)
+//	if err != nil {
+//		t.Fatalf("Failed to create dummy file: %v", err)
+//	}
+//	SHAFile.Close()
+//
+//	// Call CleanUp with the SHA of the dummy file and the temporary directory
+//	err = CleanUp(SHAFilePath)
+//	if err != nil {
+//		t.Errorf("CleanUp returned an error: %v", err)
+//	}
+//
+//	_, err = os.Stat(SHAFilePath)
+//	if !os.IsNotExist(err) {
+//		t.Errorf("CleanUp did not remove the dummy file as expected")
+//	}
+//}

--- a/asset/expander_test.go
+++ b/asset/expander_test.go
@@ -113,3 +113,33 @@ func TestExpandInvalidArchive(t *testing.T) {
 		t.Fail()
 	}
 }
+
+// ---Test to check CleanUp
+func TestCleanUp(t *testing.T) {
+	t.Parallel()
+
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	// Define the SHA and file name
+	SHAName := "shaAsset.tar"
+	SHAFilePath := filepath.Join(tmpDir, SHAName)
+
+	// Create a dummy file inside the temporary directory
+	SHAFile, err := os.Create(SHAFilePath)
+	if err != nil {
+		t.Fatalf("Failed to create dummy file: %v", err)
+	}
+	SHAFile.Close()
+
+	// Call CleanUp with the SHA of the dummy file and the temporary directory
+	err = CleanUp(SHAFilePath)
+	if err != nil {
+		t.Errorf("CleanUp returned an error: %v", err)
+	}
+
+	_, err = os.Stat(SHAFilePath)
+	if !os.IsNotExist(err) {
+		t.Errorf("CleanUp did not remove the dummy file as expected")
+	}
+}

--- a/asset/expander_test.go
+++ b/asset/expander_test.go
@@ -113,33 +113,3 @@ func TestExpandInvalidArchive(t *testing.T) {
 		t.Fail()
 	}
 }
-
-// ---Test to check CleanUp
-//func TestCleanUp(t *testing.T) {
-//	t.Parallel()
-//
-//	// Create a temporary directory for testing
-//	tmpDir := t.TempDir()
-//
-//	// Define the SHA and file name
-//	SHAName := "shaAsset.tar"
-//	SHAFilePath := filepath.Join(tmpDir, SHAName)
-//
-//	// Create a dummy file inside the temporary directory
-//	SHAFile, err := os.Create(SHAFilePath)
-//	if err != nil {
-//		t.Fatalf("Failed to create dummy file: %v", err)
-//	}
-//	SHAFile.Close()
-//
-//	// Call CleanUp with the SHA of the dummy file and the temporary directory
-//	err = CleanUp(SHAFilePath)
-//	if err != nil {
-//		t.Errorf("CleanUp returned an error: %v", err)
-//	}
-//
-//	_, err = os.Stat(SHAFilePath)
-//	if !os.IsNotExist(err) {
-//		t.Errorf("CleanUp did not remove the dummy file as expected")
-//	}
-//}


### PR DESCRIPTION
Closed #5009 

## Description
The change is regarding the denial of service from agent when asset.db gets deleted due to some external scenario. 
Which creates a DOS as SHA contains the some reference to the previous asset.db and hence forth the new one does not get created properly.

<!-- A brief one-sentence-ish description of the change. -->


## Change in behavior
To prevent the DOS of the agent in above scenario and keep the agent working properly. For new asset.db creation. 

<!-- A brief description of why the change of behavior is necessary. -->

## Added 

- The new cleanUp function for cleaning up the SHA dir from cache to prevent a DOS in case of asset.db deletion.
- Added the test to check all scenarios.

## Changed

- The expandWithDuration function in boltdb_manager has been changed a little for the cleanUp function support.

## Fixed

- This fixes the DOS in agent in case of asset database is deleted.

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

## Change verification
The changes can be verified not only by the test cases but also by checking the same behavior. That is delete the asset.db and make note of it's size. Then re-run the agent and it will run without populating error file exits and asset.db get recreated with same size.


