### PR TITLE
.initialized key issue

### DIFF
--- a/backend/store/etcd/initialization.go
+++ b/backend/store/etcd/initialization.go
@@ -11,9 +11,14 @@ import (
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
+//const (
+//	initializationLockKey = ".initialized.lock"
+//	initializationKey     = ".initialized"
+//)
+
 const (
-	initializationLockKey = ".initialized.lock"
-	initializationKey     = ".initialized"
+	initializationLockKey = "/sensu.io/.initialized"
+	initializationKey     = "/sensu.io/.initialized"
 )
 
 // StoreInitializer ...
@@ -53,7 +58,7 @@ func (s *StoreInitializer) Lock(ctx context.Context) error {
 	return s.mutex.Lock(ctx)
 }
 
-// IsInitialized checks the state of the .initialized key
+// IsInitialized checks the state of the /sensu.io/.initialized key
 func (s *StoreInitializer) IsInitialized(ctx context.Context) (bool, error) {
 	r, err := s.client.Get(ctx, path.Join(EtcdRoot, initializationKey))
 	if err != nil {
@@ -73,7 +78,7 @@ func (s *StoreInitializer) IsInitialized(ctx context.Context) (bool, error) {
 	return r.Count > 0, nil
 }
 
-// FlagAsInitialized - set .initialized key
+// FlagAsInitialized - set /sensu.io/.initialized key
 func (s *StoreInitializer) FlagAsInitialized(ctx context.Context) error {
 	_, err := s.client.Put(ctx, path.Join(EtcdRoot, initializationKey), "1")
 	return err


### PR DESCRIPTION
Closed #5047 

## Description

We wanted to implement a simple add-on to use an external etcd for our sensu backend. After configuring it as described in the(https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/cluster-sensu/#configure-key-space-access) will be enough.


## Changed

Just a change of the key replacing ".initialized" key to "/sensu.io/.initialized".
