### PR TITLE
fix: mitigate user enumeration via timing side-channel

### DIFF
--- a/backend/store/etcd/user_store.go
+++ b/backend/store/etcd/user_store.go
@@ -24,13 +24,25 @@ func GetUsersPath(ctx context.Context, id string) string {
 	return path.Join(store.Root, usersPathPrefix, id)
 }
 
+// dummyPasswordHash is a bcrypt hash used to perform a constant-time comparison
+// when a user is not found, preventing user enumeration via timing side-channel.
+var dummyPasswordHash = func() string {
+	h, _ := bcrypt.HashPassword("sensu-dummy-password-for-timing-equalization")
+	return h
+}()
+
 // AuthenticateUser authenticates a User by username and password.
 func (s *Store) AuthenticateUser(ctx context.Context, username, password string) (*corev2.User, error) {
 	user, err := s.GetUser(ctx, username)
 	if err != nil {
+		bcrypt.CheckPassword(dummyPasswordHash, password)
 		return nil, err
 	}
 	if user == nil {
+		// Perform a bcrypt comparison against a dummy hash to ensure the response
+		// time is consistent regardless of whether the user exists, preventing
+		// user enumeration via timing side-channel attacks.
+		bcrypt.CheckPassword(dummyPasswordHash, password)
 		return nil, &store.ErrNotFound{Key: username}
 	}
 

--- a/backend/store/etcd/user_store_test.go
+++ b/backend/store/etcd/user_store_test.go
@@ -100,6 +100,75 @@ func TestUserStorage(t *testing.T) {
 	})
 }
 
+func TestAuthenticateUserTimingAttackMitigation(t *testing.T) {
+	testWithEtcd(t, func(s store.Store) {
+		password := "P@ssw0rd!"
+		passwordDigest, err := bcrypt.HashPassword(password)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithDeadline(
+			context.Background(),
+			time.Now().Add(30*time.Second),
+		)
+		defer cancel()
+
+		user := types.FixtureUser("existinguser")
+		user.PasswordHash = passwordDigest
+		err = s.CreateUser(ctx, user)
+		require.NoError(t, err)
+
+		const iterations = 5
+
+		// Measure authentication time for an existing user with wrong password
+		var existingUserDurations []time.Duration
+		for i := 0; i < iterations; i++ {
+			start := time.Now()
+			_, _ = s.AuthenticateUser(ctx, "existinguser", "wrongpassword")
+			existingUserDurations = append(existingUserDurations, time.Since(start))
+		}
+
+		// Measure authentication time for a non-existing user
+		var nonExistingUserDurations []time.Duration
+		for i := 0; i < iterations; i++ {
+			start := time.Now()
+			_, _ = s.AuthenticateUser(ctx, "nonexistentuser", "wrongpassword")
+			nonExistingUserDurations = append(nonExistingUserDurations, time.Since(start))
+		}
+
+		// Calculate averages
+		var avgExisting, avgNonExisting time.Duration
+		for _, d := range existingUserDurations {
+			avgExisting += d
+		}
+		avgExisting /= time.Duration(iterations)
+
+		for _, d := range nonExistingUserDurations {
+			avgNonExisting += d
+		}
+		avgNonExisting /= time.Duration(iterations)
+
+		// Both should take roughly the same time (within 50% of each other).
+		// Before the fix, non-existing user auth would be ~100x faster because
+		// no bcrypt comparison was performed.
+		ratio := float64(avgExisting) / float64(avgNonExisting)
+		assert.InDelta(t, 1.0, ratio, 0.5,
+			"Authentication timing for existing vs non-existing users should be similar. "+
+				"Existing user avg: %v, Non-existing user avg: %v, Ratio: %.2f",
+			avgExisting, avgNonExisting, ratio)
+
+		// Verify correct error types are still returned
+		_, err = s.AuthenticateUser(ctx, "nonexistentuser", "wrongpassword")
+		assert.Error(t, err)
+		var notFoundErr *store.ErrNotFound
+		assert.ErrorAs(t, err, &notFoundErr)
+
+		_, err = s.AuthenticateUser(ctx, "existinguser", "wrongpassword")
+		assert.Error(t, err)
+		var notValidErr *store.ErrNotValid
+		assert.ErrorAs(t, err, &notValidErr)
+	})
+}
+
 // TestGetAllUsersPagination tests the store's ability to paginate Users.
 // While GetAllUsers() internally merely calls the generic List() method of the
 // store, we can't rely on that method's tests because they assume a generic,


### PR DESCRIPTION
## Summary
- Perform a bcrypt comparison against a dummy hash when a user is not found during authentication, ensuring response time is consistent regardless of whether the user exists
- This prevents attackers from enumerating valid usernames by observing response time differences

## Test plan
- [ ] Verify that authentication for non-existent users takes roughly the same time as authentication for existing users with wrong passwords
- [ ] Run integration tests: `go test -tags integration ./backend/store/etcd/ -run TestAuthenticateUserTimingAttackMitigation`
- [ ] Confirm existing authentication behavior is unchanged (correct password succeeds, wrong password fails)

Resolves sensu/sensu-enterprise-go#2606

Resolves sensu/sensu-enterprise-go#2606