### PR TITLE
fix: prevent spurious continue token on last page

### DIFF
--- a/backend/store/etcd/event_store.go
+++ b/backend/store/etcd/event_store.go
@@ -96,8 +96,15 @@ func (s *Store) DeleteEventByEntityCheck(ctx context.Context, entityName, checkN
 // GetEvents returns the events for an (optional) namespace. If namespace is the
 // empty string, GetEvents returns all events for all namespaces.
 func (s *Store) GetEvents(ctx context.Context, pred *store.SelectionPredicate) ([]*corev2.Event, error) {
+	// Request one extra record beyond the limit to reliably detect whether
+	// more results exist, avoiding spurious continue tokens on the last page.
+	queryLimit := pred.Limit
+	if queryLimit > 0 {
+		queryLimit++
+	}
+
 	opts := []clientv3.OpOption{
-		clientv3.WithLimit(pred.Limit),
+		clientv3.WithLimit(queryLimit),
 	}
 
 	keyPrefix := GetEventsPath(ctx, "")
@@ -126,8 +133,15 @@ func (s *Store) GetEvents(ctx context.Context, pred *store.SelectionPredicate) (
 		return []*corev2.Event{}, nil
 	}
 
+	// Determine if there are more results beyond the requested limit
+	hasMore := pred.Limit > 0 && int64(len(resp.Kvs)) > pred.Limit
+	kvs := resp.Kvs
+	if hasMore {
+		kvs = kvs[:pred.Limit]
+	}
+
 	events := []*corev2.Event{}
-	for _, kv := range resp.Kvs {
+	for _, kv := range kvs {
 		event := &corev2.Event{}
 		if err := unmarshal(kv.Value, event); err != nil {
 			return nil, &store.ErrDecode{Err: err}
@@ -143,7 +157,7 @@ func (s *Store) GetEvents(ctx context.Context, pred *store.SelectionPredicate) (
 		events = append(events, event)
 	}
 
-	if pred.Limit != 0 && resp.Count > pred.Limit {
+	if hasMore {
 		pred.Continue = ComputeContinueToken(ctx, events[len(events)-1])
 	} else {
 		pred.Continue = ""
@@ -158,8 +172,15 @@ func (s *Store) GetEventsByEntity(ctx context.Context, entityName string, pred *
 		return nil, &store.ErrNotValid{Err: errors.New("must specify entity name")}
 	}
 
+	// Request one extra record beyond the limit to reliably detect whether
+	// more results exist, avoiding spurious continue tokens on the last page.
+	queryLimit := pred.Limit
+	if queryLimit > 0 {
+		queryLimit++
+	}
+
 	opts := []clientv3.OpOption{
-		clientv3.WithLimit(pred.Limit),
+		clientv3.WithLimit(queryLimit),
 	}
 
 	keyPrefix := GetEventsPath(ctx, entityName)
@@ -179,8 +200,15 @@ func (s *Store) GetEventsByEntity(ctx context.Context, entityName string, pred *
 		return nil, nil
 	}
 
+	// Determine if there are more results beyond the requested limit
+	hasMore := pred.Limit > 0 && int64(len(resp.Kvs)) > pred.Limit
+	kvs := resp.Kvs
+	if hasMore {
+		kvs = kvs[:pred.Limit]
+	}
+
 	events := []*corev2.Event{}
-	for _, kv := range resp.Kvs {
+	for _, kv := range kvs {
 		event := &corev2.Event{}
 		if err := unmarshal(kv.Value, event); err != nil {
 			return nil, &store.ErrDecode{Err: err}
@@ -196,7 +224,7 @@ func (s *Store) GetEventsByEntity(ctx context.Context, entityName string, pred *
 		events = append(events, event)
 	}
 
-	if pred.Limit != 0 && resp.Count > pred.Limit {
+	if hasMore {
 		lastEvent := events[len(events)-1]
 		pred.Continue = lastEvent.Check.Name + "\x00"
 	} else {

--- a/backend/store/etcd/event_store_integration_test.go
+++ b/backend/store/etcd/event_store_integration_test.go
@@ -649,6 +649,72 @@ func testGetEventsByEntityPagination(t *testing.T, ctx context.Context, etcd sto
 	}
 }
 
+func TestGetEventsPaginationNoContinueTokenOnExactLimit(t *testing.T) {
+	testWithEtcd(t, func(s store.Store) {
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, "default")
+
+		// Create exactly 5 events
+		for i := 1; i <= 5; i++ {
+			event := corev2.FixtureEvent(fmt.Sprintf("entity%.2d", i), fmt.Sprintf("check%.2d", i))
+			_, _, err := s.UpdateEvent(ctx, event)
+			require.NoError(t, err)
+		}
+
+		// Query with limit equal to the total count — should NOT produce a continue token
+		pred := &store.SelectionPredicate{Limit: 5}
+		events, err := s.GetEvents(ctx, pred)
+		require.NoError(t, err)
+		assert.Equal(t, 5, len(events))
+		assert.Empty(t, pred.Continue, "should not have a continue token when limit equals total count")
+
+		// Query with limit less than total — should produce a continue token
+		pred = &store.SelectionPredicate{Limit: 3}
+		events, err = s.GetEvents(ctx, pred)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(events))
+		assert.NotEmpty(t, pred.Continue, "should have a continue token when more events exist")
+
+		// Follow the continue token — should get remaining 2 events with no further token
+		events, err = s.GetEvents(ctx, pred)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(events))
+		assert.Empty(t, pred.Continue, "should not have a continue token on the final page")
+	})
+}
+
+func TestGetEventsByEntityPaginationNoContinueTokenOnExactLimit(t *testing.T) {
+	testWithEtcd(t, func(s store.Store) {
+		ctx := context.WithValue(context.Background(), corev2.NamespaceKey, "default")
+
+		// Create exactly 5 checks for the same entity
+		for i := 1; i <= 5; i++ {
+			event := corev2.FixtureEvent("testentity", fmt.Sprintf("check%.2d", i))
+			_, _, err := s.UpdateEvent(ctx, event)
+			require.NoError(t, err)
+		}
+
+		// Query with limit equal to the total count — should NOT produce a continue token
+		pred := &store.SelectionPredicate{Limit: 5}
+		events, err := s.GetEventsByEntity(ctx, "testentity", pred)
+		require.NoError(t, err)
+		assert.Equal(t, 5, len(events))
+		assert.Empty(t, pred.Continue, "should not have a continue token when limit equals total count")
+
+		// Query with limit less than total — should produce a continue token
+		pred = &store.SelectionPredicate{Limit: 3}
+		events, err = s.GetEventsByEntity(ctx, "testentity", pred)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(events))
+		assert.NotEmpty(t, pred.Continue, "should have a continue token when more events exist")
+
+		// Follow the continue token — should get remaining 2 events with no further token
+		events, err = s.GetEventsByEntity(ctx, "testentity", pred)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(events))
+		assert.Empty(t, pred.Continue, "should not have a continue token on the final page")
+	})
+}
+
 func TestHandleExpireOnResolveEntries(t *testing.T) {
 	expireOnResolve := func(s *corev2.Silenced) *corev2.Silenced {
 		s.ExpireOnResolve = true


### PR DESCRIPTION
## Summary
- Request one extra record beyond the limit from etcd to reliably detect whether additional results exist
- Avoids returning a continue token that leads to an empty result set when record count equals the requested limit
- Fixes both `GetEvents` and `GetEventsByEntity`

## Test plan
- [ ] Run integration tests: `go test -tags integration ./backend/store/etcd/ -run TestGetEventsPaginationNoContinueTokenOnExactLimit`
- [ ] Run integration tests: `go test -tags integration ./backend/store/etcd/ -run TestGetEventsByEntityPaginationNoContinueTokenOnExactLimit`
- [ ] Verify existing pagination tests still pass

Resolves sensu/sensu-enterprise-go#2609

Resolves sensu/sensu-enterprise-go#2609