### PR TITLE
Fix : backend reload environment refresh behavior

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -820,6 +820,12 @@ func (b *Backend) RunWithInitializer(initialize func(context.Context, *Config) (
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
 
+	go func() {
+		<-sighup
+		logger.Info("received SIGHUP, terminating backend process for restart")
+		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	}()
+
 	err := backoff.Retry(func(int) (bool, error) {
 		err := b.runOnce()
 		b.Stop()


### PR DESCRIPTION
## What is this change?

This change updates the backend SIGHUP handling behavior to terminate the backend process gracefully when a reload signal is received.

Previously, the backend handled reloads internally without recreating the process, which caused stale environment variables to persist after `systemctl reload sensu-backend`.

## Why is this change necessary?

Environment variables configured through `/etc/default/sensu-backend` are only loaded during process creation.

Before this change:

1. Updating `/etc/default/sensu-backend`
2. Running:

   * `systemctl daemon-reload`
   * `systemctl reload sensu-backend`

did not apply updated environment variables because the backend process remained alive after handling `SIGHUP`.

As a result:

* the backend PID remained unchanged
* `/proc/<pid>/environ` continued to contain stale values

This change ensures the backend process exits on reload, allowing the service manager to recreate the process and load updated environment variables.

## Does your change need a Changelog entry?

Yes.

This change modifies backend reload behavior and fixes an issue where updated environment variables were not applied after `systemctl reload sensu-backend`.

## Do you need clarification on anything?

One consideration is that this behavior assumes the backend service is managed by a service manager (such as systemd) configured with an appropriate restart policy.

## Were there any complications while making this change?

The main complexity was identifying that the existing reload path only triggered internal backend reinitialization without terminating the process.

Although `SIGHUP` handling infrastructure already existed, the signal was not causing process recreation, which prevented updated environment variables from being reloaded from the configured `EnvironmentFile`.

Additional validation was required on a real Linux system with systemd to verify:

* PID behavior
* EnvironmentFile behavior
* reload lifecycle semantics
* graceful shutdown behavior

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No documentation updates were required.

The change modifies backend reload behavior internally and does not introduce new user-facing configuration.

## How did you verify this change?

Verified on a real Linux system using systemd.

Validation steps:

1. Configured:

   * `/etc/default/sensu-backend`
   * `EnvironmentFile`
   * `ExecReload=/bin/kill -HUP $MAINPID`

2. Started backend with:

   * `TEST_API_KEY=OLD_VALUE`

3. Verified:

   * `/proc/<pid>/environ` contained `OLD_VALUE`

4. Updated:

   * `/etc/default/sensu-backend`
   * changed value to `NEW_VALUE`

5. Executed:

   * `systemctl daemon-reload`
   * `systemctl reload sensu-backend`

Before this change:

* backend process remained alive
* PID did not change
* environment variables remained stale

After this change:

* backend process exited gracefully on reload
* service manager recreated the process
* updated environment variables were correctly loaded

## Is this change a patch?

Yes.
