### PR TITLE
Add Dependabot config for scanning branch develop/6 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,3 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop/6"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "develop/6"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop/6"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop/6"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "develop/6"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "develop/6"


### PR DESCRIPTION
## Description
Dependabot must scan develop/6 branch for dependencies.
## Change in behavior

Github dependabot used to check for dependencies in main branch only, After this changes made, it will check for develop/6 branch.

# Added
Added dependabot.yml configuration inside .github folder.

# Changed

## Fixed

Dependabot now will scan branch develop/6 for dependency , in this case "go" packages updates (if any available) and raise PR.
## Change verification