### PR TITLE
Adding keepalive flap configuration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -658,10 +658,12 @@ func (a *Agent) newKeepalive() *transport.Message {
 	}
 
 	keepalive.Check = &corev2.Check{
-		ObjectMeta: corev2.NewObjectMeta("keepalive", entity.Namespace),
-		Interval:   a.config.KeepaliveInterval,
-		Timeout:    a.config.KeepaliveWarningTimeout,
-		Ttl:        int64(a.config.KeepaliveCriticalTimeout),
+		ObjectMeta:        corev2.NewObjectMeta("keepalive", entity.Namespace),
+		Interval:          a.config.KeepaliveInterval,
+		Timeout:           a.config.KeepaliveWarningTimeout,
+		Ttl:               int64(a.config.KeepaliveCriticalTimeout),
+		HighFlapThreshold: a.config.KeepaliveHighFlapThreshold,
+		LowFlapThreshold:  a.config.KeepaliveLowFlapThreshold,
 	}
 
 	keepalive.Labels = a.config.KeepaliveCheckLabels

--- a/agent/cmd/start.go
+++ b/agent/cmd/start.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/asset"
 	"github.com/sensu/sensu-go/util/path"
 	"github.com/sensu/sensu-go/util/url"
@@ -94,6 +94,9 @@ const (
 	// Deprecated flags
 	deprecatedFlagAgentID          = "id"
 	deprecatedFlagKeepaliveTimeout = "keepalive-timeout"
+
+	flagKeepaliveHighFlapThresold = "high-flap-thresold"
+	flagKeepaliveLowFlapThresold  = "low-flap-thresold"
 )
 
 // InitializeFunc represents the signature of an initialization function, used
@@ -131,6 +134,10 @@ func NewAgentConfig(cmd *cobra.Command) (*agent.Config, error) {
 	cfg.KeepaliveCheckLabels = viper.GetStringMapString(flagKeepaliveCheckLabels)
 	cfg.KeepaliveCheckAnnotations = viper.GetStringMapString(flagKeepaliveCheckAnnotations)
 	cfg.KeepalivePipelines = viper.GetStringSlice(flagKeepalivePipelines)
+
+	cfg.KeepaliveHighFlapThreshold = viper.GetUint32(flagKeepaliveHighFlapThresold)
+	cfg.KeepaliveLowFlapThreshold = viper.GetUint32(flagKeepaliveLowFlapThresold)
+
 	cfg.Namespace = viper.GetString(flagNamespace)
 	cfg.Password = viper.GetString(flagPassword)
 	cfg.Socket.Host = viper.GetString(flagSocketHost)

--- a/agent/config.go
+++ b/agent/config.go
@@ -227,6 +227,9 @@ type Config struct {
 	// StripNetworks is a boolean to specify if we need to strip network
 	// information from the agent entity state
 	StripNetworks bool
+
+	KeepaliveHighFlapThreshold uint32
+	KeepaliveLowFlapThreshold  uint32
 }
 
 // StatsdServerConfig contains the statsd server configuration

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -538,16 +538,18 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 
 	// Initialize keepalived
 	keepalive, err := keepalived.New(keepalived.Config{
-		DeregistrationHandler: config.DeregistrationHandler,
-		Bus:                   bus,
-		Store:                 b.Store,
-		StoreV2:               b.StoreV2,
-		EventStore:            b.Store,
-		LivenessFactory:       liveness.EtcdFactory(b.RunContext(), b.Client),
-		RingPool:              b.RingPool,
-		BufferSize:            viper.GetInt(FlagKeepalivedBufferSize),
-		WorkerCount:           viper.GetInt(FlagKeepalivedWorkers),
-		StoreTimeout:          2 * time.Minute,
+		DeregistrationHandler:      config.DeregistrationHandler,
+		Bus:                        bus,
+		Store:                      b.Store,
+		StoreV2:                    b.StoreV2,
+		EventStore:                 b.Store,
+		LivenessFactory:            liveness.EtcdFactory(b.RunContext(), b.Client),
+		RingPool:                   b.RingPool,
+		BufferSize:                 viper.GetInt(FlagKeepalivedBufferSize),
+		WorkerCount:                viper.GetInt(FlagKeepalivedWorkers),
+		StoreTimeout:               2 * time.Minute,
+		HighKeepaliveFlapThreshold: config.HighKeepaliveFlapThresold,
+		LowKeepaliveFlapThreshold:  config.LowKeepaliveFlapThresold,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing %s: %s", keepalive.Name(), err)

--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -77,8 +77,10 @@ const (
 	flagDefaultSilencedExpiryTime    = "default-silenced-expiry-time"
 
 	// access token and refresh token expiry time
-	flagAccessTokenExpiry  = "access-token-expiry"
-	flagRefreshTokenExpiry = "refresh-token-expiry"
+	flagAccessTokenExpiry     = "access-token-expiry"
+	flagRefreshTokenExpiry    = "refresh-token-expiry"
+	flagHighKeepaliveThresold = "high-flap-thresold"
+	flagLowKeepaliveThresold  = "low-flap-thresold"
 
 	// Etcd flag constants
 	flagEtcdClientURLs               = "etcd-client-urls"
@@ -300,6 +302,9 @@ func StartCommand(initialize InitializeFunc) *cobra.Command {
 
 				AccessTokenExpiry:  viper.GetDuration(flagAccessTokenExpiry),
 				RefreshTokenExpiry: viper.GetDuration(flagRefreshTokenExpiry),
+
+				HighKeepaliveFlapThresold: viper.GetUint32(flagHighKeepaliveThresold),
+				LowKeepaliveFlapThresold:  viper.GetUint32(flagLowKeepaliveThresold),
 			}
 
 			if flag := cmd.Flags().Lookup(flagLabels); flag != nil && flag.Changed {

--- a/backend/config.go
+++ b/backend/config.go
@@ -140,4 +140,7 @@ type Config struct {
 	// Access/Refresh Token Expiry in Minutes
 	AccessTokenExpiry  time.Duration
 	RefreshTokenExpiry time.Duration
+
+	HighKeepaliveFlapThresold uint32
+	LowKeepaliveFlapThresold  uint32
 }

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sensu/sensu-go/agent"
 	corev2 "github.com/sensu/core/v2"
 	corev3 "github.com/sensu/core/v3"
+	"github.com/sensu/sensu-go/agent"
 	"github.com/sensu/sensu-go/backend/liveness"
 	"github.com/sensu/sensu-go/backend/messaging"
 	"github.com/sensu/sensu-go/backend/ringv2"
@@ -92,6 +92,9 @@ type Keepalived struct {
 	cancel                context.CancelFunc
 	storeTimeout          time.Duration
 	reconstructionPeriod  time.Duration
+
+	HighKeepaliveFlapThresold uint32
+	LowKeepaliveFlapThresold  uint32
 }
 
 // Option is a functional option.
@@ -99,16 +102,18 @@ type Option func(*Keepalived) error
 
 // Config configures Keepalived.
 type Config struct {
-	Store                 store.Store
-	StoreV2               storev2.Interface
-	EventStore            store.EventStore
-	Bus                   messaging.MessageBus
-	LivenessFactory       liveness.Factory
-	DeregistrationHandler string
-	RingPool              *ringv2.RingPool
-	BufferSize            int
-	WorkerCount           int
-	StoreTimeout          time.Duration
+	Store                      store.Store
+	StoreV2                    storev2.Interface
+	EventStore                 store.EventStore
+	Bus                        messaging.MessageBus
+	LivenessFactory            liveness.Factory
+	DeregistrationHandler      string
+	RingPool                   *ringv2.RingPool
+	BufferSize                 int
+	WorkerCount                int
+	StoreTimeout               time.Duration
+	HighKeepaliveFlapThreshold uint32
+	LowKeepaliveFlapThreshold  uint32
 }
 
 // New creates a new Keepalived.
@@ -129,21 +134,23 @@ func New(c Config, opts ...Option) (*Keepalived, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	k := &Keepalived{
-		store:                 c.Store,
-		storev2:               c.StoreV2,
-		eventStore:            c.EventStore,
-		bus:                   c.Bus,
-		deregistrationHandler: c.DeregistrationHandler,
-		livenessFactory:       c.LivenessFactory,
-		keepaliveChan:         make(chan interface{}, c.BufferSize),
-		workerCount:           c.WorkerCount,
-		mu:                    &sync.Mutex{},
-		errChan:               make(chan error, 1),
-		ringPool:              c.RingPool,
-		ctx:                   ctx,
-		cancel:                cancel,
-		storeTimeout:          c.StoreTimeout,
-		reconstructionPeriod:  time.Second * 120,
+		store:                     c.Store,
+		storev2:                   c.StoreV2,
+		eventStore:                c.EventStore,
+		bus:                       c.Bus,
+		deregistrationHandler:     c.DeregistrationHandler,
+		livenessFactory:           c.LivenessFactory,
+		keepaliveChan:             make(chan interface{}, c.BufferSize),
+		workerCount:               c.WorkerCount,
+		mu:                        &sync.Mutex{},
+		errChan:                   make(chan error, 1),
+		ringPool:                  c.RingPool,
+		ctx:                       ctx,
+		cancel:                    cancel,
+		storeTimeout:              c.StoreTimeout,
+		reconstructionPeriod:      time.Second * 120,
+		HighKeepaliveFlapThresold: c.HighKeepaliveFlapThreshold,
+		LowKeepaliveFlapThresold:  c.LowKeepaliveFlapThreshold,
 	}
 	for _, o := range opts {
 		if err := o(k); err != nil {
@@ -482,7 +489,7 @@ func (k *Keepalived) handleEntityRegistration(entity *corev2.Entity, event *core
 	}
 }
 
-func createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
+func (k *Keepalived) createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
 	check := rawEvent.Check
 	if check == nil {
 		check = &corev2.Check{
@@ -497,19 +504,30 @@ func createKeepaliveEvent(rawEvent *corev2.Event) *corev2.Event {
 	if len(rawEvent.Entity.KeepaliveHandlers) > 0 {
 		handlers = rawEvent.Entity.KeepaliveHandlers
 	}
+	lowFlap := check.LowFlapThreshold
+	if lowFlap <= 0 {
+		lowFlap = k.LowKeepaliveFlapThresold
+	}
+
+	highFlap := check.HighFlapThreshold
+	if highFlap <= 0 {
+		highFlap = k.HighKeepaliveFlapThresold
+	}
 
 	keepaliveCheck := &corev2.Check{
 		ObjectMeta: corev2.ObjectMeta{
 			Name:      corev2.KeepaliveCheckName,
 			Namespace: rawEvent.Entity.Namespace,
 		},
-		Interval:  check.Interval,
-		Timeout:   check.Timeout,
-		Ttl:       check.Ttl,
-		Handlers:  handlers,
-		Executed:  time.Now().Unix(),
-		Issued:    time.Now().Unix(),
-		Scheduler: corev2.EtcdScheduler,
+		Interval:          check.Interval,
+		Timeout:           check.Timeout,
+		Ttl:               check.Ttl,
+		Handlers:          handlers,
+		Executed:          time.Now().Unix(),
+		Issued:            time.Now().Unix(),
+		Scheduler:         corev2.EtcdScheduler,
+		LowFlapThreshold:  lowFlap,
+		HighFlapThreshold: highFlap,
 	}
 	keepaliveEvent := &corev2.Event{
 		ObjectMeta: rawEvent.ObjectMeta,
@@ -652,7 +670,7 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 	}
 
 	// this is a real keepalive event, emit it.
-	event := createKeepaliveEvent(currentEvent)
+	event := k.createKeepaliveEvent(currentEvent)
 	timeSinceLastSeen := time.Now().Unix() - event.Entity.LastSeen
 	warningTimeout := int64(event.Check.Timeout)
 	criticalTimeout := event.Check.Ttl
@@ -740,7 +758,7 @@ func (k *Keepalived) handleUpdate(e *corev2.Event) error {
 		return err
 	}
 
-	event := createKeepaliveEvent(e)
+	event := k.createKeepaliveEvent(e)
 	event.Check.Status = 0
 	event.Check.Output = fmt.Sprintf("Keepalive last sent from %s at %s", entity.Name, time.Unix(entity.LastSeen, 0).String())
 

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -350,9 +350,9 @@ func TestProcessRegistration(t *testing.T) {
 	}
 }
 
-func TestCreateKeepaliveEvent(t *testing.T) {
+func (k *Keepalived) TestCreateKeepaliveEvent(t *testing.T) {
 	event := corev2.FixtureEvent("entity1", "keepalive")
-	keepaliveEvent := createKeepaliveEvent(event)
+	keepaliveEvent := k.createKeepaliveEvent(event)
 	assert.Equal(t, "keepalive", keepaliveEvent.Check.Name)
 	assert.Equal(t, uint32(60), keepaliveEvent.Check.Interval)
 	assert.Equal(t, []string{"keepalive"}, keepaliveEvent.Check.Handlers)
@@ -362,7 +362,7 @@ func TestCreateKeepaliveEvent(t *testing.T) {
 	assert.NotEqual(t, int64(0), keepaliveEvent.Check.Issued)
 
 	event.Check = nil
-	keepaliveEvent = createKeepaliveEvent(event)
+	keepaliveEvent = k.createKeepaliveEvent(event)
 	assert.Equal(t, "keepalive", keepaliveEvent.Check.Name)
 	assert.Equal(t, uint32(20), keepaliveEvent.Check.Interval)
 	assert.Equal(t, uint32(120), keepaliveEvent.Check.Timeout)


### PR DESCRIPTION
## Description
Adding custom keepalive flap configuration from backend and agent cpnfig.

## Change in behavior
Custom flapping config support for keepalive events were not supported earlier. Now, desirable flap settings can be configured for keepalive events.

## Changed
Added configurable flap settings for keepalive checks. The values will be taken from backend.yaml and if per entity is required values will be taken from agent.yaml too.