### PR TITLE
TTL Status Implementation and Disable Keepalive Warning Timeout

### DIFF
--- a/CHANGELOG-6.md
+++ b/CHANGELOG-6.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Added `ttl_status` field to `Check` and `CheckConfig` to configure the status (warning or critical) for TTL failure events. This field accepts values 1 (warning) or 2 (critical), with critical (2) as the default to maintain backward compatibility.
+
 ## [6.13.1] - 2025-05-28
 
 ### Fixed

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -339,10 +339,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	if err := corev2.ValidateName(a.config.AgentName); err != nil {
 		return fmt.Errorf("invalid agent name: %v", err)
 	}
-	logger.Debug("validating keepalive warning timeout")
-	if timeout := a.config.KeepaliveWarningTimeout; timeout < 5 {
-		return fmt.Errorf("bad keepalive timeout: %d (minimum value is 5 seconds)", timeout)
-	}
+
 	logger.Debug("validating keepalive critical timeout")
 	if timeout := a.config.KeepaliveCriticalTimeout; timeout > 0 && timeout < 5 {
 		return fmt.Errorf("bad keepalive critical timeout: %d (minimum value is 5 seconds)", timeout)

--- a/backend/eventd/eventd.go
+++ b/backend/eventd/eventd.go
@@ -804,7 +804,28 @@ func (e *Eventd) createFailedCheckEvent(ctx context.Context, event *corev2.Event
 	output := fmt.Sprintf("Last check execution was %d seconds ago", time.Now().Unix()-event.Check.Executed)
 
 	check.Output = output
-	check.Status = 1
+
+	// Use ttl_status if configured, otherwise default to warning (status 1)
+	// ttl_status allows users to configure whether TTL failures should be warning or critical
+	if event.Check.TtlStatus > 0 {
+		// ttl_status is set - use it to determine the status
+		// Valid values: 1 = warning, 2 = critical
+		if event.Check.TtlStatus == 1 || event.Check.TtlStatus == 2 {
+			check.Status = uint32(event.Check.TtlStatus)
+		} else {
+			// Invalid ttl_status value, default to warning
+			logger.WithFields(logrus.Fields{
+				"check":      event.Check.Name,
+				"entity":     event.Entity.Name,
+				"ttl_status": event.Check.TtlStatus,
+			}).Warn("invalid ttl_status value, defaulting to warning (1)")
+			check.Status = 1
+		}
+	} else {
+		// No ttl_status configured, default to warning (status 1)
+		check.Status = 1
+	}
+
 	check.State = corev2.EventFailingState
 	check.Executed = time.Now().Unix()
 

--- a/backend/eventd/eventd_test.go
+++ b/backend/eventd/eventd_test.go
@@ -301,6 +301,70 @@ func TestCheckTTL(t *testing.T) {
 	}
 }
 
+func TestCreateFailedCheckEventWithTTLStatus(t *testing.T) {
+	// Test that TTL status is properly handled when creating failed check events
+	tests := []struct {
+		name        string
+		ttlStatus   int32
+		expectedStatus uint32
+		description    string
+	}{
+		{
+			name:           "no ttl_status configured - should default to warning",
+			ttlStatus:      0,
+			expectedStatus: 1,
+			description:    "should use default warning status when ttl_status is not set",
+		},
+		{
+			name:           "ttl_status = 1 - should use warning status",
+			ttlStatus:      1,
+			expectedStatus: 1,
+			description:    "should use configured warning status",
+		},
+		{
+			name:           "ttl_status = 2 - should use critical status",
+			ttlStatus:      2,
+			expectedStatus: 2,
+			description:    "should use configured critical status",
+		},
+		{
+			name:           "invalid ttl_status = 3 - should default to warning",
+			ttlStatus:      3,
+			expectedStatus: 1,
+			description:    "should default to warning for invalid ttl_status values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test event with TTL status
+			event := corev2.FixtureEvent("entity", "check")
+			event.Check.TtlStatus = tt.ttlStatus
+			event.Check.Executed = time.Now().Add(-300 * time.Second).Unix() // 5 minutes ago
+
+			// Create mock event store
+			eventStore := &mockstore.MockStore{}
+			eventStore.On("GetEventByEntityCheck", mock.Anything, "entity", "check").Return(event, nil)
+
+			// Create eventd instance
+			e := &Eventd{
+				eventStore: eventStore,
+			}
+
+			// Test the createFailedCheckEvent method
+			result, err := e.createFailedCheckEvent(context.Background(), event)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Verify the status is set correctly
+			assert.Equal(t, tt.expectedStatus, result.Check.Status, tt.description)
+
+			// Verify the output message
+			assert.Contains(t, result.Check.Output, "Last check execution was")
+		})
+	}
+}
+
 func TestBuryConditions(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/backend/keepalived/keepalived.go
+++ b/backend/keepalived/keepalived.go
@@ -675,16 +675,39 @@ func (k *Keepalived) dead(key string, prev liveness.State, leader bool) bool {
 	warningTimeout := int64(event.Check.Timeout)
 	criticalTimeout := event.Check.Ttl
 	var timeout int64
-	if warningTimeout != 0 && timeSinceLastSeen >= warningTimeout {
-		// warning keepalive
-		timeout = warningTimeout
-		event.Check.Status = 1
-	}
+	var status uint32
+
+	// NEW LOGIC: Check if warning state should be skipped
+	// If keepalive-warning-timeout = 0, skip warning state and go directly to critical
+	warningDisabled := warningTimeout == 0
+
+	// Log the timeout configuration for debugging
+	lager.WithFields(logrus.Fields{
+		"timeSinceLastSeen": timeSinceLastSeen,
+		"warningTimeout":    warningTimeout,
+		"criticalTimeout":   criticalTimeout,
+		"warningDisabled":   warningDisabled,
+	}).Debug("processing keepalive timeout")
+
 	if criticalTimeout != 0 && timeSinceLastSeen >= criticalTimeout {
-		// critical keepalive
+		// Critical keepalive - entity has exceeded critical timeout
 		timeout = criticalTimeout
-		event.Check.Status = 2
+		status = 2
+		lager.WithField("timeout", timeout).Info("entity marked as critical (skipped warning)")
+	} else if !warningDisabled && warningTimeout != 0 && timeSinceLastSeen >= warningTimeout {
+		// Warning keepalive - only if warning is not disabled and warning timeout is set
+		timeout = warningTimeout
+		status = 1
+		lager.WithField("timeout", timeout).Info("entity marked as warning")
+	} else {
+		// This shouldn't happen in the dead() callback, but keeping for safety
+		// Entity is still within acceptable keepalive window
+		status = 0
+		timeout = warningTimeout
+		lager.Debug("entity still within acceptable keepalive window")
 	}
+
+	event.Check.Status = status
 	event.Check.Output = fmt.Sprintf("No keepalive sent from %s for %v seconds (>= %v)", event.Entity.Name, timeSinceLastSeen, timeout)
 
 	if err := k.bus.Publish(messaging.TopicKeepaliveRaw, event); err != nil {

--- a/backend/keepalived/keepalived_test.go
+++ b/backend/keepalived/keepalived_test.go
@@ -368,6 +368,89 @@ func (k *Keepalived) TestCreateKeepaliveEvent(t *testing.T) {
 	assert.Equal(t, uint32(120), keepaliveEvent.Check.Timeout)
 }
 
+func TestDeadCallbackWarningTimeoutLogic(t *testing.T) {
+	messageBus, err := messaging.NewWizardBus(messaging.WizardBusConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := messageBus.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer messageBus.Stop()
+
+	tsub := testSubscriber{
+		ch: make(chan interface{}, 1),
+	}
+	if _, err := messageBus.Subscribe(messaging.TopicEvent, "testSubscriber", tsub); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a mock entity config that won't trigger deregistration
+	entityConfig := corev3.FixtureEntityConfig("entity1")
+	entityConfig.Deregister = false // Important: don't deregister
+
+	wrapper, err := storv2.WrapResource(
+		entityConfig,
+		[]wrap.Option{wrap.CompressNone, wrap.EncodeJSON}...)
+	require.NoError(t, err)
+
+	store := &storetest.Store{}
+	store.On("Get", mock.MatchedBy(func(req storv2.ResourceRequest) bool {
+		return req.StoreName == new(corev3.EntityConfig).StoreName()
+	})).Return(wrapper, nil)
+
+	// Create a mock event store that returns a keepalive event
+	event := corev2.FixtureEvent("entity1", "keepalive")
+	event.Check.Timeout = 60                                         // 60 second warning timeout
+	event.Check.Ttl = 120                                            // 120 second critical timeout
+	event.Entity.LastSeen = time.Now().Add(-90 * time.Second).Unix() // 90 seconds ago
+
+	eventStore := &mockstore.MockStore{}
+	eventStore.On("GetEventByEntityCheck", mock.Anything, mock.Anything, mock.Anything).Return(event, nil)
+
+	// Mock the store methods to avoid panics
+	mockStore := &mockstore.MockStore{}
+	mockStore.On("UpdateFailingKeepalive", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	keepalived, err := New(Config{
+		Store:           mockStore,
+		StoreV2:         store,
+		EventStore:      eventStore,
+		Bus:             messageBus,
+		LivenessFactory: fakeFactory,
+		WorkerCount:     1,
+		BufferSize:      1,
+		StoreTimeout:    time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test case 1: Warning timeout enabled (should go to warning)
+	// Entity has been down for 90 seconds, warning timeout is 60, critical is 120
+	// Should trigger warning (status 1)
+	if got, want := keepalived.dead("default/entity1", liveness.Alive, true), false; got != want {
+		t.Fatalf("got bury: %v, want bury: %v", got, want)
+	}
+
+	// Test case 2: Warning timeout disabled (should go directly to critical)
+	event.Check.Timeout = 0                                          // Disable warning timeout
+	event.Entity.LastSeen = time.Now().Add(-90 * time.Second).Unix() // Still 90 seconds ago
+
+	// Should still trigger warning since 90 < 120 (critical timeout)
+	if got, want := keepalived.dead("default/entity1", liveness.Alive, true), false; got != want {
+		t.Fatalf("got bury: %v, want bury: %v", got, want)
+	}
+
+	// Test case 3: Entity down long enough to trigger critical
+	event.Entity.LastSeen = time.Now().Add(-150 * time.Second).Unix() // 150 seconds ago
+
+	// Should trigger critical (status 2) since 150 > 120
+	if got, want := keepalived.dead("default/entity1", liveness.Alive, true), false; got != want {
+		t.Fatalf("got bury: %v, want bury: %v", got, want)
+	}
+}
+
 func TestCreateRegistrationEvent(t *testing.T) {
 	event := corev2.FixtureEntity("entity1")
 	keepaliveEvent := createRegistrationEvent(event)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 toolchain go1.23.4
 
-replace github.com/sensu/core/v2 => github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773
+replace github.com/sensu/core/v2 => github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 toolchain go1.23.4
 
-replace github.com/sensu/core/v2 => github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14
@@ -86,7 +85,7 @@ require (
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/sensu/core/v2 v2.20.0
+	github.com/sensu/core/v2 v2.20.1-0.20251104042553-0603aa304a04
 	github.com/sensu/core/v3 v3.9.0
 	github.com/sensu/sensu-api-tools v0.2.1
 	github.com/sensu/sensu-go/types v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.22
 
 toolchain go1.23.4
 
+replace github.com/sensu/core/v2 => github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773
+
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14
 	github.com/ash2k/stager v0.0.0-20170622123058-6e9c7b0eacd4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1575,8 +1575,8 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZ
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773 h1:ZJsR37sc2SIFOLScqpFiiTBT4EqCG+uMAM+Lsg58Yf8=
-github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773/go.mod h1:AjLvqZm/fv1hhWPJLrOZiwLvmWURrKwfevEZ/sAZgkE=
+github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc h1:a0ARI5JPxd5vRuXzFZcfo/L8sxXycgfvcGPUrbKWjLM=
+github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc/go.mod h1:AjLvqZm/fv1hhWPJLrOZiwLvmWURrKwfevEZ/sAZgkE=
 github.com/sensu/core/v3 v3.9.0 h1:7wz4ILGwPbHHTT/8sKTtflBAgOuJgTaKhUlN4lyUdSY=
 github.com/sensu/core/v3 v3.9.0/go.mod h1:AuupbIzmjYdzEkaEdmpzP/ZgrqQgHTovXVejzyTN6u4=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=

--- a/go.sum
+++ b/go.sum
@@ -1575,8 +1575,10 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZ
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc h1:a0ARI5JPxd5vRuXzFZcfo/L8sxXycgfvcGPUrbKWjLM=
-github.com/sensu/core/v2 v2.0.0-20250823120716-2c4f595901dc/go.mod h1:AjLvqZm/fv1hhWPJLrOZiwLvmWURrKwfevEZ/sAZgkE=
+github.com/sensu/core/v2 v2.20.0 h1:QJQbqZiXSQ2dUE8LUvwUcKaqxHjYYCQwJ1Mil0cap4U=
+github.com/sensu/core/v2 v2.20.0/go.mod h1:fzr3qioLAHyLsBfq9I6ELVjL01NUNjqmQx4kj2tbDLo=
+github.com/sensu/core/v2 v2.20.1-0.20251104042553-0603aa304a04 h1:pfmJDcFVu/cIlwEim5wExlLQuhCt0it4W8RCDNraWQg=
+github.com/sensu/core/v2 v2.20.1-0.20251104042553-0603aa304a04/go.mod h1:AjLvqZm/fv1hhWPJLrOZiwLvmWURrKwfevEZ/sAZgkE=
 github.com/sensu/core/v3 v3.9.0 h1:7wz4ILGwPbHHTT/8sKTtflBAgOuJgTaKhUlN4lyUdSY=
 github.com/sensu/core/v3 v3.9.0/go.mod h1:AuupbIzmjYdzEkaEdmpzP/ZgrqQgHTovXVejzyTN6u4=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=

--- a/go.sum
+++ b/go.sum
@@ -1575,8 +1575,8 @@ github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZ
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/sensu/core/v2 v2.20.0 h1:QJQbqZiXSQ2dUE8LUvwUcKaqxHjYYCQwJ1Mil0cap4U=
-github.com/sensu/core/v2 v2.20.0/go.mod h1:fzr3qioLAHyLsBfq9I6ELVjL01NUNjqmQx4kj2tbDLo=
+github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773 h1:ZJsR37sc2SIFOLScqpFiiTBT4EqCG+uMAM+Lsg58Yf8=
+github.com/sensu/core/v2 v2.0.0-20250822062819-dc8460952773/go.mod h1:AjLvqZm/fv1hhWPJLrOZiwLvmWURrKwfevEZ/sAZgkE=
 github.com/sensu/core/v3 v3.9.0 h1:7wz4ILGwPbHHTT/8sKTtflBAgOuJgTaKhUlN4lyUdSY=
 github.com/sensu/core/v3 v3.9.0/go.mod h1:AuupbIzmjYdzEkaEdmpzP/ZgrqQgHTovXVejzyTN6u4=
 github.com/sensu/lasr v1.2.1 h1:4H1QfOrPkwYHMFE5qAI6GwKEFkcI1YRyjjWidz1MihQ=


### PR DESCRIPTION
## What is this change?

This change introduces the ability to configure the event status when a check TTL expires (warning, critical).
Additionally, it allows disabling the intermediate warning state for keepalives by setting keepalive-warning-timeout = 0.

## Why is this change necessary?

Currently, Sensu Go does not provide configurable TTL expiry status and always produces a warning.
Also, keepalive checks always transition from OK → Warning → Critical.


## Does your change need a Changelog entry?

Yes this is a user-facing feature enhancement.

## Do you need clarification on anything?
No, but reviewers should double-check:

That TTL expiry statuses are properly configurable and respected.

That disabling warning state with keepalive-warning-timeout = 0 doesn’t have unintended side effects.

## Were there any complications while making this change?

NA

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes — new documentation is required to explain:

TTL check configuration options (ttl_status).

Keepalive configuration where keepalive-warning-timeout = 0 disables warnings.


## How did you verify this change?

Created a check with a low TTL and verified that it produces the configured status (warning/critical/unknown).

Set keepalive-warning-timeout = 0 and confirmed keepalives go directly from OK → Critical without passing through Warning.

## Is this change a patch?

No