### PR TITLE
fix: set etcd user_session ttl to refresh token expiry time

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+
+- Fixed a bug where user sessions were deleted before refresh tokens expired
+
+## [6.13.1] - 2025-05-28
+
+### Fixed
+- Fixed a bug where users were facing issues in creating silences
+- Fixed UID mapping issues in Docker on RedHat and Alpine images.
+
+
 ## [6.13.0] - 2025-03-25
 
 ### Added

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -333,6 +333,7 @@ func Initialize(ctx context.Context, config *Config) (*Backend, error) {
 	scfg := etcdstore.Config{}
 	scfg.DefaultSilencedExpiryTime = config.DefaultSilencedExpiryTime
 	scfg.MaxSilencedExpiryTimeAllowed = config.MaxSilencedExpiryTimeAllowed
+	scfg.RefreshTokenExpiry = config.RefreshTokenExpiry
 	etcdstore.SetConfig(scfg, stor)
 
 	b.Store = stor

--- a/backend/store/etcd/session.go
+++ b/backend/store/etcd/session.go
@@ -3,7 +3,6 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"github.com/sensu/sensu-go/backend/authentication/jwt"
 	"github.com/sensu/sensu-go/backend/store"
 	"go.etcd.io/etcd/client/v3"
 )
@@ -32,8 +31,7 @@ func (s *Store) GetSession(ctx context.Context, username, sessionID string) (str
 // UpdateSession applies the supplied state to the session uniquely identified
 // by the given username and session ID with attached lease and TTl for each key
 func (s *Store) UpdateSession(ctx context.Context, username, sessionID, state string) error {
-
-	leaseDuration := jwt.DefaultAccessTokenLifespan
+	leaseDuration := s.cfg.RefreshTokenExpiry
 	ttl := int64(leaseDuration.Minutes()+1) * 60
 	leaseResp, err := s.client.Grant(ctx, ttl)
 	if err != nil {

--- a/backend/store/etcd/store.go
+++ b/backend/store/etcd/store.go
@@ -26,6 +26,7 @@ const (
 type Config struct {
 	DefaultSilencedExpiryTime    time.Duration
 	MaxSilencedExpiryTimeAllowed time.Duration
+	RefreshTokenExpiry 			 time.Duration
 }
 
 // Store is an implementation of the sensu-go/backend/store.Store iface.


### PR DESCRIPTION
Otherwise the session will already be deleted when you refresh your token, and the token refresh will fail

## What is this change?
This makes the user_session etcd lease last as long as the refresh token

## Why is this change necessary?

Without it we were seeing errors like this:
```json
{"error":"key /sensu.io/user_sessions/admin/<id> not found",
"level":"info",
"msg":"unexpected error while authorizing refresh token",
"time":"2025-08-18T10:47:20+02:00"}
```

We also had trouble refreshing the token in the web ui, as a stopgap we increased the access token expiry

## Does your change need a Changelog entry?
Yes
<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/main/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?
No
<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?
check the expiry with  `etcdctl --endpoints localhost:2379 lease timetolive <lease-id> --keys `

set a low access token expiry, and wait 6 minutes and try to run a sensuctl command, and see that the token refresh now succeeds

## Is this change a patch?

<!--
If so, you should be submitting this against the current release branch. Remember to merge the release branch back into main after merging this patch!

If not, this feature work can go directly into the main branch.
-->
Yes
