### PR TITLE
Etcd cleanup

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -9,8 +9,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## [6.11.1] - 2024-09-12
 
 ### Changed
-- Added TTl to each entry in user-session within etcd
-- TTl value is 6 minutes
+- ADD TTL to each user session in the etcd data store to prevent leak.
+- TTl value is DefaultAccessTokenLifeSpan + 1 minute
 
 ## [6.11.0] - 2024-01-31
 

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -10,7 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Added TTl to each entry in user-session within etcd
-- TTl value is 11 minutes
+- TTl value is 6 minutes
 
 ## [6.11.0] - 2024-01-31
 

--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.11.1] - 2024-09-12
+
+### Changed
+- Added TTl to each entry in user-session within etcd
+- TTl value is 11 minutes
+
 ## [6.11.0] - 2024-01-31
 
 ### Changed

--- a/backend/authentication/jwt/jwt.go
+++ b/backend/authentication/jwt/jwt.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	defaultAccessTokenLifespan  = 5 * time.Minute
+	DefaultAccessTokenLifespan  = 5 * time.Minute
 	defaultRefreshTokenLifespan = 12 * time.Hour
 	secret                      []byte
 	privateKey                  *ecdsa.PrivateKey
@@ -58,7 +58,7 @@ func AccessToken(claims *corev2.Claims) (*jwt.Token, string, error) {
 	claims.Id = jti
 
 	// Add an expiration to the token
-	claims.ExpiresAt = time.Now().Add(defaultAccessTokenLifespan).Unix()
+	claims.ExpiresAt = time.Now().Add(DefaultAccessTokenLifespan).Unix()
 
 	token := jwt.NewWithClaims(signingMethod, claims)
 
@@ -78,7 +78,7 @@ func AccessToken(claims *corev2.Claims) (*jwt.Token, string, error) {
 	return token, tokenString, nil
 }
 
-// NewClaims creates new claim based on username
+:q// NewClaims creates new claim based on username
 func NewClaims(user *corev2.User) (*corev2.Claims, error) {
 	// Create a unique identifier for the token
 	jti, err := GenJTI()
@@ -91,7 +91,7 @@ func NewClaims(user *corev2.User) (*corev2.Claims, error) {
 		// library's documentation. We should replace its usage with
 		// RegisteredClaims.
 		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(defaultAccessTokenLifespan).Unix(),
+			ExpiresAt: time.Now().Add(DefaultAccessTokenLifespan).Unix(),
 			Id:        jti,
 			Subject:   user.Username,
 		},

--- a/backend/authentication/jwt/jwt.go
+++ b/backend/authentication/jwt/jwt.go
@@ -78,7 +78,7 @@ func AccessToken(claims *corev2.Claims) (*jwt.Token, string, error) {
 	return token, tokenString, nil
 }
 
-:q// NewClaims creates new claim based on username
+// NewClaims creates new claim based on username
 func NewClaims(user *corev2.User) (*corev2.Claims, error) {
 	// Create a unique identifier for the token
 	jti, err := GenJTI()

--- a/backend/authentication/jwt/jwt_test.go
+++ b/backend/authentication/jwt/jwt_test.go
@@ -121,7 +121,7 @@ func TestValidateTokenError(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The token should expire after the expiration time
-	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Hour))
+	testTime.Set(time.Now().Add(DefaultAccessTokenLifespan + time.Hour))
 	_, err = ValidateToken(tokenString)
 	assert.Error(t, err)
 }
@@ -134,7 +134,7 @@ func TestValidateExpiredToken(t *testing.T) {
 	_, tokenString, _ := AccessToken(claims)
 
 	// Wait for the token to expire
-	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Second))
+	testTime.Set(time.Now().Add(DefaultAccessTokenLifespan + time.Second))
 	_, err := ValidateExpiredToken(tokenString)
 	assert.NoError(t, err, "An expired token should not be considered as invalid")
 }
@@ -158,7 +158,7 @@ func TestValidateExpiredTokenInvalid(t *testing.T) {
 	_, tokenString, _ := AccessToken(claims)
 
 	// The token will expire
-	testTime.Set(time.Now().Add(defaultAccessTokenLifespan + time.Second))
+	testTime.Set(time.Now().Add(DefaultAccessTokenLifespan + time.Second))
 
 	// Modify the secret so it's no longer valid
 	secret = []byte("qux")

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -30,12 +30,15 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 }
 
 // UpdateSession applies the supplied state to the session uniquely identified
-// by the given username and session ID.
+// by the given username and session ID and TTL of 11 minutes
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
-	if _, err := s.client.Put(ctx, userSessionPath(username, sessionID), state); err != nil {
+	leaseResp, err := s.client.Grant(ctx, 60*11)
+	if err != nil {
+		fmt.Errorf("%s", err)
+	}
+	if _, err := s.client.Put(ctx, userSessionPath(username, sessionID), state, clientv3.WithLease(leaseResp.ID)); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -30,7 +30,7 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 }
 
 // UpdateSession applies the supplied state to the session uniquely identified
-// by the given username and session ID and TTL of 6 minutes considering access token expires in 5 minutes
+// by the given username and session ID and TTL of 6 minutes added considering access token expires in 5 minutes
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
 	leaseResp, err := s.client.Grant(ctx, 60*6)
 	if err != nil {

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -30,7 +30,7 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 }
 
 // UpdateSession applies the supplied state to the session uniquely identified
-// by the given username and session ID and TTL of 6 minutes added considering access token expires in 5 minutes
+// by the given username and session ID and TTL of 6 minutes added considering access token gets expired in 5 minutes
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
 	leaseResp, err := s.client.Grant(ctx, 60*6)
 	if err != nil {

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -34,7 +34,7 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
 	leaseResp, err := s.client.Grant(ctx, 60*6)
 	if err != nil {
-		fmt.Errorf("%s", err)
+		return fmt.Errorf("%s", err)
 	}
 	if _, err := s.client.Put(ctx, userSessionPath(username, sessionID), state, clientv3.WithLease(leaseResp.ID)); err != nil {
 		return err

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -30,7 +30,7 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 }
 
 // UpdateSession applies the supplied state to the session uniquely identified
-// by the given username and session ID and TTL of 6 minutes added considering access token gets expired in 5 minutes
+// by the given username and session ID and TTL of 6 minutes added considering access token expires in 5 minutes
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
 	leaseResp, err := s.client.Grant(ctx, 60*6)
 	if err != nil {

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -30,9 +30,9 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 }
 
 // UpdateSession applies the supplied state to the session uniquely identified
-// by the given username and session ID and TTL of 11 minutes
+// by the given username and session ID and TTL of 6 minutes considering access token expires in 5 minutes
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
-	leaseResp, err := s.client.Grant(ctx, 60*11)
+	leaseResp, err := s.client.Grant(ctx, 60*6)
 	if err != nil {
 		fmt.Errorf("%s", err)
 	}
@@ -48,6 +48,5 @@ func (s *Store) DeleteSession(ctx context.Context, username, sessionID string) e
 	if _, err := s.client.Delete(ctx, userSessionPath(username, sessionID)); err != nil {
 		return err
 	}
-
 	return nil
 }


### PR DESCRIPTION
Closed https://github.com/sensu/sensu-go/issues/5063

### Description
The user sessions gets piled up in etcd occupying upto 2bg space .

### Change in behavior
Deleting the etcd user_sesssions them after 6 minutes of creation ( Access token of session gets expired in 5 mnts) This change will make sure the memory occupancy uptil 1.8 GB  will be eradicated 

### Added
Added TTL time of 6 minutes in session.go file for each entry regarding user-sessions. 

### Fixed
This fixes the etcd space occupancy issue .

### Change verification
- Do sensuctl configure.
- Check respective entry in etcd ar /sensu.io/user-sessions/admin/xxyyzz[session_id]
- this entry will be deleted automatically after 11 minutes if the backend keep .
- I have the video of default behaviour ( which caused the issue) and the video of fixed behaviour with TTL=2mins , unfortunately cannot be uploaded due to big size.
 
