### PR TITLE
fix: disable platform metrics by default, add size-based log rotation

### DIFF
--- a/backend/cmd/start.go
+++ b/backend/cmd/start.go
@@ -187,7 +187,7 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 var (
 	// platform metric logging defaults
-	defaultDisablePlatformMetrics         = false
+	defaultDisablePlatformMetrics         = true
 	defaultPlatformMetricsLoggingInterval = 60 * time.Second
 	defaultPlatformMetricsLogFile         = filepath.Join(path.SystemLogDir(), "backend-stats.log")
 )

--- a/backend/cmd/start_test.go
+++ b/backend/cmd/start_test.go
@@ -25,6 +25,12 @@ func tempConfig(t *testing.T, content string) *os.File {
 	return file
 }
 
+func TestDefaultDisablePlatformMetrics(t *testing.T) {
+	if defaultDisablePlatformMetrics != true {
+		t.Errorf("defaultDisablePlatformMetrics = %v, want true", defaultDisablePlatformMetrics)
+	}
+}
+
 func Test_handleConfig(t *testing.T) {
 	cmd := &cobra.Command{
 		Use: "test",

--- a/backend/logging/rotate_writer.go
+++ b/backend/logging/rotate_writer.go
@@ -1,18 +1,31 @@
 package logging
 
 import (
+	"fmt"
 	"os"
 	"sync"
 )
 
+const (
+	// DefaultMaxFileSize is the default maximum log file size (100 MB) before
+	// automatic rotation occurs.
+	DefaultMaxFileSize int64 = 100 * 1024 * 1024
+
+	// maxRotatedFiles is the maximum number of rotated log files to retain.
+	maxRotatedFiles = 5
+)
+
 // RotateWriter is a special writer that re-opens the path it was opened at
-// when it receives a rotate signal.
+// when it receives a rotate signal. It also supports automatic size-based
+// rotation to prevent unbounded disk usage.
 type RotateWriter struct {
-	file      *os.File
-	isSpecial bool
-	mu        sync.Mutex
-	path      string
-	rotate    chan interface{}
+	file        *os.File
+	isSpecial   bool
+	maxSize     int64
+	mu          sync.Mutex
+	path        string
+	rotate      chan interface{}
+	writtenSize int64
 }
 
 // NewRotateWriter creates a new RotateWriter. It will open the path given and
@@ -23,8 +36,9 @@ type RotateWriter struct {
 // by this function will terminate.
 func NewRotateWriter(path string, rotate chan interface{}) (*RotateWriter, error) {
 	writer := &RotateWriter{
-		path:   path,
-		rotate: rotate,
+		path:    path,
+		rotate:  rotate,
+		maxSize: DefaultMaxFileSize,
 	}
 	if err := writer.open(); err != nil {
 		return nil, err
@@ -41,10 +55,23 @@ func (w *RotateWriter) Close() error {
 }
 
 // Write will dispatch writes to the currently-opened file. It is goroutine-safe.
+// If the file exceeds the maximum size after writing, it is automatically rotated.
 func (w *RotateWriter) Write(b []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	return w.file.Write(b)
+
+	n, err := w.file.Write(b)
+	if err != nil {
+		return n, err
+	}
+
+	w.writtenSize += int64(n)
+
+	if !w.isSpecial && w.maxSize > 0 && w.writtenSize >= w.maxSize {
+		w.rotateLocked()
+	}
+
+	return n, nil
 }
 
 // Sync syncs the currently opened file.
@@ -65,6 +92,29 @@ func (w *RotateWriter) listenSignal() {
 			logger.WithError(err).Errorf("error reopening log file %q", w.path)
 		}
 	}
+}
+
+// rotateLocked performs file rotation while holding the mutex.
+// It renames the current file and opens a new one.
+func (w *RotateWriter) rotateLocked() {
+	_ = w.file.Close()
+
+	// Shift existing rotated files
+	for i := maxRotatedFiles - 1; i > 0; i-- {
+		oldPath := fmt.Sprintf("%s.%d", w.path, i)
+		newPath := fmt.Sprintf("%s.%d", w.path, i+1)
+		_ = os.Rename(oldPath, newPath)
+	}
+	_ = os.Rename(w.path, fmt.Sprintf("%s.1", w.path))
+
+	// Open a fresh file
+	fp, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		logger.WithError(err).Errorf("error rotating log file %q", w.path)
+		return
+	}
+	w.file = fp
+	w.writtenSize = 0
 }
 
 // open will open a file and assign it to the writer underlying file. It can
@@ -91,6 +141,8 @@ func (w *RotateWriter) open() error {
 	if !info.Mode().IsRegular() {
 		w.isSpecial = true
 	}
+
+	w.writtenSize = info.Size()
 
 	return nil
 }

--- a/backend/logging/rotate_writer_test.go
+++ b/backend/logging/rotate_writer_test.go
@@ -88,3 +88,116 @@ func TestSpecialFileSync(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestRotateWriterSizeBasedRotation(t *testing.T) {
+	dir := t.TempDir()
+	logPath := dir + "/metrics.log"
+
+	rotate := make(chan interface{}, 1)
+	defer close(rotate)
+
+	w, err := NewRotateWriter(logPath, rotate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set a small max size for testing
+	w.maxSize = 100
+
+	// Write data to exceed the max size
+	data := make([]byte, 60)
+	for i := range data {
+		data[i] = 'x'
+	}
+
+	_, err = w.Write(data)
+	assert.NoError(t, err)
+
+	// This write should trigger rotation (60 + 60 = 120 > 100)
+	_, err = w.Write(data)
+	assert.NoError(t, err)
+
+	// The rotated file should exist
+	_, err = os.Stat(logPath + ".1")
+	assert.NoError(t, err, "rotated file should exist after exceeding max size")
+
+	// The current log file should be small (only the post-rotation content)
+	info, err := os.Stat(logPath)
+	assert.NoError(t, err)
+	assert.Less(t, info.Size(), int64(100), "current file should be smaller than max size after rotation")
+
+	w.Close()
+}
+
+func TestRotateWriterMultipleRotations(t *testing.T) {
+	dir := t.TempDir()
+	logPath := dir + "/metrics.log"
+
+	rotate := make(chan interface{}, 1)
+	defer close(rotate)
+
+	w, err := NewRotateWriter(logPath, rotate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set a small max size for testing
+	w.maxSize = 50
+
+	data := make([]byte, 60)
+	for i := range data {
+		data[i] = 'a'
+	}
+
+	// Trigger multiple rotations
+	for i := 0; i < 3; i++ {
+		_, err = w.Write(data)
+		assert.NoError(t, err)
+	}
+
+	// We should have rotated files .1 and .2
+	_, err = os.Stat(logPath + ".1")
+	assert.NoError(t, err, "rotated file .1 should exist")
+	_, err = os.Stat(logPath + ".2")
+	assert.NoError(t, err, "rotated file .2 should exist")
+
+	w.Close()
+}
+
+func TestRotateWriterRespectsMaxRotatedFiles(t *testing.T) {
+	dir := t.TempDir()
+	logPath := dir + "/metrics.log"
+
+	rotate := make(chan interface{}, 1)
+	defer close(rotate)
+
+	w, err := NewRotateWriter(logPath, rotate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set a small max size for testing
+	w.maxSize = 20
+
+	data := make([]byte, 30)
+	for i := range data {
+		data[i] = 'b'
+	}
+
+	// Trigger more rotations than maxRotatedFiles (5)
+	for i := 0; i < 8; i++ {
+		_, err = w.Write(data)
+		assert.NoError(t, err)
+	}
+
+	// Files beyond maxRotatedFiles should not exist
+	_, err = os.Stat(logPath + ".5")
+	assert.NoError(t, err, "rotated file .5 should exist (max)")
+
+	// File .6 should not exist due to the shift overwriting
+	// (the oldest gets pushed off)
+	_, err = os.Stat(logPath + ".6")
+	assert.True(t, os.IsNotExist(err), "rotated file .6 should not exist (exceeds max)")
+
+	w.Close()
+}


### PR DESCRIPTION
## Summary
- Disables platform metrics logging by default (`--disable-platform-metrics` now defaults to `true`) to prevent disk exhaustion
- Adds automatic size-based log rotation (100 MB max, 5 rotated files kept) to `RotateWriter` for users who opt-in to platform metrics
- Users can still enable metrics via `--disable-platform-metrics=false`

## Test plan
- [ ] Run unit tests: `go test ./backend/logging/ -run TestRotateWriter`
- [ ] Run unit tests: `go test ./backend/cmd/ -run TestDefaultDisablePlatformMetrics`
- [ ] Verify new backends start without creating a platform metrics log file by default
- [ ] Verify `--disable-platform-metrics=false` still enables metrics logging with rotation

Resolves sensu/sensu-enterprise-go#2613

Resolves #4821