### PR TITLE
Adding Prometheus metrics on APId

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added Prometheus metrics collection for HTTP API requests, including request count (`sensu_go_http_requests_total`), request duration (`sensu_go_http_request_duration_seconds`), and client error count (`sensu_go_http_client_errors_total`) for better observability of backend API performance.
+
 ## [6.13.1] - 2025-05-28
 
 ### Fixed

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -92,7 +92,7 @@ type Config struct {
 var (
 	RequestCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_requests_total",
+			Name: "sensu_go_http_requests_total",
 			Help: "Total number of HTTP requests",
 		},
 		[]string{"method", "path"},
@@ -100,7 +100,7 @@ var (
 
 	RequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_request_duration_seconds",
+			Name:    "sensu_go_http_request_duration_seconds",
 			Help:    "Histogram of request durations",
 			Buckets: prometheus.DefBuckets, // [0.005, 0.01, ..., 10.24]
 		},
@@ -109,7 +109,7 @@ var (
 
 	ClientErrorCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "http_client_errors_total",
+			Name: "sensu_go_http_client_errors_total",
 			Help: "Total number of 4xx HTTP responses",
 		},
 		[]string{"method", "path", "status"},

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -201,6 +201,14 @@ func NewRouter() *mux.Router {
 	// Register a default handler when no routes match
 	router.NotFoundHandler = middlewares.SimpleLogger{}.Then(http.HandlerFunc(notFoundHandler))
 
+	// Prometheus metrics collection middleware (APIMetrics) to track
+	// request count, request duration, and client error count for all API endpoints.
+	router.Use(middlewares.APIMetrics{
+		RequestCount:     RequestCount,
+		RequestDuration:  RequestDuration,
+		ClientErrorCount: ClientErrorCount,
+	}.Then)
+
 	return router
 }
 
@@ -226,11 +234,6 @@ func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
-		middlewares.APIMetrics{
-			RequestCount:     RequestCount,
-			RequestDuration:  RequestDuration,
-			ClientErrorCount: ClientErrorCount,
-		},
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
 		middlewares.SimpleLogger{},

--- a/backend/apid/apid.go
+++ b/backend/apid/apid.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
@@ -86,6 +87,39 @@ type Config struct {
 	HealthRouter        *routers.HealthRouter
 	AccessTokenExpiry   time.Duration
 	RefreshTokenExpiry  time.Duration
+}
+
+var (
+	RequestCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_requests_total",
+			Help: "Total number of HTTP requests",
+		},
+		[]string{"method", "path"},
+	)
+
+	RequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_request_duration_seconds",
+			Help:    "Histogram of request durations",
+			Buckets: prometheus.DefBuckets, // [0.005, 0.01, ..., 10.24]
+		},
+		[]string{"method", "path"},
+	)
+
+	ClientErrorCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_client_errors_total",
+			Help: "Total number of 4xx HTTP responses",
+		},
+		[]string{"method", "path", "status"},
+	)
+)
+
+func init() {
+	_ = prometheus.Register(RequestCount)
+	_ = prometheus.Register(RequestDuration)
+	_ = prometheus.Register(ClientErrorCount)
 }
 
 // New creates a new APId.
@@ -192,6 +226,11 @@ func AuthenticationSubrouter(router *mux.Router, cfg Config) *mux.Router {
 func CoreSubrouter(router *mux.Router, cfg Config) *mux.Router {
 	subrouter := NewSubrouter(
 		router.PathPrefix("/api/{group:core}/{version:v2}/"),
+		middlewares.APIMetrics{
+			RequestCount:     RequestCount,
+			RequestDuration:  RequestDuration,
+			ClientErrorCount: ClientErrorCount,
+		},
 		middlewares.Namespace{},
 		middlewares.Authentication{Store: cfg.Store},
 		middlewares.SimpleLogger{},

--- a/backend/apid/middlewares/authentication.go
+++ b/backend/apid/middlewares/authentication.go
@@ -58,7 +58,7 @@ func (a APIMetrics) Then(next http.Handler) http.Handler {
 		a.RequestCount.WithLabelValues(r.Method, path).Inc()
 		a.RequestDuration.WithLabelValues(r.Method, path).Observe(duration)
 
-		if rr.statusCode >= 400 && rr.statusCode < 500 {
+		if rr.statusCode >= http.StatusBadRequest && rr.statusCode < http.StatusInternalServerError {
 			a.ClientErrorCount.WithLabelValues(r.Method, path, strconv.Itoa(rr.statusCode)).Inc()
 		}
 	})

--- a/backend/apid/middlewares/authentication.go
+++ b/backend/apid/middlewares/authentication.go
@@ -54,7 +54,6 @@ func (a APIMetrics) Then(next http.Handler) http.Handler {
 
 		duration := time.Since(start).Seconds()
 
-		// Update metrics
 		a.RequestCount.WithLabelValues(r.Method, path).Inc()
 		a.RequestDuration.WithLabelValues(r.Method, path).Observe(duration)
 

--- a/backend/apid/middlewares/authentication.go
+++ b/backend/apid/middlewares/authentication.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	corev2 "github.com/sensu/core/v2"
 	"github.com/sensu/sensu-go/backend/apid/actions"
 	"github.com/sensu/sensu-go/backend/authentication/jwt"
@@ -18,6 +22,46 @@ type Authentication struct {
 	// in the case where an access token was not present.
 	IgnoreUnauthorized bool
 	Store              store.Store
+}
+
+// APIMetrics is a middleware for Prometheus metrics
+type APIMetrics struct {
+	RequestCount     *prometheus.CounterVec
+	RequestDuration  *prometheus.HistogramVec
+	ClientErrorCount *prometheus.CounterVec
+}
+
+type responseRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseRecorder) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (a APIMetrics) Then(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Wrap the response writer to capture status code
+		rr := &responseRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rr, r)
+
+		route := mux.CurrentRoute(r)
+		path, _ := route.GetPathTemplate()
+
+		duration := time.Since(start).Seconds()
+
+		// Update metrics
+		a.RequestCount.WithLabelValues(r.Method, path).Inc()
+		a.RequestDuration.WithLabelValues(r.Method, path).Observe(duration)
+
+		if rr.statusCode >= 400 && rr.statusCode < 500 {
+			a.ClientErrorCount.WithLabelValues(r.Method, path, strconv.Itoa(rr.statusCode)).Inc()
+		}
+	})
 }
 
 // Then middleware


### PR DESCRIPTION
## What is this change?

This change introduces Prometheus metrics to the Sensu API server, tracking total HTTP requests, request durations, and client error counts.


## Why is this change necessary?

These metrics improve observability into the API server's behavior, enabling operators to monitor usage patterns, diagnose performance issues, and detect client-side errors more effectively.

## Does your change need a Changelog entry?

Yes, this is a new feature that adds Prometheus metrics for API observability.

## Do you need clarification on anything?

No clarification needed at this time.


## Were there any complications while making this change?

No major complications

## Have you reviewed and updated the documentation for this change? Is new documentation required?

NA

## How did you verify this change?

1. Manually tested the /metrics endpoint to verify metric exposure.
2. Simulated various API calls to confirm correct metric increments.

## Is this change a patch?

No
